### PR TITLE
Generalize the MIR object base and receiver model

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -14,14 +14,15 @@ each stage establishes, not how.
 
 ## Sub-Steps
 
-- [ ] An object's base is one generic nominal-object reference -- a runtime-library, intra-unit, or
-      cross-unit base -- rendered through one path, not a closed runtime-base classification. A
-      runtime-library base is an imported library declaration; a cross-unit base stays a by-name
-      reference. Behavior-neutral: the emitted module shape is unchanged. (The intra-unit and
-      cross-unit base arms are not this step; an intra-unit base names the registry's canonical
-      local identity, established below. Runtime-tree membership is read adequately from how a
-      member is owned today; a base-lineage read is a later purity refinement, not done as a
-      standalone non-neutral change.)
+- [x] An object's base is one generic nominal-object reference -- a runtime-library, intra-unit, or
+      cross-unit base -- resolved through one path, not a closed runtime-base classification. A
+      runtime-library base is an imported library declaration whose name renders through the one
+      type-mapping path; whether the object is a runtime tree node, whether it exposes a def-name,
+      and its constructor prefix are facts stated on the base and read off it, never decided in the
+      backend. Behavior-neutral: the emitted module shape is unchanged. (Only the runtime-library
+      arm has a producer today; the intra-unit arm -- naming the registry's canonical local identity
+      -- and the cross-unit by-name arm land with class inheritance, each adding one arm and one
+      resolver case with no consumer change.)
 
 - [x] Each post-construction lifecycle body (the scope's resolve / initialize / activate work) is an
       ordinary method that records, as a first-class fact, which runtime-base method it overrides --

--- a/include/lyra/mir/base_contract.hpp
+++ b/include/lyra/mir/base_contract.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/mir/class_ref.hpp"
+#include "lyra/mir/param.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::mir {
+
+struct CompilationUnit;
+
+// What an object inherits from its base, resolved through one entry point so a
+// consumer reads each fact rather than re-deriving it from a closed
+// classification. `renderable` is the base type the one type-mapping dispatch
+// turns into the target base-class name. `is_runtime_tree_node` says the object
+// is a node in the runtime object tree (it participates in the elaboration
+// lifecycle and carries the scope ctor prefix); a plain object that extends
+// another plain class is not. `exposes_def_name` says the object publishes its
+// def-name for upward navigation (LRM 23.8). `ctor_prefix` is the base's
+// construction contract -- the params an instance forwards straight to the base
+// constructor.
+struct BaseContract {
+  TypeId renderable;
+  bool is_runtime_tree_node;
+  bool exposes_def_name;
+  std::vector<ParamDecl> ctor_prefix;
+};
+
+auto ResolveBaseContract(const CompilationUnit& unit, const ClassRef& base)
+    -> BaseContract;
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -35,10 +35,12 @@ struct ClassShape {
 
 struct Class {
   std::string name;
-  // The base this object extends, or absent for a plain object that is not a
-  // tree node. A backend realizes the base, the registering constructor, and
-  // the tree-node overrides only when a base is present; a baseless object is a
-  // plain struct.
+  // The base this object extends, or absent if it extends nothing. A consumer
+  // resolves it to the base contract -- the base type that renders the
+  // inheritance, whether the object is a runtime tree node, the constructor
+  // prefix it forwards. A runtime tree node realizes the registering
+  // constructor and the lifecycle overrides; an object that extends nothing is
+  // a plain struct.
   std::optional<ClassRef> base;
   TypeId self_pointer_type;
   // The class's resolved time unit and precision (LRM 3.14.2). The emitted

--- a/include/lyra/mir/class_ref.hpp
+++ b/include/lyra/mir/class_ref.hpp
@@ -3,37 +3,40 @@
 #include <cstdint>
 #include <variant>
 
+#include "lyra/mir/type_id.hpp"
+
 namespace lyra::mir {
 
-// A fixed runtime-library base class. These are object types the runtime
-// library provides, not classes of any compilation unit: `kInstance` is a
-// module / interface / program instance and `kGenScope` a named generate scope,
-// both nodes in the runtime object tree.
-enum class RuntimeClassKind : std::uint8_t {
-  kInstance,
-  kGenScope,
-};
-
-// A reference to a runtime-library base class.
+// A reference to a runtime-library base class, named by the type that renders
+// it (`InstanceType` / `GenScopeType`). The type is the identity of the
+// imported library declaration: a consumer renders the base through the one
+// type-mapping dispatch and reads the base's contract from this type, never
+// from a closed classification it switches on.
 struct RuntimeLibraryClassRef {
-  RuntimeClassKind kind;
+  TypeId base_type;
 
   auto operator==(const RuntimeLibraryClassRef&) const -> bool = default;
 };
 
-// A reference to the object type an object extends. A consumer resolves it
-// through one path rather than switching a closed classification; a base is a
-// runtime-library class.
+// A reference to the object type an object extends, identity following the
+// compilation-unit boundary. A consumer resolves it through one entry point;
+// the boundary split lives in the resolver, not in each consumer. Today the
+// only producer is a runtime-library base.
 using ClassRef = std::variant<RuntimeLibraryClassRef>;
 
-// A virtual hook the runtime base declares and the engine invokes after
-// construction: `kResolve` binds cross-instance references, `kInitialize` runs
-// variable initializers, and `kActivate` registers processes (the Resolve /
-// Initialize / Activate phases of the elaboration lifecycle).
+// A virtual the runtime base declares and a derived object may override.
+// `kResolve` / `kInitialize` / `kActivate` are the post-construction lifecycle
+// phases the engine invokes (binding cross-instance references, running
+// variable initializers, registering processes). `kTimePrecisionPower` and
+// `kDefName` are constant-property accessors a tree node overrides to report
+// its time precision (LRM 3.14.2) and, for a module instance, its def-name
+// (LRM 23.8).
 enum class RuntimeMethod : std::uint8_t {
   kResolve,
   kInitialize,
   kActivate,
+  kTimePrecisionPower,
+  kDefName,
 };
 
 // A reference to a runtime-library method.
@@ -45,7 +48,7 @@ struct RuntimeLibraryMethodRef {
 
 // A reference to the base method an instance method overrides, resolved to a
 // declaration rather than a textual name. A consumer reads the override target
-// through one path; the only base method is a runtime-library lifecycle hook.
+// through one path; the only base method is a runtime-library virtual.
 using OverriddenMethodRef = std::variant<RuntimeLibraryMethodRef>;
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -20,6 +20,8 @@ enum class TypeKind {
   kAssociativeArray,
   kWildcardIndex,
   kString,
+  kStringView,
+  kMachineInt,
   kEvent,
   kReal,
   kShortReal,
@@ -29,6 +31,8 @@ enum class TypeKind {
   kObject,
   kExternalUnitObject,
   kScope,
+  kInstance,
+  kGenScope,
   kServices,
   kFiles,
   kDiagnostic,
@@ -151,6 +155,28 @@ struct WildcardIndexType {
 struct StringType {
   auto operator==(const StringType&) const -> bool = default;
 };
+
+// A borrowed view of string bytes the value does not own (the generic-language
+// borrowed string -- Rust `&str`, C++ `std::string_view`), distinct from the
+// owning `StringType`. A constant exposed through it borrows static storage and
+// copies nothing; the owning-versus-borrowing distinction survives
+// optimization, so it is its own type rather than a use of `StringType`.
+struct StringViewType {
+  auto operator==(const StringViewType&) const -> bool = default;
+};
+
+// A primitive machine integer (the generic-language `iN` / `uN`, C `intN_t`):
+// a fixed-width 2-state scalar, distinct from the 4-state SV `PackedArrayType`.
+// It carries runtime-contract scalar metadata -- a scope's time precision power
+// (LRM 3.14.2) -- which is plain machine data, not a simulation value, and
+// lowers to a raw target integer rather than a value wrapper. The owning string
+// metadata's `StringViewType` is its string counterpart.
+struct MachineIntType {
+  std::uint32_t bit_width;
+  Signedness signedness;
+
+  auto operator==(const MachineIntType&) const -> bool = default;
+};
 struct EventType {
   auto operator==(const EventType&) const -> bool = default;
 };
@@ -196,6 +222,22 @@ struct ExternalUnitObjectType {
 // across the unit boundary, so only the runtime base is named.
 struct ScopeType {
   auto operator==(const ScopeType&) const -> bool = default;
+};
+
+// The runtime object-tree base class `lyra::runtime::Instance`, the concrete
+// base a module / interface / program instance scope extends. Distinct from
+// the type-erased `ScopeType`: this is the named base in an object's lineage,
+// never a navigation handle. An object whose base lineage is this one is a
+// runtime tree node and exposes its def-name for upward navigation (LRM 23.8).
+struct InstanceType {
+  auto operator==(const InstanceType&) const -> bool = default;
+};
+
+// The runtime object-tree base class `lyra::runtime::GenScope`, the concrete
+// base a named generate scope extends. A tree node like InstanceType, but a
+// generate scope is matched by its block name, not a def-name.
+struct GenScopeType {
+  auto operator==(const GenScopeType&) const -> bool = default;
 };
 
 // The engine facade `lyra::runtime::RuntimeServices`. A callable body reaches
@@ -269,17 +311,27 @@ struct CoroutineType {
   auto operator==(const CoroutineType&) const -> bool = default;
 };
 
+// The write capability a reference or borrow grants its holder (the
+// generic-language `&T` vs `&mut T`, a method's `const` vs non-const receiver).
+// Mutability lives on references and borrows, never as a qualifier on an
+// ordinary value type; a place's or binding's mutability is a separate axis
+// carried where that place or binding lives.
+enum class Mutability : std::uint8_t {
+  kMutable,
+  kReadOnly,
+};
+
 // A reference value aliasing a storage cell of `pointee` type (LRM 13.5.2
 // pass-by-reference; a fork branch / `$sscanf` / with-clause body sharing
 // enclosing storage). The runtime wrapper `lyra::runtime::Ref<T>` routes reads
 // through `Get` and writes through the cell's `Set` (its update-event path), so
-// a value of this type is read and written like an observable cell. `is_const`
-// marks a `const ref` formal (read-only). A library wrapper, like
+// a value of this type is read and written like an observable cell. A read-only
+// `mutability` marks a `const ref` formal (LRM 13.5.2). A library wrapper, like
 // ObservableType; constructing one from a cell is an explicit MIR operation,
 // not a backend-synthesized wrap.
 struct RefType {
   TypeId pointee;
-  bool is_const = false;
+  Mutability mutability = Mutability::kMutable;
 
   auto operator==(const RefType&) const -> bool = default;
 };
@@ -290,12 +342,16 @@ enum class PointerOwnership {
   kBorrowed,
 };
 
-// One level of indirection, classified by its lifetime axis: `kUnique` and
-// `kShared` own the pointee (`unique_ptr<T>` / `shared_ptr<T>`); `kBorrowed`
-// owns nothing and only refers (`T*`).
+// One level of indirection on two orthogonal axes: `ownership` is the lifetime
+// discipline (`kUnique` / `kShared` own the pointee as `unique_ptr<T>` /
+// `shared_ptr<T>`; `kBorrowed` owns nothing and only refers as `T*`), and
+// `mutability` is the write capability the handle grants -- a read-only borrow
+// renders `const T*`, the immutable-receiver (`&self`) case. The two axes are
+// independent: ownership says who frees, mutability says who may write.
 struct PointerType {
   TypeId pointee;
   PointerOwnership ownership;
+  Mutability mutability = Mutability::kMutable;
 
   auto operator==(const PointerType&) const -> bool = default;
 };
@@ -376,9 +432,10 @@ struct ExternalRefType {
 
 using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
-    AssociativeArrayType, WildcardIndexType, StringType, EventType, RealType,
-    ShortRealType, RealTimeType, ChandleType, VoidType, ObjectType,
-    ExternalUnitObjectType, ScopeType, ServicesType, FilesType, DiagnosticType,
+    AssociativeArrayType, WildcardIndexType, StringType, StringViewType,
+    MachineIntType, EventType, RealType, ShortRealType, RealTimeType,
+    ChandleType, VoidType, ObjectType, ExternalUnitObjectType, ScopeType,
+    InstanceType, GenScopeType, ServicesType, FilesType, DiagnosticType,
     RuntimeLibraryType, CoroutineType, RefType, PointerType, ManagedRefType,
     VectorType, TupleType, UnionType, ExternalRefType, ObservableType>;
 

--- a/include/lyra/mir/type_interner.hpp
+++ b/include/lyra/mir/type_interner.hpp
@@ -67,8 +67,14 @@ class TypeInterner {
     return Intern(CoroutineType{.payload = payload});
   }
 
-  auto PointerTo(TypeId pointee, PointerOwnership ownership) -> TypeId {
-    return Intern(PointerType{.pointee = pointee, .ownership = ownership});
+  auto PointerTo(
+      TypeId pointee, PointerOwnership ownership,
+      Mutability mutability = Mutability::kMutable) -> TypeId {
+    return Intern(
+        PointerType{
+            .pointee = pointee,
+            .ownership = ownership,
+            .mutability = mutability});
   }
 
  private:

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -14,6 +14,7 @@
 #include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
+#include "lyra/mir/base_contract.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -55,10 +56,10 @@ auto RenderMethodParam(
   return std::format("{} {}", RenderTypeAsCpp(unit, s, param.type), param.name);
 }
 
-// The C++ name of a runtime-base virtual hook. The mapping from the resolved
+// The C++ name of a runtime-base virtual. The mapping from the resolved
 // override reference to the emitted token lives only here, so the override
 // relation stays a declaration reference everywhere else.
-auto RenderRuntimeMethodName(mir::RuntimeMethod method) -> std::string_view {
+auto RuntimeVirtualName(mir::RuntimeMethod method) -> std::string_view {
   switch (method) {
     case mir::RuntimeMethod::kResolve:
       return "ResolveState";
@@ -66,8 +67,26 @@ auto RenderRuntimeMethodName(mir::RuntimeMethod method) -> std::string_view {
       return "InitializeState";
     case mir::RuntimeMethod::kActivate:
       return "CreateProcesses";
+    case mir::RuntimeMethod::kTimePrecisionPower:
+      return "TimePrecisionPower";
+    case mir::RuntimeMethod::kDefName:
+      return "DefName";
   }
-  throw InternalError("RenderRuntimeMethodName: unknown RuntimeMethod");
+  throw InternalError("RuntimeVirtualName: unknown RuntimeMethod");
+}
+
+// Whether a method's receiver is a read-only borrow (an immutable `&self`),
+// read off `self`'s own parameter type. The C++ override shim is `const`
+// exactly when its receiver is read-only.
+auto ReceiverIsReadOnly(
+    const mir::CompilationUnit& unit, const mir::MethodDecl& m) -> bool {
+  if (m.code.params.empty()) {
+    return false;
+  }
+  const auto& self_type =
+      unit.types.Get(m.code.body.vars.Get(m.code.params[0]).type).data;
+  const auto* ptr = std::get_if<mir::PointerType>(&self_type);
+  return ptr != nullptr && ptr->mutability == mir::Mutability::kReadOnly;
 }
 
 // The one renderer for every callable body. A body renders uniformly as a
@@ -103,11 +122,15 @@ auto RenderMethod(
   if (m.overrides.has_value()) {
     const std::string_view hook = std::visit(
         [](const mir::RuntimeLibraryMethodRef& ref) {
-          return RenderRuntimeMethodName(ref.method);
+          return RuntimeVirtualName(ref.method);
         },
         *m.overrides);
+    // A void hook discards; a value hook returns. `return <void-expr>;` is
+    // legal in a void function, so the same forward serves both with no branch.
+    // The shim is `const` exactly when its receiver is a read-only borrow.
     out += std::format(
-        "{}void {}() override {{ {}(this); }}\n", Indent(indent), hook, m.name);
+        "{}{} {}(){} override {{ return {}(this); }}\n", Indent(indent), ret,
+        hook, ReceiverIsReadOnly(unit, m) ? " const" : "", m.name);
   }
   return out;
 }
@@ -197,20 +220,6 @@ auto RenderConstructor(
       RenderBlockStatements(scope_view, indent + 1));
 }
 
-auto RenderBaseClass(const mir::ClassRef& base) -> std::string {
-  return std::visit(
-      [](const mir::RuntimeLibraryClassRef& ref) -> std::string {
-        switch (ref.kind) {
-          case mir::RuntimeClassKind::kInstance:
-            return "lyra::runtime::Instance";
-          case mir::RuntimeClassKind::kGenScope:
-            return "lyra::runtime::GenScope";
-        }
-        throw InternalError("RenderBaseClass: unknown RuntimeClassKind");
-      },
-      base);
-}
-
 auto VisibilityKeyword(mir::MethodVisibility visibility) -> std::string_view {
   switch (visibility) {
     case mir::MethodVisibility::kPublic:
@@ -232,24 +241,18 @@ auto RenderScopeAsClass(
           ? ScopeView::ForRoot(unit, s, s.constructor_block)
           : parent_struct_view->WithClass(s, s.constructor_block);
 
+  const std::optional<mir::BaseContract> base =
+      s.base.has_value()
+          ? std::optional{mir::ResolveBaseContract(unit, *s.base)}
+          : std::nullopt;
+
   std::string out;
   out += Indent(indent) + "class " + s.name + " final";
-  if (s.base.has_value()) {
-    out += " : public " + RenderBaseClass(*s.base);
+  if (base.has_value()) {
+    out += " : public " + RenderTypeAsCpp(unit, s, base->renderable);
   }
   out += " {\n";
   out += Indent(indent) + " public:\n";
-
-  // The scope's own time precision (LRM 3.14.2). The engine takes the minimum
-  // across the tree as the design-global tick (LRM 3.14.3); the runtime scales
-  // a local-precision delay from this value to that tick. Only a tree node --
-  // a class with a runtime base -- overrides it.
-  if (s.base.has_value()) {
-    out += Indent(indent + 1) +
-           "auto TimePrecisionPower() const -> std::int8_t override { return " +
-           std::to_string(static_cast<int>(s.time_resolution.precision_power)) +
-           "; }\n\n";
-  }
 
   for (const mir::ClassId child_id : s.contained) {
     out += RenderScopeAsClass(
@@ -263,23 +266,11 @@ auto RenderScopeAsClass(
   // base but still runs its constructor body to initialize its members. Either
   // way the constructor is emitted when there is a base to forward to or a body
   // to run; a baseless object with an empty body keeps the implicit default.
-  if (s.base.has_value()) {
-    out +=
-        RenderConstructor(this_anchor, s, RenderBaseClass(*s.base), indent + 1);
+  if (base.has_value()) {
+    out += RenderConstructor(
+        this_anchor, s, RenderTypeAsCpp(unit, s, base->renderable), indent + 1);
   } else if (!s.constructor_block.root_stmts.empty()) {
     out += RenderConstructor(this_anchor, s, "", indent + 1);
-  }
-
-  // A unit-root scope is a module instance; its name is the def-name an upward
-  // reference matches when climbing the parent chain (LRM 23.8).
-  const auto* base_instance =
-      s.base.has_value() ? std::get_if<mir::RuntimeLibraryClassRef>(&*s.base)
-                         : nullptr;
-  if (base_instance != nullptr &&
-      base_instance->kind == mir::RuntimeClassKind::kInstance) {
-    out += Indent(indent + 1) +
-           "auto DefName() const -> std::string_view override { return \"" +
-           s.name + "\"; }\n";
   }
 
   // Members follow the constructor and methods. They are public so cross-unit
@@ -428,17 +419,19 @@ auto RenderScopeHeaderFile(
     out += "\n";
   }
 
-  // A SystemVerilog class is a free-standing registry object with no runtime
-  // base and no structural parent, so it is not reached by the scope tree's
-  // `contained` walk. Emit every baseless class before the scope tree that may
-  // reference it through a handle or `new`. (The scope objects -- the module
-  // and its generate scopes -- carry a runtime base and are emitted by the
-  // tree walk below.)
+  // A SystemVerilog class is a free-standing registry object with no structural
+  // parent, so it is not reached by the scope tree's `contained` walk. Emit
+  // every non-tree-node class before the scope tree that may reference it
+  // through a handle or `new`. (The scope objects -- the module and its
+  // generate scopes -- are runtime tree nodes emitted by the tree walk below.)
   for (std::size_t i = 0; i < unit.classes.size(); ++i) {
     const mir::ClassId id{static_cast<std::uint32_t>(i)};
     if (!unit.classes.IsDefined(id)) continue;
     const mir::Class& cls = unit.GetClass(id);
-    if (cls.base.has_value()) continue;
+    if (cls.base.has_value() &&
+        mir::ResolveBaseContract(unit, *cls.base).is_runtime_tree_node) {
+      continue;
+    }
     out += RenderScopeAsClass(unit, cls, 0, nullptr);
     out += "\n";
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -121,10 +121,15 @@ auto RenderIntegerLiteralExpr(
     const ScopeView& view, const mir::Expr& expr,
     const mir::IntegerLiteral& lit) -> std::string {
   const auto& ty = view.Unit().types.Get(expr.type);
+  if (std::holds_alternative<mir::MachineIntType>(ty.data)) {
+    // A machine integer is a raw target scalar, so its literal is the bare
+    // numeric value -- no `PackedArray` wrapper.
+    return std::to_string(IntegralConstantToInt64(lit.value));
+  }
   if (!ty.IsIntegralPacked()) {
     throw InternalError(
         "RenderIntegerLiteralExpr: IntegerLiteral not typed as "
-        "PackedArrayType or EnumType");
+        "PackedArrayType, EnumType, or MachineIntType");
   }
   auto body = RenderPackedArrayIntegerLiteral(ty.AsIntegralPacked(), lit.value);
   if (ty.IsEnum()) {

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -64,6 +64,23 @@ auto RenderTypeAsCpp(
           [](const mir::StringType&) -> std::string {
             return std::string{"lyra::value::String"};
           },
+          [](const mir::StringViewType&) -> std::string {
+            return std::string{"std::string_view"};
+          },
+          [](const mir::MachineIntType& m) -> std::string {
+            const std::string_view sign =
+                m.signedness == mir::Signedness::kSigned ? "" : "u";
+            switch (m.bit_width) {
+              case 8:
+              case 16:
+              case 32:
+              case 64:
+                return std::format("std::{}int{}_t", sign, m.bit_width);
+              default:
+                throw InternalError(
+                    "RenderTypeAsCpp: unsupported MachineIntType width");
+            }
+          },
           [](const mir::EventType&) -> std::string {
             return std::string{"lyra::runtime::NamedEvent"};
           },
@@ -109,6 +126,12 @@ auto RenderTypeAsCpp(
           [](const mir::ScopeType&) -> std::string {
             return std::string{"lyra::runtime::Scope"};
           },
+          [](const mir::InstanceType&) -> std::string {
+            return std::string{"lyra::runtime::Instance"};
+          },
+          [](const mir::GenScopeType&) -> std::string {
+            return std::string{"lyra::runtime::GenScope"};
+          },
           [](const mir::ServicesType&) -> std::string {
             return std::string{"lyra::runtime::RuntimeServices&"};
           },
@@ -146,7 +169,9 @@ auto RenderTypeAsCpp(
             std::string ref = std::format(
                 "lyra::runtime::Ref<{}>",
                 RenderTypeAsCpp(unit, owner_class, r.pointee));
-            return r.is_const ? std::format("const {}", ref) : ref;
+            return r.mutability == mir::Mutability::kReadOnly
+                       ? std::format("const {}", ref)
+                       : ref;
           },
           [](const mir::VoidType&) -> std::string {
             return std::string{"void"};
@@ -162,8 +187,12 @@ auto RenderTypeAsCpp(
                 // A borrowed pointer refers to the pointee's storage cell --
                 // a `Var<T>` if the pointee is an observable wrapper, the
                 // bare type otherwise -- so the slot mirrors what it points
-                // at by recursing.
-                return std::format("{}*", inner);
+                // at by recursing. A read-only borrow grants no write
+                // capability (`const T*`), the immutable-receiver case.
+                return std::format(
+                    "{}{}*",
+                    p.mutability == mir::Mutability::kReadOnly ? "const " : "",
+                    inner);
             }
             throw InternalError("RenderTypeAsCpp: unknown PointerOwnership");
           },

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -252,7 +252,9 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
             ? module_->Unit().types.Intern(
                   mir::RefType{
                       .pointee = value_type,
-                      .is_const = dir == hir::ParamDirection::kConstRef})
+                      .mutability = dir == hir::ParamDirection::kConstRef
+                                        ? mir::Mutability::kReadOnly
+                                        : mir::Mutability::kMutable})
             : value_type;
     const mir::LocalId mir_var =
         body_block.vars.Add(mir::LocalDecl{.name = hir_var.name, .type = type});

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -86,8 +86,9 @@ auto BuildReferenceArg(
   if (std::holds_alternative<mir::ObservableType>(pointee_ty.data)) {
     pointee = std::get<mir::ObservableType>(pointee_ty.data).value;
   }
-  const mir::TypeId ref_type =
-      unit.types.Intern(mir::RefType{.pointee = pointee, .is_const = false});
+  const mir::TypeId ref_type = unit.types.Intern(
+      mir::RefType{
+          .pointee = pointee, .mutability = mir::Mutability::kMutable});
   return block.exprs.Add(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -25,6 +25,7 @@
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/base_contract.hpp"
 #include "lyra/mir/block_hops.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_ref.hpp"
@@ -948,7 +949,8 @@ auto InstallPortConnections(
 
       const mir::TypeId value_type = module.TranslateType(alias.type);
       const mir::TypeId ref_type = module.Unit().types.Intern(
-          mir::RefType{.pointee = value_type, .is_const = false});
+          mir::RefType{
+              .pointee = value_type, .mutability = mir::Mutability::kMutable});
       const mir::TypeId slot_type = module.Unit().types.PointerTo(
           ref_type, mir::PointerOwnership::kBorrowed);
       const mir::ExprId nav = resolve_block.exprs.Add(BuildDownwardNavValue(
@@ -1484,24 +1486,21 @@ auto StructuralScopeLowerer::DeclareShape(
   mir::ClassShape shape;
   shape.name = name_;
   shape.base = mir::ClassRef{mir::RuntimeLibraryClassRef{
-      .kind = parent_ == nullptr ? mir::RuntimeClassKind::kInstance
-                                 : mir::RuntimeClassKind::kGenScope}};
+      .base_type = parent_ == nullptr
+                       ? module.Unit().types.Intern(mir::InstanceType{})
+                       : module.Unit().types.Intern(mir::GenScopeType{})}};
   shape.self_pointer_type = self_pointer_type;
   shape.time_resolution = hir_scope.time_resolution;
 
-  // The runtime Scope-base contract: every Scope-derived class takes the
-  // parent pointer, its own HierarchySegment, and the engine services
-  // handle as the first three ctor params, forwarded straight to the
-  // base. The order and types are the SDK convention; the lowering states
-  // them once here so the render reads them like any other params.
+  // An object forwards its base's construction contract straight to the base
+  // constructor; the prefix params come from that contract, not restated here,
+  // and the render walks them like any other params.
   if (shape.base.has_value()) {
-    const auto& builtins = module.Unit().builtins;
-    shape.ctor_prefix_params.Add(
-        mir::ParamDecl{.name = "parent", .type = builtins.scope_ptr});
-    shape.ctor_prefix_params.Add(
-        mir::ParamDecl{.name = "segment", .type = builtins.hierarchy_segment});
-    shape.ctor_prefix_params.Add(
-        mir::ParamDecl{.name = "services", .type = builtins.services});
+    const mir::BaseContract contract =
+        mir::ResolveBaseContract(module.Unit(), *shape.base);
+    for (const auto& param : contract.ctor_prefix) {
+      shape.ctor_prefix_params.Add(param);
+    }
   }
   for (const auto& alias : hir_scope.type_aliases) {
     shape.type_aliases.push_back(
@@ -1525,12 +1524,15 @@ auto StructuralScopeLowerer::DeclareShape(
     // Any other module-scope value-storage signal becomes an observable cell so
     // writes route through `Var<T>::Set` and subscribers fire.
     const mir::TypeId mir_field_type =
-        is_reference ? module.Unit().types.Intern(
-                           mir::RefType{
-                               .pointee = mir_value_type,
-                               .is_const = *d.reference ==
-                                           hir::ReferenceBinding::kConstRef})
-                     : MaybeWrapObservable(module, mir_value_type);
+        is_reference
+            ? module.Unit().types.Intern(
+                  mir::RefType{
+                      .pointee = mir_value_type,
+                      .mutability =
+                          *d.reference == hir::ReferenceBinding::kConstRef
+                              ? mir::Mutability::kReadOnly
+                              : mir::Mutability::kMutable})
+            : MaybeWrapObservable(module, mir_value_type);
     const mir::MemberId mir_id = shape.members.Add(
         mir::MemberDecl{.name = d.name, .type = mir_field_type});
     lowerer.MapStructuralVar(hir_id, mir_id);
@@ -1852,6 +1854,90 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
             .overrides = mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
                 .method = mir::RuntimeMethod::kActivate}},
             .visibility = mir::MethodVisibility::kInternal});
+  }
+
+  // A runtime tree node overrides the runtime virtuals that report its constant
+  // properties -- its time precision (LRM 3.14.2), and a module instance its
+  // def-name (LRM 23.8) -- as ordinary methods whose body returns the constant.
+  // Added after the subroutines, whose method ids are pre-mapped.
+  if (mir_class.base.has_value()) {
+    const mir::BaseContract contract =
+        mir::ResolveBaseContract(module.Unit(), *mir_class.base);
+    const mir::TypeId self_object_type =
+        module.Unit().types.Intern(mir::ObjectType{.class_id = class_id_});
+    // These accessors only read the object, so their receiver is a read-only
+    // borrow (an immutable `&self`); the render derives the `const` shim from
+    // it.
+    const mir::TypeId self_readonly_pointer_type =
+        module.Unit().types.PointerTo(
+            self_object_type, mir::PointerOwnership::kBorrowed,
+            mir::Mutability::kReadOnly);
+    if (contract.is_runtime_tree_node) {
+      // The precision power is plain machine metadata (LRM 3.14.2), so its type
+      // is a machine integer rather than a 4-state SV value -- it stays a raw
+      // `int8` end to end, with no value-wrapper round-trip at the engine.
+      const mir::TypeId precision_type = module.Unit().types.Intern(
+          mir::MachineIntType{
+              .bit_width = 8, .signedness = mir::Signedness::kSigned});
+      mir::Block precision_block;
+      const mir::LocalId precision_self = precision_block.vars.Add(
+          mir::LocalDecl{.name = "self", .type = self_readonly_pointer_type});
+      const mir::ExprId precision_value = precision_block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::IntegerLiteral{
+                      .value =
+                          mir::IntegralConstant{
+                              .value_words = {static_cast<
+                                  std::uint64_t>(static_cast<std::int64_t>(
+                                  mir_class.time_resolution.precision_power))},
+                              .state_words = {},
+                              .width = 8,
+                              .signedness = mir::Signedness::kSigned,
+                              .state_kind = mir::IntegralStateKind::kTwoState}},
+              .type = precision_type});
+      precision_block.AppendStmt(
+          mir::ReturnStmt{
+              .value = precision_value, .is_coroutine_return = false});
+      mir_class.methods.Add(
+          mir::MethodDecl{
+              .name = "TimePrecisionPower",
+              .code =
+                  mir::CallableCode{
+                      .params = {precision_self},
+                      .result_type = precision_type,
+                      .body = std::move(precision_block)},
+              .overrides =
+                  mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
+                      .method = mir::RuntimeMethod::kTimePrecisionPower}},
+              .visibility = mir::MethodVisibility::kInternal});
+    }
+    if (contract.exposes_def_name) {
+      const mir::TypeId string_view_type =
+          module.Unit().types.Intern(mir::StringViewType{});
+      mir::Block def_name_block;
+      const mir::LocalId def_name_self = def_name_block.vars.Add(
+          mir::LocalDecl{.name = "self", .type = self_readonly_pointer_type});
+      const mir::ExprId def_name_value = def_name_block.exprs.Add(
+          mir::Expr{
+              .data = mir::StringLiteral{.value = mir_class.name},
+              .type = string_view_type});
+      def_name_block.AppendStmt(
+          mir::ReturnStmt{
+              .value = def_name_value, .is_coroutine_return = false});
+      mir_class.methods.Add(
+          mir::MethodDecl{
+              .name = "DefName",
+              .code =
+                  mir::CallableCode{
+                      .params = {def_name_self},
+                      .result_type = string_view_type,
+                      .body = std::move(def_name_block)},
+              .overrides =
+                  mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
+                      .method = mir::RuntimeMethod::kDefName}},
+              .visibility = mir::MethodVisibility::kInternal});
+    }
   }
 
   module.Unit().DefineClass(class_id_, std::move(mir_class));

--- a/src/lyra/mir/base_contract.cpp
+++ b/src/lyra/mir/base_contract.cpp
@@ -1,0 +1,27 @@
+#include "lyra/mir/base_contract.hpp"
+
+#include <variant>
+
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/param.hpp"
+#include "lyra/mir/type.hpp"
+
+namespace lyra::mir {
+
+auto ResolveBaseContract(const CompilationUnit& unit, const ClassRef& base)
+    -> BaseContract {
+  const auto& runtime_base = std::get<RuntimeLibraryClassRef>(base);
+  const bool is_instance = std::holds_alternative<InstanceType>(
+      unit.types.Get(runtime_base.base_type).data);
+  const auto& builtins = unit.builtins;
+  return BaseContract{
+      .renderable = runtime_base.base_type,
+      .is_runtime_tree_node = true,
+      .exposes_def_name = is_instance,
+      .ctor_prefix = {
+          ParamDecl{.name = "parent", .type = builtins.scope_ptr},
+          ParamDecl{.name = "segment", .type = builtins.hierarchy_segment},
+          ParamDecl{.name = "services", .type = builtins.services}}};
+}
+
+}  // namespace lyra::mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -11,6 +11,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/mir/base_contract.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_ref.hpp"
@@ -50,14 +51,16 @@ class MirDumper {
     Indent();
     DumpClass(unit.root, unit.GetClass(unit.root));
     // A class reached by a handle is not a child of the runtime tree, so it is
-    // not dumped under the root; every such class carries no runtime base.
+    // not dumped under the root; a runtime tree node is reached by the root
+    // walk's Contained recursion instead.
     for (std::size_t i = 0; i < unit.classes.size(); ++i) {
       const ClassId id{static_cast<std::uint32_t>(i)};
       if (id == unit.root || !unit.classes.IsDefined(id)) {
         continue;
       }
       const Class& cls = unit.GetClass(id);
-      if (cls.base.has_value()) {
+      if (cls.base.has_value() &&
+          ResolveBaseContract(unit, *cls.base).is_runtime_tree_node) {
         continue;
       }
       DumpClass(id, cls);
@@ -181,6 +184,14 @@ class MirDumper {
               return "WildcardIndexType";
             },
             [](const StringType&) -> std::string { return "StringType"; },
+            [](const StringViewType&) -> std::string {
+              return "StringViewType";
+            },
+            [](const MachineIntType& m) -> std::string {
+              return std::format(
+                  "MachineInt(width={}, signed={})", m.bit_width,
+                  m.signedness == Signedness::kSigned ? "true" : "false");
+            },
             [](const EventType&) -> std::string { return "EventType"; },
             [](const RealType&) -> std::string { return "RealType"; },
             [](const ShortRealType&) -> std::string { return "ShortRealType"; },
@@ -195,6 +206,8 @@ class MirDumper {
                   "ExternalUnitObject(unit=\"{}\")", e.unit_name);
             },
             [](const ScopeType&) -> std::string { return "Scope"; },
+            [](const InstanceType&) -> std::string { return "Instance"; },
+            [](const GenScopeType&) -> std::string { return "GenScope"; },
             [](const ServicesType&) -> std::string { return "Services"; },
             [](const FilesType&) -> std::string { return "Files"; },
             [](const DiagnosticType&) -> std::string { return "Diagnostic"; },
@@ -223,20 +236,26 @@ class MirDumper {
             },
             [](const RefType& r) -> std::string {
               return std::format(
-                  "Ref({}pointee=Type[{}])", r.is_const ? "const, " : "",
+                  "Ref({}pointee=Type[{}])",
+                  r.mutability == Mutability::kReadOnly ? "readonly, " : "",
                   r.pointee.value);
             },
             [](const PointerType& p) -> std::string {
+              const std::string_view ro =
+                  p.mutability == Mutability::kReadOnly ? ", readonly" : "";
               switch (p.ownership) {
                 case PointerOwnership::kUnique:
                   return std::format(
-                      "Pointer(unique, pointee=Type[{}])", p.pointee.value);
+                      "Pointer(unique{}, pointee=Type[{}])", ro,
+                      p.pointee.value);
                 case PointerOwnership::kShared:
                   return std::format(
-                      "Pointer(shared, pointee=Type[{}])", p.pointee.value);
+                      "Pointer(shared{}, pointee=Type[{}])", ro,
+                      p.pointee.value);
                 case PointerOwnership::kBorrowed:
                   return std::format(
-                      "Pointer(borrowed, pointee=Type[{}])", p.pointee.value);
+                      "Pointer(borrowed{}, pointee=Type[{}])", ro,
+                      p.pointee.value);
               }
               throw InternalError("MirDumper: unknown PointerOwnership");
             },
@@ -671,12 +690,8 @@ class MirDumper {
     Indent();
 
     if (s.base.has_value()) {
-      const auto& ref = std::get<RuntimeLibraryClassRef>(*s.base);
-      Line(
-          std::format(
-              "Base: {}", ref.kind == RuntimeClassKind::kInstance
-                              ? "Instance"
-                              : "GenScope"));
+      const TypeId renderable = ResolveBaseContract(*unit_, *s.base).renderable;
+      Line(std::format("Base: {}", FormatType(unit_->types.Get(renderable))));
     }
 
     Line("Contained:");
@@ -739,10 +754,22 @@ class MirDumper {
     if (d.overrides.has_value()) {
       const auto& ref = std::get<RuntimeLibraryMethodRef>(*d.overrides);
       std::string_view target = "Resolve";
-      if (ref.method == RuntimeMethod::kInitialize) {
-        target = "Initialize";
-      } else if (ref.method == RuntimeMethod::kActivate) {
-        target = "Activate";
+      switch (ref.method) {
+        case RuntimeMethod::kResolve:
+          target = "Resolve";
+          break;
+        case RuntimeMethod::kInitialize:
+          target = "Initialize";
+          break;
+        case RuntimeMethod::kActivate:
+          target = "Activate";
+          break;
+        case RuntimeMethod::kTimePrecisionPower:
+          target = "TimePrecisionPower";
+          break;
+        case RuntimeMethod::kDefName:
+          target = "DefName";
+          break;
       }
       Line(std::format("Overrides: {}", target));
     }

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -65,6 +65,8 @@ auto Type::Kind() const -> TypeKind {
           },
           [](const WildcardIndexType&) { return TypeKind::kWildcardIndex; },
           [](const StringType&) { return TypeKind::kString; },
+          [](const StringViewType&) { return TypeKind::kStringView; },
+          [](const MachineIntType&) { return TypeKind::kMachineInt; },
           [](const EventType&) { return TypeKind::kEvent; },
           [](const RealType&) { return TypeKind::kReal; },
           [](const ShortRealType&) { return TypeKind::kShortReal; },
@@ -76,6 +78,8 @@ auto Type::Kind() const -> TypeKind {
             return TypeKind::kExternalUnitObject;
           },
           [](const ScopeType&) { return TypeKind::kScope; },
+          [](const InstanceType&) { return TypeKind::kInstance; },
+          [](const GenScopeType&) { return TypeKind::kGenScope; },
           [](const ServicesType&) { return TypeKind::kServices; },
           [](const FilesType&) { return TypeKind::kFiles; },
           [](const DiagnosticType&) { return TypeKind::kDiagnostic; },

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -75,16 +75,20 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
           HashField(seed, t.class_id.value);
         } else if constexpr (std::is_same_v<T, ExternalUnitObjectType>) {
           HashField(seed, t.unit_name);
+        } else if constexpr (std::is_same_v<T, MachineIntType>) {
+          HashField(seed, t.bit_width);
+          HashCombine(seed, std::hash<int>{}(static_cast<int>(t.signedness)));
         } else if constexpr (std::is_same_v<T, RuntimeLibraryType>) {
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.kind)));
         } else if constexpr (std::is_same_v<T, CoroutineType>) {
           HashId(seed, t.payload);
         } else if constexpr (std::is_same_v<T, RefType>) {
           HashId(seed, t.pointee);
-          HashField(seed, t.is_const);
+          HashCombine(seed, std::hash<int>{}(static_cast<int>(t.mutability)));
         } else if constexpr (std::is_same_v<T, PointerType>) {
           HashId(seed, t.pointee);
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.ownership)));
+          HashCombine(seed, std::hash<int>{}(static_cast<int>(t.mutability)));
         } else if constexpr (std::is_same_v<T, ManagedRefType>) {
           HashId(seed, t.pointee);
         } else if constexpr (std::is_same_v<T, VectorType>) {


### PR DESCRIPTION
## Summary

This generalizes how MIR models an object's base and a method's receiver so the runtime-contract surface (a scope's lifecycle hooks, its time precision, its def-name) is expressed in MIR's generic vocabulary rather than decided in the backend. An object's base becomes one generic nominal-object reference resolved through a single path, the runtime virtuals an object overrides become ordinary methods, the scalar and string metadata they expose get their own primitive types, and a method's receiver carries its read/write capability the way a reference does. It is behavior-neutral: the emitted program is unchanged.

## Design

An object's base is one generic nominal-object reference, resolved through one entry point to a base contract. The runtime-library base is named by the type that renders it, so its target-language spelling comes from the single type-mapping dispatch like any other type; whether the object is a runtime tree node, whether it exposes a def-name, and its constructor prefix are facts stated on the base and read off it, never inferred in render. Today only the runtime-library arm has a producer; the intra-unit and cross-unit arms slot in with class inheritance, each adding one variant and one resolver case with no consumer change.

The runtime virtuals an object overrides are ordinary methods. `TimePrecisionPower` and `DefName` join the lifecycle hooks as plain `MethodDecl`s whose body returns the constant, rendered by the one general method renderer; the override shim generalizes to any return type with no per-virtual branch, and the runtime-virtual spellings stay in the single override-reference mapping. The metadata these expose is typed honestly: a borrowed string view (`std::string_view`, distinct from the owning SV string) for the def-name, and a primitive machine integer (`std::int8_t`, distinct from the 4-state SV `PackedArray`) for the precision power. Both are runtime-contract scalars, not simulation values, so they lower to raw targets and the runtime reads them with no value-wrapper round-trip.

A method's receiver carries its mutability. A reference or borrow now states whether it grants write capability (the generic `&T` vs `&mut T`), an axis orthogonal to a pointer's ownership; the existing `const ref` parameter moves onto it. A read-only method takes a read-only borrow of `self`, and the C++ backend derives the `const` override shim directly from that stated receiver type rather than from a backend-side decision.

## Testing

The full `bazel test //...` suite passes. The change is behavior-neutral; the emitted program for every existing case is unchanged.
