### PR TITLE
Stage HIR-to-MIR structural lowering in two phases

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -56,6 +56,11 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 
 - [lowering-organization](lowering-organization.md) -- how lowering passes organize their internal
   objects (facts, registries, builders, walk frame).
+- [declarations-before-bodies](declarations-before-bodies.md) -- within a compilation unit, every
+  structural declaration's identity and shape is CU-global, canonical, and queryable through the
+  compilation unit before any executable lowering begins; covers subroutine forward / mutual
+  reference, cross-scope hierarchical reference's typed segments, SV class mutual reference, and
+  hierarchical callable dispatch.
 - [foreach-lowering](foreach-lowering.md) -- the lowering shape of `foreach`.
 - [conversion-folding](conversion-folding.md) -- when type conversions are folded.
 - [variable-initialization](variable-initialization.md) -- LRM 10.5 variable initialization as a

--- a/docs/decisions/declarations-before-bodies.md
+++ b/docs/decisions/declarations-before-bodies.md
@@ -1,0 +1,286 @@
+# Declarations Before Bodies
+
+## Date
+
+2026-06-28
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+A program admits mutual references between sibling declarations: two subroutines may call each other
+(LRM 13.7), two classes may forward-declare each other and refer back in their bodies (LRM 8.24), a
+process body in one generate scope may reach a sibling's signal, a hierarchical callable in a class
+may dispatch through a base whose own body has not yet lowered. The pattern is universal across
+programming-language compilers: a body cannot reference what is not yet declared, so every IR layer
+that admits mutual reference within a structural scope must produce all identities before any body
+is lowered.
+
+The lowering today honors this for the smallest case -- a structural scope's subroutines reserve
+their `MethodId`s before any subroutine body lowers, so a peer call resolves regardless of source
+order. Larger cases (cross-scope hierarchical reference, class mutual reference, hierarchical
+callable) need the same property at compilation-unit scope. Pinning the invariant once, with a
+single mechanism, prevents the codebase from re-deriving it per feature and lets every consumer rely
+on it without inspecting how each particular declaration was built.
+
+## The invariant
+
+> Within a compilation unit, every structural declaration's identity and shape is canonical,
+> CU-global, and queryable through the compilation unit before any executable lowering begins.
+
+The four properties carry distinct weight:
+
+- **Identity** -- every declaration has a stable id (`ClassId`, `MethodId`, `MemberId`, `TypeId`,
+  ...) minted before any body lowers.
+- **Shape** -- the structural facts a body may need to read about the declaration (a class's members
+  and contained children, a method's signature, a type alias's target, an instance's external-unit
+  name) are populated alongside the identity.
+- **CU-global** -- the source of truth is the compilation unit's class / type / method registries.
+  Cross-declaration queries during body lowering reach declarations through the unit, not through a
+  sibling lowerer's private state.
+- **Queryable** -- after the declaration pass completes, any consumer can resolve any peer
+  declaration's shape by id, with no ordering dependency on which body lowers first.
+
+An IR layer that admits mutual reference must satisfy these four properties. An IR layer that does
+not (a strictly linear declaration order, no forward reference) is free to interleave declaration
+and body, but neither HIR nor MIR is such a layer.
+
+## Decisions
+
+### D1. Lowering is staged: declarations precede executable bodies
+
+A lowering pass that produces a structural-declaration-bearing IR runs in two stages over the
+compilation unit, in this order:
+
+1. **Declare** -- mint every declaration's identity and populate its shape on the compilation unit's
+   registries. No expression is lowered, no executable statement is emitted, no block accumulates.
+2. **Lower bodies** -- lower every body (subroutine, process, initializer, action, constructor,
+   install statement) into blocks attached to the relevant declarations. Cross-declaration
+   references resolve through the registries populated in stage 1.
+
+A lowering pass that violates this staging cannot satisfy mutual reference; the staging is not an
+optimization.
+
+### D2. Published shape is canonical for cross-declaration query during lowering
+
+A declared shape becomes a canonical query target the moment the declare pass publishes it. Lowerer
+objects, builder objects, and walk-time stack frames do not own published shape; they may hold local
+state while constructing one shape value, but the queryable home is a registry whose contract is
+"every id resolves to a complete shape". A consumer that wants to read peer shape during body
+lowering reaches that registry by id, never another lowerer's private state.
+
+The publication store's lifetime is the lowering pass. Once the pass returns its finished
+compilation unit, the publication store is destroyed; the compilation unit holds the sole
+authoritative class store thereafter (the final `mir::Class` registry). No half-alive,
+partially-consumed shape registry survives into the finished unit.
+
+### D3. Declaration ordering inside a CU is unspecified
+
+The declare stage may visit declarations in any order that respects each declaration's own
+dependencies (a member typed by an internal object type requires that object type's id minted
+first). The lowering pipeline picks an order that satisfies these intra-declaration dependencies;
+the order is an implementation matter and is not observable to body lowering, which reads
+declarations by id without seeing how they were ordered. Source order does not classify and does not
+select mechanism.
+
+### D4. Reservation and population are one step per declaration
+
+A declaration's identity and its shape are minted as one step. The registry does not expose a
+half-state where an id exists but the shape is absent; either the id is in the registry with a
+populated shape, or the id has not yet been minted. This is the operational form of "queryable after
+declare stage": every minted id resolves to a usable shape.
+
+A declaration may carry a forward-typed reference to another declaration that has not yet been
+minted (a class that names another class as a field type). The pass orders the mints to satisfy
+those dependencies, or uses a registry primitive that supports forward identity reservation followed
+by shape attachment for the cyclic case; either way, the consumer-visible contract is "every
+queryable id has a populated shape."
+
+### D5. Executable bodies attach to existing declarations; they never grow new shape
+
+The body-lowering stage may add executable content to existing declarations (a method's body, a
+constructor's block, a process's coroutine). It does not mint new structural declarations a peer's
+body might reference; if the body needs an identity not already minted, the declaration was missing
+from stage 1 and the pipeline is wrong. This keeps body lowering an emission step against a fixed
+declaration set.
+
+This does not forbid stage 2 from adding declarations that no body references -- a synthesized
+deferred-check site, a per-action capture descriptor -- whose existence is local to body lowering
+and whose id is never read cross-declaration.
+
+### D6. The shape store is the sole source of cross-class structural queries during body lowering
+
+During the body-lowering stage, the compilation unit's class registry is a one-way commit sink: each
+class is added once when its bodies are complete, and the registry's only use from inside the
+lowering pipeline is `Define`, never `Get`. Any cross-class structural query a body lowering needs
+(peer member ids, contained-child ids, method signatures, type aliases, name) reads from the shape
+store, which holds the full set of class shapes from the moment the declare stage completes.
+
+This invariant forbids a regression where a body lowering reads peer shape via the class registry:
+such a read would succeed for classes that happened to finalize earlier and fail for classes that
+have not yet finalized, silently reintroducing source-order dependence into what must be
+order-independent.
+
+### D7. Anticipated future extension: callable signatures join the shape
+
+When a body lowering needs peer callable identity or signature -- the case for SV class virtual
+dispatch and for hierarchical callable resolution -- the callable's signature joins the structural
+shape, leaving the callable's body in the body-lowering stage. The expected concrete form is to
+split `MethodDecl` into a signature part (name, parameter list, result type, override target -- in
+the shape) and a body part (the executable block -- composed at finalize alongside the constructor
+block and the other lifecycle blocks).
+
+The split has not happened yet because the current consumer (cross-scope typed member access) needs
+only member ids, not method ids. The split lands together with the work that first requires it; no
+field on the shape is added speculatively before then.
+
+## Applications
+
+The invariant covers every IR boundary that admits mutual reference within a structural scope. The
+following are the known applications; each is one instance of the same staging, not a separate
+mechanism.
+
+- **Subroutine forward / mutual reference within a structural scope** (LRM 13.7). Peer subroutine
+  call resolves to a `MethodId` minted before any subroutine body lowers. Today's code already
+  honors this with `MapStructuralSubroutine` reserving ids in advance.
+- **Cross-scope hierarchical reference's typed segments**
+  (`../decisions/hierarchical-reference-routing.md`). A sibling reference's typed `MemberAccess`
+  chain reaches peer scope members via `MemberId`s minted before any body lowers. The structural
+  declaration pass covers every scope in the CU; the body lowering pass reads peer members through
+  the unit registry.
+- **SV class forward / mutual reference** (LRM 8.24).
+  `typedef class Pair; class Edge; Pair p; function ...; endclass class Pair; Edge e; endclass`.
+  Both classes' shapes (fields, method signatures) live in the registry before either body lowers. A
+  method body referencing the peer class resolves its `ClassId` through the registry.
+- **Hierarchical callable dispatch.** A virtual call from a derived class through a base whose body
+  has not yet lowered resolves through the base's already-minted method signatures.
+- **Interface and modport reference.** An interface's externally visible surface (modport
+  declarations, virtual interface targets) is shape; a body that references it reads through the
+  registry.
+
+The same invariant applies to future structural concepts that admit cross-reference; new
+applications do not introduce new mechanism.
+
+## Rejected alternatives
+
+- **Lowerer-owned `optional<mir::Class>` carrying the in-progress declaration.** Puts the source of
+  truth for declared shape on a sibling lowerer object rather than on a published registry. Peer
+  body lowering must thread the lowerer tree to find a peer's shape; cross-scope queries become
+  walk-coupled. Race-prone in practice: a query against a peer whose lowerer has not yet populated
+  its `optional` fails opaquely, and the lowering tree's traversal order leaks into what a body can
+  read. Rejected.
+
+- **Lazy `MemberId` / `ClassId` backpatch.** Bodies emit forward-reference tokens at lowering time;
+  a finalize stage resolves them when the target shape eventually appears. Introduces an implicit
+  third phase whose ordering is encoded in the resolution machinery; failure timing is opaque (a
+  malformed reference does not surface until finalize); MIR sits in a partially-valid state between
+  body lowering and finalization; backends inherit a token concept they should not have to know
+  about. Rejected.
+
+- **A synthetic endpoint type wrapping each cross-instance reference.** Pushes the cross-scope
+  access through a wrapper protocol (`ReadBound(endpoint)`) rather than through ordinary access on
+  the target's existing type. Mismatched with the architecture's contract that the endpoint is the
+  target itself (`hierarchical-reference-routing.md` D3); the wrapper would also re-introduce
+  hierarchy traversal at body-execution time when the target's storage is reached only through the
+  wrapper's protocol. Rejected.
+
+- **Source-order declaration with no forward reservation.** Lower each declaration's identity in
+  source order, hope a body's references reach already-declared peers. Brittle under generate
+  expansion, fails outright on cyclic mutual reference, and reintroduces the "lexical order shapes
+  mechanism" failure that the architecture is removing elsewhere. Rejected.
+
+- **Eager `DefineClass` interspersed with the walk.** A single-pass walk that defines each class as
+  it is built. A consumer reading a peer class observes whatever subset of the peer's content has
+  been built so far; the visible state of a peer depends on where its walk currently sits, which the
+  consumer cannot know. Rejected; the registry's visibility contract is "all-or-nothing per stage",
+  not "growing as the walk progresses".
+
+- **Splitting the public IR into separate declaration and body artifacts (`ClassDecl` + `ClassBody`,
+  joined externally by id).** Pure value-immutability for both halves, but exposes the two-stage
+  construction as a permanent property of the IR. Consumers (backend, dump, validators) must pair
+  two registries on every class access; methods split into separate `MethodSignature` and method
+  body, requiring downstream code to join them. A SystemVerilog module / generate scope / class is
+  one semantic entity; the IR keeps it one entity, with the staged construction hidden inside the
+  lowering. Rejected.
+
+- **A generic `Registry::Mutate(id) -> T&` primitive, even if only one caller is intended.** Once
+  the primitive exists it advertises "registry entries are mutable" at the type level, and a future
+  contributor confronting a new two-stage problem reaches for it as an escape hatch. The "staged
+  population" need is solved by separate value-immutable artifacts (one per stage), each going
+  through the original `Declare` / `Define`-once contract, not by relaxing the primitive. The
+  parallel form `Refine(id, fn)` is the same relaxation in different syntax. Rejected.
+
+- **Per-class consume that leaves the publication store partially moved-from while still alive.** At
+  finalize time, each class's shape entry is moved into the composed `mir::Class`; the shape store
+  still exists with the remaining slots populated and the moved-from slots holding empty values. Any
+  later read of a moved-from slot returns an empty shape silently. Type / lifetime do not encode
+  "this slot has been consumed". Rejected in favor of whole-store consume: the shape store's
+  lifetime is the lowering pass; once the pass returns, the store is destroyed wholesale. Within the
+  pass, individual finalizes copy shape into the composed `mir::Class`, leaving the shape store's
+  slots intact for peer queries from later finalizes.
+
+## Consequences
+
+- **Shape and final class are two value-immutable artifacts under one identity.** A class's identity
+  is one id. Its shape is a value built once during the declare pass and published to a registry
+  that exists for the lifetime of the lowering pass; the registry's contract is the original "every
+  minted id resolves to a populated value" (one `Declare` + one `Define` per id). Its final form is
+  a second value built once during the body pass and posted to the compilation unit's own class
+  registry through the same contract. Neither value is mutated after publication; the staged
+  construction is purely internal to the lowering pass.
+
+- **The publication store of shapes lives on the lowering pass, not on the compilation unit.** After
+  the lowering pass returns its finished compilation unit, the shape store is destroyed. The
+  finished unit holds the sole authoritative class store -- the registry of fully-composed
+  `mir::Class` values. Downstream consumers (backend, dump, validators) see one class per id, with
+  shape and bodies together; they never reach for a separate shape store, and no shape store
+  survives in any form they could touch.
+
+- **The composed `mir::Class` copies its shape fields from the published shape at finalize.** The
+  shape store stays valid throughout the body pass so peer body lowerings can keep reading it
+  through finalize boundaries; each per-class finalize copies the relevant shape into the freshly
+  constructed `mir::Class` and adds the body parts. Memory cost is one extra arena per class for the
+  shape's lifetime, traded for the clean property that the publication store is never partly
+  moved-from while it is still being read.
+
+- **Lowering passes split into two CU-wide stages.** A pass that produces declared-shape-bearing IR
+  drives a recursive declare walk first and a recursive body-lowering walk second. Each stage's
+  recursion is internal to the pass; the boundary between them is the architecture-visible point. A
+  pass's class organization (per `decisions/lowering-organization.md`) is unchanged: dispatcher
+  methods, walk-frame discipline, and per-kind handlers remain. The two stages are two entries on
+  the pass class, not two pass classes.
+
+- **`StructuralScopeLowerer` carries no in-progress declared shape.** After the declare stage, the
+  scope's shape lives on the lowering pass's publication store. The lowerer's per-instance state
+  shrinks to its HIR-to-MIR identity maps, the child-lowerer tree it owns for the body stage, and
+  whichever local facts the body stage needs that derive from neither registry nor maps. The blocks
+  the body stage accumulates (constructor, resolve, initialize, activate) are body-stage locals; the
+  slot-var lists, instance-member-var lists, and generate binding tables an earlier draft of this
+  refactor cached as parallel state are derivable from the publication store plus the existing
+  identity maps and are not stored separately.
+
+- **Cross-class shape query is one path.** Peer body lowering reads peer shape through the
+  publication store's `GetClassShape(id)`. There is no parallel query route through the lowerer
+  tree; the publication store is the single source of truth for shape during the body pass.
+
+- **Acceptance for an architectural refactor under this contract is semantic equivalence, not
+  byte-for-byte MIR identity.** Declaration ordering within the unit is unspecified; consumers must
+  read by id, not by position. A refactor that changes declaration order while preserving the
+  semantic outcome is conforming.
+
+## Cross-references
+
+- `../architecture/lowering_organization.md` -- the pass-class shape (dispatcher, walk frame,
+  registries) the staged lowering builds on; this decision adds the staging discipline, not a new
+  pass class shape.
+- `../architecture/mir.md` -- the IR layer whose registries house the declared shape and the
+  executable bodies.
+- `lowering-organization.md` -- the prior decision establishing the pass-class shape.
+- `hierarchical-reference-routing.md` -- one application: cross-scope typed segments read peer
+  members through the staged registry.
+- `binding-graph-resolution.md` -- the resolution-ordering decision the routing builds on;
+  orthogonal to this decision but cited by the same lowering pipeline.
+- `object-model-storage.md` -- the class-declaration registry that is the home of declared object
+  shape.

