### PR TITLE
Give closures a first-class callable type

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -37,52 +37,55 @@ Read top to bottom on first pass:
     variable; drivers attached along the reference route
 18. `binding_and_capture.md` -- the lexical reference axis: logical binding identity, per-body
     materialization, closure capture forwarding, carrier vs view
-19. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes each
+19. `compiler_generated_storage.md` -- compiler-generated storage on the value/reference spine: the
+    closure environment as a value tuple, the activation frame as reference storage, capture forms
+20. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes each
     route segment by visibility (typed for layout-owned, SDK for opaque)
-20. `backend_contract.md` -- per-node within-artifact realization rules; type mapping vs value
+21. `backend_contract.md` -- per-node within-artifact realization rules; type mapping vs value
     emission; what a backend may and may not name in render
-21. `identity_and_ownership.md` -- identity rules and forbidden shapes
-22. `lowering_boundaries.md` -- what each lowering may and may not do
-23. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
+22. `identity_and_ownership.md` -- identity rules and forbidden shapes
+23. `lowering_boundaries.md` -- what each lowering may and may not do
+24. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
     registries, builders, walk frame)
-24. `incremental_build.md` -- query-based incremental compilation and caching
-25. `testing_strategy.md` -- test categories and structure
+25. `incremental_build.md` -- query-based incremental compilation and caching
+26. `testing_strategy.md` -- test categories and structure
 
 ## Concept Index
 
 If you are looking for a concept, this table points to the canonical doc.
 
-| Concept                                                                              | Canonical doc               |
-| ------------------------------------------------------------------------------------ | --------------------------- |
-| Primary optimization target; non-negotiable design constraints                       | `north_star.md`             |
-| Pipeline (HIR -> MIR -> LIR -> LLVM IR); compile-time vs runtime split               | `compiler_overview.md`      |
-| Compilation unit; class-level artifacts; instance records                            | `compilation_unit_model.md` |
-| Constructor vs simulation execution contexts; structural vs process                  | `runtime_model.md`          |
-| Storage and binding vs construction; type-driven member walk                         | `runtime_model.md`          |
-| Elaboration phases (build / resolve / seal / initialize / activate); ctor scope      | `elaboration_lifecycle.md`  |
-| Generate as constructor-time logic; object graph shape                               | `hierarchy_and_generate.md` |
-| Instance array as a data type; multiplicity vs generate axes                         | `hierarchy_and_generate.md` |
-| Reference routes; per-segment classification by layout visibility; sealed endpoints  | `reference_resolution.md`   |
-| Net value as the resolution of driver contributions; net vs variable; drivers        | `net_resolution.md`         |
-| Logical binding identity; per-body materialization; capture forwarding; carrier/view | `binding_and_capture.md`    |
-| Per-unit artifact emission; cross-unit realization via the SDK; no wiring            | `emission_model.md`         |
-| Per-node within-artifact render; type mapping vs value emission                      | `backend_contract.md`       |
-| Parameter values, specialization keys, per-specialization artifacts                  | `specialization_model.md`   |
-| Identity rules; ownership; forbidden identity shapes                                 | `identity_and_ownership.md` |
-| Lowering permissions (what each lowering may and may not do)                         | `lowering_boundaries.md`    |
-| Lowering pass organization (facts / registry / builder / walk frame)                 | `lowering_organization.md`  |
-| HIR shape (statements, expressions, primaries)                                       | `hir.md`                    |
-| MIR shape (objects, members, callables)                                              | `mir.md`                    |
-| Member and type model; object types; owning pointer; vector wrapper                  | `mir.md`                    |
-| Callable model; code vs value; captures; references as a field type                  | `callable.md`               |
-| Object model; nominal object types; inheritance; dispatch; handles                   | `object_model.md`           |
-| Object lifetime; managed reclamation; tracing GC; activation frames                  | `object_lifetime.md`        |
-| LIR shape (CFG, basic blocks, storage)                                               | `lir.md`                    |
-| Activation; execution instance; completion slot; cancellation domain                 | `activation.md`             |
-| Stratified scheduler; regions; suspension protocol; NBA / closure submit             | `scheduling.md`             |
-| Incremental compilation; query-based caching                                         | `incremental_build.md`      |
-| Locating/bundling the C++ runtime; run output contract                               | `runtime_distribution.md`   |
-| Test categories; suite layout; expectation forms                                     | `testing_strategy.md`       |
+| Concept                                                                                  | Canonical doc                   |
+| ---------------------------------------------------------------------------------------- | ------------------------------- |
+| Primary optimization target; non-negotiable design constraints                           | `north_star.md`                 |
+| Pipeline (HIR -> MIR -> LIR -> LLVM IR); compile-time vs runtime split                   | `compiler_overview.md`          |
+| Compilation unit; class-level artifacts; instance records                                | `compilation_unit_model.md`     |
+| Constructor vs simulation execution contexts; structural vs process                      | `runtime_model.md`              |
+| Storage and binding vs construction; type-driven member walk                             | `runtime_model.md`              |
+| Elaboration phases (build / resolve / seal / initialize / activate); ctor scope          | `elaboration_lifecycle.md`      |
+| Generate as constructor-time logic; object graph shape                                   | `hierarchy_and_generate.md`     |
+| Instance array as a data type; multiplicity vs generate axes                             | `hierarchy_and_generate.md`     |
+| Reference routes; per-segment classification by layout visibility; sealed endpoints      | `reference_resolution.md`       |
+| Net value as the resolution of driver contributions; net vs variable; drivers            | `net_resolution.md`             |
+| Logical binding identity; per-body materialization; capture forwarding; carrier/view     | `binding_and_capture.md`        |
+| Per-unit artifact emission; cross-unit realization via the SDK; no wiring                | `emission_model.md`             |
+| Per-node within-artifact render; type mapping vs value emission                          | `backend_contract.md`           |
+| Parameter values, specialization keys, per-specialization artifacts                      | `specialization_model.md`       |
+| Identity rules; ownership; forbidden identity shapes                                     | `identity_and_ownership.md`     |
+| Lowering permissions (what each lowering may and may not do)                             | `lowering_boundaries.md`        |
+| Lowering pass organization (facts / registry / builder / walk frame)                     | `lowering_organization.md`      |
+| HIR shape (statements, expressions, primaries)                                           | `hir.md`                        |
+| MIR shape (objects, members, callables)                                                  | `mir.md`                        |
+| Member and type model; object types; owning pointer; vector wrapper                      | `mir.md`                        |
+| Callable model; code vs value; captures; references as a field type                      | `callable.md`                   |
+| Closure environment as value tuple; activation frame; capture forms; callable value type | `compiler_generated_storage.md` |
+| Object model; nominal object types; inheritance; dispatch; handles                       | `object_model.md`               |
+| Object lifetime; managed reclamation; tracing GC; activation frames                      | `object_lifetime.md`            |
+| LIR shape (CFG, basic blocks, storage)                                                   | `lir.md`                        |
+| Activation; execution instance; completion slot; cancellation domain                     | `activation.md`                 |
+| Stratified scheduler; regions; suspension protocol; NBA / closure submit                 | `scheduling.md`                 |
+| Incremental compilation; query-based caching                                             | `incremental_build.md`          |
+| Locating/bundling the C++ runtime; run output contract                                   | `runtime_distribution.md`       |
+| Test categories; suite layout; expectation forms                                         | `testing_strategy.md`           |
 
 These docs are the contracts. For the trade-off records behind them -- rejected alternatives and
 load-bearing invariants, grouped by subject -- see the Index in
