### PR TITLE
Support SystemVerilog class instance methods

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -170,7 +170,13 @@ threaded down, a per-callable-body temp counter) is defined separately under "Re
    nothing) takes the fold shape instead (see "Rendering Folds"). The earlier formulation claimed
    the class pattern was identical across lowering and rendering; that conflated a structured
    backend (which does accumulate, so is a construction pass) with a text fold (which does not).
-   Concrete types are per pass; no base type spans pass boundaries.
+   Concrete types are per pass: a construction pass's registries and `WalkFrame` write-targets are
+   meaningless in a fold, so one shared type would drag dead state into whichever pass does not use
+   it. What is shared is the shape itself -- the class-plus-dispatcher convention, the fold
+   convention -- held by following it, not by a base type that owns cross-pass state. The harm to
+   avoid is a base that couples one pass's state or machinery onto another, not any type two passes
+   both name; a stateless boundary one pass declares and another consumes owns nothing and is not
+   this shape.
 
 10. Per-kind dispatch is centralised in exactly one location, and that location is decoupled from
     the pass class header so the header does not grow per kind. Per-kind handlers form a layer the
@@ -356,7 +362,14 @@ structured-IR emit is a construction pass.
   `Build*` factory and interned by the caller; `mir::ExprId`-returning helpers are reserved for
   transforms keyed on an input `mir::ExprId` (which read or pass through an existing arena node).
   See "Expression-Builder Helpers".
-- A shared base class spanning construction-pass classes. The pattern is shared; types are per pass.
+- A base class that spans construction-pass classes to share their state or machinery -- registries,
+  a dispatcher, `WalkFrame` fields, the root output. The construction-pass shape is followed, not
+  inherited; a base that owns cross-pass state forces every derived pass to carry state it may not
+  use. This forbids a state-coupling base, not every type two passes both name: a stateless boundary
+  one pass declares and another consumes owns no shared state and is a different thing. Even then,
+  prefer a fact that models the relationship as it is -- a body that has no enclosing structural
+  scope holds a null scope, it does not implement a scope interface that throws -- over an interface
+  that makes a pass answer for a capability it does not have.
 - A dispatcher method or per-kind handler that mutates the class's fact members. Facts are mutated
   only by the constructor.
 - A bundle of multiple kinds (facts + registry + builder) into one type. Each member of a class is a

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -7,6 +7,7 @@
 #include "lyra/base/arena.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
@@ -21,13 +22,16 @@ struct ClassField {
   std::optional<ExprId> initializer;
 };
 
-// A SystemVerilog class declaration (LRM 8). The class's properties and the
-// expressions their initializers reference; references to a class name resolve
-// to this declaration's id. A class is reached through a handle, so it carries
-// no structural position of its own.
+// A SystemVerilog class declaration (LRM 8). The class's properties, its
+// instance methods, and the expressions their initializers reference;
+// references to a class name resolve to this declaration's id. A class is
+// reached through a handle, so it carries no structural position of its own.
+// Each method (LRM 8.6) is a subroutine reached through the instance, so its
+// body reads the receiver and the class's properties through the receiver.
 struct ClassDecl {
   std::string name;
   std::vector<ClassField> fields;
+  std::vector<SubroutineDecl> methods;
   base::Arena<Expr, ExprId> exprs;
 };
 

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -44,7 +44,7 @@ struct NullLiteral {};
 // tag.
 using Primary = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
