### PR TITLE
Lower compound assignment via write-back references

### DIFF
--- a/docs/decisions/arena-reference-lifetime.md
+++ b/docs/decisions/arena-reference-lifetime.md
@@ -34,13 +34,18 @@ live reference.
 
 `Get` is a transient view; the `Id` is the only durable handle.
 
-1. **The arena stays a relocatable `vector`.** Dense contiguous storage, the cheapest `Id -> T`
-   indexing, and good iteration locality are kept. The arena does not promise that a `Get` reference
-   survives an `Add`.
+1. **The arena stays a relocatable `vector`.** Contiguous storage, good iteration / cache locality,
+   and the simplest storage model are kept. (A `deque` or paged arena would still index in O(1); the
+   cost of switching is contiguity and locality, not lookup speed.) The arena does not promise that
+   a `Get` reference survives an `Add`.
 
 2. **Same-arena mutation invalidates prior `Get` results.** Any `Add` may relocate the backing
    storage, invalidating every reference, pointer, and iterator a prior `Get` returned to that
-   arena. This contract lives on the `Arena` type.
+   arena. This contract lives on the `Arena` type. A `Get` reference is usable by any caller, not
+   only the arena's owner, but only within a lexical region in which that arena is guaranteed not to
+   grow -- it is a scoped borrow, never an identity that is stored or passed on. `reserve()` does
+   not change this: capacity that happens to be sufficient in one run is not a contract, and a
+   caller may never rely on a reference surviving an `Add` because the vector looked large enough.
 
 3. **Lowering projects facts before mutating.** To carry information from a node past an `Add`, a
    caller projects the value it needs -- an `Id`, a kind, a copied field -- before the `Add`, and
@@ -57,9 +62,14 @@ live reference.
 - **Stable-reference storage (deque / segmented / paged) so `Get` references survive `Add`.** This
   extends the contract of every arena -- system-wide -- to serve a capability no site requires: the
   usage evidence shows the value needed past a mutation is always a projectable fact, never a live
-  whole-node borrow. It trades contiguity, locality, and the cheapest indexing on a read-heavy hot
-  path for a guarantee nothing depends on, and over-extends the abstraction from an incidental code
-  shape. Reconsider only if a genuine need for a stable cross-mutation whole-node borrow appears.
+  whole-node borrow. The deeper cost is not performance but the abstraction boundary: the
+  relocatable-`vector` contract is what forces every cross-mutation dataflow to be an explicit `Id`
+  or projected value. Stable-reference storage would invite treating a live `Get` reference as a
+  passable, savable identity -- an erosion of the id-first model, not a neutral container swap. It
+  also trades contiguity and locality on a read-heavy hot path for a guarantee nothing depends on.
+  Reconsider only if a genuine need appears for a live whole-node borrow held across an arena
+  mutation that cannot be re-expressed as an `Id`, a copy, a snapshot, or an owned descriptor; a
+  recurring copy-before-`Add` is the expected shape, not evidence for the change.
 
 - **`Get` returns by value.** Safe by construction, but copies a fat node (`Type`, `Expr`) on every
   read, on the hot path, when most reads touch a single field. The need is to copy the _one fact_

--- a/docs/decisions/compound-assignment-write-location.md
+++ b/docs/decisions/compound-assignment-write-location.md
@@ -1,0 +1,140 @@
+# Compound assignment lowers uniformly; every write target is an op=-able location
+
+Date: 2026-06-28 Status: accepted
+
+## Context
+
+A compound assignment `lhs op= rhs` (LRM 11.4.1) has one semantic rule that distinguishes it from
+`lhs = lhs op rhs`: **the left-hand side is evaluated exactly once** -- in particular every
+left-hand subscript runs a single time, even one with a side effect (`a[f()] += b` calls `f()`
+once).
+
+The question is at which layer that "evaluate once" is realized. Two shapes were possible:
+
+1. **Desugar at HIR-to-MIR.** Lower `lhs op= rhs` to an explicit read-modify-write
+   (`store(place, load(place) op rhs)`), hoisting every subscript into a temp at the lowering so the
+   read and write sites share it. This makes "once" a lowering concern and bakes a read-op-write
+   shape into MIR.
+2. **Carry the compound as a high-level node, realize "once" in the backend.** Lower to
+   `AssignExpr{target, compound_op, value}` where `target` is an ordinary lvalue expression, and let
+   each backend realize the operator on a single evaluation of the target -- the C++ `op=` evaluates
+   its left operand once; a future LIR computes the target address once and does load-modify-store.
+
+`slice-value-semantics.md` already settled the access model this rests on: a read materializes a
+value, a write targets a location realized by a reference or a write-back proxy, and that asymmetry
+is "uniform across whole-variable access, element access, and slice access." Under that model a
+packed-array element write is `arr.ElementRef(i)` returning a `PackedArrayRef` proxy whose
+`operator=` and `operator+=` read-modify-write through a captured position, and a struct-member
+write is a `TupleGet` yielding a real `T&`. Both are op=-able locations, so for those targets shape
+2 is already what the compiler does: `arr[i] += v` lowers to `AssignExpr{ElementRef(arr,i), +=, v}`
+and renders to `arr.ElementRef(i) += v`, with "once" provided by C++.
+
+Only two write targets did not fit, because they exposed no op=-able location: a string character
+(realized as `getc` / `putc` method calls) and an unpacked-union member (realized as a whole-union
+rebuild). For those, shape 1 was used as a local desugar -- which is the inconsistency this decision
+removes.
+
+## Decision
+
+**Compound assignment lowers uniformly to `AssignExpr{target, compound_op, value}` for every target,
+and "evaluate the left-hand side once" is the backend's mechanical realization, not a HIR-to-MIR
+desugar.** This requires every write target to be an op=-able location, so the two holdouts gain
+write-side locations.
+
+1. **The write side of any element / member access is a location.** A read materializes a value; a
+   write yields a write-back location -- a reference for storage that exists in place, a proxy for
+   storage that is synthesized, overlapping, or sub-addressed. This is the existing read-value /
+   write-location model (`slice-value-semantics.md`), now applied to every element and member kind
+   without exception. The "no element lvalue" special case is retired.
+
+2. **String character access is a matched value / reference pair, like a packed array element.** The
+   indexed read `s[i]` is `String::Element(i)` (the character value); the write `s[i] = ...` is
+   `String::ElementRef(i)`, a `StringCharRef` write-back proxy that captures the index once, routes
+   `operator=` through `putc`, and reads-modifies-writes for each compound operator. A string
+   exposes no in-place character reference (`putc` enforces the out-of-range / NUL rules, LRM
+   6.16.2), so the write side is a proxy. The explicit `s.getc(i)` / `s.putc(i, c)` methods (LRM
+   6.16.3 / 6.16.2) stay for the method-call forms; `Element` / `ElementRef` are the indexing forms.
+
+3. **A union member access is a matched value / reference pair, like a packed array element.** The
+   read `u.f` is `UnionMemberExpr` rendering `Union::Member<I>()` (the active-member value, the
+   inactive-member default if `I` is not active); the write is `UnionMemberRefExpr` rendering
+   `Union::MemberRef<I>()`, a reference to the active member's storage that makes `I` active first
+   if it is not. The two are separate access forms because a union member's read realization (a
+   value) differs from its write realization (an activating reference) -- the same reason a packed
+   array element splits into `Element` / `ElementRef`. The write reference is a real reference, not
+   a proxy, so `u.f = v`, `u.f op= v`, and a nested `u.f.g = v` or `u.h[i] = v` all compose on it
+   exactly as a struct member's reference does. The only difference from a struct member is the
+   activation step; the active-member representation (not a byte overlay, see
+   `unpacked-union-representation.md`) is why a write activates the member rather than reinterprets
+   shared bytes. There is no union-specific reference concept -- this is the `Element` /
+   `ElementRef` access split, by compile-time index.
+
+4. **MIR carries one compound shape.** `AssignExpr{target, compound_op, value}` is the single
+   representation; `target` is the lvalue expression (a container-access chain ending in
+   `kElementRef` for a string character, a `UnionMemberRefExpr` for a union member, a `TupleGetExpr`
+   for a struct member, an `ElementRef` chain for an array element). There is no read-op-write
+   desugar in MIR, and no per-target compound lowering. The HIR-to-MIR string-element and
+   union-member assignment special cases, and the subscript-hoisting machinery that supported them,
+   are deleted.
+
+5. **"Evaluate once" is the backend's mechanical job.** The C++ backend renders
+   `AssignExpr{target, op, value}` as `<target> op= <value>`; C++ evaluates the target expression --
+   including every nested subscript -- exactly once before applying the operator. A future LIR
+   backend computes the target's address once and does load-modify-store. The lowering states the
+   semantic (`compound_op` on `AssignExpr`); each backend realizes "once" by a fixed function of
+   that node, with no decision logic (`backend_contract.md`).
+
+## Rejected
+
+- **Desugar compound to read-op-write at HIR-to-MIR (shape 1), with per-target subscript hoisting.**
+  It bakes one realization into MIR, gives the same SystemVerilog operation two MIR shapes (a
+  high-level `AssignExpr` for array elements, a desugared read-op-write for string / union), and
+  forces the "evaluate once" obligation to be re-implemented at every no-lvalue target -- the place
+  it was missed. The uniform high-level node plus a backend-realized "once" is the shape the LLVM-IR
+  cross-check wants (`backend_contract.md` invariant 5): one node, one mechanical lowering, for
+  every target.
+
+- **Keep string character / union member as non-op=-able and special-case their compound forever.**
+  This is the inconsistency above; it scales a special case across every operation (simple write,
+  compound, future `ref` / `output` binding) instead of giving the target one write-location form
+  that all operations consume.
+
+## Consequences
+
+- One runtime write-back proxy, `StringCharRef`: a string character has no in-place reference
+  (`putc` enforces the out-of-range / NUL-byte rules, LRM 6.16.2), so its write side follows the
+  `PackedArrayRef` proxy shape. A union member needs no proxy -- `Union::MemberRef<I>()` returns a
+  real reference to the active member's storage.
+- Every component access is a matched value / reference pair distinguished by access form, named `X`
+  / `XRef`: array element `Element` / `ElementRef`, slice `Slice` / `SliceRef`, union member
+  `Member` / `MemberRef`, string character `Element` / `ElementRef`. A struct member is the one
+  collapse: its value and reference realizations are the same `T&`, so a single `TupleGetExpr`
+  (rendering `Get<i>`) serves both, the receiver's const-ness picking read from write.
+- A union member read is `UnionMemberExpr` (renders `Member<I>`); the write is `UnionMemberRefExpr`
+  (renders `MemberRef<I>`) -- two access forms, by compile-time index, the active-member analogue of
+  `kElement` / `kElementRef`.
+- `value-type-concepts.md` is updated: `String` now participates in the `Indexable` concept --
+  `Element` is the indexed character read, `ElementRef` (-> `StringCharRef`) the write; `getc` /
+  `putc` stay for the explicit method calls.
+- `unpacked-union-representation.md` decision points 4 / 5 are revised: union member access is a
+  read form (`UnionMemberExpr`) and a write form (`UnionMemberRefExpr`), not a target that "never
+  survives as a writable place"; the write renders to a reference to the active member. The union
+  value model (active-member variant) is unchanged; only the member-write realization changes.
+- `operators.md` W13 closes structurally: the left-hand index is evaluated once because the target
+  is a single lvalue the backend renders once, for every target kind, with no lowering desugar.
+
+## Cross-references
+
+- `../architecture/backend_contract.md` -- render is a fixed function of one node; the LLVM-IR
+  cross-check that wants one uniform compound shape; the wrapper-API pattern (redesign the runtime
+  API so MIR calls through existing primitives, then render is uniform).
+- `../architecture/lir.md` -- LIR owns addresses and load / store; "evaluate the address once" is
+  realized there for the LIR path.
+- [slice-value-semantics](slice-value-semantics.md) -- the read-value / write-location model this
+  extends to string characters and union members.
+- [value-type-concepts](value-type-concepts.md) -- the value-type surface; updated for `String`'s
+  write-side element reference.
+- [unpacked-union-representation](unpacked-union-representation.md) -- the union representation;
+  member-write realization revised here.
+- LRM anchors: 11.4.1 (compound assignment, evaluate left-hand side once), 7.3 (unpacked union),
+  6.16.2 / 6.16.3 (string putc / getc).