@@ -105,7 +108,7 @@ it compiles and passes tests.
 | Identity / ownership / id kinds                                | `north_star`, `identity_and_ownership`                                                                                       |
 | Object model / classes / inheritance / dispatch / handles      | `north_star`, `object_model`, `object_lifetime`, `mir`, `callable`, `runtime_model`                                          |
 | Object lifetime / managed reclamation / GC / activation frames | `north_star`, `object_lifetime`, `object_model`, `mir`, `runtime_model`, `scheduling`                                        |
-| Locals / closures / capture / receiver / lexical references    | `north_star`, `binding_and_capture`, `callable`, `mir`, `reference_resolution`                                               |
+| Locals / closures / capture / receiver / lexical references    | `north_star`, `binding_and_capture`, `compiler_generated_storage`, `callable`, `mir`, `reference_resolution`                 |
 
 The failure mode this guards against: anchoring on current code -- which may be a transitional
 shortcut -- instead of the contract. Current code that contradicts a contract is wrong; read the

--- a/docs/architecture/compiler_generated_storage.md
+++ b/docs/architecture/compiler_generated_storage.md
@@ -1,0 +1,221 @@
+# Compiler-Generated Storage
+
+## Purpose
+
+This doc owns the storage shape of the two compiler-synthesized entities that carry state: the
+**environment** a closure value holds, and the **activation frame** that owns a callable's automatic
+locals. Neither is a nominal SystemVerilog object (`object_model.md`) and neither is loose program
+data (`mir.md`'s value-type system). They are the storage the lowering generates so a deferred or
+concurrent body can reach the state it needs and so an automatic local can outlive the execution
+that created it.
+
+MIR's type system has one deliberate top-level split: value types versus reference types. This doc
+places both compiler-generated entities on that split and keeps them there:
+
+> A closure environment is a **value** aggregate. An activation frame is **reference** storage with
+> identity. They sit on opposite sides of the value/reference spine and are never the same shape.
+
+The conceptual peers are the same as the rest of MIR: a closure is code plus a captured environment
+(C++ lambda, Rust closure), and a frame is the activation record that owns a call's locals (the
+stack frame a language promotes to the heap when a closure outlives it).
+
+## Owns
+
+- The closure environment as a **value aggregate** -- a `TupleType` -- and the closure value as
+  callable code plus that environment.
+- The two type levels of a callable value: the **concrete closure value** (carrying its exact
+  environment) and the **erased `Callable<Sig>`**, and the explicit erasure boundary between them.
+- The three **capture forms** -- snapshot, live-place alias, retained-frame -- and the rule that the
+  form is carried by the captured field's type.
+- The **activation frame**: identity-bearing reference storage that owns a callable's automatic
+  locals, and its shared-ownership retention model.
+- The **reference-storage substrate** that the activation frame and the nominal object both
+  specialize: ordered slots, slot types, and construction / destruction rules for identity-bearing
+  field storage.
+
+## Does Not Own
+
+- Which binding a reference names, per-body materialization, and capture forwarding across closure
+  boundaries. That is the lexical axis, owned by `binding_and_capture.md`. This doc owns the storage
+  shape the captured fields land in; that doc owns which origin fills each field and how it is
+  forwarded.
+- The callable concept -- code versus value, the signature, the result type as call protocol. That
+  is `callable.md`. This doc owns the environment half of a callable value and the value's type
+  levels.
+- The nominal object model -- methods, inheritance, dispatch, lifecycle, managed handles. That is
+  `object_model.md`. The activation frame shares the object's reference-storage substrate but is not
+  a nominal object.
+- The value-type system, including the tuple as the one heterogeneous product type. That is
+  `mir.md`. This doc uses the tuple as the closure environment; it does not define the tuple.
+- The runtime execution instance -- the process / task / fork activation, its scheduler token, and
+  its completion slot. That is `activation.md`. This doc owns the frame storage an execution
+  instance owns or refers to, never the execution instance itself.
+- Which capture form a SystemVerilog construct requires (snapshot a loop variable, alias a `ref`,
+  retain a frame for a detached branch). That is HIR-to-MIR capture / lifetime policy
+  (`lowering_boundaries.md`); this doc owns only the resulting storage facts.
+- Physical placement -- a flat stack frame, an inline coroutine frame, a heap allocation, a
+  shared-owned record -- and the realization of retention (intrusive refcount, runtime handle).
+  Those are LIR and backend concerns.
+
+## Core Invariants
+
+1. **A closure value is callable code plus a value environment.** The environment is a `TupleType`,
+   the one heterogeneous value product (`mir.md`); it is copied when the closure value is copied.
+   _Consequence: a closure carries its captured state by value, like a C++ lambda or a Rust closure
+   struct; there is no closure-specific storage universe beside the value-type system._
+
+2. **The environment is the only place captured state lives, and a captured field is a value-product
+   slot.** A body reads a capture through the ordinary value-aggregate projection over its
+   environment, not through a closure-specific reference node or a closure-specific id space.
+   _Consequence: the capture-only `CaptureId` / `CaptureRef` / capture-init shapes do not exist; a
+   captured read is an aggregate slot projection, the same primitive every other product access
+   uses._
+
+3. **A captured field is a snapshot, a live-place alias, or a retained frame -- by its type.** A
+   value-typed field is a snapshot taken at construction; a `RefType` field is a live alias of an
+   observable cell (not a raw borrowed pointer, `reference-as-data-type.md`); a
+   `Shared<ActivationFrame>` field plus a slot projection is a retained frame. _Consequence:
+   snapshot-versus-alias-versus-retain is the field's type, never a separate capture-mode axis
+   (`callable.md` invariant 5); owner retention (`Shared<ActivationFrame>`) and place aliasing
+   (`RefType`) are different dimensions, not two spellings of one._
+
+4. **A captured binding's identity is its origin; the slot index is a deterministic materialization
+   of it.** The environment's slot order is a deterministic function of each captured binding's
+   origin identity (`binding_and_capture.md`), so a dump is stable and self-explanatory and a
+   forwarding / dedup keys off the origin. _Consequence: a slot index is a representation a backend
+   lowers to, never the stable identity of "which binding was captured"; the identity lives in the
+   origin, recovered for dump and diagnostics from there._
+
+5. **A callable value has two type levels with an explicit erasure between them.** A concrete
+   closure value's type carries its exact environment; an erased `Callable<Sig>` carries only the
+   signature. A concrete value keeps its environment type until an explicit erasure produces the
+   abstract one. _Consequence: a heterogeneous collection of callables (a region's deferred-effect
+   queue) holds `Callable<Sig>`; a closure used at its construction site stays concrete; erasure
+   never happens implicitly, so ownership and placement never become hidden magic._
+
+6. **An erased `Callable<Sig>` carries a complete contract.** It states an invoke entry, an
+   ownership / destruction contract for its held environment, and a copy / move contract.
+   _Consequence: a backend realizes the erased callable from a stated contract, not from a
+   convention it invents; the first backend may leave placement unoptimized, but the IR contract is
+   whole._
+
+7. **Every automatic local belongs to exactly one activation frame, which is its semantic owner.**
+   Where the frame is placed -- a flat stack frame, an inline coroutine frame, a heap allocation, a
+   shared-owned record -- is not a source-semantic fact. _Consequence: a non-retained frame keeps
+   the ordinary, optimized placement; only a frame that something retains is materialized as
+   shared-owned storage. "Local belongs to a frame" is a semantic statement, not a demand that every
+   local be wrapped in an explicit aggregate._
+
+8. **An activation frame is identity-bearing reference storage, retained per-frame.** It is reached
+   through a pointer, never copied by value, and is not a value product and not a nominal object.
+   Work that may outlive the owning execution retains the whole frame through a
+   `Shared<ActivationFrame>` handle. _Consequence: an escaped automatic local is never individually
+   boxed; the work retains the frame that already owns it (`lifetime-extended-automatic-scope.md`),
+   and one retained handle is both the access path and the lifetime guarantee._
+
+9. **The activation frame and the nominal object are two specializations of one reference-storage
+   substrate.** The substrate is identity-bearing field storage -- ordered slots, slot types,
+   construction / destruction. The frame adds shared-ownership and omits methods, inheritance,
+   dispatch, and nominal identity; the object adds them. _Consequence: there is no second,
+   independent object IR; a frame is the thin reference-storage specialization, an object the rich
+   one, and they share the storage substrate they sit on (`object_model.md` invariant 1 stands)._
+
+10. **Compiler-generated retained frames and SystemVerilog class handles are distinct reference
+    regimes.** A retained frame uses deterministic shared ownership (`PointerType{kShared}`, an
+    acyclic DAG by construction); an SV class handle uses the managed, precisely-traced reference
+    (`object-model.md`). _Consequence: a frame is never reached through the managed handle and a
+    class handle is never reached through the shared one; deterministic release and traced
+    reclamation are not interchanged._
+
+## Boundary to Adjacent Layers
+
+- **`mir.md`** owns the `TupleType` (the one heterogeneous value product) and the reference types
+  (`PointerType` with `kShared` / `kBorrowed` / `kUnique`, `RefType`, the managed reference). This
+  doc composes them: a closure environment is a `TupleType`; a retained-frame field is a
+  `Shared<ActivationFrame>`; an alias field is a `RefType`.
+- **`callable.md`** owns the callable concept and the receiver rule. This doc owns the environment
+  as a value aggregate and the two value type levels; the receiver of a closure body is its
+  environment, reached as an ordinary receiver binding.
+- **`binding_and_capture.md`** owns origin identity and capture forwarding. This doc states that the
+  capture layout it materializes is a value `TupleType` whose slots are the deterministic
+  materialization of those origins; the snapshot / alias / retain view is the slot's type.
+- **`object_model.md`** owns the nominal object. This doc states that the object and the activation
+  frame share one reference-storage substrate, and that the frame is the thin specialization without
+  the object's behavior.
+- **`activation.md`** owns the runtime execution instance. This doc owns the frame storage an
+  execution instance owns or refers to; the execution instance is not the frame.
+- **HIR-to-MIR** decides which capture form each source construct and binding requires and emits the
+  corresponding field type; the storage facts this doc owns are its output. LIR and the backend
+  decide physical placement and realize retention.
+
+## Forbidden Shapes
+
+- A closure-specific capture id space, or a capture-read node distinct from value-aggregate
+  projection. Captures are environment-tuple slots. (Invariant 2.)
+- A second value-product type minted for closure environments. There is one heterogeneous value
+  product, the `TupleType`. (Invariant 1, `unpacked-struct-representation.md`.)
+- A tuple slot index used as the stable identity of a captured binding. The identity is the binding
+  origin; the index is its deterministic materialization. (Invariant 4.)
+- `RefType` described or used as a plain borrowed pointer. It is the observable-cell reference and
+  routes a write through the cell's update path. (Invariant 3, `reference-as-data-type.md`.)
+- A live-place alias (`RefType`) captured across an execution boundary that may outlive the aliased
+  storage. That case retains the owning frame instead. (Invariant 3, 8.)
+- Per-variable boxing of an escaped automatic local. The owning frame is retained as a whole.
+  (Invariant 8.)
+- An activation frame modeled as a `mir::Class`, or as a value tuple. It is the thin
+  reference-storage specialization. (Invariant 8, 9.)
+- A second reference-storage IR independent of the object model's substrate -- frame storage and
+  object storage growing parallel layout, projection, ownership, and lowering. They share one
+  substrate. (Invariant 9.)
+- Implicit erasure of a concrete closure to `Callable<Sig>`. Erasure is an explicit operation.
+  (Invariant 5.)
+- An activation frame reached through the managed (traced) reference, or an SV class handle reached
+  through the shared frame reference. (Invariant 10.)
+- Naming the storage owner of automatic locals an "activation". The activation is the runtime
+  execution instance (`activation.md`); the storage owner is the activation frame. (Invariant 7,
+  boundary.)
+
+## Notes / Examples
+
+A fork branch that reads an enclosing local, in single-line lowered form:
+
+```text
+SV:
+  int x = 5;
+  fork  $display(x);  join_none
+
+closure environment : Tuple< M*, int >          // slot 0 = class self, slot 1 = x snapshot
+build environment   : env = tuple( read self, read x )
+read x in body      : tuple_get( env, slot_of(x) )      // slot_of is deterministic from x's origin
+class member access  : member_access( deref( tuple_get(env, slot_of(self)) ), <member> )
+closure value type   : concrete closure over Tuple<M*, int>, signature () -> Coroutine<void>
+```
+
+The same body's three capture forms differ only by field type:
+
+```text
+snapshot capture     : env slot type = int                        // a value
+live-place alias     : env slot type = Ref<logic>                 // an observable-cell alias
+retained-frame       : env slot type = Shared<ActivationFrame>    // retain the owner; read frame.slot(x)
+```
+
+A detached branch that must keep an enclosing automatic local alive does not box `x`. It retains the
+frame that owns `x`:
+
+```text
+env slot type = Shared<ActivationFrame>
+read x        = member_access( deref( frame_handle ), slot_of(x) )
+```
+
+The frame stays alive while any holder retains its handle, and dies when the last handle drops --
+deterministic shared ownership, distinct from the traced reclamation an SV class handle uses.
+
+A closure submitted to a heterogeneous region queue is erased at the submit site:
+
+```text
+concrete closure over Tuple<...>, signature () -> void
+  --[ explicit erase ]-->  Callable< () -> void >
+```
+
+The queue holds `Callable< () -> void >` values of identical signature and differing environments;
+each erased value carries its invoke, ownership / destruction, and copy / move contract.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -83,6 +83,11 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
   Result type is the call protocol (`Coroutine<T>`), parameter direction normalizes to data flow
   (`output` / `inout` to an output pack, `ref` to `Ref<T>`), DPI is an external-callable variant,
   process is an instance-bound value registered at constructor time. Target model; not yet built.
