### PR TITLE
Support net-typed port connections

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -80,10 +80,11 @@ full support.
       separate, optional feature off the critical path to running Ibex.
 - [x] **Packed array whose element is a struct or enum** (a packed array of a packed aggregate, not
       just of a scalar bit/logic).
-- [ ] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the
-      testbench does when wiring the DUT (the parent's clock / reset signal drives the DUT's input
-      net). The first wall the full top-level testbench hits, and a single-driver connection.
-      Tracked under `nets.md` (N2).
+- [x] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the
+      testbench does when wiring the DUT: the parent's clock / reset signal drives the DUT's input
+      net, a single-driver connection. Both directions lower (a parent driving a child input net, a
+      child output net driving a parent net or variable), so the full top-level testbench now passes
+      this wall to the cross-unit parameter reference below. Tracked under `nets.md` (N2).
 - [x] **`$signed` / `$unsigned`** system functions.
 - [x] **`$clog2`** system function (LRM 20.8.1). A type-agnostic value query: ceil(log2) of the
       argument read as unsigned, with `$clog2(0)` defined as 0. It lowers to a runtime value query,

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -81,8 +81,9 @@ full support.
 - [x] **Packed array whose element is a struct or enum** (a packed array of a packed aggregate, not
       just of a scalar bit/logic).
 - [ ] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the
-      testbench does when wiring the DUT. The first wall the full top-level testbench hits. Tracked
-      under `nets.md` (N3).
+      testbench does when wiring the DUT (the parent's clock / reset signal drives the DUT's input
+      net). The first wall the full top-level testbench hits, and a single-driver connection.
+      Tracked under `nets.md` (N2).
 - [x] **`$signed` / `$unsigned`** system functions.
 - [x] **`$clog2`** system function (LRM 20.8.1). A type-agnostic value query: ceil(log2) of the
       argument read as unsigned, with `$clog2(0)` defined as 0. It lowers to a runtime value query,

--- a/docs/progress/nets.md
+++ b/docs/progress/nets.md
@@ -26,8 +26,12 @@ This workstream reasons from these and does not restate them:
 
 ## Lifecycle prerequisite
 
-- [x] The Seal barrier is realized as a design-wide phase between Resolve and Initialize. The
-      lifecycle defines it; net topology validation (N4) is the first consumer that requires it.
+- [ ] The Seal barrier is a design-global, coordinator-owned step, materialized when its first
+      consumer needs it (N4 net-topology validation). It validates and freezes the whole design's
+      driver topology at once -- a single-driver constraint or a forwarding chain spans scopes -- so
+      it is an engine-level pass over the elaborated design, never a per-scope hook. Until that
+      consumer lands, the Resolve-before-Initialize ordering the engine already enforces is the only
+      barrier the in-scope sub-steps require.
 
 ## Sub-steps
 
@@ -36,15 +40,18 @@ This workstream reasons from these and does not restate them:
       (`wire w = expr`). The driver attaches at Resolve, seeds at Initialize, and updates in the
       activation process; a read observes the driver's value. Single-driver is the identity case of
       the resolution model, not a special path.
-- [ ] N2 -- The `wire` / `tri` resolution function over the driver set: an undriven net (no driver)
+- [ ] N2 -- Net-typed port connections: a net driven across a module port in either direction (a
+      child output driving a parent net, a parent net driving a child input net), single-driver,
+      distributed across an instance array. The single-driver case reuses N1's identity resolver;
+      the new work is attaching a driver across the scope boundary in the Resolve phase, not the
+      resolution math. This is the net facet of the port work tracked in `hierarchy.md` (E5) and the
+      first full-testbench wall in `ibex.md`.
+- [ ] N3 -- The `wire` / `tri` resolution function over the driver set: an undriven net (no driver)
       reads high-impedance (`z`) at the net's width, and two or more drivers resolve under the
       tri-state truth table (LRM 6.6.1) -- agreement passes through, conflict yields `x`,
-      all-high-impedance yields high-impedance. The N=0 and N>=2 cases of the resolver that N1's
-      single driver exercises as identity.
-- [ ] N3 -- Net-typed port connections: a net driven across a module port in either direction (a
-      child output driving a parent net, a parent net driving a child input net), single- and
-      multi-driver, distributed across an instance array. This is the net facet of the port work
-      tracked in `hierarchy.md` (E5) and the first full-testbench wall in `ibex.md`.
+      all-high-impedance yields high-impedance. A multiply-driven net -- whether the drivers are
+      local continuous assignments or sources arriving across ports (N2) -- resolves here. The N=0
+      and N>=2 cases of the resolver that N1's single driver exercises as identity.
 - [ ] N4 -- A single-driver net type (`uwire`) reports a diagnostic when more than one driver
       attaches, naming each driver's source. The constraint is on the number of attached drivers,
       not on any current value.

--- a/docs/progress/nets.md
+++ b/docs/progress/nets.md
@@ -40,18 +40,21 @@ This workstream reasons from these and does not restate them:
       (`wire w = expr`). The driver attaches at Resolve, seeds at Initialize, and updates in the
       activation process; a read observes the driver's value. Single-driver is the identity case of
       the resolution model, not a special path.