--- a/docs/decisions/compound-assignment-write-location.md
+++ b/docs/decisions/compound-assignment-write-location.md
@@ -55,23 +55,23 @@ write-side locations.
    6.16.2), so the write side is a proxy. The explicit `s.getc(i)` / `s.putc(i, c)` methods (LRM
    6.16.3 / 6.16.2) stay for the method-call forms; `Element` / `ElementRef` are the indexing forms.
 
-3. **A union member access is a matched value / reference pair, like a packed array element.** The
-   read `u.f` is `UnionMemberExpr` rendering `Union::Member<I>()` (the active-member value, the
-   inactive-member default if `I` is not active); the write is `UnionMemberRefExpr` rendering
-   `Union::MemberRef<I>()`, a reference to the active member's storage that makes `I` active first
-   if it is not. The two are separate access forms because a union member's read realization (a
-   value) differs from its write realization (an activating reference) -- the same reason a packed
-   array element splits into `Element` / `ElementRef`. The write reference is a real reference, not
-   a proxy, so `u.f = v`, `u.f op= v`, and a nested `u.f.g = v` or `u.h[i] = v` all compose on it
-   exactly as a struct member's reference does. The only difference from a struct member is the
-   activation step; the active-member representation (not a byte overlay, see
-   `unpacked-union-representation.md`) is why a write activates the member rather than reinterprets
-   shared bytes. There is no union-specific reference concept -- this is the `Element` /
-   `ElementRef` access split, by compile-time index.
+3. **A union member access is a matched value / reference pair, like a struct member.** The read
+   `u.f` is `UnionGetExpr` rendering `Union::Get<I>()` (the active-member value, the inactive-member
+   default if `I` is not active); the write is `UnionGetRefExpr` rendering `Union::GetRef<I>()`, a
+   reference to the active member's storage that makes `I` active first if it is not. `Get` /
+   `GetRef` is the same verb a struct member uses (`std::get<I>` is the standard accessor for both a
+   `std::tuple` and a `std::variant`, the runtime realizations of struct and union). The two are
+   separate access forms because a union member's read realization (a value) differs from its write
+   realization (an activating reference) -- whereas a struct member's read and write are one `T&`,
+   so a struct collapses to a single `Get`. The write reference is a real reference, not a proxy, so
+   `u.f = v`, `u.f op= v`, and a nested `u.f.g = v` or `u.h[i] = v` all compose on it exactly as a
+   struct member's reference does. The only difference from a struct member is the activation step;
+   the active-member representation (not a byte overlay, see `unpacked-union-representation.md`) is
+   why a write activates the member rather than reinterprets shared bytes.
 
 4. **MIR carries one compound shape.** `AssignExpr{target, compound_op, value}` is the single
    representation; `target` is the lvalue expression (a container-access chain ending in
-   `kElementRef` for a string character, a `UnionMemberRefExpr` for a union member, a `TupleGetExpr`
+   `kElementRef` for a string character, a `UnionGetRefExpr` for a union member, a `TupleGetExpr`
    for a struct member, an `ElementRef` chain for an array element). There is no read-op-write
    desugar in MIR, and no per-target compound lowering. The HIR-to-MIR string-element and
    union-member assignment special cases, and the subscript-hoisting machinery that supported them,
@@ -103,23 +103,24 @@ write-side locations.
 
 - One runtime write-back proxy, `StringCharRef`: a string character has no in-place reference
   (`putc` enforces the out-of-range / NUL-byte rules, LRM 6.16.2), so its write side follows the