+- [closure-environment-and-activation-frame](closure-environment-and-activation-frame.md) -- the
+  closure environment is a value `TupleType` (not a closure-only capture universe, not an object);
+  the callable value gains a concrete type and an erased `Callable<Sig>` with an explicit erasure;
+  the activation frame is a thin reference-storage specialization sharing one substrate with the
+  nominal object, not a baseless `mir::Class`. Target model; not yet built.
 - [builtin-call-identity](builtin-call-identity.md) -- built-in method calls carry a flat
   closed-namespace identifier (`support::BuiltinFn`) shared between HIR and MIR; per-family enum
   splits are out.

--- a/docs/decisions/closure-environment-and-activation-frame.md
+++ b/docs/decisions/closure-environment-and-activation-frame.md
@@ -1,0 +1,225 @@
+# Closure environment is a value tuple; activation frame is reference storage
+
+Date: 2026-06-29 Status: accepted as the target model; not yet implemented.
+
+## Why this decision matters
+
+MIR carries several "ordered fields plus a construction" entities through unrelated shapes. The
+closure environment is a closure-only world (`CaptureId` / `CaptureRef` / capture-init), the value
+aggregates are `TupleType` / `UnionType`, the object model is `mir::Class`, and an escaped automatic
+scope is promoted into a baseless `mir::Class` reached through a shared handle. The same idea -- "a
+body reads compiler-generated stored state" -- is expressed two ways at once: a closure reads a
+`CaptureRef`, while the promotion box is read as `handle->member` (an object member access), and a
+detached fork already mixes them (the branch captures the box handle as a closure capture, then
+reads its members as object accesses).
+
+This entry settles what the compiler-generated storage actually is, so the two shapes collapse into
+one model without crossing the value/reference spine. It is the design round R52
+(`../progress/refactor.md`) asked for, now that the binding/capture contract has landed
+(`../architecture/binding_and_capture.md`). The contract form is
+`../architecture/compiler_generated_storage.md`; this entry records the reasoning and the rejected
+alternatives behind it.
+
+## The axis that decides it: value versus reference
+
+MIR's type system keeps one deliberate top-level split (`mir.md`, reinforced by
+`unpacked-struct-representation.md` and `unpacked-union-representation.md`): value types (the tuple
+product, copied on assignment, interned by shape) versus reference types (reached through a pointer,
+identity-bearing). The first question of the whole design is which side the closure environment is
+on, because every other choice follows from it.
+
+A closure value is copied by value: a fork branch is frame-copied, a deferred effect is an
+independent value submitted to a region, a with-clause closure is used in place. When a closure is
+copied, its environment is copied with it. So the closure environment is **value-semantic**, and the
+one value product in MIR is `TupleType`. The sharing a detached fork needs (an enclosing automatic
+local that the branch and the parent both mutate) is not the environment being shared -- it is a
+single environment **field** holding a shared handle to the storage's owner. Sharing lives in a
+field, not in the environment.
+
+The storage that owns automatic locals -- the **activation frame** -- is the opposite. It has
+identity, it is reached through a pointer, and a detached branch and its parent reach the same
+frame. It is reference storage. A frame and a closure environment therefore sit on opposite sides of
+the spine and are never the same shape.
+
+## The decisions
+
+```text
+D1. The closure environment is a value TupleType. Captured state lives in its slots; the
+    closure value is callable code plus that environment. The closure-only capture-storage IR
+    (CaptureId / CaptureRef / capture-init) disappears -- a captured read is an ordinary
+    value-aggregate slot projection.
+
+D2. TupleType remains the only heterogeneous value-product type. The closure environment reuses
+    it; no second value product is minted.
+
+D3. A callable value has two type levels: a concrete closure value carrying its exact
+    environment, and an erased Callable<Sig> reached through an explicit erasure. The type model
+    is designed whole; implementation may follow real consumers.
+
+D4. The activation frame is a thin, identity-bearing reference-storage entity. It is not a
+    mir::Class and not a value tuple.
+
+D5. The activation frame and the nominal object (Class) share one reference-storage substrate
+    (identity-bearing slots, slot types, construction / destruction). They are not two unrelated
+    object IR systems; the frame omits the object's methods / inheritance / dispatch / nominal
+    identity, the object adds them.
+
+D6. "Activation" remains the runtime execution instance (activation.md). The storage owner of
+    automatic locals is the activation frame; an execution instance owns or refers to a frame.
+
+D7. A capture is exactly one of: a snapshot (a value-typed field), a live-place alias (a RefType
+    field), or a retained frame (a Shared<ActivationFrame> field plus a slot projection). The
+    form is the field's type.
+
+D8. HIR-to-MIR owns the SystemVerilog capture / lifetime policy that decides which form each
+    construct and binding requires; MIR expresses only the resulting storage facts.
+```
+
+### Why the activation frame is not a `mir::Class`, yet not a second object IR (D4, D5)
+
+The promotion box is a `mir::Class` today, which gives frame storage access to inheritance,
+dispatch, lifecycle, and managed-handle machinery it must never use. The fix is not a fully
+independent reference-aggregate universe either: that would grow a parallel layout, projection,
+ownership, and backend lowering beside the object model's -- trading "the box is a baseless class"
+for "the frame is a second object IR," which `object_model.md` invariant 1 forbids. The resolution
+is one reference-storage substrate (identity-bearing field storage) with two specializations: the
+frame (thin -- shared ownership, no behavior) and the object (rich -- methods, inheritance,
+dispatch, lifecycle). This honors invariant 1 (no second object IR) and keeps frame storage from
+inheriting object behavior. The substrate need not be a public mega-abstraction; it may be internal
+shared layout / projection machinery. What is decided is that the frame and the object speak one
+reference-storage language, and that the cross-tuple generalization (a single root over value tuples
+and reference storage) is **not** built -- the value/reference spine is the top split.
+
+### Why the binding's identity is the origin, not the tuple index (D1)
+
+Reusing `TupleType` makes a captured read a positional `tuple_get(env, index)`. Left there, "which
+binding was captured" degrades into "which slot it happens to occupy," and forwarding, dedup, stable
+dumps, coroutine spill, and diagnostic provenance all become fragile. The resolution matches how an
+unpacked struct already drops field names to positional access
+(`unpacked-struct-representation.md`): the index is the representation, but it is assigned as a
+deterministic function of the captured binding's origin identity (`binding_and_capture.md` already
+requires origins to be deterministic and dump-stable). The closure-only `CaptureId` is not
+preserved; it generalizes into an aggregate slot identity backed by the origin, materialized as a
+tuple index.
+
+### Why `RefType` is not a plain borrow (D7)
+
+The live-place alias capture is a `RefType` field, and `RefType` is the observable-cell reference
+(`reference-as-data-type.md`): a write through it fires the cell's update event. Calling it a
+"borrow" invites a future reader to treat it as a transient raw pointer and bypass the update path.
+Owner retention (`Shared<ActivationFrame>`) and place aliasing (`RefType`) are two different
+dimensions, not two spellings of one: the first says "I keep the storage's owner alive," the second
+says "I alias a cell." A live-place alias is legal only when the aliased storage is independently
+known to outlive the closure; an automatic local of a frame that may finish first is captured by
+retaining the frame, not by aliasing the cell.
+
+### Why two callable type levels with an explicit erasure (D3)
+
+A closure used at its construction site is concrete -- the call site knows its exact environment. A
+region's deferred-effect queue holds many closures of one signature and differing environments, so
+it needs an erased `Callable<Sig>`. Both levels are real: with only `Callable<Sig>` the model erases
+too early and loses the concrete environment; with only the concrete value it cannot express the
+heterogeneous queue. The erasure is an explicit MIR transition, never implicit, so ownership,
+destruction, and placement do not become hidden behavior; the erased `Callable<Sig>` carries a
+complete contract (invoke, ownership / destruction, copy / move) even before a backend optimizes its
+placement. This is the first-class callable type `unified-callable-model.md` already committed to;
+today the closure's MIR type is its call result type, a shorthand that survives only because every
+closure is consumed at its construction site.
+
+### Why deterministic shared ownership for frames, not GC (D4, D6)
+
+A retained frame is reclaimed by deterministic shared ownership (`PointerType{kShared}`, an acyclic
+DAG by construction, `lifetime-extended-automatic-scope.md`), released when the last holder drops
+it. A SystemVerilog class handle is the managed, precisely-traced reference (`object-model.md`),
+because class graphs form cycles. The two reference regimes stay distinct: a frame is never reached
+through the managed handle and a class handle is never reached through the shared one. Garbage
+collection is the wrong tool for frames -- it gives imprecise release timing, drags in root tracing
+and scheduler queue scanning, and a GC-object environment would break the value-copy semantics of a
+closure (two closure copies would share one environment object). Shared ownership gives precise,
+deterministic release and composes with the value closure.
+
+## Rejected alternatives
+
+- **The closure environment is a `mir::Class` (or any nominal object).** Gives the environment
+  inheritance, dispatch, lifecycle, and managed-handle semantics it must not have, and puts a
+  value-semantic entity into the reference universe -- the same error
+  `unpacked-struct-representation.md` rejected for unpacked struct. A closure value is copied by
+  value; its environment is value storage.
+
+- **A second value-product type for closure environments.** Two near-identical heterogeneous
+  products violate `mir.md`'s one-product identity, exactly as a distinct `StructType` was rejected.
+  The environment reuses `TupleType`.
+
+- **The closure keeps its own `CaptureId` / `CaptureRef` / capture-init universe.** Keeps a
+  closure-only storage world in MIR forever; scope activation, deferred work, and ordinary aggregate
+  access drift into parallel, not-quite-consistent shapes. The environment joins the value-aggregate
+  family instead.
+
+- **The tuple index is the captured binding's identity.** Degrades a semantic identity into a
+  positional accident; forwarding, dedup, dumps, spill, and diagnostics become fragile. The origin
+  is the identity; the index is its deterministic materialization.
+
+- **The activation frame stays a `mir::Class`.** Frame storage inherits object behavior it must
+  never use. The frame is the thin reference-storage specialization.
+
+- **The activation frame is a fully independent reference-aggregate IR.** Trades one awkwardness for
+  another -- a second object IR with parallel layout, projection, ownership, and lowering, which
+  `object_model.md` invariant 1 forbids. The frame shares the object's reference-storage substrate.
+
+- **`RefType` treated as a borrowed pointer for alias captures.** Loses the observable-cell update
+  protocol; a write through it would not wake sensitive processes. `RefType` is the reference type,
+  not a raw pointer.
+
+- **Per-variable boxing of an escaped automatic local.** Splits one logical cell across the frame
+  slot and a box; spreads the storage decision across every read, write, and projection. The owning
+  frame is retained as a whole (`lifetime-extended-automatic-scope.md`).
+
+- **Garbage-collecting activation frames, or reusing the managed handle for them.** Imprecise
+  release, root-tracing cost, broken value-closure copy semantics, and conflation with the SV
+  class-handle regime. Frames use deterministic shared ownership.
+
+- **Only `Callable<Sig>`, or implicit erasure.** Erases the concrete environment too early or hides
+  ownership and placement behind implicit conversion. Two explicit type levels with an explicit
+  erasure.
+
+## Consequences
+
+- `../architecture/compiler_generated_storage.md` states this model as contract.
+- The closure-only capture IR (`CaptureId` / `CaptureRef` / capture-init) is removed; the closure
+  environment is a `TupleType`, built by a tuple construction and read by tuple-slot projection,
+  with slots assigned deterministically from binding origins.
+- MIR gains a first-class callable value type with two levels (concrete and erased `Callable<Sig>`)
+  and an explicit erasure operation; the closure's MIR type stops being its call result type. This
+  realizes the first-class callable type `unified-callable-model.md` committed to.
+- The promotion box stops being a `mir::Class`; the activation frame becomes the thin
+  reference-storage specialization, and `mir::Class` and the frame are refactored onto one
+  reference-storage substrate.
+- The binding/capture contract (`binding_and_capture.md`) keeps its origin identity and forwarding;
+  only the materialized capture-layout representation changes from a closure-only id space to value
+  tuple slots.
+- HIR-to-MIR keeps and generalizes the capture / lifetime policy (the current `CapturePolicy`
+  handles fork; it extends to deferred scheduling, coroutine suspension, `ref` formals,
+  observable-cell identity, and storage class).
+- Staged implementation and the concrete cuts are tracked in `../progress/refactor.md` (R52).
+
+## Cross-references
+
+- `../architecture/compiler_generated_storage.md` -- the contract form of this decision.
+- `../architecture/mir.md` -- `TupleType` as the one value product; the value/reference split; the
+  no-redundant-field and no-re-derivation invariants.
+- `../architecture/callable.md` -- the callable concept; the capture-by-field-type rule; the
+  receiver.
+- `../architecture/binding_and_capture.md` -- origin identity, per-body materialization, and capture
+  forwarding, which this decision keeps; only the materialized layout representation changes.
+- `../architecture/object_model.md` -- invariant 1 (no second object IR), which the shared
+  reference-storage substrate honors.
+- `../architecture/activation.md` -- the runtime execution instance; the activation frame is the
+  storage it owns, not the instance.
+- `unified-callable-model.md` -- the first-class callable type this decision's D3 realizes.
+- `unpacked-struct-representation.md`, `unpacked-union-representation.md` -- the one-value-product
+  invariant and positional access this decision reuses.
+- `reference-as-data-type.md` -- `RefType` as the observable-cell reference, not a borrowed pointer.
+- `lifetime-extended-automatic-scope.md` -- per-scope retention through a shared handle, which this
+  decision reframes as retaining the activation frame.
+- `object-model.md` -- the managed (traced) class-handle reference, distinct from the shared frame
+  reference.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -699,30 +699,41 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       **Likely interacts with**: R8 (callable-model unification) and R47 (SV class object model),
       since both touch what "a class with a body" looks like at MIR.
 