-- [ ] N2 -- Net-typed port connections: a net driven across a module port in either direction (a
-      child output driving a parent net, a parent net driving a child input net), single-driver,
-      distributed across an instance array. The single-driver case reuses N1's identity resolver;
-      the new work is attaching a driver across the scope boundary in the Resolve phase, not the
-      resolution math. This is the net facet of the port work tracked in `hierarchy.md` (E5) and the
-      first full-testbench wall in `ibex.md`.
-- [ ] N3 -- The `wire` / `tri` resolution function over the driver set: an undriven net (no driver)
-      reads high-impedance (`z`) at the net's width, and two or more drivers resolve under the
-      tri-state truth table (LRM 6.6.1) -- agreement passes through, conflict yields `x`,
-      all-high-impedance yields high-impedance. A multiply-driven net -- whether the drivers are
-      local continuous assignments or sources arriving across ports (N2) -- resolves here. The N=0
-      and N>=2 cases of the resolver that N1's single driver exercises as identity.
+- [x] N2 -- Net-typed port connections (LRM 23.3.3), single-driver, both directions: a parent net or
+      variable drives a child's input net, and a child's output net drives a parent variable or net,
+      distributed across an instance array and through multi-level chains. A connection is one
+      reactive edge -- the source is read, the sink is driven (a net sink attaches a driver, a
+      variable sink writes) -- reusing N1's identity resolver; the new work is reaching the
+      cross-unit net through the binding route. A net is a readable, well-typed observable from
+      construction: it installs its empty-driver value (an undriven `wire` / `tri` reads `z` at its
+      width), so a read before any driver attaches is valid rather than an uninitialized cell. This
+      is the net facet of the port work in `hierarchy.md` (E5) and clears the first full-testbench
+      wall in `ibex.md`.
+- [ ] N3 -- Multi-driver `wire` / `tri` resolution (LRM 6.6.1, Table 6-2): two or more drivers on
+      one net -- local continuous assignments, sources arriving across ports, or both -- resolve
+      under the tri-state truth table, where agreement passes through, conflict yields `x`, and
+      all-high-impedance yields `z`. This is the N>=2 case of the resolver; the N=0 undriven value
+      and the N=1 single driver are the identity cases N1 and N2 already establish.
 - [ ] N4 -- A single-driver net type (`uwire`) reports a diagnostic when more than one driver
       attaches, naming each driver's source. The constraint is on the number of attached drivers,
       not on any current value.

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -101,12 +101,18 @@ using CrossUnitRefHead =
 // A cross-unit reference resolved once at construction. `head` is where
 // navigation starts; `path` carries the shared navigation from the head down to
 // the referenced leaf, by name across the unit boundary; `type` is the
-// slang-resolved leaf type. The slot is read / written / observed through one
-// stored direct reference.
+// slang-resolved leaf data type. `target_net_type` is the target's net type
+// when the target is a net (LRM 6.7: the net type fixes how drivers resolve and
+// the undriven value), or empty when the target is a variable. Together they
+// determine the producer's actual cell -- a resolved net of that net type, or a
+// variable's observable cell -- which the realized cross-unit cell must match
+// so a read reaches the right access protocol. The slot is read / written /
+// observed through one stored direct reference.
 struct CrossUnitRefDecl {
   CrossUnitRefHead head;
   std::vector<PathStep> path;
   TypeId type;
+  std::optional<NetType> target_net_type;
 };
 
 // `target_unit` is a cross-unit reference -- the name of the instantiated unit,
@@ -123,11 +129,13 @@ struct InstanceMemberDecl {
 enum class PortDirection : std::uint8_t { kInput, kOutput, kRef };
 
 // How the child port is reached, by realization. An input or output port has
-// its own cell and is realized as a reactive edge that reads it during
-// simulation, so it holds a persistent cross-unit reference (`cell`, a
-// `CrossUnitVarRef`). A `ref` port owns no cell; it is bound once in the
-// resolve phase, so it holds only the by-name reach (`head` + `path`, with
-// `type` the port value type) -- no persistent slot.
+// its own cell and is realized as a reactive edge over it (a variable cell is
+// written / read, a net cell is driven / read), so it holds a persistent
+// cross-unit reference (`cell`, a `CrossUnitVarRef`) whose target capability
+// (net versus variable) the reference itself carries. A `ref` port owns no
+// cell; it is bound once in the resolve phase, so it holds only the by-name
+// reach
+// (`head` + `path`, with `type` the port value type) -- no persistent slot.
 struct PortCellEndpoint {
   ExprId cell;
 };

--- a/include/lyra/runtime/net.hpp
+++ b/include/lyra/runtime/net.hpp
@@ -46,6 +46,15 @@ struct WireResolver {
         "WireResolver::Resolve: more than one driver contribution; the "
         "lowering rejects multi-driver nets");
   }
+
+  // The empty-driver value of a `wire` / `tri` net: high-impedance at the
+  // declared width (LRM 6.6.1). `prototype` carries the net's declared type;
+  // its contents are unused. The net installs this at construction so an
+  // undriven read sees the net type's undriven value.
+  [[nodiscard]] static auto ResolveEmpty(const value::PackedArray& prototype)
+      -> value::PackedArray {
+    return value::PackedArray::HighImpedanceLike(prototype);
+  }
 };
 
 template <value::LyraValue T, class Resolver>
