### PR TITLE
Streamline commit and merged slash commands

### DIFF
--- a/.claude/commands/commit-pr.md
+++ b/.claude/commands/commit-pr.md
@@ -26,6 +26,7 @@ Do NOT proceed with formatting or staging until you are on a feature branch.
 - **Commits on this branch:** !`git log --oneline main..HEAD 2>/dev/null || echo "(new branch)"`
 - **Full diff from main:** !`git diff --merge-base origin/main HEAD --stat`
 - **Commits behind main:** !`git fetch origin main --quiet 2>/dev/null && git rev-list --count HEAD..origin/main 2>/dev/null || echo "0"`
+- **Prettier (must match package-lock; run `npm ci` if it drifts):** !`npx prettier --version`
 
 ## Branch Rules
 
@@ -71,7 +72,7 @@ Each tool runs **once**. Formatters run in write mode; rerunning them in check m
    - Do not narrow `//...`. Fix failures before continuing.
 3. **Format (write mode, once each):**
    - `find src include tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i`
-   - `npx prettier --write "**/*.md"`
+   - `npm run format` (markdown; lock-pinned Prettier, not a bare `npx prettier`)
    - `buildifier -r .`
 4. **Lint and policy:**
    - `buildifier -mode=check -lint=warn -r .`

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -41,7 +41,7 @@ Same target set CI runs. Do not narrow `//...`. Fix failures before staging.
 
 ```bash
 find src include tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i
-npx prettier --write "**/*.md"
+npm run format  # markdown; lock-pinned Prettier, not a bare npx prettier
 buildifier -r .
 ```
 

--- a/.claude/commands/merged.md
+++ b/.claude/commands/merged.md
@@ -11,15 +11,22 @@ Clean up local branch after PR is merged.
 ## Context
 
 - **Current branch:** !`git branch --show-current`
+- **PR state:** !`gh pr view --json state --jq '.state' 2>/dev/null || echo "(no PR for this branch)"`
+- **PR url:** !`gh pr view --json url --jq '.url' 2>/dev/null || echo "-"`
 - **All local branches:** !`git branch`
 
 ## Instructions
 
-1. Check if the PR for the current branch is merged: `gh pr view --json state --jq '.state'`
-   - If **not merged**: tell the user it's not merged yet, provide the PR link (`gh pr view --json url --jq '.url'`), and stop.
-   - If **merged**: continue with cleanup below.
-2. Switch to main: `git switch main`
-3. Pull latest: `git pull`
-4. Delete local branch with `-D` (squash merge requires force): `git branch -D <branch>`
+Read **PR state** above -- it is already resolved, no need to query again.
 
-The remote branch is auto-deleted by GitHub on merge.
+- Not `MERGED`: tell the user it is not merged yet, give the **PR url**, and stop.
+- `MERGED`: clean up in one command (each `&&` gates the next, so a failed step stops before the
+  delete):
+
+  ```bash
+  git switch main && git pull && git branch -D <branch>
+  ```
+
+  Fill `<branch>` with the merged branch (the **Current branch** above) -- named explicitly, not
+  auto-detected, so a stray run on the wrong branch cannot silently delete it. `-D` because a squash
+  merge requires force; GitHub auto-deletes the remote branch.


### PR DESCRIPTION
## Summary

The commit / commit-pr slash commands formatted markdown with a bare `npx prettier`, which uses whatever Prettier version is resolvable -- often newer than the version `package-lock.json` pins and CI installs via `npm ci`. The two versions wrap prose differently, so a file formatted locally passed but failed the CI markdown check. The skills now format via `npm run format` (the lock-pinned Prettier, exactly what CI runs) and `commit-pr` surfaces the active Prettier version in its context so any drift is visible at a glance.

The `merged` command now resolves the PR state in its context (via a `!` command) instead of as a separate query step, so merged-or-not is immediate on invocation, and collapses the cleanup into one gated command (the branch to delete is still named explicitly, not auto-detected, so a stray run cannot silently delete the wrong branch).