### PR TITLE
Show actual output on test matcher mismatch

### DIFF
--- a/tests/framework/matcher.cpp
+++ b/tests/framework/matcher.cpp
@@ -133,13 +133,15 @@ auto CheckOutput(
   for (const auto& needle : expected.contains) {
     if (cleaned.find(needle) == std::string::npos) {
       return std::format(
-          "{}: expected substring not found: \"{}\"", context, needle);
+          "{}: expected substring not found: \"{}\"\n--- actual ---\n{}",
+          context, needle, cleaned);
     }
   }
   for (const auto& needle : expected.not_contains) {
     if (cleaned.find(needle) != std::string::npos) {
       return std::format(
-          "{}: forbidden substring present: \"{}\"", context, needle);
+          "{}: forbidden substring present: \"{}\"\n--- actual ---\n{}",
+          context, needle, cleaned);
     }
   }
   return std::nullopt;


### PR DESCRIPTION
## Summary

When a YAML case's `contains` / `not_contains` assertion on stderr or stdout fails, the matcher reported only the missing or forbidden needle, not what the process actually produced. Diagnosing a mismatch then meant re-running the tool by hand -- or even building a reference tree -- just to see the actual output. This appends the captured output to those two failure messages, matching the format the `exact`-mismatch case already uses, so a stderr/stdout expectation failure is self-diagnosing from the test log alone.

## Testing

`bazel test //...` passes.