-    StructuralVarRef, ProceduralVarRef, LoopVarRef, CrossUnitVarRef,
-    IterationBindingRef>;
+    StructuralVarRef, ProceduralVarRef, ClassPropertyRef, LoopVarRef,
+    CrossUnitVarRef, IterationBindingRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -202,8 +202,7 @@ struct StructuralScope {
   base::Arena<InstanceMemberDecl, InstanceMemberId> instance_members;
   std::vector<PortConnection> port_connections;
   base::Arena<CrossUnitRefDecl, CrossUnitRefId> cross_unit_refs;
-  base::Arena<StructuralSubroutineDecl, StructuralSubroutineId>
-      structural_subroutines;
+  base::Arena<SubroutineDecl, StructuralSubroutineId> structural_subroutines;
   std::vector<TypeAliasDecl> type_aliases;
 
   [[nodiscard]] auto NextGenerateId() const -> GenerateId {

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -48,7 +48,7 @@ struct SubroutineParam {
 // through the function name. `result_var` indexes the body's procedural-var
 // arena for that variable; it is absent for void functions and tasks, which
 // yield no value.
-struct StructuralSubroutineDecl {
+struct SubroutineDecl {
   std::string name;
   SubroutineKind kind;
   TypeId result_type;

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstdint>
 #include <variant>
 
+#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/subroutine_id.hpp"
 #include "lyra/support/builtin_fn.hpp"
@@ -14,6 +17,15 @@ namespace lyra::hir {
 struct StructuralSubroutineRef {
   StructuralHops hops;
   StructuralSubroutineId subroutine;
+};
+
+// Calls an instance method (LRM 8.6) on `receiver`, an expression yielding the
+// class handle the call dispatches through. `class_id` names the declaring
+// class and `method_index` is the method's declaration-order position in it.
+struct MethodCallRef {
+  ExprId receiver;
+  ClassId class_id;
+  std::uint32_t method_index;
 };
 
 // Calls a `$xxx` system subroutine. The id resolves through
@@ -31,6 +43,7 @@ struct BuiltinMethodRef {
 };
 
 using SubroutineRef = std::variant<
-    StructuralSubroutineRef, SystemSubroutineRef, BuiltinMethodRef>;
+    StructuralSubroutineRef, MethodCallRef, SystemSubroutineRef,
+    BuiltinMethodRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -42,6 +42,16 @@ struct ProceduralVarRef {
   auto operator==(const ProceduralVarRef&) const -> bool = default;
 };
 
+// A reference to a class property (LRM 8.4) from within an instance method
+// body, where the property is named without an explicit handle and reaches the
+// invoking object through the method's receiver. `field_index` is the
+// property's declaration-order position in the enclosing class.
+struct ClassPropertyRef {
+  std::uint32_t field_index;
+
+  auto operator==(const ClassPropertyRef&) const -> bool = default;
+};
+
 struct LoopVarRef {
   StructuralHops hops;
   LoopVarDeclId loop_var;

--- a/include/lyra/lowering/ast_to_hir/expression/selects.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/selects.hpp
@@ -5,6 +5,8 @@
 // MemberAccess (LRM 11.5.2 struct/union member access). Both procedural and
 // structural contexts.
 
+#include <cstdint>
+
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
@@ -15,11 +17,18 @@ namespace slang::ast {
 class ElementSelectExpression;
 class MemberAccessExpression;
 class RangeSelectExpression;
+class ClassPropertySymbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
 
 class ProcessLowerer;
+
+// A class property's declaration-order index among its class's properties
+// (LRM 8.4), matching the order the HIR ClassDecl registers its fields, so the
+// index identifies the same property on either side.
+auto ClassPropertyIndex(const slang::ast::ClassPropertySymbol& prop)
+    -> std::uint32_t;
 
 // LRM 7.10 `$` (UnboundedLiteral) in a queue index / slice bound. Resolves to
 // the queue's last index via the base bound on the walk frame. A queue is a

--- a/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
+++ b/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/subroutine.hpp"
+#include "lyra/lowering/ast_to_hir/walk_frame.hpp"
+
+namespace slang::ast {
+class SubroutineSymbol;
+}  // namespace slang::ast
+
+namespace lyra::lowering::ast_to_hir {
+
+class ModuleLowerer;
+
+// Lowers a slang subroutine (LRM 13) into a hir::SubroutineDecl: its result
+// type, its formals as body-local procedural vars carrying their direction, the
+// implicit result variable of a non-void function (LRM 13.4.1), and its lowered
+// body. The same shape serves a structural-scope subroutine and a class method;
+// `frame` is the enclosing context the body is lowered against. The caller
+// records the result where it belongs (a scope's subroutine arena, a class's
+// method list).
+auto LowerSubroutineDecl(
+    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym,
+    WalkFrame frame) -> diag::Result<hir::SubroutineDecl>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
@@ -13,8 +13,14 @@ namespace lyra::lowering::hir_to_mir {
 // extends no runtime base (it is not a tree node), is reached through a managed
 // reference, and is built by `new`. Its properties become plain value-typed
 // members -- not observable cells -- and their construction-time defaults are
-// the body of its constructor. `object_type` is the interned object type that
-// names the class, minted with its registry identity before type translation.
+// the body of its constructor. Its instance methods (LRM 8.6) are lowered as
+// callables receiving the object handle as `self`. `object_type` is the
+// interned object type that names the class, minted with its registry identity
+// before type translation.
+//
+// A class method body names only its receiver and its own locals, so it is
+// lowered inside no structural scope -- its body lowerer carries a null
+// enclosing scope, never an owner that stands in for one.
 class ClassDeclLowerer {
  public:
   ClassDeclLowerer(

--- a/include/lyra/lowering/hir_to_mir/completion_payload.hpp
+++ b/include/lyra/lowering/hir_to_mir/completion_payload.hpp
@@ -15,7 +15,7 @@ namespace lyra::lowering::hir_to_mir {
 // the callee body and every call site share, so neither re-derives the layout
 // independently (LRM 13.5).
 auto CompletionComponentTypes(
-    const ModuleLowerer& module, const hir::StructuralSubroutineDecl& decl)
+    const ModuleLowerer& module, const hir::SubroutineDecl& decl)
     -> std::vector<mir::TypeId>;
 
 // Normalizes a completion payload by component count: no component is `Void`,

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -70,21 +70,30 @@ using ProceduralVarBinding =
 class ProcessLowerer {
  public:
   // Facts: every parameter is set once at construction and never mutated for
-  // the lowerer's lifetime. `callable_name` is the synthesized identifier the
+  // the lowerer's lifetime. `enclosing_scope_lowerer` is the lowering pass for
+  // the structural scope this body sits inside; its registries resolve every
+  // reference to an enclosing-scope declaration. It is null for a class method
+  // body, which sits inside no structural scope. `callable_name` is the
+  // synthesized identifier the
   // enclosing scope chose for this callable (LRM processes are anonymous, so
   // the caller passes `"process_N"`; methods pass `src.name`). The
   // `owner_ctor_frame` is the enclosing class's constructor-time
   // frame -- the static-local lowering reads it to place per-instance storage
-  // and its init AssignExpr into the owner's constructor_block.
+  // and its init AssignExpr into the owner's constructor_block. `visibility` is
+  // the access the produced method declares: a class instance method is public,
+  // a scope's processes and subroutines are internal.
   ProcessLowerer(
-      ModuleLowerer& module, const StructuralScopeLowerer& lowerer,
+      ModuleLowerer& module,
+      const StructuralScopeLowerer* enclosing_scope_lowerer,
       TimeResolution time_resolution, const hir::ProceduralBody& hir_body,
-      std::string callable_name, WalkFrame owner_ctor_frame)
+      std::string callable_name, mir::MethodVisibility visibility,
+      WalkFrame owner_ctor_frame)
       : module_(&module),
-        owner_(&lowerer),
+        enclosing_scope_lowerer_(enclosing_scope_lowerer),
         time_resolution_(time_resolution),
         hir_body_(&hir_body),
         callable_name_(std::move(callable_name)),
+        visibility_(visibility),
         owner_ctor_frame_(std::move(owner_ctor_frame)) {
   }
 
@@ -99,8 +108,7 @@ class ProcessLowerer {
   // Pre-registers the formal params as body locals so call references resolve,
   // then walks the body. Functions with a non-void result close with a
   // trailing `return` of the implicit result variable.
-  auto Run(const hir::StructuralSubroutineDecl& src)
-      -> diag::Result<mir::MethodDecl>;
+  auto Run(const hir::SubroutineDecl& src) -> diag::Result<mir::MethodDecl>;
 
   // Central expression dispatcher. One switch over `hir::Expr::data` routing
   // each kind to the per-family handler in `expression/{operators, calls,
@@ -143,8 +151,19 @@ class ProcessLowerer {
     return *module_;
   }
 
-  [[nodiscard]] auto Owner() const -> const StructuralScopeLowerer& {
-    return *owner_;
+  // The lowering pass for the structural scope this body sits inside; its
+  // registries resolve every reference to an enclosing-scope declaration (a
+  // structural variable, a generate loop variable, a cross-unit reference, a
+  // peer subroutine). A class method body resolves no such reference and sits
+  // inside no structural scope; reaching this from one is a compiler bug.
+  [[nodiscard]] auto EnclosingScopeLowerer() const
+      -> const StructuralScopeLowerer& {
+    if (enclosing_scope_lowerer_ == nullptr) {
+      throw InternalError(
+          "ProcessLowerer::EnclosingScopeLowerer: a class method body sits "
+          "inside no structural scope");
+    }
+    return *enclosing_scope_lowerer_;
   }
 
   // The structural-subroutine tables live on the owning structural-scope pass;
@@ -152,13 +171,13 @@ class ProcessLowerer {
   // through the same surface on either pass class.
   [[nodiscard]] auto LookupHirSubroutine(
       hir::StructuralHops hops, hir::StructuralSubroutineId id) const
-      -> const hir::StructuralSubroutineDecl& {
-    return owner_->LookupHirSubroutine(hops, id);
+      -> const hir::SubroutineDecl& {
+    return EnclosingScopeLowerer().LookupHirSubroutine(hops, id);
   }
   [[nodiscard]] auto TranslateStructuralSubroutine(
       hir::StructuralHops hops, hir::StructuralSubroutineId id) const
       -> mir::Direct {
-    return owner_->TranslateStructuralSubroutine(hops, id);
+    return EnclosingScopeLowerer().TranslateStructuralSubroutine(hops, id);
   }
 
   [[nodiscard]] auto Resolution() const -> TimeResolution {
@@ -217,6 +236,12 @@ class ProcessLowerer {
     return callable_name_;
   }
 
+  // The access the produced method declares, carried onto every `MethodDecl`
+  // this lowerer returns.
+  [[nodiscard]] auto Visibility() const -> mir::MethodVisibility {
+    return visibility_;
+  }
+
   // The owner class's constructor-time frame. The static-local
   // lowering reads it to place the per-instance storage's init AssignExpr
   // into the owner's constructor block using the owner's own `self` binding,
@@ -242,10 +267,11 @@ class ProcessLowerer {
 
  private:
   ModuleLowerer* module_;
-  const StructuralScopeLowerer* owner_;
+  const StructuralScopeLowerer* enclosing_scope_lowerer_;
   TimeResolution time_resolution_;
   const hir::ProceduralBody* hir_body_;
   std::string callable_name_;
+  mir::MethodVisibility visibility_;
   WalkFrame owner_ctor_frame_;
   std::vector<ProceduralVarBinding> bindings_;
 

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -48,10 +48,18 @@ struct ScopeEntryStructuralParamBinding {
 
 // A located structural param: the enclosing-scope distance to the scope that
 // owns it and the param's id on that scope. The reading site turns it into a
-// receiver-addressed `mir::ParamRef` via `BuildStructuralParamAccessExpr`.
+// receiver-addressed `mir::ParamRef`.
 struct StructuralParamLocation {
   mir::EnclosingHops hops = {};
   mir::ParamId param = {};
+};
+
+// The MIR slot a HIR cross-unit ref resolves to: a member ref to the slot
+// bundled with the slot's MIR type, so a body reader decides whether the read
+// dereferences without re-touching the owning scope.
+struct CrossUnitRefMeta {
+  mir::MemberRef target = {};
+  mir::TypeId slot_type = {};
 };
 
 // Per-scope lowering registries for one `mir::Class`. Carries
@@ -120,7 +128,7 @@ class StructuralScopeLowerer {
   // formals' directions and types from here.
   [[nodiscard]] auto LookupHirSubroutine(
       hir::StructuralHops hops, hir::StructuralSubroutineId id) const
-      -> const hir::StructuralSubroutineDecl& {
+      -> const hir::SubroutineDecl& {
     if (hops.value == 0) {
       return hir_scope_->structural_subroutines.Get(id);
     }
@@ -132,16 +140,6 @@ class StructuralScopeLowerer {
     return parent_->LookupHirSubroutine(
         hir::StructuralHops{.value = hops.value - 1}, id);
   }
-
-  // The MIR target each HIR cross-unit ref slot lowers to, in HIR slot order: a
-  // `StructuralVarRef` to the slot member -- a synthesized ExternalRef member
-  // for an upward ref, a borrowed-pointer slot for a downward ref -- bundled
-  // with the slot's MIR type so a body reader can decide whether the read
-  // dereferences without re-touching the structural scope.
-  struct CrossUnitRefMeta {
-    mir::MemberRef target;
-    mir::TypeId slot_type;
-  };
 
   void AddCrossUnitRefTarget(mir::MemberRef target, mir::TypeId slot_type) {
     cross_unit_ref_targets_.push_back(

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -173,9 +173,11 @@ struct CallExpr {
   std::vector<ExprId> arguments;
 };
 
-// Dereferences a borrowed pointer to reach the cell it refers to. An
-// lvalue-producing navigation like ElementSelectExpr; `Expr::type` is the
-// pointee value type.
+// Dereferences a reference -- a borrowed pointer or a managed handle -- to
+// reach the object or cell it refers to. An lvalue-producing navigation like
+// ElementSelectExpr; `Expr::type` is the referent's value type. Taking the
+// address of a dereferenced managed handle is how a borrowed pointer to a
+// managed object is obtained.
 struct DerefExpr {
   ExprId pointer;
 };
@@ -185,7 +187,9 @@ struct DerefExpr {
 // place (a primary value reference, a member access, a dereference, or a
 // place-producing access primitive); a value expression is not addressable.
 // `Expr::type` is `PointerType{ ownership = kBorrowed, pointee = operand.type
-// }`. `AddressOf(Deref(p))` collapses to `p` at backend lowering.
+// }`. `AddressOf(Deref(p))` collapses to `p` at backend lowering when `p` is a
+// borrowed pointer (the round-trip is a no-op); over a managed handle it does
+// not collapse, since the address of the handle's object is not the handle.
 struct AddressOfExpr {
   ExprId operand;
 };

--- a/include/lyra/mir/method.hpp
+++ b/include/lyra/mir/method.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -7,6 +8,14 @@
 #include "lyra/mir/class_ref.hpp"
 
 namespace lyra::mir {
+
+// Whether a method is part of the object's externally callable surface or an
+// internal mechanism. A class instance method (LRM 8.6) is callable through a
+// handle, so it is public; a scope's processes, lifecycle hooks, and helper
+// subroutines are reached only by the owning runtime or by the scope's own
+// bodies, so they are internal. A backend reads which access a method has from
+// here rather than inferring it from the object's base or the method's role.
+enum class MethodVisibility : std::uint8_t { kPublic, kInternal };
 
 // A named, class-level callable: callable code plus a name. Every SystemVerilog
 // function and task, every process body, and the synthesized lifecycle bodies
@@ -29,6 +38,7 @@ struct MethodDecl {
   // body overrides the runtime base's matching hook; a backend reads the
   // override target here rather than re-deriving it from the method name.
   std::optional<OverriddenMethodRef> overrides;
+  MethodVisibility visibility;
 };
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -211,6 +211,16 @@ auto RenderBaseClass(const mir::ClassRef& base) -> std::string {
       base);
 }
 
+auto VisibilityKeyword(mir::MethodVisibility visibility) -> std::string_view {
+  switch (visibility) {
+    case mir::MethodVisibility::kPublic:
+      return "public";
+    case mir::MethodVisibility::kInternal:
+      return "private";
+  }
+  throw InternalError("VisibilityKeyword: unknown MethodVisibility");
+}
+
 auto RenderScopeAsClass(
     const mir::CompilationUnit& unit, const mir::Class& s, std::size_t indent,
     const ScopeView* parent_struct_view) -> std::string {
@@ -292,10 +302,17 @@ auto RenderScopeAsClass(
     return out;
   }
 
-  out += "\n";
-  out += std::format("{} private:\n", Indent(indent));
-
+  // Each method declares its access -- a class instance method is the object's
+  // public callable surface, a scope's processes and lifecycle hooks are
+  // internal -- and the access specifier follows that stated visibility,
+  // coalescing a run of methods that share one.
+  std::optional<mir::MethodVisibility> open_section;
   for (const auto& sub : s.methods) {
+    if (open_section != sub.visibility) {
+      open_section = sub.visibility;
+      out += std::format(
+          "\n{} {}:\n", Indent(indent), VisibilityKeyword(sub.visibility));
+    }
     out += "\n";
     out += RenderMethod(parent_struct_view, unit, s, sub, indent + 1);
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -739,13 +739,19 @@ auto RenderDerefExpr(const ScopeView& view, const mir::DerefExpr& d)
 }
 
 // `&place` emitted as the C++ address-of operator. Backend-side
-// canonicalization: `&(*p)` collapses to `p` directly, avoiding a no-op
-// round-trip through the address-of/dereference pair.
+// canonicalization: `&(*p)` collapses to `p` directly when `p` is a borrowed
+// pointer, avoiding a no-op round-trip; dereferencing a managed handle yields
+// the object, whose address is a distinct borrowed pointer, so that case does
+// not collapse.
 auto RenderAddressOfExpr(const ScopeView& view, const mir::AddressOfExpr& a)
     -> std::string {
   const mir::Expr& operand_expr = view.Expr(a.operand);
   if (const auto* deref = std::get_if<mir::DerefExpr>(&operand_expr.data)) {
-    return RenderExpr(view, view.Expr(deref->pointer));
+    const mir::Expr& inner = view.Expr(deref->pointer);
+    if (std::holds_alternative<mir::PointerType>(
+            view.Unit().types.Get(inner.type).data)) {
+      return RenderExpr(view, inner);
+    }
   }
   return std::format("&{}", RenderLhsExpr(view, operand_expr));
 }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -406,6 +406,9 @@ class HirDumper {
             [](const ProceduralVarRef& r) -> std::string {
               return std::format("ProceduralVar[{}]", r.var.value);
             },
+            [](const ClassPropertyRef& r) -> std::string {
+              return std::format("ClassProperty[{}]", r.field_index);
+            },
             [](const LoopVarRef& r) -> std::string {
               return std::format(
                   "LoopVar[{}](hops={})", r.loop_var.value, r.hops.value);
@@ -536,6 +539,11 @@ class HirDumper {
               return std::format(
                   "StructuralSubroutine[{}](hops={}) \"{}\"",
                   u.subroutine.value, u.hops.value, decl.name);
+            },
+            [](const MethodCallRef& m) -> std::string {
+              return std::format(
+                  "Method class=Class[{}] index={} recv=Expr[{}]",
+                  m.class_id.value, m.method_index, m.receiver.value);
             },
             [](const SystemSubroutineRef& s) -> std::string {
               const auto& desc = support::LookupSystemSubroutine(s.id);
@@ -831,6 +839,9 @@ class HirDumper {
         Line(std::format("{}:Type[{}]", field.name, field.type.value));
       }
     }
+    for (std::size_t i = 0; i < c.methods.size(); ++i) {
+      DumpSubroutine("Method", i, c.methods[i]);
+    }
     Dedent();
   }
 
@@ -863,9 +874,10 @@ class HirDumper {
               "LoopVarDecl[{}] \"{}\" : Type[{}]", i, lv.name, lv.type.value));
     }
     for (std::size_t i = 0; i < s.structural_subroutines.size(); ++i) {
-      DumpStructuralSubroutine(
-          i, s.structural_subroutines.Get(
-                 StructuralSubroutineId{static_cast<std::uint32_t>(i)}));
+      DumpSubroutine(
+          "StructuralSubroutine", i,
+          s.structural_subroutines.Get(
+              StructuralSubroutineId{static_cast<std::uint32_t>(i)}));
     }
     if (!s.exprs.empty()) {
       Line("Exprs:");
@@ -931,11 +943,11 @@ class HirDumper {
     scope_stack_.pop_back();
   }
 
-  void DumpStructuralSubroutine(
-      std::size_t index, const StructuralSubroutineDecl& d) {
+  void DumpSubroutine(
+      std::string_view label, std::size_t index, const SubroutineDecl& d) {
     Line(
         std::format(
-            "StructuralSubroutine[{}] {} \"{}\" : Type[{}]", index,
+            "{}[{}] {} \"{}\" : Type[{}]", label, index,
             d.kind == SubroutineKind::kTask ? "task" : "function", d.name,
             d.result_type.value));
     Indent();

--- a/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
@@ -128,6 +128,12 @@ auto ValidateAssignableImpl(
     case EK::NamedValue: {
       const auto& nv = expr.as<slang::ast::NamedValueExpression>();
       const auto& sym = nv.symbol;
+      // A class property named without a handle (LRM 8.4) is written through
+      // the enclosing method's receiver; it appears only in a method body, so
+      // it is always a legal procedural assignment target.
+      if (sym.kind == slang::ast::SymbolKind::ClassProperty) {
+        return {};
+      }
       if (sym.kind != slang::ast::SymbolKind::Variable &&
           sym.kind != slang::ast::SymbolKind::FormalArgument) {
         return reject("assignment target must be a variable reference");

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -1,6 +1,7 @@
 #include "lyra/lowering/ast_to_hir/expression/calls.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <expected>
 #include <optional>
 #include <string>
@@ -14,10 +15,13 @@
 #include <slang/ast/expressions/AssignmentExpressions.h>
 #include <slang/ast/expressions/CallExpression.h>
 #include <slang/ast/expressions/MiscExpressions.h>
+#include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/AllTypes.h>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
@@ -51,6 +55,23 @@ auto MakeReturnConventionType(
       return builtins.realtime;
   }
   throw InternalError("MakeReturnConventionType: unknown ReturnConvention");
+}
+
+// An instance method's declaration-order index among its class's methods,
+// matching the order the HIR ClassDecl registers them, so the index names the
+// same method when the call is lowered (LRM 8.6).
+auto ClassMethodIndex(const slang::ast::SubroutineSymbol& method)
+    -> std::uint32_t {
+  const auto* scope = method.getParentScope();
+  std::uint32_t index = 0;
+  for (const auto& member :
+       scope->membersOfType<slang::ast::SubroutineSymbol>()) {
+    if (&member == &method) {
+      return index;
+    }
+    ++index;
+  }
+  throw InternalError("ClassMethodIndex: method not found in its class");
 }
 
 }  // namespace
@@ -408,6 +429,45 @@ auto LowerCallExpr(
     throw InternalError(
         "AST->HIR call: user call missing resolved SubroutineSymbol");
   }
+
+  // An instance-method call (LRM 8.6) carries the receiver handle in
+  // `thisClass`; the call dispatches through that handle's class rather than
+  // through an enclosing-scope subroutine.
+  if (const slang::ast::Expression* this_class = call.thisClass();
+      this_class != nullptr) {
+    for (const auto* formal : sym->getArguments()) {
+      if (formal->direction != slang::ast::ArgumentDirection::In) {
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedClassFeature,
+            "instance methods with output / inout / ref arguments are not yet "
+            "supported");
+      }
+    }
+    auto receiver_or = lowerer.LowerExpr(*this_class, frame);
+    if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
+    const hir::ExprId receiver = frame.Exprs().Add(*std::move(receiver_or));
+    auto class_id = module.InternClass(
+        this_class->type->getCanonicalType().as<slang::ast::ClassType>(), span);
+    if (!class_id) return std::unexpected(std::move(class_id.error()));
+    auto method_result_type = module.InternType(*call.type, span);
+    if (!method_result_type) {
+      return std::unexpected(std::move(method_result_type.error()));
+    }
+    return hir::Expr{
+        .type = *method_result_type,
+        .data =
+            hir::CallExpr{
+                .callee =
+                    hir::MethodCallRef{
+                        .receiver = receiver,
+                        .class_id = *class_id,
+                        .method_index = ClassMethodIndex(*sym)},
+                .arguments = std::move(arg_ids),
+            },
+        .span = span,
+    };
+  }
+
   const auto binding = module.LookupSubroutineBinding(*sym);
   if (!binding.has_value()) {
     throw InternalError(

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -13,6 +13,7 @@
 #include <slang/ast/HierarchicalReference.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/expressions/MiscExpressions.h>
+#include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/MemberSymbols.h>
@@ -26,6 +27,7 @@
 #include "lyra/hir/expr_builders.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
+#include "lyra/lowering/ast_to_hir/expression/selects.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -78,6 +80,19 @@ auto LowerNamedValueProc(
     if (!type_id) return std::unexpected(std::move(type_id.error()));
     return MakeEnumValueExpr(
         sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
+  }
+
+  // Inside an instance method, a class property named without an explicit
+  // handle (LRM 8.4) reaches the invoking object through the method's receiver,
+  // so it lowers to a receiver-relative property reference, not a body local.
+  if (sym.kind == slang::ast::SymbolKind::ClassProperty) {
+    auto type_id = module.InternType(*named.type, span);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    return hir::MakeRefExpr(
+        hir::ClassPropertyRef{
+            .field_index =
+                ClassPropertyIndex(sym.as<slang::ast::ClassPropertySymbol>())},
+        *type_id, span);
   }
 
   if (sym.kind == slang::ast::SymbolKind::Variable ||

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -163,9 +163,6 @@ auto LowerRangeSelectExpr(
   };
 }
 
-// A class property's index is its position among the class's properties in
-// slang's member order -- the same order `InternClass` registers the HIR
-// ClassDecl fields, so the two indices align.
 auto ClassPropertyIndex(const slang::ast::ClassPropertySymbol& prop)
     -> std::uint32_t {
   const auto* scope = prop.getParentScope();

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -33,22 +33,13 @@
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/specialization_name.hpp"
+#include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
 #include "lyra/lowering/ast_to_hir/time_resolution.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
 namespace {
-
-auto ToHirSubroutineKind(slang::ast::SubroutineKind k) -> hir::SubroutineKind {
-  switch (k) {
-    case slang::ast::SubroutineKind::Function:
-      return hir::SubroutineKind::kFunction;
-    case slang::ast::SubroutineKind::Task:
-      return hir::SubroutineKind::kTask;
-  }
-  throw InternalError("ToHirSubroutineKind: unknown SubroutineKind");
-}
 
 auto IsCaseConstruct(
     const std::vector<const slang::ast::GenerateBlockSymbol*>& siblings)
@@ -63,26 +54,6 @@ auto IsCaseConstruct(
     }
   }
   return false;
-}
-
-// slang has no ConstRef direction (LRM 13.5.2): a `const ref` formal carries
-// direction Ref with the Const variable flag, so the const-ness must be read
-// off the formal rather than the direction enum alone.
-auto ParamDirectionOf(const slang::ast::FormalArgumentSymbol& formal)
-    -> hir::ParamDirection {
-  switch (formal.direction) {
-    case slang::ast::ArgumentDirection::In:
-      return hir::ParamDirection::kInput;
-    case slang::ast::ArgumentDirection::Out:
-      return hir::ParamDirection::kOutput;
-    case slang::ast::ArgumentDirection::InOut:
-      return hir::ParamDirection::kInOut;
-    case slang::ast::ArgumentDirection::Ref:
-      return formal.flags.has(slang::ast::VariableFlags::Const)
-                 ? hir::ParamDirection::kConstRef
-                 : hir::ParamDirection::kRef;
-  }
-  throw InternalError("ParamDirectionOf: unknown ArgumentDirection");
 }
 
 }  // namespace
@@ -307,46 +278,8 @@ auto StructuralScopeLowerer::PopulateVariableMember(
 auto StructuralScopeLowerer::PopulateSubroutineMember(
     const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
     -> diag::Result<void> {
-  const auto& mapper = module_->SourceMapper();
-  auto return_type_id_or = module_->InternType(
-      sym.getReturnType(), mapper.PointSpanOf(sym.location));
-  if (!return_type_id_or) {
-    return std::unexpected(std::move(return_type_id_or.error()));
-  }
-
-  hir::ProceduralBody sub_body;
-  ProcessLowerer sub_lowerer(*module_, sym);
-  sub_lowerer.AnalyzeLifetimeExtended(sym.getBody());
-  const WalkFrame sub_frame =
-      frame.WithProceduralBody(&sub_body, &sub_body.exprs);
-
-  std::vector<hir::SubroutineParam> params;
-  params.reserve(sym.getArguments().size());
-  for (const auto* formal : sym.getArguments()) {
-    auto formal_type_or = module_->InternType(
-        formal->getType(), mapper.PointSpanOf(formal->location));
-    if (!formal_type_or) {
-      return std::unexpected(std::move(formal_type_or.error()));
-    }
-    const hir::ProceduralVarId var =
-        sub_lowerer.AddProceduralVar(sub_body, *formal, *formal_type_or);
-    params.push_back(
-        hir::SubroutineParam{
-            .var = var, .direction = ParamDirectionOf(*formal)});
-  }
-
-  // LRM 13.4.1: a non-void function implicitly declares a body-local
-  // variable of the return type, named after the function, that the body
-  // reads and writes to produce the return value.
-  std::optional<hir::ProceduralVarId> result_var;
-  if (sym.returnValVar != nullptr) {
-    result_var = sub_lowerer.AddProceduralVar(
-        sub_body, *sym.returnValVar, *return_type_id_or);
-  }
-
-  auto body_stmt_or = sub_lowerer.LowerStmt(sym.getBody(), sub_frame);
-  if (!body_stmt_or) return std::unexpected(std::move(body_stmt_or.error()));
-  sub_body.root_stmt = sub_body.stmts.Add(*std::move(body_stmt_or));
+  auto decl_or = LowerSubroutineDecl(*module_, sym, frame);
+  if (!decl_or) return std::unexpected(std::move(decl_or.error()));
 
   const auto binding = module_->LookupSubroutineBinding(sym);
   if (!binding.has_value() ||
@@ -360,13 +293,7 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
         "order");
   }
   frame.current_structural_scope->structural_subroutines.Add(
-      hir::StructuralSubroutineDecl{
-          .name = std::string{sym.name},
-          .kind = ToHirSubroutineKind(sym.subroutineKind),
-          .result_type = *return_type_id_or,
-          .params = std::move(params),
-          .result_var = result_var,
-          .body = std::move(sub_body)});
+      *std::move(decl_or));
   return {};
 }
 

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -1,0 +1,103 @@
+#include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
+
+#include <expected>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <slang/ast/Symbol.h>
+#include <slang/ast/symbols/SubroutineSymbols.h>
+#include <slang/ast/symbols/VariableSymbols.h>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+auto ToHirSubroutineKind(slang::ast::SubroutineKind k) -> hir::SubroutineKind {
+  switch (k) {
+    case slang::ast::SubroutineKind::Function:
+      return hir::SubroutineKind::kFunction;
+    case slang::ast::SubroutineKind::Task:
+      return hir::SubroutineKind::kTask;
+  }
+  throw InternalError("ToHirSubroutineKind: unknown SubroutineKind");
+}
+
+// slang has no ConstRef direction (LRM 13.5.2): a `const ref` formal carries
+// direction Ref with the Const variable flag, so the const-ness must be read
+// off the formal rather than the direction enum alone.
+auto ParamDirectionOf(const slang::ast::FormalArgumentSymbol& formal)
+    -> hir::ParamDirection {
+  switch (formal.direction) {
+    case slang::ast::ArgumentDirection::In:
+      return hir::ParamDirection::kInput;
+    case slang::ast::ArgumentDirection::Out:
+      return hir::ParamDirection::kOutput;
+    case slang::ast::ArgumentDirection::InOut:
+      return hir::ParamDirection::kInOut;
+    case slang::ast::ArgumentDirection::Ref:
+      return formal.flags.has(slang::ast::VariableFlags::Const)
+                 ? hir::ParamDirection::kConstRef
+                 : hir::ParamDirection::kRef;
+  }
+  throw InternalError("ParamDirectionOf: unknown ArgumentDirection");
+}
+
+}  // namespace
+
+auto LowerSubroutineDecl(
+    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym,
+    WalkFrame frame) -> diag::Result<hir::SubroutineDecl> {
+  const auto& mapper = module.SourceMapper();
+  auto return_type_or =
+      module.InternType(sym.getReturnType(), mapper.PointSpanOf(sym.location));
+  if (!return_type_or) {
+    return std::unexpected(std::move(return_type_or.error()));
+  }
+
+  hir::ProceduralBody body;
+  ProcessLowerer lowerer(module, sym);
+  lowerer.AnalyzeLifetimeExtended(sym.getBody());
+  const WalkFrame body_frame = frame.WithProceduralBody(&body, &body.exprs);
+
+  std::vector<hir::SubroutineParam> params;
+  params.reserve(sym.getArguments().size());
+  for (const auto* formal : sym.getArguments()) {
+    auto formal_type_or = module.InternType(
+        formal->getType(), mapper.PointSpanOf(formal->location));
+    if (!formal_type_or) {
+      return std::unexpected(std::move(formal_type_or.error()));
+    }
+    const hir::ProceduralVarId var =
+        lowerer.AddProceduralVar(body, *formal, *formal_type_or);
+    params.push_back(
+        hir::SubroutineParam{
+            .var = var, .direction = ParamDirectionOf(*formal)});
+  }
+
+  std::optional<hir::ProceduralVarId> result_var;
+  if (sym.returnValVar != nullptr) {
+    result_var =
+        lowerer.AddProceduralVar(body, *sym.returnValVar, *return_type_or);
+  }
+
+  auto body_stmt_or = lowerer.LowerStmt(sym.getBody(), body_frame);
+  if (!body_stmt_or) return std::unexpected(std::move(body_stmt_or.error()));
+  body.root_stmt = body.stmts.Add(*std::move(body_stmt_or));
+
+  return hir::SubroutineDecl{
+      .name = std::string{sym.name},
+      .kind = ToHirSubroutineKind(sym.subroutineKind),
+      .result_type = *return_type_or,
+      .params = std::move(params),
+      .result_var = result_var,
+      .body = std::move(body)};
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -11,6 +11,7 @@
 #include <slang/ast/Expression.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/ClassSymbols.h>
+#include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
 #include <slang/ast/types/Type.h>
@@ -24,6 +25,7 @@
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -475,6 +477,37 @@ auto ModuleLowerer::InternClass(
             .name = std::string(prop.name),
             .type = *field_type,
             .initializer = std::nullopt});
+  }
+  for (const auto& method : cls.membersOfType<slang::ast::SubroutineSymbol>()) {
+    // Every class carries compiler-generated built-ins (the randomize family,
+    // LRM 18.6); they are provided by the runtime, not lowered from source.
+    if (method.flags.has(slang::ast::MethodFlags::BuiltIn)) {
+      continue;
+    }
+    if (method.flags.has(slang::ast::MethodFlags::Constructor)) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "user-defined class constructors are not yet supported");
+    }
+    if (method.flags.has(slang::ast::MethodFlags::Static)) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "static class methods are not yet supported");
+    }
+    if (method.flags.has(
+            slang::ast::MethodFlags::Virtual | slang::ast::MethodFlags::Pure)) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "virtual class methods are not yet supported");
+    }
+    if (method.subroutineKind == slang::ast::SubroutineKind::Task) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "class task methods are not yet supported");
+    }
+    auto method_decl = LowerSubroutineDecl(*this, method, WalkFrame{});
+    if (!method_decl) return std::unexpected(std::move(method_decl.error()));
+    decl.methods.push_back(*std::move(method_decl));
   }
   unit_.classes.Define(id, std::move(decl));
   return id;

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -1,8 +1,10 @@
 #include "lyra/lowering/hir_to_mir/class_decl_lowerer.hpp"
 
+#include <expected>
 #include <utility>
 
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/class.hpp"
@@ -63,6 +65,23 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   }
 
   mir_class.constructor_block = std::move(ctor_block);
+
+  // Each instance method (LRM 8.6) is lowered as a callable this class owns: it
+  // resolves the body's `self` to the managed handle, and the method's
+  // declaration-order position becomes its `MethodId`, so a call site naming
+  // the index reaches the same method.
+  for (const auto& method : hir_class.methods) {
+    ScopeChainNode method_link{};
+    const WalkFrame method_owner_frame =
+        WalkFrame{}.WithClass(&mir_class, method_link);
+    ProcessLowerer method_lowerer(
+        module, nullptr, mir_class.time_resolution, method.body, method.name,
+        mir::MethodVisibility::kPublic, method_owner_frame);
+    auto method_or = method_lowerer.Run(method);
+    if (!method_or) return std::unexpected(std::move(method_or.error()));
+    mir_class.methods.Add(*std::move(method_or));
+  }
+
   return mir_class;
 }
 

--- a/src/lyra/lowering/hir_to_mir/completion_payload.cpp
+++ b/src/lyra/lowering/hir_to_mir/completion_payload.cpp
@@ -8,7 +8,7 @@
 namespace lyra::lowering::hir_to_mir {
 
 auto CompletionComponentTypes(
-    const ModuleLowerer& module, const hir::StructuralSubroutineDecl& decl)
+    const ModuleLowerer& module, const hir::SubroutineDecl& decl)
     -> std::vector<mir::TypeId> {
   std::vector<mir::TypeId> components;
   if (decl.result_var.has_value()) {

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -88,7 +88,8 @@ auto LowerContinuousAssign(
               .params = {self_id},
               .result_type = lowerer.Module().Unit().builtins.coroutine_void,
               .body = std::move(process_block)},
-      .overrides = std::nullopt};
+      .overrides = std::nullopt,
+      .visibility = mir::MethodVisibility::kInternal};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -328,7 +328,7 @@ auto LowerStructuralSubroutineCall(
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  const hir::StructuralSubroutineDecl& decl =
+  const hir::SubroutineDecl& decl =
       lowerer.LookupHirSubroutine(usr.hops, usr.subroutine);
   for (const auto& param : decl.params) {
     if (hir::RequiresWriteback(param.direction)) {
@@ -512,6 +512,58 @@ auto LowerBuiltinMethodCall(
       .type = result_type};
 }
 
+// An instance-method call (LRM 8.6): the receiver handle is the first argument,
+// followed by the method's value arguments. The callee names the class method
+// directly; the receiver's class layout, not the call site, decides how the
+// backend dispatches.
+template <ExprLowerer Lowerer>
+auto LowerMethodCall(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    const hir::MethodCallRef& m, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  auto& block = *frame.current_block;
+  std::vector<mir::ExprId> args;
+  args.reserve(c.arguments.size() + 1);
+
+  // The receiver evaluates to the managed handle; the method body operates on
+  // a borrowed pointer to the object (LRM 8.6). Reaching the object from the
+  // handle and taking its address yields that borrowed receiver -- the body
+  // does not own or root the object, the caller's handle does.
+  auto receiver_or =
+      lowerer.LowerExpr(lowerer.HirExprs().Get(m.receiver), frame);
+  if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
+  auto& types = lowerer.Module().Unit().types;
+  const mir::TypeId object_type =
+      std::get<mir::ManagedRefType>(types.Get(receiver_or->type).data).pointee;
+  const mir::ExprId handle_id = block.exprs.Add(*std::move(receiver_or));
+  const mir::ExprId object_id = block.exprs.Add(
+      mir::Expr{
+          .data = mir::DerefExpr{.pointer = handle_id}, .type = object_type});
+  const mir::TypeId self_pointer_type =
+      types.PointerTo(object_type, mir::PointerOwnership::kBorrowed);
+  args.push_back(
+      block.exprs.Add(mir::MakeAddressOfExpr(object_id, self_pointer_type)));
+
+  for (const auto& arg : c.arguments) {
+    if (!arg.has_value()) {
+      throw InternalError("LowerMethodCall: method-call argument elided");
+    }
+    auto arg_or = lowerer.LowerExpr(lowerer.HirExprs().Get(*arg), frame);
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    args.push_back(block.exprs.Add(*std::move(arg_or)));
+  }
+
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::Direct{
+                      .target = mir::MethodId{.value = m.method_index},
+                      .qualification = std::nullopt},
+              .arguments = std::move(args)},
+      .type = result_type};
+}
+
 }  // namespace
 
 template <ExprLowerer Lowerer>
@@ -540,6 +592,9 @@ auto LowerHirCallExpr(
               -> diag::Result<mir::Expr> {
             return LowerStructuralSubroutineCall(
                 lowerer, frame, c, usr, span, result_type);
+          },
+          [&](const hir::MethodCallRef& m) -> diag::Result<mir::Expr> {
+            return LowerMethodCall(lowerer, frame, c, m, result_type);
           },
           [&](const hir::BuiltinMethodRef& b) -> diag::Result<mir::Expr> {
             return LowerBuiltinMethodCall(lowerer, frame, c, b, result_type);

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -282,7 +282,9 @@ auto LowerHirIntegralConstant(const hir::IntegralConstant& c)
 auto LowerHirPrimaryExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::Primary& p,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& lowerer = process.Owner();
+  // A reference to an enclosing-scope declaration resolves against the body's
+  // structural scope; it appears only in a structural body, so the scope is
+  // reached lazily and a class method body never requests it.
   return std::visit(
       Overloaded{
           [&](const hir::IntegerLiteral& i) -> mir::Expr {
@@ -302,16 +304,29 @@ auto LowerHirPrimaryExprProc(
             return LowerHirNullLiteral(result_type);
           },
           [&](const hir::StructuralVarRef& m) -> mir::Expr {
-            return LowerStructuralVarRefExpr(lowerer, frame, m);
+            return LowerStructuralVarRefExpr(
+                process.EnclosingScopeLowerer(), frame, m);
           },
           [&](const hir::ProceduralVarRef& l) -> mir::Expr {
             return LowerProceduralVarRefExpr(process, frame, l, result_type);
           },
+          [&](const hir::ClassPropertyRef& r) -> mir::Expr {
+            const mir::TypeId self_type =
+                frame.current_class->self_pointer_type;
+            const mir::ExprId self_ref = frame.current_block->exprs.Add(
+                MakeSelfRefExpr(frame, self_type));
+            return mir::MakeMemberAccessExpr(
+                self_ref,
+                mir::MemberRef{.var = mir::MemberId{.value = r.field_index}},
+                result_type);
+          },
           [&](const hir::LoopVarRef& lv) -> mir::Expr {
-            return LowerLoopVarRefExpr(lowerer, frame, lv, result_type);
+            return LowerLoopVarRefExpr(
+                process.EnclosingScopeLowerer(), frame, lv, result_type);
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
-            return LowerCrossUnitVarRefExpr(lowerer, frame, c);
+            return LowerCrossUnitVarRefExpr(
+                process.EnclosingScopeLowerer(), frame, c);
           },
           [&](const hir::IterationBindingRef& r) -> mir::Expr {
             return LowerIterationBindingRefExpr(r, frame, result_type);
@@ -347,6 +362,11 @@ auto LowerHirPrimaryExprStructural(
           [](const hir::ProceduralVarRef&) -> mir::Expr {
             throw InternalError(
                 "LowerHirPrimaryExprStructural: HIR ProceduralVarRef does not "
+                "appear in structural expressions");
+          },
+          [](const hir::ClassPropertyRef&) -> mir::Expr {
+            throw InternalError(
+                "LowerHirPrimaryExprStructural: HIR ClassPropertyRef does not "
                 "appear in structural expressions");
           },
           [&](const hir::LoopVarRef& lv) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
@@ -69,7 +69,7 @@ auto LowerPrintTimescaleSystemSubroutineCall(
   // assembled here once and the runtime only sees the same sink write that
   // $display lands on.
   const std::string message = std::format(
-      "Time scale of ({}) is {} / {}", process.Owner().Name(),
+      "Time scale of ({}) is {} / {}", process.EnclosingScopeLowerer().Name(),
       value::TimeUnitText(resolution.unit_power),
       value::TimeUnitText(resolution.precision_power));
   const mir::ExprId text_lit = body.exprs.Add(

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -126,7 +126,8 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
               .params = {self_id},
               .result_type = process.Module().Unit().builtins.coroutine_void,
               .body = std::move(process_block)},
-      .overrides = std::nullopt};
+      .overrides = std::nullopt,
+      .visibility = process.Visibility()};
 }
 
 // Wraps the body in a `forever` loop. `implicit_sensitivity`, if present,
@@ -153,7 +154,8 @@ auto LowerForeverProcess(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     if (implicit_sensitivity != nullptr) {
       body_block.AppendStmt(MakeSensitivityWaitStmt(
-          body_block, body_frame, process.Owner(), *implicit_sensitivity));
+          body_block, body_frame, process.EnclosingScopeLowerer(),
+          *implicit_sensitivity));
     }
   }
 
@@ -176,7 +178,8 @@ auto LowerForeverProcess(
               .params = {self_id},
               .result_type = process.Module().Unit().builtins.coroutine_void,
               .body = std::move(process_block)},
-      .overrides = std::nullopt};
+      .overrides = std::nullopt,
+      .visibility = process.Visibility()};
 }
 
 }  // namespace
@@ -197,7 +200,7 @@ auto ProcessLowerer::Run(const hir::Process& src)
   throw InternalError("ProcessLowerer::Run: unknown HIR ProcessKind");
 }
 
-auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
+auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
     -> diag::Result<mir::MethodDecl> {
   const WalkFrame& parent = owner_ctor_frame_;
   mir::Block body_block;
@@ -328,7 +331,8 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
               .params = std::move(params),
               .result_type = result_type,
               .body = std::move(body_block)},
-      .overrides = std::nullopt};
+      .overrides = std::nullopt,
+      .visibility = Visibility()};
 }
 
 auto ProcessLowerer::BuildReturnPayload(

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -8,6 +8,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -208,12 +208,12 @@ auto LowerDestructuringAssign(
 // callee, or an all-`input` user callee).
 auto SubroutineWithWritebacks(
     const StructuralScopeLowerer& lowerer, const hir::CallExpr& call)
-    -> const hir::StructuralSubroutineDecl* {
+    -> const hir::SubroutineDecl* {
   const auto* ref = std::get_if<hir::StructuralSubroutineRef>(&call.callee);
   if (ref == nullptr) {
     return nullptr;
   }
-  const hir::StructuralSubroutineDecl& decl =
+  const hir::SubroutineDecl& decl =
       lowerer.LookupHirSubroutine(ref->hops, ref->subroutine);
   for (const auto& param : decl.params) {
     if (hir::RequiresWriteback(param.direction)) {
@@ -243,8 +243,8 @@ struct CompletionWriteback {
 auto LowerSubroutineCallWithWritebacks(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::CallExpr& call, const hir::StructuralSubroutineRef& callee_ref,
-    const hir::StructuralSubroutineDecl& decl,
-    std::optional<hir::ExprId> assign_target) -> diag::Result<mir::Stmt> {
+    const hir::SubroutineDecl& decl, std::optional<hir::ExprId> assign_target)
+    -> diag::Result<mir::Stmt> {
   if (call.arguments.size() != decl.params.size()) {
     throw InternalError(
         "LowerSubroutineCallWithWritebacks: argument / formal count mismatch");
@@ -349,8 +349,9 @@ auto LowerSubroutineCallWithWritebacks(
       mir::Expr{
           .data =
               mir::CallExpr{
-                  .callee = process.Owner().TranslateStructuralSubroutine(
-                      callee_ref.hops, callee_ref.subroutine),
+                  .callee = process.EnclosingScopeLowerer()
+                                .TranslateStructuralSubroutine(
+                                    callee_ref.hops, callee_ref.subroutine),
                   .arguments = std::move(call_args)},
           .type = call_result_type});
 
@@ -430,7 +431,8 @@ auto LowerExprStmt(
   // outputs), so the await result is void and the enclosing statement discards
   // it.
   if (const auto* call = std::get_if<hir::CallExpr>(&inner.data)) {
-    if (const auto* decl = SubroutineWithWritebacks(process.Owner(), *call)) {
+    if (const auto* decl =
+            SubroutineWithWritebacks(process.EnclosingScopeLowerer(), *call)) {
       return LowerSubroutineCallWithWritebacks(
           process, frame, std::move(label), *call,
           std::get<hir::StructuralSubroutineRef>(call->callee), *decl,
@@ -457,7 +459,7 @@ auto LowerExprStmt(
         const auto* struct_ref =
             std::get_if<hir::StructuralSubroutineRef>(&call->callee)) {
       suspends =
-          process.Owner()
+          process.EnclosingScopeLowerer()
               .LookupHirSubroutine(struct_ref->hops, struct_ref->subroutine)
               .kind == hir::SubroutineKind::kTask;
     }
@@ -490,8 +492,8 @@ auto LowerExprStmt(
         conv_target_type = rhs->type;
       }
       if (const auto* call = std::get_if<hir::CallExpr>(&call_carrier->data)) {
-        if (const auto* decl =
-                SubroutineWithWritebacks(process.Owner(), *call)) {
+        if (const auto* decl = SubroutineWithWritebacks(
+                process.EnclosingScopeLowerer(), *call)) {
           if (!conv_target_type.has_value()) {
             return LowerSubroutineCallWithWritebacks(
                 process, frame, std::move(label), *call,

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -170,7 +170,8 @@ auto LowerEventTimedStmt(
           }
         }
         return MakeSensitivityWaitStmt(
-            child_block, child_frame, process.Owner(), union_reads);
+            child_block, child_frame, process.EnclosingScopeLowerer(),
+            union_reads);
       });
 }
 
@@ -184,7 +185,8 @@ auto LowerImplicitEventTimedStmt(
       [&](mir::Block& child_block,
           WalkFrame child_frame) -> diag::Result<mir::Stmt> {
         return MakeSensitivityWaitStmt(
-            child_block, child_frame, process.Owner(), ie.sensitivity_list);
+            child_block, child_frame, process.EnclosingScopeLowerer(),
+            ie.sensitivity_list);
       });
 }
 
@@ -306,7 +308,7 @@ auto LowerWaitStmt(
   mir::Block inner_block;
   const WalkFrame inner_frame = wrapper_frame.WithBlock(&inner_block).Deeper();
   inner_block.AppendStmt(MakeSensitivityWaitStmt(
-      inner_block, inner_frame, process.Owner(), reads));
+      inner_block, inner_frame, process.EnclosingScopeLowerer(), reads));
 
   const mir::BlockId inner_scope_id =
       wrapper.child_scopes.Add(std::move(inner_block));

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -1757,8 +1757,8 @@ auto StructuralScopeLowerer::Run(
     const auto& src = hir_scope.structural_subroutines.Get(
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
     ProcessLowerer subroutine_lowerer(
-        module, lowerer, hir_scope.time_resolution, src.body, src.name,
-        scope_frame);
+        module, &lowerer, hir_scope.time_resolution, src.body, src.name,
+        mir::MethodVisibility::kInternal, scope_frame);
     auto decl_or = subroutine_lowerer.Run(src);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId added = mir_class.methods.Add(*std::move(decl_or));
@@ -1772,8 +1772,8 @@ auto StructuralScopeLowerer::Run(
   for (const auto& p : hir_scope.processes) {
     std::string name = std::format("process_{}", mir_class.methods.size());
     ProcessLowerer process_lowerer(
-        module, lowerer, hir_scope.time_resolution, p.body, std::move(name),
-        scope_frame);
+        module, &lowerer, hir_scope.time_resolution, p.body, std::move(name),
+        mir::MethodVisibility::kInternal, scope_frame);
     auto decl_or = process_lowerer.Run(p);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
@@ -1829,7 +1829,8 @@ auto StructuralScopeLowerer::Run(
                     .result_type = void_type,
                     .body = std::move(resolve_block)},
             .overrides = mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
-                .method = mir::RuntimeMethod::kResolve}}});
+                .method = mir::RuntimeMethod::kResolve}},
+            .visibility = mir::MethodVisibility::kInternal});
   }
   if (!initialize_block.root_stmts.empty()) {
     mir_class.methods.Add(
@@ -1841,7 +1842,8 @@ auto StructuralScopeLowerer::Run(
                     .result_type = void_type,
                     .body = std::move(initialize_block)},
             .overrides = mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
-                .method = mir::RuntimeMethod::kInitialize}}});
+                .method = mir::RuntimeMethod::kInitialize}},
+            .visibility = mir::MethodVisibility::kInternal});
   }
   if (!activate_block.root_stmts.empty()) {
     mir_class.methods.Add(
@@ -1853,7 +1855,8 @@ auto StructuralScopeLowerer::Run(
                     .result_type = void_type,
                     .body = std::move(activate_block)},
             .overrides = mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
-                .method = mir::RuntimeMethod::kActivate}}});
+                .method = mir::RuntimeMethod::kActivate}},
+            .visibility = mir::MethodVisibility::kInternal});
   }
 
   module.Unit().DefineClass(own_id, std::move(mir_class));

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -49,6 +49,19 @@ class MirDumper {
     Line("Class:");
     Indent();
     DumpClass(unit.root, unit.GetClass(unit.root));
+    // A class reached by a handle is not a child of the runtime tree, so it is
+    // not dumped under the root; every such class carries no runtime base.
+    for (std::size_t i = 0; i < unit.classes.size(); ++i) {
+      const ClassId id{static_cast<std::uint32_t>(i)};
+      if (id == unit.root || !unit.classes.IsDefined(id)) {
+        continue;
+      }
+      const Class& cls = unit.GetClass(id);
+      if (cls.base.has_value()) {
+        continue;
+      }
+      DumpClass(id, cls);
+    }
     Dedent();
     Dedent();
     return std::move(out_);
@@ -719,6 +732,10 @@ class MirDumper {
         std::format(
             "[{}] \"{}\" : Type[{}]", index, d.name, d.code.result_type.value));
     Indent();
+    Line(
+        std::format(
+            "Visibility: {}",
+            d.visibility == MethodVisibility::kPublic ? "public" : "internal"));
     if (d.overrides.has_value()) {
       const auto& ref = std::get<RuntimeLibraryMethodRef>(*d.overrides);
       std::string_view target = "Resolve";

--- a/tests/cases/cpp/class_methods/case.yaml
+++ b/tests/cases/cpp/class_methods/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_methods
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    after_set: 10
+    after_add: 15

--- a/tests/cases/cpp/class_methods/main.sv
+++ b/tests/cases/cpp/class_methods/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  class Counter;
+    int value;
+    function void set(int v);
+      value = v;
+    endfunction
+    function void add(int delta);
+      value = value + delta;
+    endfunction
+    function int get();
+      return value;
+    endfunction
+  endclass
+
+  Counter c;
+  int after_set;
+  int after_add;
+  initial begin
+    c = new;
+    c.set(10);
+    after_set = c.get();
+    c.add(5);
+    after_add = c.get();
+  end
+endmodule


### PR DESCRIPTION
## Summary

This adds the first working SystemVerilog class instance methods: a class declares `function` methods that read and write its properties, and other code calls them through a handle (`h.set(5)`, `r = h.get()`). It completes the minimal class surface started earlier (fields, `new`, handle equality) with direct instance-method calls carrying input arguments and a value or void return.

## Design

A method body's receiver `self` is a borrowed pointer to the object, not the managed handle. object_lifetime.md fixes the receiver used in a body as a borrow that derives from a root, so the call site coerces the handle to a borrowed object pointer through existing primitives (`AddressOf(Deref(handle))`) rather than passing the handle as `self`. This keeps `self` uniform across constructor bodies, scope callables, and class methods, and removes a type branch from the call render.

Method access is a stated MIR attribute (`MethodVisibility` on `mir::MethodDecl`): a class instance method is public callable surface, while a scope's processes, lifecycle hooks, and helper subroutines are internal. The C++ backend reads that attribute instead of inferring visibility from the object's base, which also keeps it correct once class inheritance gives a derived class a base.

Class method bodies reuse the one procedural-body lowerer. That lowerer now carries its enclosing structural scope as a nullable fact -- a class method body sits inside no structural scope, so the fact is absent there -- which models the relationship as it is rather than through a base class spanning the scope and class lowering passes. lowering_organization.md's invariant on shared base classes is rewritten to target the real harm, a base that couples one pass's state onto another, instead of forbidding any shared type.

## Testing

A new end-to-end case (`tests/cases/cpp/class_methods`) exercises a class with `set` / `add` / `get` methods called through a handle and asserts the resulting variable values. The full `bazel test //...` suite passes.