@@ -63,10 +72,20 @@ class ResolvedNet : public Observable {
  public:
   ResolvedNet() = default;
 
-  // The undriven value (high-impedance for the common net types) seeds the
-  // resolution when no driver contributes.
-  explicit ResolvedNet(T undriven)
-      : resolved_(undriven), undriven_(std::move(undriven)) {
+  // Installs, once at construction, the net's empty-driver resolved value at
+  // the prototype's declared type. The net is therefore a readable, well-typed
+  // observable before any driver attaches, and an undriven read sees the net
+  // type's undriven value rather than an uninitialized cell. Installing twice
+  // is a lowering defect.
+  void Initialize(T prototype) {
+    if constexpr (std::same_as<T, value::PackedArray>) {
+      if (!resolved_.IsUninitialized()) {
+        throw InternalError(
+            "ResolvedNet::Initialize: cell is already initialized");
+      }
+    }
+    undriven_ = Resolver::ResolveEmpty(prototype);
+    resolved_ = undriven_;
   }
 
   ResolvedNet(const ResolvedNet&) = delete;

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -130,19 +130,16 @@ class Scope {
 
   // The post-construction elaboration phases, each a top-down walk over the
   // whole subtree. Services and structure are already wired in the constructor;
-  // these install behavior that needs the whole tree to exist. They run in
-  // order across the design: every scope resolves, then every scope seals, then
-  // every scope initializes, then every scope activates.
+  // these install behavior that needs the whole tree to exist. The engine runs
+  // them in order across the design: every scope resolves, then every scope
+  // initializes, then every scope activates.
   //
   // Resolve relocates registered `ExternUp` members (cross-tree references) and
-  // attaches cross-instance drivers. Seal freezes the resolved topology and
-  // validates it (a net's single-driver constraint, an unresolved endpoint),
-  // after every attachment across the design exists. Initialize runs variable
-  // initializers and seeds driver contributions, after sealing, so an
-  // initializer observes connected and bound values. Activate creates this
-  // scope's processes, after initialization.
+  // attaches cross-instance drivers. Initialize runs variable initializers and
+  // seeds driver contributions, after every reference across the design is
+  // resolved, so an initializer observes connected and bound values. Activate
+  // creates this scope's processes, after initialization.
   void Resolve();
-  void Seal();
   void Initialize();
   void Activate();
 
@@ -182,13 +179,6 @@ class Scope {
   // child's reference (a `ref` port) override this. Called in the resolve
   // phase, once the whole tree is constructed.
   virtual void ResolveState() {
-  }
-
-  // A scope with no topology to validate validates none; only scopes that must
-  // check their sealed topology (a net's single-driver constraint) override
-  // this. Called in the seal phase, after every cross-instance attachment in
-  // the design exists and before any initializer runs.
-  virtual void SealState() {
   }
 
   // A scope with no variable initializers runs none; only scopes with

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -170,6 +170,14 @@ class PackedArray {
   // a freshly-defaulted element would read as.
   auto ResetToDefault() -> void;
 
+  // The all-high-impedance value at `prototype`'s declared type: every bit `z`
+  // for a 4-state shape (the undriven value of a `wire` / `tri` net, LRM
+  // 6.6.1), and the all-zero canonical default for a 2-state shape, which has
+  // no high-impedance state. The prototype's contents are unused; only its
+  // declared type (width, signedness, state domain) is read.
+  [[nodiscard]] static auto HighImpedanceLike(const PackedArray& prototype)
+      -> PackedArray;
+
   // LRM 9.4.2 update event predicate (engine change-detection hook): are the
   // two values bit-identical, considering both the value plane and the
   // unknown plane. Distinct from the SV `===` operator (`CaseEqual`) only in

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -15,6 +15,7 @@
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/NetType.h>
 #include <slang/ast/types/Type.h>
 
 #include "lyra/base/internal_error.hpp"
@@ -143,6 +144,33 @@ auto ModuleLowerer::LookupOwnedChildBinding(
   return it->second;
 }
 
+namespace {
+
+// The HIR net type of a cross-unit reference's target when the target is a net
+// (LRM 6.7), or empty when it is a variable. The net type, not a plain net
+// flag, is what determines the target's resolved cell -- its resolver and
+// undriven value. Only `wire` / `tri` are supported; other net types are
+// rejected at the net's own declaration, so encountering one here is a lowering
+// invariant violation, not a user-facing case.
+auto TargetNetType(const slang::ast::ValueSymbol& target)
+    -> std::optional<hir::NetType> {
+  if (target.kind != slang::ast::SymbolKind::Net) {
+    return std::nullopt;
+  }
+  switch (target.as<slang::ast::NetSymbol>().netType.netKind) {
+    case slang::ast::NetType::Wire:
+      return hir::NetType::kWire;
+    case slang::ast::NetType::Tri:
+      return hir::NetType::kTri;
+    default:
+      throw InternalError(
+          "TargetNetType: cross-unit reference to an unsupported net type; the "
+          "net's own declaration validates the supported net types");
+  }
+}
+
+}  // namespace
+
 auto ModuleLowerer::MapOrGetCrossUnitRef(
     const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
     hir::CrossUnitRefHead head, std::vector<hir::PathStep> path,
@@ -155,7 +183,10 @@ auto ModuleLowerer::MapOrGetCrossUnitRef(
   const hir::CrossUnitRefId id{static_cast<std::uint32_t>(slots.size())};
   slots.push_back(
       hir::CrossUnitRefDecl{
-          .head = std::move(head), .path = std::move(path), .type = type});
+          .head = std::move(head),
+          .path = std::move(path),
+          .type = type,
+          .target_net_type = TargetNetType(target)});
   frame_dedup.emplace(&target, id);
   return id;
 }
@@ -204,19 +235,22 @@ auto ModuleLowerer::TranslateSensitivityReads(
   std::vector<hir::SensitivityEntry> out;
   out.reserve(reads.size());
   for (const auto& read : reads) {
-    const auto* var = read.symbol->as_if<slang::ast::VariableSymbol>();
-    if (var == nullptr) continue;
+    // Both a variable and a net are observable value symbols a process can wait
+    // on; sensitivity subscribes to either (a net's resolved value changing is
+    // an update event just like a variable write, LRM 9.4.2).
+    const auto* value = read.symbol->as_if<slang::ast::ValueSymbol>();
+    if (value == nullptr) continue;
     // A footprint is meaningful only for a signal the runtime bit-addresses: a
     // packed bit vector, which renders to one observable cell whose change set
     // is read per bit. For an enum, unpacked aggregate, string, or real the
     // runtime observes the whole signal on any change, so the read carries no
     // footprint regardless of the flat-bit view the DFA computed over its own
     // encoding.
-    const auto& read_type = var->getType();
+    const auto& read_type = value->getType();
     const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
         read_type.isIntegral() && !read_type.isEnum() ? read.footprint
                                                       : std::nullopt;
-    if (const auto binding = LookupStructuralDataObjectBinding(*var)) {
+    if (const auto binding = LookupStructuralDataObjectBinding(*value)) {
       const auto hops = frame.HopsTo(binding->home_frame);
       if (!hops.has_value()) continue;
       out.push_back(
@@ -230,7 +264,7 @@ auto ModuleLowerer::TranslateSensitivityReads(
     // A read of a cross-unit member resolves to the slot that body lowering
     // created for it; subscribing through the slot is what makes always_comb
     // re-trigger on a child's signal.
-    if (const auto slot = LookupCrossUnitRef(frame.Current(), *var)) {
+    if (const auto slot = LookupCrossUnitRef(frame.Current(), *value)) {
       out.push_back(
           hir::SensitivityEntry{
               .ref = hir::CrossUnitVarRef{.id = *slot},

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -12,6 +12,7 @@
 #include <slang/ast/symbols/PortSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/NetType.h>
 #include <slang/ast/types/Type.h>
 #include <slang/numeric/ConstantValue.h>
 
@@ -59,10 +60,6 @@ auto ConnectElementPorts(
       return PortConnectionUnsupported(
           span, "inout port connection is not yet supported");
     }
-    if (port.isNetPort()) {
-      return PortConnectionUnsupported(
-          span, "net-typed port connection is not yet supported");
-    }
     const auto* internal =
         port.internalSymbol == nullptr
             ? nullptr
@@ -86,6 +83,21 @@ auto ConnectElementPorts(
       // default initial value (LRM 23.3.3.2); no parent driver is installed.
       continue;
     }
+    // A net port's child member is a resolved-net cell, reached across the
+    // boundary like any cross-unit cell (LRM 6.5, 23.3.3); HIR-to-MIR realizes
+    // the connection as a reactive edge whose net side attaches a driver. Only
+    // the `wire` / `tri` resolution is supported; other net types are rejected.
+    if (port.isNetPort()) {
+      switch (internal->as<slang::ast::NetSymbol>().netType.netKind) {
+        case slang::ast::NetType::Wire:
+        case slang::ast::NetType::Tri:
+          break;
+        default:
+          return PortConnectionUnsupported(
+              span, "this net type is not yet supported");
+      }
+    }
+
     const bool is_ref = port.direction == slang::ast::ArgumentDirection::Ref;
     if (is_ref) {
       // A `const ref` port shares storage but forbids the child writing through

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -458,6 +458,11 @@ void DeclareCrossUnitRefSlots(
         std::holds_alternative<hir::UpwardRootHead>(cu.head) ||
         std::holds_alternative<hir::UpwardNamedHead>(cu.head);
     if (is_upward) {
+      if (cu.target_net_type.has_value()) {
+        throw InternalError(
+            "DeclareCrossUnitRefSlots: an upward cross-unit reference to a net "
+            "is not yet supported");
+      }
       // The member's type carries only the wrapped element; the
       // per-reference navigation plan is emitted as ordinary `CallExpr`
       // statements in the constructor body when the bind sweep runs.
@@ -468,12 +473,17 @@ void DeclareCrossUnitRefSlots(
           mir::MemberDecl{.name = std::move(member_name), .type = ext_type});
       lowerer.AddCrossUnitRefTarget(mir::MemberRef{.var = var}, ext_type);
     } else {
-      // The pointee matches the producer's storage cell. A producer-side
-      // value-storage signal is wrapped in `ObservableType` at its declaration
-      // (so a write fires subscribers), and the cross-unit pointer must point
-      // at the same wrapped cell -- otherwise the C++ types mismatch.
+      // The pointee matches the producer's actual storage cell so a read or
+      // drive reaches the right access protocol. A net producer owns a resolved
+      // cell (`ResolvedType`); any other value-storage signal is wrapped in
+      // `ObservableType` at its declaration so a write fires subscribers. The
+      // cross-unit pointer must point at that same cell -- otherwise the C++
+      // types mismatch.
+      const mir::TypeId value = module.TranslateType(cu.type);
       const mir::TypeId leaf =
-          MaybeWrapObservable(module, module.TranslateType(cu.type));
+          cu.target_net_type.has_value()
+              ? module.Unit().types.Intern(mir::ResolvedType{.value = value})
+              : MaybeWrapObservable(module, value);
       const mir::TypeId slot_type =
           module.Unit().types.PointerTo(leaf, mir::PointerOwnership::kBorrowed);
       const mir::MemberId slot = shape.members.Add(
@@ -900,21 +910,35 @@ void AppendProcessRegistration(
   block.AppendStmt(mir::ExprStmt{.expr = reg_call});
 }
 
+auto AttachNetDriver(
+    const StructuralScopeLowerer& lowerer, mir::Class& mir_class,
+    mir::ExprId net_access, mir::TypeId value_type,
+    const std::string& driver_name, hir::ExprId source,
+    const WalkFrame& resolve_frame, const WalkFrame& init_frame,
+    mir::TypeId self_ptr_type) -> diag::Result<NetDriver>;
+
+auto ContinuousAssignNetTarget(
+    const StructuralScopeLowerer& lowerer, const mir::Class& mir_class,
+    const hir::ContinuousAssign& ca) -> std::optional<mir::MemberId>;
+
 // Realizes each port connection (LRM 23.3.3). An input or output port is the
 // implied continuous assignment between the two cells, materialized as the same
-// synthesized process a scope-level `assign` produces, registered as a process.
-// A `ref` port instead binds the child's reference member -- navigated by name
-// from the owned child -- to the connected variable's cell, emitted into the
-// resolve block: one assignment of a reference, with no second cell and no
-// continuous assignment.
+// synthesized process a scope-level `assign` produces, registered as a process;
+// when the driven side is a net the edge attaches a driver rather than writing
+// the cell. A `ref` port instead binds the child's reference member --
+// navigated by name from the owned child -- to the connected variable's cell,
+// emitted into the resolve block: one assignment of a reference, with no second
+// cell and no continuous assignment.
 auto InstallPortConnections(
     StructuralScopeLowerer& lowerer, WalkFrame frame, WalkFrame resolve_frame,
-    WalkFrame activate_frame) -> diag::Result<void> {
+    WalkFrame init_frame, WalkFrame activate_frame) -> diag::Result<void> {
   mir::Class& mir_class = *frame.current_class;
   mir::Block& resolve_block = *resolve_frame.current_block;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   ModuleLowerer& module = lowerer.Module();
   const mir::TypeId scope_ptr_type = module.Unit().builtins.scope_ptr;
+  const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
+  std::size_t net_port_index = 0;
   for (const auto& pc : hir_scope.port_connections) {
     if (pc.direction == hir::PortDirection::kRef) {
       // Bind the child's reference member to the connected variable's cell in
@@ -963,14 +987,72 @@ auto InstallPortConnections(
     }
     const auto& cell = std::get<hir::PortCellEndpoint>(pc.endpoint);
     const bool is_input = pc.direction == hir::PortDirection::kInput;
+    // A port connection is a reactive edge: the source is read, the sink is
+    // driven. An input port's source is the parent expression and its sink is
+    // the child cell; an output port's source is the child cell and its sink is
+    // the parent target. The edge body is the same continuous assignment either
+    // way; only the sink's capability picks the write protocol -- a net cell
+    // takes a driver, a variable cell a direct assignment (LRM 23.3.3).
     const hir::ContinuousAssign assign{
         .span = pc.span,
         .lhs = is_input ? cell.cell : pc.peer,
         .rhs = is_input ? pc.peer : cell.cell,
         .sensitivity_list = pc.sensitivity};
+
+    // The sink is a net in two shapes: an input port whose child cell is a net
+    // (reached cross-unit), or an output port whose parent target is a net
+    // (local). Either resolves to a driver the edge's process updates; a
+    // non-net sink keeps the direct continuous-assign write.
+    std::optional<NetDriver> net_driver;
+    auto attach_sink_driver = [&](mir::ExprId net_access,
+                                  hir::ExprId source) -> diag::Result<void> {
+      const mir::TypeId value_type =
+          std::get<mir::ResolvedType>(
+              module.Unit()
+                  .types.Get(resolve_block.exprs.Get(net_access).type)
+                  .data)
+              .value;
+      const std::string driver_name =
+          std::format("net_port_{}__driver", net_port_index++);
+      auto driver_or = AttachNetDriver(
+          lowerer, mir_class, net_access, value_type, driver_name, source,
+          resolve_frame, init_frame, self_ptr_type);
+      if (!driver_or) return std::unexpected(std::move(driver_or.error()));
+      net_driver = *driver_or;
+      return {};
+    };
+    if (is_input) {
+      const auto* prim =
+          std::get_if<hir::PrimaryExpr>(&hir_scope.exprs.Get(cell.cell).data);
+      const auto* cuv = prim != nullptr
+                            ? std::get_if<hir::CrossUnitVarRef>(&prim->data)
+                            : nullptr;
+      if (cuv != nullptr &&
+          hir_scope.cross_unit_refs.Get(cuv->id).target_net_type.has_value()) {
+        auto net_or =
+            lowerer.LowerLhsExpr(hir_scope.exprs.Get(cell.cell), resolve_frame);
+        if (!net_or) return std::unexpected(std::move(net_or.error()));
+        const mir::ExprId net_access =
+            resolve_block.exprs.Add(*std::move(net_or));
+        auto r = attach_sink_driver(net_access, pc.peer);
+        if (!r) return std::unexpected(std::move(r.error()));
+      }
+    } else if (
+        const auto net_member =
+            ContinuousAssignNetTarget(lowerer, mir_class, assign)) {
+      const mir::TypeId net_type = mir_class.members.Get(*net_member).type;
+      const mir::ExprId net_self = resolve_block.exprs.Add(
+          MakeSelfRefExpr(resolve_frame, self_ptr_type));
+      const mir::ExprId net_access = resolve_block.exprs.Add(
+          mir::MakeMemberAccessExpr(
+              net_self, mir::MemberRef{.var = *net_member}, net_type));
+      auto r = attach_sink_driver(net_access, assign.rhs);
+      if (!r) return std::unexpected(std::move(r.error()));
+    }
+
     std::string name = std::format("process_{}", mir_class.methods.size());
-    auto decl_or =
-        LowerContinuousAssign(lowerer, frame, std::move(name), assign);
+    auto decl_or = LowerContinuousAssign(
+        lowerer, frame, std::move(name), assign, net_driver);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
     AppendProcessRegistration(module, activate_frame, body, false);
@@ -1022,14 +1104,17 @@ auto ContinuousAssignNetTarget(
   return target;
 }
 
-// Installs a driver for a net-targeted continuous assignment: a driver-handle
-// member bound at Resolve (`self->driver = (self->net).AttachDriver()`) and
-// seeded at Initialize (`self->driver.Update(services, rhs)`). Returns the
-// driver handle the activation process updates whenever the right-hand side
-// changes.
+// Installs a driver on a net cell reached through a route: a driver-handle
+// member bound at Resolve (`self->driver = net_access.AttachDriver()`) and
+// seeded at Initialize (`self->driver.Update(services, source)`). `net_access`
+// is the resolve-phase lvalue of the net cell -- a local member access for a
+// continuous assignment, a cross-unit navigation for a port connection -- and
+// `source` is the driving expression, lowered in the initialize phase. Returns
+// the driver handle the activation process updates whenever the source changes.
 auto AttachNetDriver(
     const StructuralScopeLowerer& lowerer, mir::Class& mir_class,
-    mir::MemberId net_member, const hir::ContinuousAssign& ca,
+    mir::ExprId net_access, mir::TypeId value_type,
+    const std::string& driver_name, hir::ExprId source,
     const WalkFrame& resolve_frame, const WalkFrame& init_frame,
     mir::TypeId self_ptr_type) -> diag::Result<NetDriver> {
   ModuleLowerer& module = lowerer.Module();
@@ -1037,29 +1122,18 @@ auto AttachNetDriver(
   mir::Block& resolve_block = *resolve_frame.current_block;
   mir::Block& init_block = *init_frame.current_block;
 
-  const mir::TypeId net_type = mir_class.members.Get(net_member).type;
-  const mir::TypeId value_type =
-      std::get<mir::ResolvedType>(module.Unit().types.Get(net_type).data).value;
   const mir::TypeId driver_type =
       module.Unit().types.Intern(mir::DriverType{.value = value_type});
   const mir::MemberId driver_member = mir_class.members.Add(
-      mir::MemberDecl{
-          .name =
-              std::format("{}__driver", mir_class.members.Get(net_member).name),
-          .type = driver_type});
+      mir::MemberDecl{.name = driver_name, .type = driver_type});
 
-  const auto resolve_self = [&] {
-    return resolve_block.exprs.Add(
-        MakeSelfRefExpr(resolve_frame, self_ptr_type));
-  };
-  const mir::ExprId net_access = resolve_block.exprs.Add(
-      mir::MakeMemberAccessExpr(
-          resolve_self(), mir::MemberRef{.var = net_member}, net_type));
   const mir::ExprId attach = resolve_block.exprs.Add(
       mir::MakeNetAttachDriverCallExpr(net_access, driver_type));
+  const mir::ExprId resolve_self =
+      resolve_block.exprs.Add(MakeSelfRefExpr(resolve_frame, self_ptr_type));
   const mir::ExprId driver_lhs = resolve_block.exprs.Add(
       mir::MakeMemberAccessExpr(
-          resolve_self(), mir::MemberRef{.var = driver_member}, driver_type));
+          resolve_self, mir::MemberRef{.var = driver_member}, driver_type));
   const mir::ExprId attach_assign = resolve_block.exprs.Add(
       mir::Expr{
           .data = mir::AssignExpr{.target = driver_lhs, .value = attach},
@@ -1068,9 +1142,9 @@ auto AttachNetDriver(
       mir::Stmt{
           .label = std::nullopt, .data = mir::ExprStmt{.expr = attach_assign}});
 
-  auto rhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(ca.rhs), init_frame);
-  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const mir::ExprId seed_rhs = init_block.exprs.Add(*std::move(rhs_or));
+  auto source_or = lowerer.LowerExpr(hir_scope.exprs.Get(source), init_frame);
+  if (!source_or) return std::unexpected(std::move(source_or.error()));
+  const mir::ExprId seed_value = init_block.exprs.Add(*std::move(source_or));
   const auto init_self = [&] {
     return init_block.exprs.Add(MakeSelfRefExpr(init_frame, self_ptr_type));
   };
@@ -1081,7 +1155,7 @@ auto AttachNetDriver(
           init_self(), mir::MemberRef{.var = driver_member}, driver_type));
   const mir::ExprId seed_update = init_block.exprs.Add(
       mir::MakeNetDriverUpdateCallExpr(
-          seed_driver, seed_services, seed_rhs,
+          seed_driver, seed_services, seed_value,
           module.Unit().builtins.void_type));
   init_block.AppendStmt(
       mir::Stmt{
@@ -1810,6 +1884,27 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
       }
     }
 
+    // A net cell installs its empty-driver resolved value at construction (LRM
+    // 6.6.1), in the constructor rather than the initialize phase: a net is a
+    // readable, well-typed observable before any driver attaches, and before a
+    // cross-unit reader seeds from it during the parent-first initialize phase,
+    // so an undriven read sees the net type's undriven value, never an
+    // uninitialized cell. Drivers, attached at Resolve, update it from there.
+    if (is_net) {
+      const mir::ExprId net_target = ctor_block.exprs.Add(
+          mir::MakeMemberAccessExpr(
+              self_read(), mir::MemberRef{.var = mir_id}, mir_field_type));
+      const mir::ExprId prototype = ctor_block.exprs.Add(
+          BuildDefaultValueFromHir(module, ctor_frame, d.type));
+      ctor_block.AppendStmt(
+          mir::Stmt{
+              .label = std::nullopt,
+              .data = mir::ExprStmt{
+                  .expr = ctor_block.exprs.Add(
+                      mir::MakeObservableInitializeCallExpr(
+                          net_target, prototype, void_type))}});
+    }
+
     // A value signal, or a named event, records its address under its name so a
     // cross-unit referrer resolves it by name at construction. The excluded
     // members -- owned children and cross-unit reference slots -- are not
@@ -1892,9 +1987,23 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
             "a net with more than one driver is not yet supported");
       }
       driven_nets.push_back(*net_member);
+      // The net cell is a local member; its resolve-phase lvalue is a member
+      // access off `self`.
+      mir::Block& resolve_block = *resolve_frame.current_block;
+      const mir::TypeId net_type = mir_class.members.Get(*net_member).type;
+      const mir::TypeId value_type =
+          std::get<mir::ResolvedType>(module.Unit().types.Get(net_type).data)
+              .value;
+      const mir::ExprId net_self = resolve_block.exprs.Add(
+          MakeSelfRefExpr(resolve_frame, self_ptr_type));
+      const mir::ExprId net_access = resolve_block.exprs.Add(
+          mir::MakeMemberAccessExpr(
+              net_self, mir::MemberRef{.var = *net_member}, net_type));
+      const std::string driver_name =
+          std::format("{}__driver", mir_class.members.Get(*net_member).name);
       auto driver_or = AttachNetDriver(
-          lowerer, mir_class, *net_member, ca, resolve_frame, init_frame,
-          self_ptr_type);
+          lowerer, mir_class, net_access, value_type, driver_name, ca.rhs,
+          resolve_frame, init_frame, self_ptr_type);
       if (!driver_or) return std::unexpected(std::move(driver_or.error()));
       net_driver = *driver_or;
     }
@@ -1928,7 +2037,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   EmitInstanceMemberConstruction(lowerer, ctor_frame);
   InstallCrossUnitRefs(lowerer, ctor_frame);
   auto port_conn_r = InstallPortConnections(
-      lowerer, ctor_frame, resolve_frame, activate_frame);
+      lowerer, ctor_frame, resolve_frame, init_frame, activate_frame);
   if (!port_conn_r) return std::unexpected(std::move(port_conn_r.error()));
 
   ctor_code.params = {self_id};

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -53,16 +53,12 @@ void Engine::BindDesign(std::span<const TopBinding> tops) {
   }
   // Link every top before any phase runs, so an upward climb during resolution
   // sees the whole tree (the root and all sibling tops already exist). The
-  // phases run design-wide in order: resolve every reference and attachment,
-  // seal and validate the whole design's topology, initialize every scope's
-  // variables, then activate every scope's processes -- so sealing sees every
-  // attachment, an initializer observes resolved references, and processes
-  // start only after all initialization.
+  // phases run design-wide in order: resolve every reference and attachment
+  // across the design, then initialize every scope's variables (so an
+  // initializer observes resolved references), then activate every scope's
+  // processes (so processes start only after all initialization).
   for (const auto& top : tops) {
     top.scope->Resolve();
-  }
-  for (const auto& top : tops) {
-    top.scope->Seal();
   }
   for (const auto& top : tops) {
     top.scope->Initialize();

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -123,14 +123,6 @@ void Scope::Resolve() {
   ForEachChild([](Scope& child) { child.Resolve(); });
 }
 
-void Scope::Seal() {
-  // The whole design has resolved before sealing runs, so every cross-instance
-  // attachment (a net's drivers, a bound reference) exists; a scope can now
-  // validate its sealed topology against constraints that span the design.
-  SealState();
-  ForEachChild([](Scope& child) { child.Seal(); });
-}
-
 void Scope::Initialize() {
   InitializeState();
   ForEachChild([](Scope& child) { child.Initialize(); });

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -283,6 +283,23 @@ auto PackedArray::ResetToDefault() -> void {
   }
 }
 
+auto PackedArray::HighImpedanceLike(const PackedArray& prototype)
+    -> PackedArray {
+  if (!prototype.type_.is_four_state) {
+    // A 2-state shape has no high-impedance state; the undriven value is the
+    // all-zero canonical default (z collapses to 0 outside the 4-state domain).
+    return PackedArray(prototype.type_);
+  }
+  // z is the value plane all-0 with the unknown plane all-1 (x is value 1,
+  // unknown 1). Construction masks the bits above the declared width in the top
+  // word.
+  const std::uint64_t width = prototype.type_.bit_width;
+  const std::size_t words = static_cast<std::size_t>((width + 63) / 64);
+  const std::vector<std::uint64_t> value_words(words, 0);
+  const std::vector<std::uint64_t> unknown_words(words, ~std::uint64_t{0});
+  return FromWords(value_words, unknown_words, prototype.type_);
+}
+
 auto PackedArray::Dims() const -> std::span<const PackedRange> {
   return std::span<const PackedRange>{type_.dims.data(), type_.dims.size()};
 }

--- a/tests/cases/cpp/nets_input_port_wire/case.yaml
+++ b/tests/cases/cpp/nets_input_port_wire/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.nets_input_port_wire
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "child sees 42"

--- a/tests/cases/cpp/nets_input_port_wire/main.sv
+++ b/tests/cases/cpp/nets_input_port_wire/main.sv
@@ -1,0 +1,17 @@
+// A net-typed input port (LRM 23.3.3): the parent drives the child's input
+// `wire` across the port boundary. The child's input net owns its own resolved
+// cell and resolves its single driver -- the connection the parent attaches --
+// so the child reads the parent's value. The driver attaches at Resolve, seeds
+// at Initialize, and the parent's process updates it when the source changes.
+module Child(input wire [7:0] in_net);
+  initial begin
+    #1;
+    $display("child sees %0d", in_net);
+  end
+endmodule
+
+module Top;
+  logic [7:0] src;
+  Child u(.in_net(src));
+  initial src = 8'd42;
+endmodule

--- a/tests/cases/cpp/nets_output_port_wire/case.yaml
+++ b/tests/cases/cpp/nets_output_port_wire/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.nets_output_port_wire
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "var=33 net=33 chain=33"

--- a/tests/cases/cpp/nets_output_port_wire/main.sv
+++ b/tests/cases/cpp/nets_output_port_wire/main.sv
@@ -1,0 +1,29 @@
+// A net-typed output port (LRM 23.3.3): a child drives its `output wire`, and
+// the connection carries that value to the parent across the boundary. The
+// parent side is read uniformly and driven per its own kind -- a variable takes
+// the value directly, a parent net takes it through a driver. A chain of output
+// nets (`Leaf -> Mid -> Top`) converges because each net is sensitive to the
+// child net it reads. The single-driver case here reuses the resolution model;
+// driven values are 2-state so this runs in both state modes.
+module Source(output wire [7:0] o);
+  assign o = 8'd33;
+endmodule
+
+module Mid(output wire [7:0] o);
+  Source inner(.o(o));
+endmodule
+
+module Top;
+  logic [7:0] seen_var;
+  wire  [7:0] from_net;
+  wire  [7:0] from_chain;
+
+  Source to_var(.o(seen_var));
+  Source to_net(.o(from_net));
+  Mid    chain(.o(from_chain));
+
+  initial begin
+    #1;
+    $display("var=%0d net=%0d chain=%0d", seen_var, from_net, from_chain);
+  end
+endmodule

--- a/tests/cases/cpp/nets_undriven_wire/four_state.yaml
+++ b/tests/cases/cpp/nets_undriven_wire/four_state.yaml
@@ -1,0 +1,12 @@
+id: cpp.nets_undriven_wire
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "undriven=zzzzzzzz"

--- a/tests/cases/cpp/nets_undriven_wire/main.sv
+++ b/tests/cases/cpp/nets_undriven_wire/main.sv
@@ -1,0 +1,16 @@
+// An undriven net reads its net type's undriven value (LRM 6.6.1): a `wire`
+// with no driver is high-impedance at its full width. The net is a readable,
+// well-typed observable from construction, so reading it before (or without)
+// any driver yields `z`, never an uninitialized cell. The output port here
+// attaches no driver because the child never drives `o`.
+module Source(output wire [7:0] o);
+endmodule
+
+module Top;
+  wire [7:0] w;
+  Source u(.o(w));
+  initial begin
+    #1;
+    $display("undriven=%b", w);
+  end
+endmodule


### PR DESCRIPTION
## Summary

This adds SystemVerilog net-typed port connections (LRM 23.3.3), single-driver, in both directions: a parent net or variable drives a child's input net, and a child's output net drives a parent variable or net, distributed across instance arrays and multi-level chains. A port connection lowers to one reactive edge -- the source is read and the sink is driven -- where the sink's capability picks the write protocol: a net sink attaches a driver (reusing the single-driver resolution model), a variable sink writes directly. Direction, locality, and multiplicity stop being dispatch axes; only the sink capability is. The full Ibex testbench now lowers past its net-typed-port wall.

## Design

A net conforms to the runtime value model: it installs its empty-driver resolved value at construction -- an undriven `wire` / `tri` reads `z` at its width -- so it is a readable, well-typed observable before any driver attaches, not an uninitialized cell. A cross-unit reference carries its target's net type (not a plain net flag, matching how the LRM and the frontend model net-ness), so the realized cross-unit cell matches the producer's actual cell and a read reaches the right access protocol. Process sensitivity now subscribes to nets as well as variables, so a net's resolved-value change wakes dependents and multi-level net chains converge. The branch also removes the speculative per-scope seal phase: the seal barrier is a design-global, coordinator-owned step to be materialized when its first consumer (net-topology validation) needs it, never a per-scope hook.

## Testing

cpp_run cases cover the input net port, the output net port driving a variable and a parent net plus a Leaf-Mid-Top chain, and (in 4-state) an undriven net reading `z`. The full `bazel test //...` suite passes, and the Ibex top-level testbench now passes the net-typed-port wall to the cross-unit parameter reference.