-  `PackedArrayRef` proxy shape. A union member needs no proxy -- `Union::MemberRef<I>()` returns a
-  real reference to the active member's storage.
-- Every component access is a matched value / reference pair distinguished by access form, named `X`
-  / `XRef`: array element `Element` / `ElementRef`, slice `Slice` / `SliceRef`, union member
-  `Member` / `MemberRef`, string character `Element` / `ElementRef`. A struct member is the one
-  collapse: its value and reference realizations are the same `T&`, so a single `TupleGetExpr`
-  (rendering `Get<i>`) serves both, the receiver's const-ness picking read from write.
-- A union member read is `UnionMemberExpr` (renders `Member<I>`); the write is `UnionMemberRefExpr`
-  (renders `MemberRef<I>`) -- two access forms, by compile-time index, the active-member analogue of
-  `kElement` / `kElementRef`.
+  `PackedArrayRef` proxy shape. A union member needs no proxy -- `Union::GetRef<I>()` returns a real
+  reference to the active member's storage.
+- Two access families, each a value / reference pair named `X` / `XRef`. Subscript access by a
+  runtime index: array / string element `Element` / `ElementRef`, slice `Slice` / `SliceRef`.
+  Positional member access by a compile-time index: struct and union member `Get` / `GetRef`
+  (`std::get<I>` is the standard accessor for both the `std::tuple` and the `std::variant` that back
+  them). A struct member collapses to a single `Get` (its value and reference realizations are the
+  same `T&`, the receiver's const-ness picking read from write); a union member keeps both forms
+  because its read (a value) and write (an activating reference) differ.
+- A union member read is `UnionGetExpr` (renders `Get<I>`); the write is `UnionGetRefExpr` (renders
+  `GetRef<I>`) -- two access forms, by compile-time index, parallel to `kElement` / `kElementRef`.
 - `value-type-concepts.md` is updated: `String` now participates in the `Indexable` concept --
   `Element` is the indexed character read, `ElementRef` (-> `StringCharRef`) the write; `getc` /
   `putc` stay for the explicit method calls.
 - `unpacked-union-representation.md` decision points 4 / 5 are revised: union member access is a
-  read form (`UnionMemberExpr`) and a write form (`UnionMemberRefExpr`), not a target that "never
-  survives as a writable place"; the write renders to a reference to the active member. The union
-  value model (active-member variant) is unchanged; only the member-write realization changes.
+  read form (`UnionGetExpr`) and a write form (`UnionGetRefExpr`), not a target that "never survives
+  as a writable place"; the write renders to a reference to the active member. The union value model
+  (active-member variant) is unchanged; only the member-write realization changes.
 - `operators.md` W13 closes structurally: the left-hand index is evaluated once because the target
   is a single lvalue the backend renders once, for every target kind, with no lowering desugar.
 

--- a/docs/decisions/unpacked-union-representation.md
+++ b/docs/decisions/unpacked-union-representation.md
@@ -53,17 +53,25 @@ not a product with a different label.
    is a semantic statement, not a storage-layout claim; how a backend stores it is a realization
    concern owned by the backend contract.
 
-4. **Member read is an access primitive `UnionGetExpr{union, index}`**, parallel to `TupleGetExpr`.
-   It is read-only: it never appears as an lvalue or a writable place.
+4. **Member access is a matched read / write access pair, the active-member analogue of a packed
+   array element's `Element` / `ElementRef`.** The read is `UnionMemberExpr{union, index}` (yielding
+   the active member's value, the inactive-member default, point 8); the write is
+   `UnionMemberRefExpr{union, index}` (a reference to the active member's storage). They are two
+   access forms, not one, because a union member's read realization (a value) differs from its write
+   realization (an activating reference) -- the same reason a packed array element splits into a
+   value form and a reference form (`slice-value-semantics.md`). They are distinguished by index at
+   compile time, so each is a node rather than a callee. There is no union-specific reference
+   concept: the write form is an ordinary reference into the active member's storage.
 
-5. **Member write is whole-union replacement.** `u.f = v` lowers to assigning the union _place_ a
-   freshly built single-member union value: `UnionExpr{index, value}`. The member access never
-   survives as a writable place; the write targets the union one level up. This is the same shape as
-   a string element write, which has no element lvalue and realizes as `putc` against the string
-   place (LRM 6.16.2). A compound `u.f op= v` reads the active member through `UnionGetExpr`,
-   applies the operator, and rebuilds the union -- the read side uses `UnionGetExpr`, the write side
-   uses `UnionExpr`, and the two are never conflated. Taking a place or a `ref` / `output` binding
-   to a union member is rejected for now.
+5. **Member write and compound assignment are uniform with every other lvalue.** `u.f = v`,
+   `u.f op= v`, and a nested `u.f.g = v` lower to `AssignExpr` over `UnionMemberRefExpr`, exactly as
+   an array-element or struct-member write does; there is no whole-union-replacement desugar and no
+   read-modify-write at the lowering. The backend renders the write target as a reference to the
+   active member's storage (making the member active first if it is not), so a nested member or
+   element write composes on it as on a struct member; "evaluate the left-hand side once" (LRM
+   11.4.1) is the backend's job on the single target (see
+   [compound-assignment-write-location](compound-assignment-write-location.md)). `UnionExpr` builds
+   a whole union value (default initialization, point 6); it is not the member-write shape.
 
 6. **Default initialization synthesizes `UnionExpr{0, <member 0's Table 7-1 default>}`** at each
    default-construct site, never stored on the type. As with the struct, the interned `UnionType`
@@ -108,8 +116,8 @@ not a product with a different label.
 
 ## Consequences
 
-- A new MIR type variant (`UnionType`) and two expression primitives (`UnionExpr`, `UnionGetExpr`),
-  parallel to the tuple pair.
+- A new MIR type variant (`UnionType`) and three expression primitives: `UnionExpr` (build a whole
+  union value), `UnionMemberExpr` (read a member), and `UnionMemberRefExpr` (write a member).
 - A new runtime value type `lyra::value::Union<Ts...>`, composing `LyraValue` from its active
   member.
 - `struct-union.md` N1-N3 build on this. A declared union must default-initialize to run, so the

--- a/docs/decisions/unpacked-union-representation.md
+++ b/docs/decisions/unpacked-union-representation.md
@@ -53,19 +53,20 @@ not a product with a different label.
    is a semantic statement, not a storage-layout claim; how a backend stores it is a realization
    concern owned by the backend contract.
 
-4. **Member access is a matched read / write access pair, the active-member analogue of a packed
-   array element's `Element` / `ElementRef`.** The read is `UnionMemberExpr{union, index}` (yielding
-   the active member's value, the inactive-member default, point 8); the write is
-   `UnionMemberRefExpr{union, index}` (a reference to the active member's storage). They are two
-   access forms, not one, because a union member's read realization (a value) differs from its write
-   realization (an activating reference) -- the same reason a packed array element splits into a
-   value form and a reference form (`slice-value-semantics.md`). They are distinguished by index at
-   compile time, so each is a node rather than a callee. There is no union-specific reference
-   concept: the write form is an ordinary reference into the active member's storage.
+4. **Member access is a matched read / write access pair, named `Get` / `GetRef` like a struct
+   member** (`std::get<I>` is the standard accessor for both the `std::tuple` and the `std::variant`
+   that back struct and union). The read is `UnionGetExpr{union, index}` (yielding the active
+   member's value, the inactive-member default, point 8); the write is
+   `UnionGetRefExpr{union, index}` (a reference to the active member's storage). They are two access
+   forms, not one, because a union member's read realization (a value) differs from its write
+   realization (an activating reference) -- whereas a struct member's read and write are one `T&`,
+   so a struct collapses to a single `Get`. They are distinguished by index at compile time, so each
+   is a node rather than a callee. There is no union-specific reference concept: the write form is
+   an ordinary reference into the active member's storage.
 
 5. **Member write and compound assignment are uniform with every other lvalue.** `u.f = v`,
-   `u.f op= v`, and a nested `u.f.g = v` lower to `AssignExpr` over `UnionMemberRefExpr`, exactly as
-   an array-element or struct-member write does; there is no whole-union-replacement desugar and no
+   `u.f op= v`, and a nested `u.f.g = v` lower to `AssignExpr` over `UnionGetRefExpr`, exactly as an
+   array-element or struct-member write does; there is no whole-union-replacement desugar and no
    read-modify-write at the lowering. The backend renders the write target as a reference to the
    active member's storage (making the member active first if it is not), so a nested member or
    element write composes on it as on a struct member; "evaluate the left-hand side once" (LRM
@@ -117,7 +118,7 @@ not a product with a different label.
 ## Consequences
 
 - A new MIR type variant (`UnionType`) and three expression primitives: `UnionExpr` (build a whole
-  union value), `UnionMemberExpr` (read a member), and `UnionMemberRefExpr` (write a member).
+  union value), `UnionGetExpr` (read a member), and `UnionGetRefExpr` (write a member).
 - A new runtime value type `lyra::value::Union<Ts...>`, composing `LyraValue` from its active
   member.
 - `struct-union.md` N1-N3 build on this. A declared union must default-initialize to run, so the

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -53,11 +53,12 @@ C  Non-local access substrate
 - [x] A1 -- More than one module definition compiles in a single run; the design is no longer
       assumed to be a single top module. Each module is its own independently compiled unit. The LRM
       permits multiple top-level blocks (LRM 3.11): every elaborated but uninstantiated module is
-      implicitly a top-level block, and all of them sit under one implicit root scope ($root). The
-      program constructs every top-level block as a child of $root and runs them all under a single
-      scheduler on one shared time axis -- there is no single "main" block. This is end-to-end
-      testable with no instantiation edge: two independent top modules each run their own processes
-      under the shared schedule.
+      implicitly a top-level block, and all of them sit under one implicit root scope
+      ($root). The
+      program constructs every top-level block as a child of $root and runs them
+      all under a single scheduler on one shared time axis -- there is no single "main" block. This
+      is end-to-end testable with no instantiation edge: two independent top modules each run their
+      own processes under the shared schedule.
 - [x] A2 -- A module instantiated with different parameter values yields distinct specializations
       that each behave according to their own values. Distinct parameter bindings produce distinct
       compiled artifacts with distinct identity (see `docs/decisions/specialization-identity.md`),

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -53,12 +53,11 @@ C  Non-local access substrate
 - [x] A1 -- More than one module definition compiles in a single run; the design is no longer
       assumed to be a single top module. Each module is its own independently compiled unit. The LRM
       permits multiple top-level blocks (LRM 3.11): every elaborated but uninstantiated module is
-      implicitly a top-level block, and all of them sit under one implicit root scope
-      ($root). The
-      program constructs every top-level block as a child of $root and runs them
-      all under a single scheduler on one shared time axis -- there is no single "main" block. This
-      is end-to-end testable with no instantiation edge: two independent top modules each run their
-      own processes under the shared schedule.
+      implicitly a top-level block, and all of them sit under one implicit root scope ($root). The
+      program constructs every top-level block as a child of $root and runs them all under a single
+      scheduler on one shared time axis -- there is no single "main" block. This is end-to-end
+      testable with no instantiation edge: two independent top modules each run their own processes
+      under the shared schedule.
 - [x] A2 -- A module instantiated with different parameter values yields distinct specializations
       that each behave according to their own values. Distinct parameter bindings produce distinct
       compiled artifacts with distinct identity (see `docs/decisions/specialization-identity.md`),

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -89,8 +89,8 @@ merged node.
       write-back location, so compound lowers uniformly to `AssignExpr{target, op, value}` and the
       backend evaluates the single target once (C++ `op=`; a future LIR computes the address once).
       A string character write is a write-back proxy (`String::ElementRef`) and a union member write
-      a member-reference proxy (`UnionMemberRefExpr`); neither is a read-modify-write desugar at the
-      lowering.
+      a reference to the active member (`Union::GetRef`); neither is a read-modify-write desugar at
+      the lowering.
 
 ## Cross-references
 

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -14,8 +14,7 @@ Done when:
 
 ## Actionable
 
-The operator surface in scope is complete except W13: compound assignment to a no-element-lvalue
-target evaluates the left-hand index more than once (LRM 11.4.1).
+All items closed; operator surface in scope is complete.
 
 ## Sub-Steps
 
@@ -84,13 +83,14 @@ merged node.
       selector chains (`array[i]++`, `++a[15:8]`) and observable structural roots are covered. NBA
       contexts (`b <= a++`, `var[i++] <= rhs`) evaluate the inc / dec exactly once at submit time.
       Replication / concatenation operands are rejected as targets per LRM 11.4.12.1.
-- [ ] W13 -- Compound assignment to a target that has no element lvalue and so must
-      read-modify-write the whole value -- a string element (`s[i] op= v`), and a union member once
-      a union is usable in that position -- currently evaluates the left-hand index expression more
-      than once, contrary to LRM 11.4.1 (the left-hand index shall be evaluated exactly once). A
-      side-effecting index (e.g. a function call) therefore runs twice. Targets that lower to a
-      native read-modify-write (whole-var, selector) are correct (W11); only the no-element-lvalue
-      targets are affected.
+- [x] W13 -- Compound assignment evaluates the left-hand side exactly once (LRM 11.4.1) for every
+      target, including a side-effecting subscript (`a[f()] op= b`) at any nesting. Every write
+      target -- whole var, array / string element, struct / union member -- is an op=-able
+      write-back location, so compound lowers uniformly to `AssignExpr{target, op, value}` and the
+      backend evaluates the single target once (C++ `op=`; a future LIR computes the address once).
+      A string character write is a write-back proxy (`String::ElementRef`) and a union member write
+      a member-reference proxy (`UnionMemberRefExpr`); neither is a read-modify-write desugar at the
+      lowering.
 
 ## Cross-references
 

--- a/include/lyra/lowering/hir_to_mir/lhs_observable.hpp
+++ b/include/lyra/lowering/hir_to_mir/lhs_observable.hpp
@@ -11,7 +11,8 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-// Walks through container-access CallExprs to the LHS chain's root primary.
+// Walks through container-access CallExprs and member-ref projections to the
+// LHS chain's root primary.
 [[nodiscard]] auto FindLhsRootId(const mir::Block& block, mir::ExprId lhs_id)
     -> mir::ExprId;
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -272,20 +272,35 @@ struct TupleGetExpr {
 // Builds a union value whose active member is component `index`, carrying
 // `value`. The value-build primitive for `UnionType`, the active-member
 // analogue of `TupleExpr`: a tuple literal lists every component, a union
-// literal names the one live member. A union member write `u.f = v` lowers to
-// assigning the union place a fresh `UnionExpr{index, value}` -- the member
-// access never survives as a writable place. `Expr::type` is the `UnionType`.
+// literal names the one live member. Used to construct a union value -- a
+// default-initialized union builds `UnionExpr{0, <member 0 default>}`.
+// `Expr::type` is the `UnionType`.
 struct UnionExpr {
   std::size_t index;
   ExprId value;
 };
 
-// Reads component `index` out of a union value (`union.index`), the read-only
-// active-member analogue of `TupleGetExpr`. `Expr::type` is the component's
-// type. Never appears as an lvalue: a write is a whole-union replacement via
-// `UnionExpr`, not a projection. Reading a member other than the live one is
-// undefined in SV (LRM 7.3); the backend returns that member's default.
-struct UnionGetExpr {
+// Reads component `index` of a union value (`union.index`), the read side of
+// union member access and the active-member analogue of `TupleGetExpr`.
+// `Expr::type` is the component's type. Reading an inactive member is undefined
+// in SV (LRM 7.3) and the backend returns that member's default. The write side
+// is `UnionMemberRefExpr`; the read and write are separate access forms because
+// a union member's read realization (a value) differs from its write
+// realization (a reference that activates the member), exactly as a packed
+// array element splits into element-value and element-reference forms.
+struct UnionMemberExpr {
+  ExprId union_value;
+  std::size_t index;
+};
+
+// The writable location of union member `index` (`u.f` as an assignment
+// target), the write side and by-reference counterpart of `UnionMemberExpr`.
+// `Expr::type` is the component's type. As an `AssignExpr` target it carries
+// `u.f = v`, `u.f op= v`, and a nested `u.f.g = v` uniformly with every other
+// lvalue; the backend renders it as a reference to the active member (making
+// the member active first if needed), so further member or element projection
+// composes on it as on a struct member.
+struct UnionMemberRefExpr {
   ExprId union_value;
   std::size_t index;
 };
@@ -296,7 +311,7 @@ using ExprData = std::variant<
     ConditionalExpr, AssignExpr, IncDecExpr, CallExpr, DerefExpr, AddressOfExpr,
     PointerCastExpr, CastExpr, MemberAccessExpr, ClosureExpr, ConcatExpr,
     ReplicationExpr, ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr,
-    UnionExpr, UnionGetExpr>;
+    UnionExpr, UnionMemberExpr, UnionMemberRefExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -281,26 +281,27 @@ struct UnionExpr {
 };
 
 // Reads component `index` of a union value (`union.index`), the read side of
-// union member access and the active-member analogue of `TupleGetExpr`.
-// `Expr::type` is the component's type. Reading an inactive member is undefined
-// in SV (LRM 7.3) and the backend returns that member's default. The write side
-// is `UnionMemberRefExpr`; the read and write are separate access forms because
-// a union member's read realization (a value) differs from its write
-// realization (a reference that activates the member), exactly as a packed
-// array element splits into element-value and element-reference forms.
-struct UnionMemberExpr {
+// union member access and the active-member analogue of `TupleGetExpr` (both
+// `std::get<I>`-style positional access). `Expr::type` is the component's type.
+// Reading an inactive member is undefined in SV (LRM 7.3) and the backend
+// returns that member's default. The write side is `UnionGetRefExpr`; the read
+// and write are separate access forms because a union member's read realization
+// (a value) differs from its write realization (a reference that activates the
+// member), exactly as a packed array element splits into element-value and
+// element-reference forms.
+struct UnionGetExpr {
   ExprId union_value;
   std::size_t index;
 };
 
 // The writable location of union member `index` (`u.f` as an assignment
-// target), the write side and by-reference counterpart of `UnionMemberExpr`.
+// target), the write side and by-reference counterpart of `UnionGetExpr`.
 // `Expr::type` is the component's type. As an `AssignExpr` target it carries
 // `u.f = v`, `u.f op= v`, and a nested `u.f.g = v` uniformly with every other
 // lvalue; the backend renders it as a reference to the active member (making
 // the member active first if needed), so further member or element projection
 // composes on it as on a struct member.
-struct UnionMemberRefExpr {
+struct UnionGetRefExpr {
   ExprId union_value;
   std::size_t index;
 };
@@ -311,7 +312,7 @@ using ExprData = std::variant<
     ConditionalExpr, AssignExpr, IncDecExpr, CallExpr, DerefExpr, AddressOfExpr,
     PointerCastExpr, CastExpr, MemberAccessExpr, ClosureExpr, ConcatExpr,
     ReplicationExpr, ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr,
-    UnionExpr, UnionMemberExpr, UnionMemberRefExpr>;
+    UnionExpr, UnionGetExpr, UnionGetRefExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -335,7 +335,7 @@ struct TupleType {
 // `TupleType` and from a tagged sum). The value-layer realization of an SV
 // untagged unpacked union (LRM 7.3); the member names are dropped to positions
 // at HIR-to-MIR, the index is the carrier. Built by `UnionExpr`, read by
-// `UnionMemberExpr`, written through `UnionMemberRefExpr`. Carries component
+// `UnionGetExpr`, written through `UnionGetRefExpr`. Carries component
 // types only: a tagged union is a separate concept rejected at the HIR-to-MIR
 // gate, so no flag distinguishes one here.
 struct UnionType {

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -334,9 +334,10 @@ struct TupleType {
 // value at a time (the generic-language C `union`, distinct from the product
 // `TupleType` and from a tagged sum). The value-layer realization of an SV
 // untagged unpacked union (LRM 7.3); the member names are dropped to positions
-// at HIR-to-MIR, the index is the carrier. Built and read by `UnionExpr` /
-// `UnionGetExpr`. Carries component types only: a tagged union is a separate
-// concept rejected at the HIR-to-MIR gate, so no flag distinguishes one here.
+// at HIR-to-MIR, the index is the carrier. Built by `UnionExpr`, read by
+// `UnionMemberExpr`, written through `UnionMemberRefExpr`. Carries component
+// types only: a tagged union is a separate concept rejected at the HIR-to-MIR
+// gate, so no flag distinguishes one here.
 struct UnionType {
   std::vector<TypeId> elements;
 

--- a/include/lyra/value/concepts.hpp
+++ b/include/lyra/value/concepts.hpp
@@ -116,8 +116,9 @@ concept Lengthable = requires(const T& t) {
 // a reference-form (`ElementRef`) returning a write-through reference. The
 // pair models the bare-vs-`Ref`-suffix naming convention: the bare method
 // hands you the element, the `Ref` method hands you a handle to it. String
-// uses LRM-mandated `Getc` / `Putc` (LRM 6.16.2 / 6.16.3) instead and does
-// not claim Indexable directly.
+// participates through character access -- `Element` is the indexed read and
+// `ElementRef` a write-through proxy (a `StringCharRef`) -- while the LRM-named
+// `Getc` / `Putc` methods (LRM 6.16) stay for the explicit method calls.
 template <typename T>
 concept Indexable = requires(T& t, const PackedArray& pos) {
   { t.Element(pos) };

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -15,6 +15,8 @@
 
 namespace lyra::value {
 
+class StringCharRef;
+
 // Runtime representation of the SystemVerilog `string` type (LRM 6.16). The
 // SV semantics -- equality on contents, lexicographic compare, and the method
 // family in LRM 6.16.1 through 6.16.15 -- are exposed as member operators and
@@ -139,6 +141,22 @@ class String {
     return PackedArray::Byte(
         static_cast<std::int8_t>(impl_[static_cast<std::size_t>(i)]));
   }
+
+  // The read side of indexed character access `s[i]`: the character value, with
+  // the same out-of-range default as `getc`. Distinct from `Getc` only in role
+  // (the indexing form versus the LRM 6.16.3 method), so it shares the query.
+  [[nodiscard]] auto Element(const PackedArray& i_arg) const -> PackedArray {
+    return Getc(i_arg);
+  }
+
+  // The write side of indexed character access `s[i]`: a write-back reference
+  // to the character. A string exposes no in-place character reference --
+  // writes go through `putc` (LRM 6.16.2) with its out-of-range / NUL rules --
+  // so the reference is a proxy that captures the index once, routes
+  // `operator=` through `putc`, and reads-modifies-writes for each compound
+  // operator. The read/write pair `Element` / `ElementRef` mirrors a packed
+  // array element. Defined after `StringCharRef` below.
+  [[nodiscard]] auto ElementRef(const PackedArray& i_arg) -> StringCharRef;
 
   // LRM 6.16.4. Receiver unchanged.
   [[nodiscard]] auto Toupper() const -> String {
@@ -268,7 +286,77 @@ class String {
   std::string impl_;
 };
 
+// The write-back location for a string character (the write side of `s[i]`). A
+// string exposes no in-place character reference -- writes go through `putc`
+// (LRM 6.16.2) -- so the proxy captures the receiver and index once and routes
+// every write through it: `operator=` is `putc`, and each compound operator
+// reads the current character (`getc`), combines with `rhs`, and writes back.
+// The captured index is the eval-once mechanism: the lvalue is built once by
+// the caller, and both the read and the write here use the same captured index.
+class StringCharRef {
+ public:
+  StringCharRef(String& target, PackedArray index)
+      : target_(&target), index_(std::move(index)) {
+  }
+
+  StringCharRef(const StringCharRef&) = delete;
+  auto operator=(const StringCharRef&) -> StringCharRef& = delete;
+  StringCharRef(StringCharRef&&) noexcept = default;
+  auto operator=(StringCharRef&&) noexcept -> StringCharRef& = default;
+  ~StringCharRef() = default;
+
+  [[nodiscard]] auto ToOwned() const -> PackedArray {
+    return target_->Getc(index_);
+  }
+  auto operator=(const PackedArray& value) -> StringCharRef& {
+    target_->Putc(index_, value);
+    return *this;
+  }
+  auto operator+=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() + rhs;
+  }
+  auto operator-=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() - rhs;
+  }
+  auto operator*=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() * rhs;
+  }
+  auto operator/=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() / rhs;
+  }
+  auto operator%=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() % rhs;
+  }
+  auto operator&=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() & rhs;
+  }
+  auto operator|=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() | rhs;
+  }
+  auto operator^=(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned() ^ rhs;
+  }
+  auto ShiftLeftAssign(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned().ShiftLeft(rhs);
+  }
+  auto LogicalShiftRightAssign(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned().LogicalShiftRight(rhs);
+  }
+  auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> StringCharRef& {
+    return *this = ToOwned().ArithmeticShiftRight(rhs);
+  }
+
+ private:
+  String* target_;
+  PackedArray index_;
+};
+
+inline auto String::ElementRef(const PackedArray& i_arg) -> StringCharRef {
+  return StringCharRef{*this, i_arg};
+}
+
 static_assert(LyraValue<String>);
 static_assert(Lengthable<String>);
+static_assert(Indexable<String>);
 
 }  // namespace lyra::value

--- a/include/lyra/value/union.hpp
+++ b/include/lyra/value/union.hpp
@@ -39,11 +39,12 @@ class Union {
     return u;
   }
 
-  // Read component `I` (the read side of member access). Returns the value when
-  // `I` is the active member; otherwise returns that component's default, the
-  // deterministic stand-in for an SV-undefined cross-member read.
+  // Read component `I` (the read side of member access; `std::get<I>` for a
+  // variant). Returns the value when `I` is the active member; otherwise
+  // returns that component's default, the deterministic stand-in for an
+  // SV-undefined cross-member read.
   template <std::size_t I>
-  [[nodiscard]] auto Member() const
+  [[nodiscard]] auto Get() const
       -> std::variant_alternative_t<I, std::variant<Ts...>> {
     using Component = std::variant_alternative_t<I, std::variant<Ts...>>;
     if (const auto* active = std::get_if<I>(&data_)) {
@@ -53,14 +54,14 @@ class Union {
   }
 
   // The writable location of component `I` (the write side of member access),
-  // the by-reference counterpart of `Member`. Returns a reference to the active
+  // the by-reference counterpart of `Get`. Returns a reference to the active
   // member's storage, making `I` active first if it is not -- so a write
-  // activates the member it targets. A read goes through `Member` and never
+  // activates the member it targets. A read goes through `Get` and never
   // activates; only a write takes this reference, so `u.f = v`, `u.f op= v`,
   // and a nested `u.f.g = v` all compose on it the way a struct member's
   // reference does.
   template <std::size_t I>
-  [[nodiscard]] auto MemberRef()
+  [[nodiscard]] auto GetRef()
       -> std::variant_alternative_t<I, std::variant<Ts...>>& {
     if (auto* active = std::get_if<I>(&data_)) {
       return *active;

--- a/include/lyra/value/union.hpp
+++ b/include/lyra/value/union.hpp
@@ -39,17 +39,33 @@ class Union {
     return u;
   }
 
-  // Read component `I`. Returns the value when `I` is the active member;
-  // otherwise returns that component's default, the deterministic stand-in for
-  // an SV-undefined cross-member read.
+  // Read component `I` (the read side of member access). Returns the value when
+  // `I` is the active member; otherwise returns that component's default, the
+  // deterministic stand-in for an SV-undefined cross-member read.
   template <std::size_t I>
-  [[nodiscard]] auto Get() const
+  [[nodiscard]] auto Member() const
       -> std::variant_alternative_t<I, std::variant<Ts...>> {
-    using Member = std::variant_alternative_t<I, std::variant<Ts...>>;
+    using Component = std::variant_alternative_t<I, std::variant<Ts...>>;
     if (const auto* active = std::get_if<I>(&data_)) {
       return *active;
     }
-    return Member{};
+    return Component{};
+  }
+
+  // The writable location of component `I` (the write side of member access),
+  // the by-reference counterpart of `Member`. Returns a reference to the active
+  // member's storage, making `I` active first if it is not -- so a write
+  // activates the member it targets. A read goes through `Member` and never
+  // activates; only a write takes this reference, so `u.f = v`, `u.f op= v`,
+  // and a nested `u.f.g = v` all compose on it the way a struct member's
+  // reference does.
+  template <std::size_t I>
+  [[nodiscard]] auto MemberRef()
+      -> std::variant_alternative_t<I, std::variant<Ts...>>& {
+    if (auto* active = std::get_if<I>(&data_)) {
+      return *active;
+    }
+    return data_.template emplace<I>();
   }
 
   // LRM 11.4.5 `==` / `!=` (Any data type). Unions are equal only when the same

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -370,7 +370,7 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
           },
           // HIR-to-MIR lowers an LHS selector chain to write-form nodes -- a
           // container-access `CallExpr` with a write callee (per
-          // `mir::IsContainerAccessCall`), a `UnionMemberRefExpr`, a
+          // `mir::IsContainerAccessCall`), a `UnionGetRefExpr`, a
           // `TupleGetExpr` on a mutable base -- whose value-side render is
           // already a writable place. So the lvalue rendering of a container
           // access is just its value-side render, with no extra fix-up here.
@@ -393,9 +393,9 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
           // through the addressable union (the Mutate snapshot). The reference
           // makes the member active, so the projection is itself the assignment
           // target and composes for a nested `u.f.g`.
-          [&](const mir::UnionMemberRefExpr& g) -> std::string {
+          [&](const mir::UnionGetRefExpr& g) -> std::string {
             return std::format(
-                "({}).template MemberRef<{}>()",
+                "({}).template GetRef<{}>()",
                 RenderLhsExpr(view, view.Expr(g.union_value)), g.index);
           },
           [&](const auto&) -> std::string {
@@ -858,17 +858,17 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
                 RenderTypeAsCpp(view.Unit(), view.Class(), expr.type), u.index,
                 RenderExpr(view, view.Expr(u.value)));
           },
-          [&](const mir::UnionMemberExpr& g) -> std::string {
+          [&](const mir::UnionGetExpr& g) -> std::string {
             return std::format(
-                "({}).template Member<{}>()",
+                "({}).template Get<{}>()",
                 RenderExpr(view, view.Expr(g.union_value)), g.index);
           },
           // The write node reaches rvalue render only as the receiver of a
           // container-access write (`u.h[i] = v`), where it is still the active
           // member reference; it renders the same as in lvalue position.
-          [&](const mir::UnionMemberRefExpr& g) -> std::string {
+          [&](const mir::UnionGetRefExpr& g) -> std::string {
             return std::format(
-                "({}).template MemberRef<{}>()",
+                "({}).template GetRef<{}>()",
                 RenderExpr(view, view.Expr(g.union_value)), g.index);
           },
       },

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -368,11 +368,12 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
           [&](const mir::LocalRef& l) -> std::string {
             return LookupLocalName(view, l);
           },
-          // HIR-to-MIR lowers an LHS selector chain to a container-access
-          // `CallExpr` (per `mir::IsContainerAccessCall`). The C++ surface
-          // returns a write-through reference, so the natural value-side
-          // rendering is itself the assignment
-          // target; LHS context needs no extra fix-up.
+          // HIR-to-MIR lowers an LHS selector chain to write-form nodes -- a
+          // container-access `CallExpr` with a write callee (per
+          // `mir::IsContainerAccessCall`), a `UnionMemberRefExpr`, a
+          // `TupleGetExpr` on a mutable base -- whose value-side render is
+          // already a writable place. So the lvalue rendering of a container
+          // access is just its value-side render, with no extra fix-up here.
           [&](const mir::CallExpr&) -> std::string {
             return RenderExpr(view, expr);
           },
@@ -387,6 +388,15 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
             return std::format(
                 "({}).template Get<{}>()",
                 RenderLhsExpr(view, view.Expr(g.tuple)), g.index);
+          },
+          // A union member write: a reference to the active member reached
+          // through the addressable union (the Mutate snapshot). The reference
+          // makes the member active, so the projection is itself the assignment
+          // target and composes for a nested `u.f.g`.
+          [&](const mir::UnionMemberRefExpr& g) -> std::string {
+            return std::format(
+                "({}).template MemberRef<{}>()",
+                RenderLhsExpr(view, view.Expr(g.union_value)), g.index);
           },
           [&](const auto&) -> std::string {
             throw InternalError(
@@ -848,9 +858,17 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
                 RenderTypeAsCpp(view.Unit(), view.Class(), expr.type), u.index,
                 RenderExpr(view, view.Expr(u.value)));
           },
-          [&](const mir::UnionGetExpr& g) -> std::string {
+          [&](const mir::UnionMemberExpr& g) -> std::string {
             return std::format(
-                "({}).template Get<{}>()",
+                "({}).template Member<{}>()",
+                RenderExpr(view, view.Expr(g.union_value)), g.index);
+          },
+          // The write node reaches rvalue render only as the receiver of a
+          // container-access write (`u.h[i] = v`), where it is still the active
+          // member reference; it renders the same as in lvalue position.
+          [&](const mir::UnionMemberRefExpr& g) -> std::string {
+            return std::format(
+                "({}).template MemberRef<{}>()",
                 RenderExpr(view, view.Expr(g.union_value)), g.index);
           },
       },

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -17,7 +17,6 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
-#include "lyra/hir/type.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
@@ -30,7 +29,6 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
-#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -47,6 +45,12 @@ auto IsExprRootedAtStructuralVar(const mir::Block& block, mir::ExprId expr_id)
           [](const mir::MemberRef&) { return true; },
           [](const mir::MemberAccessExpr&) { return true; },
           [](const mir::LocalRef&) { return false; },
+          [&](const mir::TupleGetExpr& g) {
+            return IsExprRootedAtStructuralVar(block, g.tuple);
+          },
+          [&](const mir::UnionMemberRefExpr& g) {
+            return IsExprRootedAtStructuralVar(block, g.union_value);
+          },
           [&](const mir::CallExpr& c) {
             if (!mir::IsContainerAccessCallee(c.callee) ||
                 c.arguments.empty()) {
@@ -121,6 +125,28 @@ auto CloneLhsExprForNbaBody(
           [&](const mir::MemberRef&) -> mir::ExprId {
             return body.exprs.Add(outer_expr);
           },
+          [&](const mir::TupleGetExpr& g) -> mir::ExprId {
+            return body.exprs.Add(
+                mir::Expr{
+                    .data =
+                        mir::TupleGetExpr{
+                            .tuple = CloneLhsExprForNbaBody(
+                                closure, outer_block, self_ptr_type,
+                                snapshot_counter, g.tuple),
+                            .index = g.index},
+                    .type = outer_expr.type});
+          },
+          [&](const mir::UnionMemberRefExpr& g) -> mir::ExprId {
+            return body.exprs.Add(
+                mir::Expr{
+                    .data =
+                        mir::UnionMemberRefExpr{
+                            .union_value = CloneLhsExprForNbaBody(
+                                closure, outer_block, self_ptr_type,
+                                snapshot_counter, g.union_value),
+                            .index = g.index},
+                    .type = outer_expr.type});
+          },
           [&](const mir::MemberAccessExpr& m) -> mir::ExprId {
             const mir::ExprId body_receiver = body.exprs.Add(
                 mir::Expr{
@@ -146,17 +172,6 @@ auto CloneLhsExprForNbaBody(
           },
       },
       outer_expr.data);
-}
-
-auto MakeStringMethodCallExpr(
-    support::BuiltinFn fn, std::vector<mir::ExprId> args, mir::TypeId type)
-    -> mir::Expr {
-  return mir::Expr{
-      .data =
-          mir::CallExpr{
-              .callee = mir::Direct{.target = fn},
-              .arguments = std::move(args)},
-      .type = type};
 }
 
 // Axis B (timing), deferred half: build the closure the NBA region invokes.
@@ -271,119 +286,6 @@ auto LowerObservableAssign(
       });
 }
 
-// Axis A for a string element target: putc, the symmetric counterpart of the
-// getc index read, because a string exposes no element lvalue (LRM 6.16.2). A
-// compound `s[i] op= v` is desugared here to a getc read-modify so the effect
-// always carries the final byte; the receiver routes through `Var<String>::
-// Mutate` so a deferred write still wakes the cell's subscribers.
-auto LowerStringElementAssign(
-    ProcessLowerer& process, WalkFrame frame, const hir::AssignExpr& a,
-    const hir::ElementSelectExpr& sel, diag::SourceSpan span,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
-  const auto& unit = process.Module().Unit();
-  auto& block = *frame.current_block;
-
-  const auto& base_hir = hir_process.exprs.Get(sel.base_value);
-  auto cell_or = process.LowerLhsExpr(base_hir, frame.WithLvalueTarget(true));
-  if (!cell_or) return std::unexpected(std::move(cell_or.error()));
-  const mir::ExprId cell_id = block.exprs.Add(*std::move(cell_or));
-
-  auto idx_or = process.LowerExpr(hir_process.exprs.Get(sel.index), frame);
-  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
-
-  auto rhs_or = process.LowerExpr(hir_process.exprs.Get(a.rhs), frame);
-  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  mir::ExprId value_id = block.exprs.Add(*std::move(rhs_or));
-
-  // A compound write only ever reaches here blocking (compound + NBA is not a
-  // legal SV form, rejected upstream), so the read-modify lands in the active
-  // region before the effect runs.
-  if (a.compound_op.has_value()) {
-    auto base_read_or = process.LowerExpr(base_hir, frame);
-    if (!base_read_or) return std::unexpected(std::move(base_read_or.error()));
-    const mir::ExprId base_read_id = block.exprs.Add(*std::move(base_read_or));
-    const mir::ExprId cur_id = block.exprs.Add(MakeStringMethodCallExpr(
-        support::BuiltinFn::kGetc, {base_read_id, idx_id}, result_type));
-    value_id = block.exprs.Add(BuildMirBinaryExpr(
-        unit, block, LowerBinaryOp(*a.compound_op), cur_id, value_id,
-        result_type));
-  }
-
-  const std::array<mir::ExprId, 2> operands{idx_id, value_id};
-  return ApplyAssignEffect(
-      process, frame, a.kind, span, cell_id, operands,
-      [&](mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
-          mir::ExprId services) -> mir::Expr {
-        mir::ExprId recv = target;
-        const mir::ExprId root = FindLhsRootId(blk, target);
-        if (mir::IsObservableCellType(
-                unit.types.Get(blk.exprs.Get(root).type))) {
-          recv = RewriteLhsRootWithMutate(unit, blk, target, services);
-        }
-        return MakeStringMethodCallExpr(
-            support::BuiltinFn::kPutc, {recv, ops[0], ops[1]},
-            unit.builtins.void_type);
-      });
-}
-
-// Axis A for a union member target: a whole-union replacement (LRM 7.3). A
-// union holds one member at a time, so `u.f = v` is the union place taking a
-// fresh single-member value `UnionExpr{f, v}` -- the member access is never a
-// writable place, the same shape as a string element write that has no element
-// lvalue. A compound `u.f op= v` reads the active member, applies the operator,
-// and rebuilds; the receiver routes through the cell's Set / Mutate path so the
-// timing envelope and observable wakeup are shared with every other target.
-auto LowerUnionMemberAssign(
-    ProcessLowerer& process, WalkFrame frame, const hir::AssignExpr& a,
-    const hir::MemberAccessExpr& sel, diag::SourceSpan span,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
-  const auto& unit = process.Module().Unit();
-  auto& block = *frame.current_block;
-
-  const auto& base_hir = hir_process.exprs.Get(sel.base_value);
-  auto place_or = process.LowerLhsExpr(base_hir, frame.WithLvalueTarget(true));
-  if (!place_or) return std::unexpected(std::move(place_or.error()));
-  const mir::ExprId place_id = block.exprs.Add(*std::move(place_or));
-  const mir::TypeId union_type = process.Module().TranslateType(base_hir.type);
-
-  auto rhs_or = process.LowerExpr(hir_process.exprs.Get(a.rhs), frame);
-  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  mir::ExprId member_value_id = block.exprs.Add(*std::move(rhs_or));
-
-  // A compound write only ever reaches here blocking (compound + NBA is not a
-  // legal SV form, rejected upstream), so the read of the active member lands
-  // in the active region before the effect runs.
-  if (a.compound_op.has_value()) {
-    auto cur_or = process.LowerExpr(hir_process.exprs.Get(a.lhs), frame);
-    if (!cur_or) return std::unexpected(std::move(cur_or.error()));
-    const mir::ExprId cur_id = block.exprs.Add(*std::move(cur_or));
-    member_value_id = block.exprs.Add(BuildMirBinaryExpr(
-        unit, block, LowerBinaryOp(*a.compound_op), cur_id, member_value_id,
-        result_type));
-  }
-
-  const mir::ExprId union_value_id = block.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::UnionExpr{
-                  .index = sel.field_index, .value = member_value_id},
-          .type = union_type});
-
-  const std::array<mir::ExprId, 1> operands{union_value_id};
-  const mir::TypeId void_type = unit.builtins.void_type;
-  return ApplyAssignEffect(
-      process, frame, a.kind, span, place_id, operands,
-      [&](mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
-          mir::ExprId services) -> mir::Expr {
-        return BuildObservableAssignExpr(
-            unit, blk, services, target, ops[0], std::nullopt, union_type,
-            void_type);
-      });
-}
-
 }  // namespace
 
 auto LowerHirAssignExprProc(
@@ -395,28 +297,12 @@ auto LowerHirAssignExprProc(
         "is not a legal SV form (LRM A.6.2 grammar)");
   }
 
-  // Axis A: pick the target's write effect. A string element has no lvalue, so
-  // it realizes as putc (LRM 6.16.2); every other target is an observable cell
-  // or a local. Axis B (blocking vs deferred) is handled uniformly inside each.
-  const auto& hir_process = process.HirBody();
-  const hir::Expr& hir_lhs = hir_process.exprs.Get(a.lhs);
-  if (const auto* sel = std::get_if<hir::ElementSelectExpr>(&hir_lhs.data)) {
-    const hir::Type& base_ty = process.Module().Hir().types.Get(
-        hir_process.exprs.Get(sel->base_value).type);
-    if (base_ty.Kind() == hir::TypeKind::kString) {
-      return LowerStringElementAssign(
-          process, frame, a, *sel, span, result_type);
-    }
-  }
-  // A union member write is a whole-union replacement, not a place projection,
-  // so it is intercepted here before the generic place-based path (LRM 7.3).
-  if (const auto* sel = std::get_if<hir::MemberAccessExpr>(&hir_lhs.data)) {
-    const hir::Type& base_ty = process.Module().Hir().types.Get(
-        hir_process.exprs.Get(sel->base_value).type);
-    if (base_ty.Kind() == hir::TypeKind::kUnpackedUnion) {
-      return LowerUnionMemberAssign(process, frame, a, *sel, span, result_type);
-    }
-  }
+  // Every target -- whole var, array / string element, struct / union member --
+  // lowers to one shape: the LHS is an op=-able write location, and the write
+  // is a single `AssignExpr{target, compound_op?, value}`. "Evaluate the
+  // left-hand side once" (LRM 11.4.1) is the backend's job on that single
+  // target. The blocking vs deferred (NBA) choice is the timing envelope
+  // inside.
   return LowerObservableAssign(process, frame, a, span, result_type);
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -48,7 +48,7 @@ auto IsExprRootedAtStructuralVar(const mir::Block& block, mir::ExprId expr_id)
           [&](const mir::TupleGetExpr& g) {
             return IsExprRootedAtStructuralVar(block, g.tuple);
           },
-          [&](const mir::UnionMemberRefExpr& g) {
+          [&](const mir::UnionGetRefExpr& g) {
             return IsExprRootedAtStructuralVar(block, g.union_value);
           },
           [&](const mir::CallExpr& c) {
@@ -136,11 +136,11 @@ auto CloneLhsExprForNbaBody(
                             .index = g.index},
                     .type = outer_expr.type});
           },
-          [&](const mir::UnionMemberRefExpr& g) -> mir::ExprId {
+          [&](const mir::UnionGetRefExpr& g) -> mir::ExprId {
             return body.exprs.Add(
                 mir::Expr{
                     .data =
-                        mir::UnionMemberRefExpr{
+                        mir::UnionGetRefExpr{
                             .union_value = CloneLhsExprForNbaBody(
                                 closure, outer_block, self_ptr_type,
                                 snapshot_counter, g.union_value),

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -797,7 +797,7 @@ auto LowerHirMemberAccessExpr(
         .type = result_type};
   }
   // LRM 7.3: an unpacked union member read projects the active member by index
-  // out of the overlapping-storage value (`UnionMemberExpr`); reading an
+  // out of the overlapping-storage value (`UnionGetExpr`); reading an
   // inactive member is undefined and the backend returns that member's default.
   if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedUnion) {
@@ -806,8 +806,7 @@ auto LowerHirMemberAccessExpr(
     const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     return mir::Expr{
         .data =
-            mir::UnionMemberExpr{
-                .union_value = base_id, .index = sel.field_index},
+            mir::UnionGetExpr{.union_value = base_id, .index = sel.field_index},
         .type = result_type};
   }
   const auto& fields =
@@ -916,8 +915,8 @@ auto LowerHirMemberAccessExprLhs(
         .type = result_type};
   }
   // LRM 7.3: an unpacked union member write is the write-side access form
-  // `UnionMemberRefExpr` over the union place (the by-reference counterpart of
-  // the `UnionMemberExpr` read). The observable root routes through the cell's
+  // `UnionGetRefExpr` over the union place (the by-reference counterpart of
+  // the `UnionGetExpr` read). The observable root routes through the cell's
   // mutate path later; the place is just the projection here.
   if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedUnion) {
@@ -926,7 +925,7 @@ auto LowerHirMemberAccessExprLhs(
     const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     return mir::Expr{
         .data =
-            mir::UnionMemberRefExpr{
+            mir::UnionGetRefExpr{
                 .union_value = base_id, .index = sel.field_index},
         .type = result_type};
   }

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -8,7 +8,6 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
-#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
@@ -711,13 +710,15 @@ auto LowerHirElementSelectExpr(
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
   const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
-  // LRM 6.16.3: a string has no element lvalue, so an index read realizes as
-  // the getc query (the write side realizes as putc in the assignment path).
+  // LRM 6.16: indexed character read `s[i]` is the element-value access, the
+  // read-side dual of the element-reference write. It joins the generic
+  // element-access path (the explicit `getc` / `putc` methods are a separate
+  // lowering); the value-vs-reference pair mirrors a packed array element.
   if (hir_base_ty.Kind() == hir::TypeKind::kString) {
     return mir::Expr{
         .data =
             mir::CallExpr{
-                .callee = mir::Direct{.target = support::BuiltinFn::kGetc},
+                .callee = ElementAccessCallee(AccessSide::kRead),
                 .arguments = {base_id, idx_id}},
         .type = result_type};
   }
@@ -796,8 +797,8 @@ auto LowerHirMemberAccessExpr(
         .type = result_type};
   }
   // LRM 7.3: an unpacked union member read projects the active member by index
-  // out of the overlapping-storage value (`UnionGetExpr`); reading an inactive
-  // member is undefined and the backend returns that member's default.
+  // out of the overlapping-storage value (`UnionMemberExpr`); reading an
+  // inactive member is undefined and the backend returns that member's default.
   if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedUnion) {
     auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
@@ -805,7 +806,8 @@ auto LowerHirMemberAccessExpr(
     const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     return mir::Expr{
         .data =
-            mir::UnionGetExpr{.union_value = base_id, .index = sel.field_index},
+            mir::UnionMemberExpr{
+                .union_value = base_id, .index = sel.field_index},
         .type = result_type};
   }
   const auto& fields =
@@ -840,6 +842,18 @@ auto LowerHirElementSelectExprLhs(
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
   const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
+  // LRM 6.16: indexed character write `s[i] = ...` is the element-reference
+  // access, the write-side dual of the element-value read. It joins the generic
+  // element-access path so the place flows through the observable mutate route
+  // and the assignment shape uniformly.
+  if (hir_base_ty.Kind() == hir::TypeKind::kString) {
+    return mir::Expr{
+        .data =
+            mir::CallExpr{
+                .callee = ElementAccessCallee(AccessSide::kLhs),
+                .arguments = {base_id, idx_id}},
+        .type = result_type};
+  }
   return LowerElementSelectInner(
       module, block, hir_base_ty, module.TranslateType(hir_idx.type), base_id,
       idx_id, AccessSide::kLhs, result_type, false);
@@ -901,15 +915,20 @@ auto LowerHirMemberAccessExprLhs(
         .data = mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index},
         .type = result_type};
   }
-  // A union member write is a whole-union replacement, intercepted at
-  // assignment lowering before any place is built; a union member never yields
-  // a writable place. Reaching here means a ref / output binding to a union
-  // member (LRM 7.3), which is not yet supported.
+  // LRM 7.3: an unpacked union member write is the write-side access form
+  // `UnionMemberRefExpr` over the union place (the by-reference counterpart of
+  // the `UnionMemberExpr` read). The observable root routes through the cell's
+  // mutate path later; the place is just the projection here.
   if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedUnion) {
-    return diag::Fail(
-        base_hir_expr.span, diag::DiagCode::kUnsupportedAssignmentTarget,
-        "a reference or output binding to a union member is not yet supported");
+    auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
+    if (!base_or) return std::unexpected(std::move(base_or.error()));
+    const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
+    return mir::Expr{
+        .data =
+            mir::UnionMemberRefExpr{
+                .union_value = base_id, .index = sel.field_index},
+        .type = result_type};
   }
   const auto& fields =
       GetAggregateFields(module.Hir().types.Get(base_hir_expr.type));

--- a/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
+++ b/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
@@ -32,7 +32,7 @@ auto FindLhsRootId(const mir::Block& block, mir::ExprId lhs_id) -> mir::ExprId {
       lhs_id = g->tuple;
       continue;
     }
-    if (const auto* m = std::get_if<mir::UnionMemberRefExpr>(&expr.data)) {
+    if (const auto* m = std::get_if<mir::UnionGetRefExpr>(&expr.data)) {
       lhs_id = m->union_value;
       continue;
     }
@@ -55,8 +55,8 @@ auto RewriteLhsRootWithMutate(
         RewriteLhsRootWithMutate(unit, block, rewritten.tuple, services_id);
     return block.exprs.Add(mir::Expr{.data = rewritten, .type = result_ty});
   }
-  if (const auto* m = std::get_if<mir::UnionMemberRefExpr>(&expr.data)) {
-    mir::UnionMemberRefExpr rewritten = *m;
+  if (const auto* m = std::get_if<mir::UnionGetRefExpr>(&expr.data)) {
+    mir::UnionGetRefExpr rewritten = *m;
     const mir::TypeId result_ty = expr.type;
     rewritten.union_value = RewriteLhsRootWithMutate(
         unit, block, rewritten.union_value, services_id);

--- a/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
+++ b/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 
+#include <utility>
 #include <variant>
 
 #include "lyra/mir/expr.hpp"
@@ -24,11 +25,15 @@ auto AsContainerAccessBase(const mir::Expr& expr) -> const mir::ExprId* {
 auto FindLhsRootId(const mir::Block& block, mir::ExprId lhs_id) -> mir::ExprId {
   while (true) {
     const auto& expr = block.exprs.Get(lhs_id);
-    // An unpacked-struct member write projects through a tuple component; the
-    // observable root is the tuple base, reached the same way a container
-    // access reaches its receiver.
+    // A struct member projects through a tuple component and a union member
+    // through its union access; the observable root is the base, reached the
+    // same way a container access reaches its receiver.
     if (const auto* g = std::get_if<mir::TupleGetExpr>(&expr.data)) {
       lhs_id = g->tuple;
+      continue;
+    }
+    if (const auto* m = std::get_if<mir::UnionMemberRefExpr>(&expr.data)) {
+      lhs_id = m->union_value;
       continue;
     }
     if (const auto* base = AsContainerAccessBase(expr)) {
@@ -48,6 +53,13 @@ auto RewriteLhsRootWithMutate(
     const mir::TypeId result_ty = expr.type;
     rewritten.tuple =
         RewriteLhsRootWithMutate(unit, block, rewritten.tuple, services_id);
+    return block.exprs.Add(mir::Expr{.data = rewritten, .type = result_ty});
+  }
+  if (const auto* m = std::get_if<mir::UnionMemberRefExpr>(&expr.data)) {
+    mir::UnionMemberRefExpr rewritten = *m;
+    const mir::TypeId result_ty = expr.type;
+    rewritten.union_value = RewriteLhsRootWithMutate(
+        unit, block, rewritten.union_value, services_id);
     return block.exprs.Add(mir::Expr{.data = rewritten, .type = result_ty});
   }
   if (AsContainerAccessBase(expr) != nullptr) {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -633,14 +633,14 @@ class MirDumper {
               return std::format(
                   "UnionExpr index={} value=Expr[{}]", u.index, u.value.value);
             },
-            [](const UnionMemberExpr& g) -> std::string {
+            [](const UnionGetExpr& g) -> std::string {
               return std::format(
-                  "UnionMemberExpr union=Expr[{}] index={}",
-                  g.union_value.value, g.index);
+                  "UnionGetExpr union=Expr[{}] index={}", g.union_value.value,
+                  g.index);
             },
-            [](const UnionMemberRefExpr& g) -> std::string {
+            [](const UnionGetRefExpr& g) -> std::string {
               return std::format(
-                  "UnionMemberRefExpr union=Expr[{}] index={}",
+                  "UnionGetRefExpr union=Expr[{}] index={}",
                   g.union_value.value, g.index);
             },
         },

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -633,10 +633,15 @@ class MirDumper {
               return std::format(
                   "UnionExpr index={} value=Expr[{}]", u.index, u.value.value);
             },
-            [](const UnionGetExpr& g) -> std::string {
+            [](const UnionMemberExpr& g) -> std::string {
               return std::format(
-                  "UnionGetExpr union=Expr[{}] index={}", g.union_value.value,
-                  g.index);
+                  "UnionMemberExpr union=Expr[{}] index={}",
+                  g.union_value.value, g.index);
+            },
+            [](const UnionMemberRefExpr& g) -> std::string {
+              return std::format(
+                  "UnionMemberRefExpr union=Expr[{}] index={}",
+                  g.union_value.value, g.index);
             },
         },
         e.data);

--- a/tests/cases/cpp/string_element_compound_index_once/case.yaml
+++ b/tests/cases/cpp/string_element_compound_index_once/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.string_element_compound_index_once
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    elem_calls: 1
+    base_calls: 1
+    s: "hfllo"
+    sarr0_after: "wprld"

--- a/tests/cases/cpp/string_element_compound_index_once/main.sv
+++ b/tests/cases/cpp/string_element_compound_index_once/main.sv
@@ -1,0 +1,32 @@
+module Top;
+  string s;
+  string sarr[2];
+  int    calls;
+  int    elem_calls;
+  int    base_calls;
+  string sarr0_after;
+
+  function automatic int idx1();
+    calls = calls + 1;
+    return 1;
+  endfunction
+
+  function automatic int idx0();
+    calls = calls + 1;
+    return 0;
+  endfunction
+
+  initial begin
+    s = "hello";
+    sarr[0] = "world";
+
+    calls = 0;
+    s[idx1()] += 1;
+    elem_calls = calls;
+
+    calls = 0;
+    sarr[idx0()][1] += 1;
+    base_calls = calls;
+    sarr0_after = sarr[0];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_union_member_access/case.yaml
+++ b/tests/cases/cpp/unpacked_union_member_access/case.yaml
@@ -13,3 +13,8 @@ expect:
     t_rt: 0x0AABBCCD
     t_ovr: 0x7f
     t_h: 0xBEEF
+    c_rt: 15
+    n_rt: 99
+    nu_x: 11
+    nu_y: 22
+    nu_hbit: 16

--- a/tests/cases/cpp/unpacked_union_member_access/main.sv
+++ b/tests/cases/cpp/unpacked_union_member_access/main.sv
@@ -10,14 +10,32 @@ module Top;
     bit [15:0] h;
   } three_t;
 
-  two_t   a;
-  two_t   d;
-  three_t t;
-  int     def_i;
-  int     a_rt;
-  int     t_rt;
-  int     t_ovr;
-  int     t_h;
+  typedef struct {
+    int x;
+    int y;
+  } pair_t;
+
+  typedef union {
+    pair_t     p;
+    bit [15:0] h;
+  } nested_t;
+
+  two_t    a;
+  two_t    d;
+  two_t    c;
+  two_t    n;
+  three_t  t;
+  nested_t nu;
+  int      def_i;
+  int      a_rt;
+  int      t_rt;
+  int      t_ovr;
+  int      t_h;
+  int      c_rt;
+  int      n_rt;
+  int      nu_x;
+  int      nu_y;
+  int      nu_hbit;
 
   initial begin
     def_i = d.i;
@@ -33,5 +51,23 @@ module Top;
 
     t.h = 16'hBEEF;
     t_h = t.h;
+
+    c.i = 10;
+    c.i += 5;
+    c_rt = c.i;
+
+    n.i = 1;
+    n.i <= 99;
+    #1;
+    n_rt = n.i;
+
+    nu.p.x = 11;
+    nu.p.y = 22;
+    nu_x = nu.p.x;
+    nu_y = nu.p.y;
+
+    nu.h = 16'h0000;
+    nu.h[4] = 1'b1;
+    nu_hbit = nu.h;
   end
 endmodule


### PR DESCRIPTION
## Summary

Compound assignment (`lhs op= rhs`, LRM 11.4.1) must evaluate the left-hand side exactly once. The previous lowering enforced this for string-character and union-member targets by desugaring at HIR-to-MIR -- hoisting every subscript into a temp and emitting an explicit read-modify-write -- which is work that belongs to a lower IR level (addresses and load/store). This change makes every write target an op=-able write-back location, so compound assignment lowers uniformly to `AssignExpr{target, compound_op, value}` and "evaluate once" becomes the backend's mechanical job (the C++ `op=` evaluates its left operand once; a future LIR computes the address once). The HIR-to-MIR subscript-hoisting machinery is deleted.

## Design

Every component access is a matched value / reference pair, named `X` / `XRef`: an array element is `Element` / `ElementRef`, a slice `Slice` / `SliceRef`, a union member `Member` / `MemberRef`, a string character `Element` / `ElementRef`. A struct member is the one collapse -- its value and reference realizations are the same `T&`, so a single node serves both. Union member access gains a read node (`UnionMemberExpr`, rendering `Member<I>`) and a write node (`UnionMemberRefExpr`, rendering `MemberRef<I>`, a reference that activates the member); a string character joins the `Indexable` concept, with the LRM `getc` / `putc` methods reserved for the explicit method-call forms.

## Testing

`bazel test //...` green. Added coverage for string-character read / write / compound and for nested union-member writes (`u.f.g`, `u.h[i]`) and non-blocking writes to a union member.