--- a/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
@@ -10,6 +12,8 @@
 #include "lyra/diag/source_manager.hpp"
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/mir/class.hpp"
+#include "lyra/mir/class_id.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/type.hpp"
 
@@ -110,6 +114,31 @@ class ModuleLowerer {
   [[nodiscard]] auto NextGenerateScopeName(std::string_view arm_tag)
       -> std::string;
 
+  // Posts a class's structural shape; the shape is committed once and is
+  // read back during peer-body lowering.
+  void DefineClassShape(mir::ClassId id, mir::ClassShape shape) {
+    if (id.value >= class_shapes_.size()) {
+      class_shapes_.resize(id.value + 1);
+    }
+    auto& slot = class_shapes_[id.value];
+    if (slot.has_value()) {
+      throw InternalError(
+          "ModuleLowerer::DefineClassShape: shape for this id is already "
+          "defined");
+    }
+    slot = std::move(shape);
+  }
+
+  [[nodiscard]] auto GetClassShape(mir::ClassId id) const
+      -> const mir::ClassShape& {
+    if (id.value >= class_shapes_.size() ||
+        !class_shapes_[id.value].has_value()) {
+      throw InternalError(
+          "ModuleLowerer::GetClassShape: shape for this id is not defined");
+    }
+    return *class_shapes_[id.value];
+  }
+
  private:
   [[nodiscard]] auto TranslateTypeData(const hir::TypeData& data) const
       -> mir::TypeData;
@@ -121,6 +150,10 @@ class ModuleLowerer {
   std::vector<mir::ClassId> class_map_;
   std::vector<mir::TypeId> class_object_type_map_;
   std::uint32_t next_generate_scope_name_ = 0;
+  // Class shapes published during the declare pass and read during peer-body
+  // lowering. Lives only on the lowerer; the finished compilation unit holds
+  // the only authoritative class representation.
+  std::vector<std::optional<mir::ClassShape>> class_shapes_;
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <span>
 #include <string>
@@ -62,9 +63,13 @@ struct CrossUnitRefMeta {
   mir::TypeId slot_type = {};
 };
 
-// Per-scope lowering registries for one `mir::Class`. Carries
-// scope-local HIR-to-MIR translation maps and the cross-unit-ref slot table.
-// Holds no pointer to the IR scope being built: handlers reach it through
+// Lowers one HIR structural scope into one MIR class across two ordered
+// phases. Carries the scope-local HIR-to-MIR identity mappings populated in
+// `DeclareShape` and consulted in `PopulateBodies`; borrows the enclosing
+// scope's lowerer through `parent_` for hops-walked cross-scope lookups; and
+// owns descendant scope lowerers in `children_` so the structural-scope tree
+// stays alive across the phase boundary. The lowerer itself holds no
+// pointer to the in-progress `mir::Class`: body handlers reach it through
 // `frame.current_class`.
 class StructuralScopeLowerer {
  public:
@@ -77,14 +82,20 @@ class StructuralScopeLowerer {
         hir_scope_(&hir_scope) {
   }
 
-  // Registers this object in the unit, walks the HIR scope body to build its
-  // declaration, and returns its identity. Handlers reached through dispatch
-  // write to `frame.current_class`. `entry_bindings` are the structural params
+  // Mints this class's identity, builds its structural shape, publishes the
+  // shape so peer body lowering can query it, and recurses to declare every
+  // descendant scope's shape. `entry_bindings` are the structural params
   // injected by an enclosing for-generate iteration.
-  auto Run(
-      WalkFrame parent_frame,
+  auto DeclareShape(
       std::span<const ScopeEntryStructuralParamBinding> entry_bindings = {})
       -> diag::Result<mir::ClassId>;
+
+  // Lowers every body and every install statement against the already-
+  // published shape, recurses into descendants, and commits the composed
+  // class to the compilation unit. `parent_frame` carries the
+  // enclosing-class chain this scope's bodies thread through; the root call
+  // receives a default `WalkFrame`.
+  auto PopulateBodies(WalkFrame parent_frame) -> diag::Result<void>;
 
   // Central scope-level expression dispatcher. One switch over `hir::Expr::
   // data` routing each kind to the per-family handler in `expression/*.cpp`.
@@ -243,6 +254,16 @@ class StructuralScopeLowerer {
     instance_member_map_.push_back(mir_id);
   }
 
+  [[nodiscard]] auto TranslateInstanceMember(hir::InstanceMemberId hir_id) const
+      -> mir::MemberId {
+    if (hir_id.value >= instance_member_map_.size()) {
+      throw InternalError(
+          "StructuralScopeLowerer::TranslateInstanceMember: unmapped HIR "
+          "instance member");
+    }
+    return instance_member_map_[hir_id.value];
+  }
+
   void MapGenerate(hir::GenerateId hir_id, GenerateBindings bindings) {
     if (hir_id.value != generate_map_.size()) {
       throw InternalError(
@@ -251,6 +272,16 @@ class StructuralScopeLowerer {
           "order");
     }
     generate_map_.push_back(std::move(bindings));
+  }
+
+  [[nodiscard]] auto LookupGenerateBindings(hir::GenerateId hir_id) const
+      -> const GenerateBindings& {
+    if (hir_id.value >= generate_map_.size()) {
+      throw InternalError(
+          "StructuralScopeLowerer::LookupGenerateBindings: unmapped HIR "
+          "generate");
+    }
+    return generate_map_[hir_id.value];
   }
 
   // Resolves an owned-child reference (the `child` field of a
@@ -394,6 +425,8 @@ class StructuralScopeLowerer {
   std::vector<std::optional<mir::LocalRef>> loop_var_procedural_map_;
   std::vector<mir::MemberId> instance_member_map_;
   std::vector<GenerateBindings> generate_map_;
+  mir::ClassId class_id_{};
+  std::vector<std::unique_ptr<StructuralScopeLowerer>> children_;
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -17,6 +17,22 @@
 
 namespace lyra::mir {
 
+// The structural portion of a class declaration: the fields a peer needs to
+// read about a class while its own body is being lowered. Each field has the
+// same semantics as the same-named field on `Class`; the executable parts
+// (`constructor_block`, `methods`) are not represented here.
+struct ClassShape {
+  std::string name;
+  std::optional<ClassRef> base;
+  TypeId self_pointer_type;
+  TimeResolution time_resolution;
+  base::Arena<ParamDecl, ParamId> ctor_prefix_params;
+  base::Arena<ParamDecl, ParamId> params;
+  base::Arena<MemberDecl, MemberId> members;
+  std::vector<ClassId> contained;
+  std::vector<TypeAliasDecl> type_aliases;
+};
+
 struct Class {
   std::string name;
   // The base this object extends, or absent for a plain object that is not a

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -50,9 +50,14 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
     unit_.DefineClass(TranslateClass(hir_id), *std::move(class_or));
   }
 
+  // Two-sweep structural lowering: the first sweep mints every class identity
+  // and publishes its shape; the second lowers every body and commits the
+  // composed class to the unit.
   StructuralScopeLowerer root(*this, nullptr, hir_->name, hir_->root_scope);
-  auto top_r = root.Run(root_frame);
+  auto top_r = root.DeclareShape();
   if (!top_r) return std::unexpected(std::move(top_r.error()));
+  auto body_r = root.PopulateBodies(root_frame);
+  if (!body_r) return std::unexpected(std::move(body_r.error()));
 
   unit_.root = *top_r;
   return std::move(unit_);

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -69,20 +69,13 @@ auto CompanionVarNameFor(std::string_view child_scope_name) -> std::string {
 }
 
 void CheckNoNameCollision(
-    const mir::CompilationUnit& unit, const mir::Class& owner_class,
-    std::string_view child_scope_name, std::string_view companion_var_name) {
-  for (const auto& v : owner_class.members) {
+    const mir::ClassShape& owner_shape, std::string_view child_scope_name,
+    std::string_view companion_var_name) {
+  for (const auto& v : owner_shape.members) {
     if (v.name == companion_var_name || v.name == child_scope_name) {
       throw InternalError(
           "child class or companion var name collides with an existing "
           "member declaration in the enclosing class");
-    }
-  }
-  for (const mir::ClassId child : owner_class.contained) {
-    if (unit.GetClass(child).name == child_scope_name) {
-      throw InternalError(
-          "child class name collides with an existing nested class "
-          "declaration in the enclosing class");
     }
   }
 }
@@ -416,17 +409,16 @@ void AppendExternalUnitConstruction(
       var.type, dims, indices);
 }
 
-// Returns the StructuralVarId of each instance member, indexed by
-// InstanceMemberId, so cross-unit reference resolution can reach the child
-// instance var by the same id the HIR recipe carries.
-auto InstallInstanceMembers(StructuralScopeLowerer& lowerer, WalkFrame frame)
-    -> std::vector<mir::MemberId> {
-  mir::Class& mir_class = *frame.current_class;
+// Declares one MIR member per instance member of the HIR scope and registers
+// each in the lowerer's HIR-to-MIR map. Pure shape: no construction code is
+// emitted; the construction call is appended in a later sweep that consults
+// the same map by HIR instance-member id.
+void DeclareInstanceMemberShapes(
+    StructuralScopeLowerer& lowerer, mir::ClassShape& shape) {
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
-  std::vector<mir::MemberId> instance_member_vars;
-  instance_member_vars.reserve(hir_scope.instance_members.size());
+  std::uint32_t next_index = 0;
   for (const auto& im : hir_scope.instance_members) {
-    for (const auto& v : mir_class.members) {
+    for (const auto& v : shape.members) {
       if (v.name == im.instance_name) {
         throw InternalError(
             "instance member name collides with an existing member "
@@ -435,35 +427,38 @@ auto InstallInstanceMembers(StructuralScopeLowerer& lowerer, WalkFrame frame)
     }
     const mir::TypeId var_type = MakeExternalUnitMemberType(
         lowerer.Module(), im.target_unit, im.array_dims.size());
-    const mir::MemberId var_id = mir_class.members.Add(
+    const mir::MemberId var_id = shape.members.Add(
         mir::MemberDecl{.name = im.instance_name, .type = var_type});
-    instance_member_vars.push_back(var_id);
-    lowerer.MapInstanceMember(
-        hir::InstanceMemberId{
-            static_cast<std::uint32_t>(instance_member_vars.size() - 1)},
-        var_id);
+    lowerer.MapInstanceMember(hir::InstanceMemberId{next_index++}, var_id);
+  }
+}
 
+// Emits the constructor-body construction call for each instance member,
+// reading the MemberId through the HIR-to-MIR map populated when the shape
+// was declared.
+void EmitInstanceMemberConstruction(
+    StructuralScopeLowerer& lowerer, WalkFrame frame) {
+  const hir::StructuralScope& hir_scope = lowerer.HirScope();
+  std::uint32_t next_index = 0;
+  for (const auto& im : hir_scope.instance_members) {
+    const mir::MemberId var_id =
+        lowerer.TranslateInstanceMember(hir::InstanceMemberId{next_index++});
     AppendExternalUnitConstruction(
         lowerer.Module(), frame, var_id, im.instance_name, im.array_dims);
   }
-  return instance_member_vars;
 }
 
 // Allocates one MIR member per cross-unit reference. Upward references take
 // the wrapper-typed ExternUp form whose per-reference state lands as ordinary
 // `CallExpr` statements in the constructor body. Downward references take a
 // borrowed-pointer slot the constructor fills by navigating from `self` once
-// the children are built. Both run before processes so reads resolve to the
+// the children are built. Both run before bodies so reads resolve to the
 // member; both record their MIR read target as a StructuralVarRef to that
-// member, in HIR slot order. The returned vector carries the allocated member
-// per ref in HIR order.
-auto MaterializeCrossUnitRefTargets(
-    StructuralScopeLowerer& lowerer, WalkFrame frame)
-    -> std::vector<mir::MemberId> {
+// member, in HIR slot order.
+void DeclareCrossUnitRefSlots(
+    StructuralScopeLowerer& lowerer, mir::ClassShape& shape) {
   ModuleLowerer& module = lowerer.Module();
-  mir::Class& mir_class = *frame.current_class;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
-  std::vector<mir::MemberId> slot_vars;
   std::uint32_t slot_index = 0;
   for (const auto& cu : hir_scope.cross_unit_refs) {
     std::string member_name = "xref" + std::to_string(slot_index++);
@@ -471,16 +466,15 @@ auto MaterializeCrossUnitRefTargets(
         std::holds_alternative<hir::UpwardRootHead>(cu.head) ||
         std::holds_alternative<hir::UpwardNamedHead>(cu.head);
     if (is_upward) {
-      // The member's type carries only the wrapped element; the per-reference
-      // navigation plan is emitted as ordinary `CallExpr` statements in the
-      // constructor body (see `InstallCrossUnitRefs`).
+      // The member's type carries only the wrapped element; the
+      // per-reference navigation plan is emitted as ordinary `CallExpr`
+      // statements in the constructor body when the bind sweep runs.
       const mir::TypeId leaf = module.TranslateType(cu.type);
       const mir::TypeId ext_type =
           module.Unit().types.Intern(mir::ExternalRefType{.element = leaf});
-      const mir::MemberId var = mir_class.members.Add(
+      const mir::MemberId var = shape.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = ext_type});
       lowerer.AddCrossUnitRefTarget(mir::MemberRef{.var = var}, ext_type);
-      slot_vars.push_back(var);
     } else {
       // The pointee matches the producer's storage cell. A producer-side
       // value-storage signal is wrapped in `ObservableType` at its declaration
@@ -490,13 +484,11 @@ auto MaterializeCrossUnitRefTargets(
           MaybeWrapObservable(module, module.TranslateType(cu.type));
       const mir::TypeId slot_type =
           module.Unit().types.PointerTo(leaf, mir::PointerOwnership::kBorrowed);
-      const mir::MemberId slot = mir_class.members.Add(
+      const mir::MemberId slot = shape.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = slot_type});
       lowerer.AddCrossUnitRefTarget(mir::MemberRef{.var = slot}, slot_type);
-      slot_vars.push_back(slot);
     }
   }
-  return slot_vars;
 }
 
 // Builds the resolve value for a downward reference: a chain of generic
@@ -580,11 +572,11 @@ auto BuildDownwardNavValue(
 // that O(N) at construction time is irrelevant. The within-class name is
 // unique by the structural-scope lowering's allocation rule, so this is a
 // deterministic lookup despite the linear scan.
-auto FindMemberByName(const mir::Class& cls, std::string_view name)
+auto FindMemberByName(const mir::ClassShape& shape, std::string_view name)
     -> std::optional<mir::MemberId> {
-  for (std::size_t i = 0; i < cls.members.size(); ++i) {
+  for (std::size_t i = 0; i < shape.members.size(); ++i) {
     const mir::MemberId id{static_cast<std::uint32_t>(i)};
-    const auto& m = cls.members.Get(id);
+    const auto& m = shape.members.Get(id);
     const std::string_view key = m.source_name.empty() ? m.name : m.source_name;
     if (key == name) {
       return id;
@@ -641,8 +633,10 @@ auto BuildTypedEnclosingNavValue(
         "BuildTypedEnclosingNavValue: head pointee is not an intra-unit "
         "object type");
   }
-  const mir::Class* current_class =
-      &module.Unit().GetClass(head_obj_ty->class_id);
+  // Peer shape queries read the published shape store, not the unit's class
+  // registry, which is not yet fully populated during body lowering.
+  const mir::ClassShape* current_shape =
+      &module.GetClassShape(head_obj_ty->class_id);
   for (std::size_t i = 0; i < path.size(); ++i) {
     const auto& step = path[i];
     const auto* mh = std::get_if<hir::MemberHop>(&step);
@@ -651,12 +645,12 @@ auto BuildTypedEnclosingNavValue(
           "BuildTypedEnclosingNavValue: index hop in typed intra-unit descent "
           "is not yet supported");
     }
-    const auto step_member = FindMemberByName(*current_class, mh->name);
+    const auto step_member = FindMemberByName(*current_shape, mh->name);
     if (!step_member.has_value()) {
       throw InternalError(
           "BuildTypedEnclosingNavValue: descent step member not found");
     }
-    const mir::TypeId step_type = current_class->members.Get(*step_member).type;
+    const mir::TypeId step_type = current_shape->members.Get(*step_member).type;
     receiver = ctor_block.exprs.Add(
         mir::Expr{
             .data =
@@ -681,7 +675,7 @@ auto BuildTypedEnclosingNavValue(
           "BuildTypedEnclosingNavValue: intermediate descent into a non-"
           "object type");
     }
-    current_class = &module.Unit().GetClass(step_obj_ty->class_id);
+    current_shape = &module.GetClassShape(step_obj_ty->class_id);
   }
   return ctor_block.exprs.Add(
       mir::Expr{
@@ -808,11 +802,7 @@ void AppendExternUpBinding(
 // the member, followed by one `AddSuffixStep` call per descent step -- ordinary
 // `CallExpr` carrying flat MIR primitives, so the backend renders them
 // uniformly with every other call.
-void InstallCrossUnitRefs(
-    StructuralScopeLowerer& lowerer, WalkFrame frame,
-    const std::vector<mir::MemberId>& instance_member_vars,
-    const std::vector<GenerateBindings>& gen_bindings,
-    const std::vector<mir::MemberId>& slot_vars) {
+void InstallCrossUnitRefs(StructuralScopeLowerer& lowerer, WalkFrame frame) {
   mir::Class& mir_class = *frame.current_class;
   mir::Block& ctor_block = *frame.current_block;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
@@ -825,9 +815,9 @@ void InstallCrossUnitRefs(
             .data = mir::StringLiteral{.value = s}, .type = builtins.string});
   };
   for (std::size_t ci = 0; ci < hir_scope.cross_unit_refs.size(); ++ci) {
-    const auto& cu = hir_scope.cross_unit_refs.Get(
-        hir::CrossUnitRefId{static_cast<std::uint32_t>(ci)});
-    const mir::MemberId member = slot_vars.at(ci);
+    const hir::CrossUnitRefId hir_id{static_cast<std::uint32_t>(ci)};
+    const auto& cu = hir_scope.cross_unit_refs.Get(hir_id);
+    const mir::MemberId member = lowerer.CrossUnitRefTarget(hir_id).target.var;
     if (std::holds_alternative<hir::UpwardRootHead>(cu.head)) {
       const mir::ExprId origin_self = ctor_block.exprs.Add(
           MakeSelfRefExpr(frame, mir_class.self_pointer_type));
@@ -858,15 +848,8 @@ void InstallCrossUnitRefs(
       nav = BuildTypedEnclosingNavValue(
           lowerer, frame, *down, cu.path, slot_type);
     } else {
-      mir::MemberId head_var{};
-      if (const auto* im = std::get_if<hir::InstanceMemberId>(&down->child)) {
-        head_var = instance_member_vars.at(im->value);
-      } else {
-        const auto& g = std::get<hir::GenerateChildRef>(down->child);
-        head_var = gen_bindings.at(g.generate.value)
-                       .by_scope_id.at(g.scope.value)
-                       .var_id;
-      }
+      const mir::MemberId head_var =
+          lowerer.TranslateOwnedChild(hir::StructuralHops{0}, down->child);
       const auto& head = mir_class.members.Get(head_var);
       const std::string head_name =
           head.source_name.empty() ? head.name : head.source_name;
@@ -939,9 +922,7 @@ void AppendProcessRegistration(
 // continuous assignment.
 auto InstallPortConnections(
     StructuralScopeLowerer& lowerer, WalkFrame frame, WalkFrame resolve_frame,
-    WalkFrame activate_frame,
-    const std::vector<mir::MemberId>& instance_member_vars,
-    const std::vector<GenerateBindings>& gen_bindings) -> diag::Result<void> {
+    WalkFrame activate_frame) -> diag::Result<void> {
   mir::Class& mir_class = *frame.current_class;
   mir::Block& resolve_block = *resolve_frame.current_block;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
@@ -958,15 +939,8 @@ auto InstallPortConnections(
         throw InternalError(
             "InstallPortConnections: a ref port reaches its child downward");
       }
-      mir::MemberId head_var{};
-      if (const auto* im = std::get_if<hir::InstanceMemberId>(&down->child)) {
-        head_var = instance_member_vars.at(im->value);
-      } else {
-        const auto& g = std::get<hir::GenerateChildRef>(down->child);
-        head_var = gen_bindings.at(g.generate.value)
-                       .by_scope_id.at(g.scope.value)
-                       .var_id;
-      }
+      const mir::MemberId head_var =
+          lowerer.TranslateOwnedChild(hir::StructuralHops{0}, down->child);
       const auto& head_member = mir_class.members.Get(head_var);
       const std::string head_name = head_member.source_name.empty()
                                         ? head_member.name
@@ -1018,8 +992,30 @@ auto InstallPortConnections(
   return {};
 }
 
+// Walks a member's type through any vector wrappers and a unique-pointer
+// layer to return the intra-unit `ClassId` it owns, or nullopt for any other
+// shape (external-unit object, ref, non-class type).
+auto AsOwnedGenerateChildClassId(
+    const mir::CompilationUnit& unit, mir::TypeId type)
+    -> std::optional<mir::ClassId> {
+  mir::TypeId leaf = type;
+  while (const auto* vec =
+             std::get_if<mir::VectorType>(&unit.types.Get(leaf).data)) {
+    leaf = vec->element;
+  }
+  const auto* ptr = std::get_if<mir::PointerType>(&unit.types.Get(leaf).data);
+  if (ptr == nullptr || ptr->ownership != mir::PointerOwnership::kUnique) {
+    return std::nullopt;
+  }
+  const auto& data = unit.types.Get(ptr->pointee).data;
+  if (const auto* obj = std::get_if<mir::ObjectType>(&data)) {
+    return obj->class_id;
+  }
+  return std::nullopt;
+}
+
 void ValidateOwnedChildConstruction(
-    const mir::CompilationUnit& unit, const mir::Class& owner_class,
+    ModuleLowerer& module, const mir::Class& owner_class,
     const mir::Block& block, mir::MemberId target_var,
     mir::ClassId child_scope_id, std::span<const mir::ExprId> ctor_args) {
   if (std::ranges::find(owner_class.contained, child_scope_id) ==
@@ -1034,24 +1030,24 @@ void ValidateOwnedChildConstruction(
         "class");
   }
   const auto& var = owner_class.members.Get(target_var);
-  const auto child = mir::GetChildScope(unit, var.type);
-  const auto* generate =
-      child ? std::get_if<mir::GenerateScopeChild>(&*child) : nullptr;
-  const auto& child_scope = unit.GetClass(child_scope_id);
-  if (generate == nullptr || generate->name != child_scope.name) {
+  const auto target_class_id =
+      AsOwnedGenerateChildClassId(module.Unit(), var.type);
+  const auto& child_scope_shape = module.GetClassShape(child_scope_id);
+  if (!target_class_id.has_value() ||
+      module.GetClassShape(*target_class_id).name != child_scope_shape.name) {
     throw InternalError(
         "owned-child construction: target var does not own the requested "
         "class");
   }
-  if (ctor_args.size() != child_scope.params.size()) {
+  if (ctor_args.size() != child_scope_shape.params.size()) {
     throw InternalError(
         "owned-child construction: args count does not match child class "
         "param count");
   }
   for (std::size_t i = 0; i < ctor_args.size(); ++i) {
     const auto& arg = block.exprs.Get(ctor_args[i]);
-    const auto& param =
-        child_scope.params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
+    const auto& param = child_scope_shape.params.Get(
+        mir::ParamId{static_cast<std::uint32_t>(i)});
     if (arg.type != param.type) {
       throw InternalError(
           "owned-child construction: arg type does not match structural "
@@ -1077,8 +1073,7 @@ void AppendOwnedChildConstruction(
   mir::Block& arm_block = *arm_frame.current_block;
   const mir::Class& owner_class = *arm_frame.current_class;
   ValidateOwnedChildConstruction(
-      module.Unit(), owner_class, arm_block, target_var, child_scope_id,
-      ctor_args);
+      module, owner_class, arm_block, target_var, child_scope_id, ctor_args);
 
   const mir::MemberDecl& var = owner_class.members.Get(target_var);
   const std::string& runtime_label =
@@ -1469,180 +1464,61 @@ auto LowerGenerateAsStmt(
       gen.data);
 }
 
-auto InstallGenerateOwnedChildScopes(
-    StructuralScopeLowerer& lowerer, WalkFrame frame)
-    -> diag::Result<std::vector<GenerateBindings>> {
-  ModuleLowerer& module = lowerer.Module();
-  mir::Class& mir_class = *frame.current_class;
-  const hir::StructuralScope& hir_scope = lowerer.HirScope();
-  std::vector<GenerateBindings> bindings_by_generate;
-  bindings_by_generate.reserve(hir_scope.generates.size());
-
-  for (std::size_t gen_idx = 0; gen_idx < hir_scope.generates.size();
-       ++gen_idx) {
-    const auto& gen = hir_scope.generates.Get(
-        hir::GenerateId{static_cast<std::uint32_t>(gen_idx)});
-    GenerateBindings gen_bindings;
-    gen_bindings.by_scope_id.resize(gen.child_scopes.size());
-
-    auto specs = EnumerateGenerateChildSpecs(gen, hir_scope, module);
-    for (auto& spec : specs) {
-      const auto companion_name = CompanionVarNameFor(spec.scope_name);
-      CheckNoNameCollision(
-          module.Unit(), mir_class, spec.scope_name, companion_name);
-
-      StructuralScopeLowerer child_scope(
-          module, &lowerer, std::move(spec.scope_name), *spec.scope);
-      auto child_r = child_scope.Run(frame, spec.entry_bindings);
-      if (!child_r) return std::unexpected(std::move(child_r.error()));
-
-      const mir::ClassId child_id = *child_r;
-      mir_class.contained.push_back(child_id);
-      mir::TypeId var_type = MakeUniqueObjectPointer(module, child_id);
-      if (spec.is_repeated) {
-        var_type =
-            module.Unit().types.Intern(mir::VectorType{.element = var_type});
-      }
-      const mir::MemberId var_id = mir_class.members.Add(
-          mir::MemberDecl{
-              .name = companion_name,
-              .source_name = spec.scope->source_name,
-              .type = var_type});
-
-      gen_bindings.by_scope_id.at(spec.scope_id.value) =
-          ChildStructuralScopeBinding{.scope_id = child_id, .var_id = var_id};
-    }
-
-    lowerer.MapGenerate(
-        hir::GenerateId{static_cast<std::uint32_t>(gen_idx)}, gen_bindings);
-    bindings_by_generate.push_back(std::move(gen_bindings));
-  }
-  return bindings_by_generate;
-}
-
 }  // namespace
 
-auto StructuralScopeLowerer::Run(
-    WalkFrame frame,
+auto StructuralScopeLowerer::DeclareShape(
     std::span<const ScopeEntryStructuralParamBinding> entry_bindings)
     -> diag::Result<mir::ClassId> {
   ModuleLowerer& module = *module_;
   const hir::StructuralScope& hir_scope = *hir_scope_;
   StructuralScopeLowerer& lowerer = *this;
 
-  // The identity is minted before the body so the object's own self type names
-  // it; the registry slot is filled from the finished declaration below.
-  const mir::ClassId own_id = module.Unit().DeclareClass();
+  // The identity is minted before the shape is populated so the class's own
+  // `self_pointer_type` can name it.
+  class_id_ = module.Unit().DeclareClass();
   const mir::TypeId self_object_type =
-      module.Unit().types.Intern(mir::ObjectType{.class_id = own_id});
+      module.Unit().types.Intern(mir::ObjectType{.class_id = class_id_});
   const mir::TypeId self_pointer_type = module.Unit().types.PointerTo(
       self_object_type, mir::PointerOwnership::kBorrowed);
-  mir::Class mir_class{
-      .name = name_,
-      .base = mir::ClassRef{mir::RuntimeLibraryClassRef{
-          .kind = parent_ == nullptr ? mir::RuntimeClassKind::kInstance
-                                     : mir::RuntimeClassKind::kGenScope}},
-      .self_pointer_type = self_pointer_type,
-      .time_resolution = hir_scope.time_resolution,
-      .ctor_prefix_params = {},
-      .params = {},
-      .members = {},
-      .constructor_block = {},
-      .contained = {},
-      .methods = {},
-      .type_aliases = {}};
+
+  mir::ClassShape shape;
+  shape.name = name_;
+  shape.base = mir::ClassRef{mir::RuntimeLibraryClassRef{
+      .kind = parent_ == nullptr ? mir::RuntimeClassKind::kInstance
+                                 : mir::RuntimeClassKind::kGenScope}};
+  shape.self_pointer_type = self_pointer_type;
+  shape.time_resolution = hir_scope.time_resolution;
 
   // The runtime Scope-base contract: every Scope-derived class takes the
   // parent pointer, its own HierarchySegment, and the engine services
   // handle as the first three ctor params, forwarded straight to the
   // base. The order and types are the SDK convention; the lowering states
   // them once here so the render reads them like any other params.
-  if (mir_class.base.has_value()) {
+  if (shape.base.has_value()) {
     const auto& builtins = module.Unit().builtins;
-    mir_class.ctor_prefix_params.Add(
+    shape.ctor_prefix_params.Add(
         mir::ParamDecl{.name = "parent", .type = builtins.scope_ptr});
-    mir_class.ctor_prefix_params.Add(
+    shape.ctor_prefix_params.Add(
         mir::ParamDecl{.name = "segment", .type = builtins.hierarchy_segment});
-    mir_class.ctor_prefix_params.Add(
+    shape.ctor_prefix_params.Add(
         mir::ParamDecl{.name = "services", .type = builtins.services});
   }
   for (const auto& alias : hir_scope.type_aliases) {
-    mir_class.type_aliases.push_back(
+    shape.type_aliases.push_back(
         mir::TypeAliasDecl{
             .name = alias.name, .target = module.TranslateType(alias.target)});
   }
 
   for (const auto& binding : entry_bindings) {
-    const mir::ParamId mir_id = mir_class.params.Add(binding.param);
+    const mir::ParamId mir_id = shape.params.Add(binding.param);
     lowerer.MapLoopVarAsStructuralParam(binding.source_loop_var, mir_id);
   }
-
-  mir::Block ctor_block;
-  const mir::LocalId self_id = ctor_block.vars.Add(
-      mir::LocalDecl{.name = "self", .type = mir_class.self_pointer_type});
-  ScopeChainNode outer_scope_link{};
-  const WalkFrame scope_frame =
-      frame.WithClass(&mir_class, outer_scope_link)
-          .WithBlock(&ctor_block)
-          .WithSelfBinding(self_id, frame.block_depth);
-  const mir::TypeId void_type = module.Unit().builtins.void_type;
-  const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
-  const auto self_read = [&]() -> mir::ExprId {
-    return ctor_block.exprs.Add(MakeSelfRefExpr(scope_frame, self_ptr_type));
-  };
-
-  // Variable initialization is a distinct phase from construction: the
-  // constructor only allocates and registers the shell, while initializers run
-  // after the whole tree's references are resolved, so an initializer observes
-  // connected and bound values. The init body is its own block with its own
-  // `self`; the constructor records signal addresses, the init body assigns
-  // values.
-  mir::Block initialize_block;
-  const mir::LocalId init_self_id = initialize_block.vars.Add(
-      mir::LocalDecl{.name = "self", .type = mir_class.self_pointer_type});
-  const WalkFrame init_frame =
-      frame.WithClass(&mir_class, outer_scope_link)
-          .WithBlock(&initialize_block)
-          .WithSelfBinding(init_self_id, frame.block_depth);
-  const auto init_self_read = [&]() -> mir::ExprId {
-    return initialize_block.exprs.Add(
-        MakeSelfRefExpr(init_frame, self_ptr_type));
-  };
-
-  // Cross-instance binding (a `ref` port binding its child's reference member)
-  // runs in the resolve phase, after the whole tree is constructed and before
-  // initialization. Like the init body it is its own block with its own `self`.
-  mir::Block resolve_block;
-  const mir::LocalId resolve_self_id = resolve_block.vars.Add(
-      mir::LocalDecl{.name = "self", .type = mir_class.self_pointer_type});
-  const WalkFrame resolve_frame =
-      frame.WithClass(&mir_class, outer_scope_link)
-          .WithBlock(&resolve_block)
-          .WithSelfBinding(resolve_self_id, frame.block_depth);
-
-  // Process activation runs after initialization (LRM 9.2). Like the resolve
-  // and init bodies it is its own block with its own `self`; it holds the
-  // lifecycle registration for every process this scope owns.
-  mir::Block activate_block;
-  const mir::LocalId activate_self_id = activate_block.vars.Add(
-      mir::LocalDecl{.name = "self", .type = mir_class.self_pointer_type});
-  const WalkFrame activate_frame =
-      frame.WithClass(&mir_class, outer_scope_link)
-          .WithBlock(&activate_block)
-          .WithSelfBinding(activate_self_id, frame.block_depth);
 
   for (std::size_t i = 0; i < hir_scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
     const auto& d = hir_scope.structural_vars.Get(hir_id);
     const mir::TypeId mir_value_type = module.TranslateType(d.type);
-
-    // The value type's kind classifies the member in the checks below: a plain
-    // value is an assignable signal; a pointer / vector / object / ref slot is
-    // not.
-    const mir::TypeKind var_kind =
-        module.Unit().types.Get(mir_value_type).Kind();
     const bool is_reference = d.reference.has_value();
-
     // A `ref` / `const ref` port member aliases the connected variable, filled
     // by the parent at construction (LRM 23.3.3.2): its type is a reference,
     // not its own cell, so it owns no storage and takes no value initializer.
@@ -1655,10 +1531,143 @@ auto StructuralScopeLowerer::Run(
                                .is_const = *d.reference ==
                                            hir::ReferenceBinding::kConstRef})
                      : MaybeWrapObservable(module, mir_value_type);
-    const mir::MemberId mir_id = mir_class.members.Add(
+    const mir::MemberId mir_id = shape.members.Add(
         mir::MemberDecl{.name = d.name, .type = mir_field_type});
     lowerer.MapStructuralVar(hir_id, mir_id);
+  }
 
+  DeclareCrossUnitRefSlots(lowerer, shape);
+
+  // Reserve each subroutine's MIR id before any body lowers, so a call in
+  // one body resolves a forward or mutual reference to a peer (LRM 13.7).
+  // The id reserved here is the index the decl will occupy when it is later
+  // added to the class's methods arena.
+  for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
+    lowerer.MapStructuralSubroutine(
+        hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)},
+        mir::MethodId{static_cast<std::uint32_t>(i)});
+  }
+
+  // Recursively declare every owned generate child's class shape; each child
+  // lowerer is retained for the body sweep.
+  for (std::size_t gen_idx = 0; gen_idx < hir_scope.generates.size();
+       ++gen_idx) {
+    const auto& gen = hir_scope.generates.Get(
+        hir::GenerateId{static_cast<std::uint32_t>(gen_idx)});
+    GenerateBindings gen_bindings;
+    gen_bindings.by_scope_id.resize(gen.child_scopes.size());
+
+    auto specs = EnumerateGenerateChildSpecs(gen, hir_scope, module);
+    for (auto& spec : specs) {
+      const auto companion_name = CompanionVarNameFor(spec.scope_name);
+      CheckNoNameCollision(shape, spec.scope_name, companion_name);
+
+      auto child = std::make_unique<StructuralScopeLowerer>(
+          module, &lowerer, std::move(spec.scope_name), *spec.scope);
+      auto child_r = child->DeclareShape(spec.entry_bindings);
+      if (!child_r) return std::unexpected(std::move(child_r.error()));
+
+      const mir::ClassId child_id = *child_r;
+      shape.contained.push_back(child_id);
+      mir::TypeId var_type = MakeUniqueObjectPointer(module, child_id);
+      if (spec.is_repeated) {
+        var_type =
+            module.Unit().types.Intern(mir::VectorType{.element = var_type});
+      }
+      const mir::MemberId var_id = shape.members.Add(
+          mir::MemberDecl{
+              .name = companion_name,
+              .source_name = spec.scope->source_name,
+              .type = var_type});
+
+      gen_bindings.by_scope_id.at(spec.scope_id.value) =
+          ChildStructuralScopeBinding{.scope_id = child_id, .var_id = var_id};
+      children_.push_back(std::move(child));
+    }
+
+    lowerer.MapGenerate(
+        hir::GenerateId{static_cast<std::uint32_t>(gen_idx)},
+        std::move(gen_bindings));
+  }
+
+  // Instance members shape: one MIR slot per child instance.
+  DeclareInstanceMemberShapes(lowerer, shape);
+
+  module.DefineClassShape(class_id_, std::move(shape));
+  return class_id_;
+}
+
+auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
+    -> diag::Result<void> {
+  ModuleLowerer& module = *module_;
+  const hir::StructuralScope& hir_scope = *hir_scope_;
+  StructuralScopeLowerer& lowerer = *this;
+
+  const mir::ClassShape& shape = module.GetClassShape(class_id_);
+  mir::Class mir_class;
+  mir_class.name = shape.name;
+  mir_class.base = shape.base;
+  mir_class.self_pointer_type = shape.self_pointer_type;
+  mir_class.time_resolution = shape.time_resolution;
+  mir_class.ctor_prefix_params = shape.ctor_prefix_params;
+  mir_class.params = shape.params;
+  mir_class.members = shape.members;
+  mir_class.contained = shape.contained;
+  mir_class.type_aliases = shape.type_aliases;
+
+  const mir::TypeId void_type = module.Unit().builtins.void_type;
+  const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
+
+  // The four bodies the scope emits to, with their own `self` locals and
+  // walk frames. Stack-local; live only for this call.
+  mir::Block ctor_block;
+  const mir::LocalId ctor_self_id = ctor_block.vars.Add(
+      mir::LocalDecl{.name = "self", .type = self_ptr_type});
+  mir::Block initialize_block;
+  const mir::LocalId init_self_id = initialize_block.vars.Add(
+      mir::LocalDecl{.name = "self", .type = self_ptr_type});
+  mir::Block resolve_block;
+  const mir::LocalId resolve_self_id = resolve_block.vars.Add(
+      mir::LocalDecl{.name = "self", .type = self_ptr_type});
+  mir::Block activate_block;
+  const mir::LocalId activate_self_id = activate_block.vars.Add(
+      mir::LocalDecl{.name = "self", .type = self_ptr_type});
+
+  ScopeChainNode outer_scope_link{};
+  const WalkFrame ctor_frame =
+      parent_frame.WithClass(&mir_class, outer_scope_link)
+          .WithBlock(&ctor_block)
+          .WithSelfBinding(ctor_self_id, parent_frame.block_depth);
+  const WalkFrame init_frame =
+      parent_frame.WithClass(&mir_class, outer_scope_link)
+          .WithBlock(&initialize_block)
+          .WithSelfBinding(init_self_id, parent_frame.block_depth);
+  const WalkFrame resolve_frame =
+      parent_frame.WithClass(&mir_class, outer_scope_link)
+          .WithBlock(&resolve_block)
+          .WithSelfBinding(resolve_self_id, parent_frame.block_depth);
+  const WalkFrame activate_frame =
+      parent_frame.WithClass(&mir_class, outer_scope_link)
+          .WithBlock(&activate_block)
+          .WithSelfBinding(activate_self_id, parent_frame.block_depth);
+  const auto self_read = [&]() -> mir::ExprId {
+    return ctor_block.exprs.Add(MakeSelfRefExpr(ctor_frame, self_ptr_type));
+  };
+  const auto init_self_read = [&]() -> mir::ExprId {
+    return initialize_block.exprs.Add(
+        MakeSelfRefExpr(init_frame, self_ptr_type));
+  };
+
+  for (std::size_t i = 0; i < hir_scope.structural_vars.size(); ++i) {
+    const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
+    const auto& d = hir_scope.structural_vars.Get(hir_id);
+    const mir::MemberId mir_id =
+        lowerer.TranslateStructuralVar(hir::StructuralHops{0}, hir_id);
+    const mir::TypeId mir_field_type = mir_class.members.Get(mir_id).type;
+    const mir::TypeId mir_value_type = module.TranslateType(d.type);
+    const bool is_reference = d.reference.has_value();
+    const mir::TypeKind var_kind =
+        module.Unit().types.Get(mir_value_type).Kind();
     // Owned children (pointer / vector / object), resolution slots, upward
     // refs, and named events have no "value assignment" -- their declaration
     // shape itself fixes the field at construction. Value-typed signals
@@ -1737,35 +1746,19 @@ auto StructuralScopeLowerer::Run(
     }
   }
 
-  // Upward refs become ExternalRef members and every cross-unit slot's MIR
-  // target is recorded before any body is lowered, so reads and sensitivity in
-  // subroutines and processes resolve each slot.
-  const auto cross_unit_slot_vars =
-      MaterializeCrossUnitRefTargets(lowerer, scope_frame);
-
-  // Map every subroutine's identity before lowering any body, so a call in one
-  // body resolves a forward or mutual reference to a peer (LRM 13.7). Only the
-  // HIR -> MIR id mapping has to precede the bodies; the MIR id is the index
-  // each decl will occupy, and the loop below adds the lowered decls in that
-  // same order.
-  for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
-    lowerer.MapStructuralSubroutine(
-        hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)},
-        mir::MethodId{static_cast<std::uint32_t>(i)});
-  }
   for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
     const auto& src = hir_scope.structural_subroutines.Get(
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
     ProcessLowerer subroutine_lowerer(
         module, &lowerer, hir_scope.time_resolution, src.body, src.name,
-        mir::MethodVisibility::kInternal, scope_frame);
+        mir::MethodVisibility::kInternal, ctor_frame);
     auto decl_or = subroutine_lowerer.Run(src);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId added = mir_class.methods.Add(*std::move(decl_or));
     if (added.value != i) {
       throw InternalError(
-          "StructuralScopeLowerer::Run: subroutine added out of mapped "
-          "id order");
+          "StructuralScopeLowerer::PopulateBodies: subroutine added out of "
+          "mapped id order");
     }
   }
 
@@ -1773,7 +1766,7 @@ auto StructuralScopeLowerer::Run(
     std::string name = std::format("process_{}", mir_class.methods.size());
     ProcessLowerer process_lowerer(
         module, &lowerer, hir_scope.time_resolution, p.body, std::move(name),
-        mir::MethodVisibility::kInternal, scope_frame);
+        mir::MethodVisibility::kInternal, ctor_frame);
     auto decl_or = process_lowerer.Run(p);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
@@ -1784,32 +1777,34 @@ auto StructuralScopeLowerer::Run(
   for (const auto& ca : hir_scope.continuous_assigns) {
     std::string name = std::format("process_{}", mir_class.methods.size());
     auto decl_or =
-        LowerContinuousAssign(lowerer, scope_frame, std::move(name), ca);
+        LowerContinuousAssign(lowerer, ctor_frame, std::move(name), ca);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
     AppendProcessRegistration(module, activate_frame, body, false);
   }
 
-  auto bindings_r = InstallGenerateOwnedChildScopes(lowerer, scope_frame);
-  if (!bindings_r) return std::unexpected(std::move(bindings_r.error()));
+  // Recurse into descendants. Every class's shape is already published, so a
+  // body that names a peer's member resolves through the existing identity
+  // model regardless of which sibling lowers next.
+  for (auto& child : children_) {
+    auto child_r = child->PopulateBodies(ctor_frame);
+    if (!child_r) return std::unexpected(std::move(child_r.error()));
+  }
 
   for (std::size_t i = 0; i < hir_scope.generates.size(); ++i) {
     auto stmt = LowerGenerateAsStmt(
-        lowerer, scope_frame,
+        lowerer, ctor_frame,
         hir_scope.generates.Get(hir::GenerateId{static_cast<std::uint32_t>(i)}),
-        bindings_r->at(i));
+        lowerer.LookupGenerateBindings(
+            hir::GenerateId{static_cast<std::uint32_t>(i)}));
     if (!stmt) return std::unexpected(std::move(stmt.error()));
     ctor_block.AppendStmt(*std::move(stmt));
   }
 
-  const auto instance_member_vars =
-      InstallInstanceMembers(lowerer, scope_frame);
-  InstallCrossUnitRefs(
-      lowerer, scope_frame, instance_member_vars, *bindings_r,
-      cross_unit_slot_vars);
+  EmitInstanceMemberConstruction(lowerer, ctor_frame);
+  InstallCrossUnitRefs(lowerer, ctor_frame);
   auto port_conn_r = InstallPortConnections(
-      lowerer, scope_frame, resolve_frame, activate_frame, instance_member_vars,
-      *bindings_r);
+      lowerer, ctor_frame, resolve_frame, activate_frame);
   if (!port_conn_r) return std::unexpected(std::move(port_conn_r.error()));
 
   mir_class.constructor_block = std::move(ctor_block);
@@ -1859,8 +1854,8 @@ auto StructuralScopeLowerer::Run(
             .visibility = mir::MethodVisibility::kInternal});
   }
 
-  module.Unit().DefineClass(own_id, std::move(mir_class));
-  return own_id;
+  module.Unit().DefineClass(class_id_, std::move(mir_class));
+  return {};
 }
 
 }  // namespace lyra::lowering::hir_to_mir


### PR DESCRIPTION
## Summary

A program admits mutual references between sibling structural declarations: mutual subroutine calls (LRM 13.7), classes referencing each other's members (LRM 8.24), bodies in one generate scope reaching peer signals across the structural-scope tree, hierarchical callable dispatch through a base whose own body has not yet lowered. The old HIR-to-MIR pass intermixed declaration and body work in a single recursive walk, which let body lowering succeed only when the peer had already finished lowering -- forcing source-order constraints on otherwise-symmetric SV constructs. This PR stages HIR-to-MIR structural lowering into two ordered phases: a declare pass mints every class's identity and publishes its structural shape, then a body pass lowers every body and install statement against the already-published shapes.

## Design

A new `mir::ClassShape` carries the structural-only view of `mir::Class` (members, contained classes, params, type aliases, the base ref, the self pointer type) -- the parts a peer needs to read while its own body is being lowered, with no executable content. `ModuleLowerer` holds the per-CU shape store (`vector<optional<ClassShape>>` keyed by ClassId) and exposes `DefineClassShape` / `GetClassShape` for the two phases to publish and consume.

`StructuralScopeLowerer`'s old `Run()` splits into `DeclareShape()` and `PopulateBodies()`. `DeclareShape` mints the class identity, builds the local shape, publishes it through the store, and recurses to declare every descendant scope's shape. `PopulateBodies` reads back the published shape, lowers every body and install statement, recurses into descendants through the same lowerer tree (owned via `children_`), and commits the composed `mir::Class` to the unit. After the root call returns, the shape store is destroyed; the compilation unit's class registry is the sole authoritative class store consumers see.

Body lowering reads peer class shapes through `ModuleLowerer::GetClassShape`, never through `unit.GetClass` -- the unit's class registry is a commit sink during phase 2 and is only fully populated once every body finalizes. The decision and its rejected alternatives (`mir::ClassShape` on `CompilationUnit`, mutable `Registry::Mutate`, separate shape + body stores) are recorded in `docs/decisions/declarations-before-bodies.md`.

Consumer code is untouched: `mir::Class`, `mir::CompilationUnit`, backend, dump, runtime all read the same post-lowering shape they always did. The change is contained to the HIR-to-MIR pass and its private state.

## Testing

`bazel test //... --test_output=errors` -- four targets, all PASS. No test edits required: the change is a refactor of when work happens within HIR-to-MIR, not what MIR is produced for any existing test.