-- [ ] R52 -- Unify the compiler-generated aggregate, and decide whether a closure is one. An
-      "aggregate with fields plus a construction" is represented several ways today: `mir::Class`
-      (the object model -- nominal, reference-reached, with optional base / methods / dispatch /
-      lifecycle; a baseless `mir::Class` is already used as the promotion activation box, so a
-      compiler-generated aggregate over `mir::Class` already exists), the value aggregates
-      `TupleType` / `UnionType` (structural, value-semantic, by-position, no construction protocol),
-      and the closure environment (its own capture-layout / capture-init shape from the
-      binding/capture reset). A coroutine frame is a fourth, today backend-implicit and not a MIR
-      aggregate at all. These are all ordered (name, type) fields plus a construction, differing
-      only along orthogonal axes -- nominal vs structural identity, value vs reference reachability,
-      fields-only vs with-methods, and placement (inline / stack / heap / coroutine-frame /
-      scheduler). The target is a from-scratch design round -- "what is Lyra's fundamental
-      compiler-generated aggregate" -- in which closure environment, activation record, coroutine
-      frame, and the value aggregates are each a role-specialization of one underlying notion, NOT a
-      collapse of everything into `mir::Class` (a closure environment must not inherit object
-      dispatch / lifecycle / managed-reference semantics). The closure-as-object question -- whether
-      a closure value is an instance of a generated environment aggregate whose body is its method,
-      the C++/Rust closure-type model -- is the central decision; the existing activation box is the
-      grounding precedent, and the open axis is nominal (a registered baseless class, like the
-      activation box) vs structural (anonymous by-shape, like a tuple). The binding/capture reset's
-      capture-layout (field decls) and capture-init (construction initializers) are the foundation
-      this builds on, not throwaway. **Blocker**: the binding/capture contract must finalize first;
-      and this is a research topic that warrants its own design round before any code. **Interacts
-      with**: R47 (object model), R51 (a class with a body), R8 (callable model).
+- [ ] R52 -- Collapse the closure environment and the activation frame onto MIR's value/reference
+      spine. The design round this entry once held is resolved: the contract is
+      `../architecture/compiler_generated_storage.md` and the trade-offs are
+      `../decisions/closure-environment-and-activation-frame.md`. The resolution: a closure
+      environment is a value `TupleType` (not a closure-only capture universe, not an object); the
+      callable value gains a first-class type with a concrete level and an erased `Callable<Sig>`
+      level; and the activation frame is a thin reference-storage specialization sharing one
+      substrate with the nominal object rather than being a baseless `mir::Class`. The
+      value/reference spine is the top split -- a single root over value tuples and reference
+      storage is explicitly not built. Staged cuts, each its own review:
+  - [ ] R52a -- First-class callable value type. A closure's MIR type stops being its call result
+        type; MIR gains a concrete closure value type and an erased `Callable<Sig>` with an explicit
+        erasure boundary carrying invoke / ownership / copy contracts. Realizes the first-class
+        callable type `../decisions/unified-callable-model.md` committed to.
+
+  - [ ] R52b -- The closure environment is a value `TupleType`. The closure-only capture-storage IR
+        (`CaptureId` / `CaptureRef` / capture-init) retires; a captured read is a tuple-slot
+        projection whose slot is assigned deterministically from the binding origin, so dumps stay
+        stable and forwarding / dedup keep keying off the origin. `binding_and_capture.md` identity
+        and forwarding are unchanged; only the materialized layout representation changes.
+
+  - [ ] R52c -- The activation frame splits out of `mir::Class`. The promotion box stops being a
+        baseless `mir::Class`; `mir::Class` and the frame are refactored onto one reference-storage
+        substrate (identity-bearing slots, construction / destruction), the frame the thin
+        specialization (shared ownership, no methods / dispatch / lifecycle), the object the rich
+        one. Honors `object_model.md` invariant 1 (no second object IR). "Activation" stays the
+        runtime execution instance; the storage owner is the activation frame.
+
+  - [ ] R52d -- Generalize the HIR-to-MIR capture / lifetime policy. The three capture forms
+        (snapshot value, live-place alias `Ref<T>`, retained frame `Shared<frame>` plus a slot
+        projection) extend beyond fork to deferred scheduling, coroutine suspension, `ref` formals,
+        observable-cell identity, and storage class; a snapshot is a source semantic or a proven
+        equivalence, never a guessed optimization.
+
+    **Interacts with**: R47 (object model), R51 (a class with a body), R8 (callable model).
 
 ## Out of Scope
 

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -48,6 +48,7 @@ enum class TypeKind {
   kObservable,
   kResolved,
   kDriver,
+  kCallable,
 };
 
 enum class BitAtom {
@@ -313,6 +314,19 @@ struct CoroutineType {
   auto operator==(const CoroutineType&) const -> bool = default;
 };
 
+// The type of a callable value: its signature -- the per-invocation parameter
+// types and the result type. A closure expression carries this type. It states
+// the call interface a referencing site uses; the bound environment is not part
+// of it and stays inside the value. The result type is the call protocol (a
+// CoroutineType for a suspending callable, a value type or Void otherwise), the
+// same protocol a directly-invoked callable's result type carries.
+struct CallableType {
+  std::vector<TypeId> params;
+  TypeId result;
+
+  auto operator==(const CallableType&) const -> bool = default;
+};
+
 // The write capability a reference or borrow grants its holder (the
 // generic-language `&T` vs `&mut T`, a method's `const` vs non-const receiver).
 // Mutability lives on references and borrows, never as a qualifier on an
@@ -461,7 +475,7 @@ using TypeData = std::variant<
     InstanceType, GenScopeType, ServicesType, FilesType, DiagnosticType,
     RuntimeLibraryType, CoroutineType, RefType, PointerType, ManagedRefType,
     VectorType, TupleType, UnionType, ExternalRefType, ObservableType,
-    ResolvedType, DriverType>;
+    ResolvedType, DriverType, CallableType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/mir/type_interner.hpp
+++ b/include/lyra/mir/type_interner.hpp
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "lyra/base/arena.hpp"
 #include "lyra/mir/type.hpp"
@@ -65,6 +67,10 @@ class TypeInterner {
   // one canonical id rather than a duplicate.
   auto CoroutineOf(TypeId payload) -> TypeId {
     return Intern(CoroutineType{.payload = payload});
+  }
+
+  auto CallableOf(std::vector<TypeId> params, TypeId result) -> TypeId {
+    return Intern(CallableType{.params = std::move(params), .result = result});
   }
 
   auto PointerTo(

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -537,23 +537,22 @@ auto RenderBindingParamDecl(const ScopeView& view, const mir::LocalDecl& bind)
 // pass as frame-copied lambda parameters supplied by an immediate call -- a
 // capturing coroutine lambda would dangle once the spawned branch outlives the
 // referencing site.
-auto RenderClosureExpr(
-    const ScopeView& view, const mir::ClosureExpr& closure,
-    mir::TypeId result_type) -> std::string {
+auto RenderClosureExpr(const ScopeView& view, const mir::ClosureExpr& closure)
+    -> std::string {
   if (closure.code == nullptr) {
     throw InternalError("RenderClosureExpr: closure has no code");
   }
   const mir::CallableCode& code = *closure.code;
 
   const std::string return_clause = std::format(
-      " -> {}", RenderTypeAsCpp(view.Unit(), view.Class(), result_type));
+      " -> {}", RenderTypeAsCpp(view.Unit(), view.Class(), code.result_type));
 
   const ScopeView body_view = view.WithClosure(code);
   const std::string body =
       std::format(" {{\n{}}}", RenderBlockStatements(body_view, 1));
 
   if (std::holds_alternative<mir::CoroutineType>(
-          view.Unit().types.Get(result_type).data)) {
+          view.Unit().types.Get(code.result_type).data)) {
     if (!code.params.empty()) {
       throw InternalError(
           "RenderClosureExpr: coroutine closure has per-invocation parameters");
@@ -813,7 +812,7 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
                 MemberFieldName(view, m));
           },
           [&](const mir::ClosureExpr& cl) -> std::string {
-            return RenderClosureExpr(view, cl, expr.type);
+            return RenderClosureExpr(view, cl);
           },
           [&](const mir::ConcatExpr& c) -> std::string {
             return RenderConcatExpr(view, expr, c);

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/mir/callable_code.hpp"
@@ -58,10 +59,17 @@ auto ClosureBuilder::CaptureByValue(mir::ExprId outer_id, std::string_view name)
 auto ClosureBuilder::Finish(mir::TypeId result_type) -> mir::Expr {
   code_.result_type = result_type;
   code_.params = invocation_params_;
+  std::vector<mir::TypeId> param_types;
+  param_types.reserve(code_.params.size());
+  for (const mir::LocalId param : code_.params) {
+    param_types.push_back(code_.locals.Get(param).type);
+  }
+  const mir::TypeId callable_type =
+      unit_->types.CallableOf(std::move(param_types), result_type);
   mir::ClosureExpr closure;
   closure.capture_inits = bindings_.TakeCaptureInits();
   closure.code = std::make_unique<mir::CallableCode>(std::move(code_));
-  return mir::Expr{.data = std::move(closure), .type = result_type};
+  return mir::Expr{.data = std::move(closure), .type = callable_type};
 }
 
 auto ClosureBuilder::Build(mir::ExprId result) -> mir::Expr {
@@ -81,7 +89,8 @@ auto ClosureBuilder::BuildVoid() -> mir::Expr {
 }
 
 auto BuildClosureCallExpr(mir::Block& block, mir::Expr closure) -> mir::Expr {
-  const mir::TypeId result_type = closure.type;
+  const mir::TypeId result_type =
+      std::get<mir::ClosureExpr>(closure.data).code->result_type;
   const mir::ExprId closure_id = block.exprs.Add(std::move(closure));
   return mir::Expr{
       .data =

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -236,6 +236,16 @@ class MirDumper {
               return std::format(
                   "Coroutine(payload=Type[{}])", c.payload.value);
             },
+            [](const CallableType& c) -> std::string {
+              std::string params;
+              for (std::size_t i = 0; i < c.params.size(); ++i) {
+                if (i != 0) params += ", ";
+                params += std::format("Type[{}]", c.params[i].value);
+              }
+              return std::format(
+                  "Callable(params=[{}], result=Type[{}])", params,
+                  c.result.value);
+            },
             [](const RefType& r) -> std::string {
               return std::format(
                   "Ref({}pointee=Type[{}])",

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -95,6 +95,7 @@ auto Type::Kind() const -> TypeKind {
           [](const ObservableType&) { return TypeKind::kObservable; },
           [](const ResolvedType&) { return TypeKind::kResolved; },
           [](const DriverType&) { return TypeKind::kDriver; },
+          [](const CallableType&) { return TypeKind::kCallable; },
       },
       data);
 }

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -82,6 +82,11 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.kind)));
         } else if constexpr (std::is_same_v<T, CoroutineType>) {
           HashId(seed, t.payload);
+        } else if constexpr (std::is_same_v<T, CallableType>) {
+          for (TypeId param : t.params) {
+            HashId(seed, param);
+          }
+          HashId(seed, t.result);
         } else if constexpr (std::is_same_v<T, RefType>) {
           HashId(seed, t.pointee);
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.mutability)));


### PR DESCRIPTION
## Summary

A closure's MIR type was its call result type, a shorthand that only held because every closure is consumed at its construction site. This gives a closure a first-class `mir::CallableType` carrying its signature (the per-invocation parameter types plus the result type), so the type states the call interface rather than the value a call yields. The change is behavior-neutral: the emitted C++ is identical, because a closure still renders as a lambda and a closure call now reads its result type from the closure's code instead of from the closure's own type.

It also lands the design for the broader closure-storage work: a new architecture contract (`compiler_generated_storage.md`) and decision record place the closure environment (a value tuple) and the activation frame (thin reference storage) on MIR's value/reference spine, with the staged implementation cuts tracked under R52.

## Testing

`bazel test //...` passes (all four targets).