### PR TITLE
Support named procedural block as hierarchical head

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -134,6 +134,12 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 - [object-model-storage](object-model-storage.md) -- a compilation unit owns one canonical registry
   of local nominal object declarations; identity, lexical name resolution, and backend emission
   nesting are separate relations; the lexical-tree-only storage and a second identity are rejected.
+- [procedural-storage-scope](procedural-storage-scope.md) -- HIR carries a lexical procedural scope
+  tree (downward ownership, no backrefs) alongside its statement tree; a HIR-to-MIR two-pass
+  scope-tree fold decides which named begin/ends materialize as runtime hierarchy children and where
+  each static's storage physically lives; lexical owner and physical owner are distinct so an
+  unnamed scope nested in a named one places its statics in the named scope's class without exposing
+  them to cross-unit by-name lookup.
 - [elaboration-lifecycle-phases](elaboration-lifecycle-phases.md) -- a generated constructor only
   allocates; SystemVerilog elaboration is a staged build / resolve / initialize / activate protocol,
   with connections declarative until a single resolve phase and initializers running after it;

--- a/docs/decisions/declarations-before-bodies.md
+++ b/docs/decisions/declarations-before-bodies.md
@@ -159,6 +159,11 @@ mechanism.
 - **Interface and modport reference.** An interface's externally visible surface (modport
   declarations, virtual interface targets) is shape; a body that references it reads through the
   registry.
+- **Procedural storage scope materialization** (`procedural-storage-scope.md`). A named procedural
+  block whose subtree owns hierarchy-addressable storage is a structural declaration: its class
+  identity, its statics, the parent's owning-pointer companion member, and the contained-class edge
+  are minted by the shape pass. A sibling process's body lowering reads its peer block's members
+  through a typed segment chain; the body never mints any of these.
 
 The same invariant applies to future structural concepts that admit cross-reference; new
 applications do not introduce new mechanism.

--- a/docs/decisions/procedural-storage-scope.md
+++ b/docs/decisions/procedural-storage-scope.md
@@ -1,0 +1,206 @@
+# Procedural Storage Scope
+
+## Date
+
+2026-06-30
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+A named procedural block (LRM 9.3.5 `begin : name ... end`) is a hierarchical-reference head (LRM
+23.9): `Top.outer.x` reaches a static inside `outer` from another scope. The block is therefore not
+statement-tree decoration -- it is part of the compilation unit's hierarchical structure. Once that
+is true, every existing rule for structural declaration applies to it: it has a stable identity, its
+layout and storage are settled before any executable lowering, and a peer body that reaches into it
+does so by typed segment, not by re-walking source.
+
+This decision pins the named procedural block as a first-class structural concept, separates the
+HIR-side lexical view from the MIR-side runtime realization, and forbids body lowering from creating
+any of the structural state the runtime tree exposes.
+
+## The invariant
+
+A procedural body has two distinct semantic views, both first-class in HIR but never duplicated
+between each other:
+
+- the **statement tree** carries execution semantics (control flow, expression composition);
+- the **procedural scope tree** carries lexical declaration semantics (which scope owns which
+  declaration; which scope is nested inside which).
+
+Lexical containment lives only in the scope tree, expressed as downward ownership: each scope holds
+the ids of its direct declarations and its direct child scopes. No child holds a parent-pointer; no
+var holds a declaring-scope pointer; no scope holds anything derivable from its children. A scope is
+reached by walking from a body's `root_scope` through the `direct_child_scopes` lists -- never by
+walking the statement tree.
+
+A named procedural block whose subtree owns hierarchy-addressable storage, or whose descendants do,
+materializes as a runtime hierarchy child of its nearest enclosing addressable scope. Its identity,
+layout, and parent-attachment are settled before any executable lowering runs; body lowering
+consumes the planner's bindings and never creates new structural shape.
+
+This is the strict reading of `declarations-before-bodies.md`'s D5: body lowering grows no
+structural shape, not even shape that happens to be peer-unreferenced. Structural shape includes any
+class, member, or contained edge that participates in the runtime object tree or the typed access
+graph.
+
+## Decisions
+
+### D1. HIR carries a lexical procedural scope tree
+
+Every procedural body has a `root_scope`; every `begin/end`, `fork/join`, and `foreach` loop
+introduces its own scope. Each scope record holds:
+
+- a kind (process root, begin/end block, fork/join, foreach loop);
+- an optional SV `block_identifier` (LRM 9.3.5) -- present only for a named begin/end;
+- the ids of the variables declared directly in that scope;
+- the ids of the scopes nested directly inside it.
+
+There is no `parent` field on a scope and no `declaring_scope` field on a var: those facts are
+already in the downward ownership tree and storing them again would be a cache that drifts. The link
+from the statement tree to the scope tree is one direction only: a `BlockStmt` / `ForkStmt` for a
+source-level block carries the `ProceduralScopeId` it introduces; nothing in the scope tree carries
+a back-link into the statement tree.
+
+A scope's runtime addressability (whether it is a valid hierarchical-reference head) is an abstract
+property derived from kind + label, not a hardcoded enum check. Today only a named begin/end
+qualifies; future named-fork support would extend that property without reshaping the registry.
+
+### D2. Three distinct layers: HIR lexical scope, MIR materialization, MIR storage placement
+
+```
+HIR lexical scope tree   = every declaration-bearing scope (root + unnamed + named)
+MIR materialization      = the subset of named scopes that need runtime hierarchy nodes
+MIR storage placement    = which class actually owns each static's persistent storage
+```
+
+These layers are not the same and cannot be collapsed. The lexical tree preserves SV semantics
+(visibility, shadowing, future scope-aware constructs like `disable` and named fork).
+Materialization is a runtime-storage policy decided at HIR-to-MIR shape phase. Placement is the
+final per-static decision that follows from materialization but is not identical to it: a static
+inside an unnamed scope nested in a named one is **lexically** in the unnamed scope, but its
+**physical** storage owner is the nearest materialized ancestor.
+
+### D3. Materialization predicate
+
+A procedural scope materializes iff it is runtime-addressable AND (it directly owns a static OR a
+descendant scope is materialized). Process roots, unnamed begin/ends, foreach loops, and fork scopes
+are never runtime-addressable in the supported subset today and therefore never materialize.
+
+The descendant clause is load-bearing: in `begin : outer begin : inner static int y; end end`,
+`outer` materializes even though it owns no static of its own, because `outer.inner.y` requires
+`outer` to exist as a navigable step in the runtime path.
+
+### D4. Lexical owner is not physical owner
+
+The **lexical owner** of a static is the scope whose direct declarations list it -- this is the SV
+truth, used for shadowing, visibility, and future scope-aware semantics. The **physical storage
+owner** is the nearest materialized addressable ancestor (or the structural class when no such
+ancestor exists); this is the MIR class whose member arena holds the per-instance storage.
+
+A static lexically inside an unnamed scope nested in a named one flows through to the named scope's
+class for storage, but does NOT become a hierarchically-addressable signal of the named scope: the
+member is declared with its mangled name only, with no source-name and no by-name signal
+registration. SV's hierarchical-reference rules already forbid `Top.outer.hidden` for a `hidden`
+declared inside an unnamed block under `outer`; the placement rule mirrors that.
+
+### D5. `kProceduralStorageScope` is a distinct MIR `TypeKind`
+
+MIR enumerates the generate scope kind and a separate `kProceduralStorageScope`. A procedural
+storage scope shares the runtime Scope base with a generate scope -- same attach-to-parent, same
+signal registration, same by-name lookup -- but the two are not conflated. The kind axis
+distinguishes them so dump, debug, and per-kind extensions classify on the source-language origin
+without inferring from class name or scope position.
+
+### D6. Planner is a two-pass fold over the scope tree
+
+The HIR-to-MIR shape phase derives the storage plan by folding the lexical scope tree, not by
+visiting the statement tree:
+
+- **Pass 1 (post-order)** computes per-scope materialization. Each scope returns whether it is
+  materialized; the parent uses its children's results plus its own direct statics to decide its own
+  materialization.
+- **Pass 2 (top-down)** assigns physical storage placement. Each scope receives the chain of
+  materialized addressable ancestors above it; statics are placed on the nearest materialized
+  ancestor's class (or the structural class), and a materialized scope contributes its companion to
+  the chain before recursion descends into its children.
+
+The body lowering looks up the planner's resulting binding per static var; it does not re-derive
+placement and does not visit the statement tree for any planner concern.
+
+### D7. Intra-unit access to a procedural-scope static is a typed segment
+
+The same owned-child binding registry that routes downward access through an instance or
+generate-block head registers materialized procedural scopes too. A reference of the form `outer.x`
+from a sibling process resolves through the typed segment chain (`self -> outer_companion -> x`);
+the runtime by-name walk is used only across compilation-unit boundaries. Procedural-scope heads
+share routing mechanism with the other structural-child kinds; the distinction is the head's
+`TypeKind`, not the resolution path.
+
+## Forbidden shapes
+
+- A `ProceduralVarDecl` carrying a declaring-scope pointer back to its enclosing scope. The downward
+  ownership in the scope tree is the canonical fact; a backref is a cache that drifts.
+- A `ProceduralScopeDecl` carrying a parent pointer to its enclosing scope. Same reason: the
+  downward child-scope lists are the canonical fact.
+- A planner that walks the statement tree to derive scope ownership. The lexical scope tree is the
+  planner's input; the statement tree carries execution semantics, not declaration semantics.
+- A materialization flag stored on a HIR scope decl. HIR holds lexical structure; the storage plan
+  holds the realization, computed once at HIR-to-MIR shape phase.
+- An unnamed scope's static exposed as a public signal of its nearest materialized ancestor.
+  Physical placement does not imply hierarchical addressability; the source-name registration must
+  follow the var's lexical scope, not its physical owner.
+- A generate-scope MIR class standing in for a procedural storage scope. The kinds share a runtime
+  base but are distinct structural concepts.
+
+## Consequences
+
+- The HIR-to-MIR planner is a small fold over a small tree (the procedural scope tree is sparse
+  compared to the statement tree). It dispatches on scope kind, not on statement variant; the number
+  of statement-tree kinds it has to handle is zero.
+- A static's storage owner is a derived fact recorded once by the planner; the body lowering reads
+  the resulting binding per reference without re-deriving.
+- The owned-child binding registry carries an enlarged set of head kinds; the lookup path is
+  unchanged.
+- A named procedural block whose subtree owns no addressable storage anywhere never materializes and
+  contributes nothing to the MIR class graph -- its lexical existence in HIR is sufficient for
+  SV-side semantics (shadowing, future `disable`) without runtime cost.
+
+## Rejected alternatives
+
+- **Stmt-tree visitor in the planner.** Walk the statement tree at HIR-to-MIR shape phase to
+  discover named blocks and their statics. Rejected: the statement tree carries execution semantics;
+  declaration semantics live in the scope tree. Mixing the two forces the planner to dispatch on
+  every control-flow statement kind to find embedded declarations and creates a walker pattern that
+  has no peer elsewhere in the HIR-to-MIR layer.
+- **Backref on var or scope decl.** Store a declaring-scope pointer on `ProceduralVarDecl` or a
+  parent pointer on `ProceduralScopeDecl`. Rejected: duplicate of the canonical downward ownership;
+  introduces drift risk and forces every IR-mutating pass to update the cache.
+- **Lazy single-pass fold combining materialization and placement.** Compute both in one walk by
+  returning partial state up the tree. Rejected: materialization is a bottom-up decision while
+  placement is a top-down assignment; entangling them produces harder-to-verify code than two small
+  clean passes over a small tree.
+- **Body-lowering mints the scope on encounter.** The procedural-scope class is created when the
+  body lowering enters the named begin/end. Rejected: re-binds structural graph to executable
+  traversal even when the class id appears peer-unreferenced; the intra-unit typed segment rule (D7)
+  shows the id IS peer-referenced.
+- **Reuse the generate-scope MIR `TypeKind` for procedural storage scopes.** The runtime base is
+  identical, so use one kind. Rejected: dump, debug, and per-kind semantics (named fork, disable
+  label, lifetime extension) need to discriminate the source, and inference from class name is
+  fragile.
+- **Lexical owner equals physical owner for all cases.** Place a static in the lexical scope that
+  contains it, materializing every scope that has any static. Rejected: would force materialization
+  of unnamed blocks and other non-addressable lexical scopes that have no hierarchical
+  addressability; the resulting runtime hierarchy would not match the SV-visible path namespace.
+
+## Cross-references
+
+- `declarations-before-bodies.md` -- the strict-D5 invariant a procedural-scope class respects.
+- `variable-lifetime-storage.md` -- the storage-owner rule for static-lifetime body locals, read
+  through the addressable-scope concept this decision provides.
+- `hierarchical-reference-routing.md` -- one routing path per access shape; procedural-scope heads
+  resolve through the same typed-segment route as generate-block heads for intra-unit access, and
+  through the runtime by-name walk for cross-unit access.
+- `object-model-storage.md` -- the unit's class registry that holds the procedural-scope classes.

--- a/docs/decisions/variable-lifetime-storage.md
+++ b/docs/decisions/variable-lifetime-storage.md
@@ -40,18 +40,23 @@ local declared in place" to map onto.
 ## Decision
 
 **Honor the frontend's resolved lifetime; realize a static-lifetime body local as a per-instance
-member of the enclosing unit's class, default-initialized once; realize an automatic local as a C++
-local at its source position.** A process and a method use the identical mechanism.
+member of its nearest enclosing addressable scope's class, default-initialized once; realize an
+automatic local as a C++ local at its source position.** A process and a method use the identical
+mechanism.
 
+- An addressable scope is the structural scope (module / generate / SV class) or a materialized
+  procedural storage scope (`procedural-storage-scope.md`). A static at the body's top level lives
+  on the structural class; a static directly inside a materialized named block lives on the block's
+  class.
 - The body reaches the static local by the same scoped reference it uses for any local; the backend
   resolves that reference to the per-instance member.
 - The per-instance member is a flat member on the owner class's member arena -- not a sub-struct
   grouping per callable. SystemVerilog's per-callable scoping is already settled by HIR name-binding
-  before MIR sees the program; MIR has no visibility dimension, so the callable grouping is not a
-  MIR-level fact to preserve. Modeling each static local as a plain member collapses static-local
-  storage and access onto the same paths the rest of MIR already uses for module-level signals (one
-  type of decl, one MemberAccess shape, one render path, no static-frame walker state on the
-  backend).
+  before MIR sees the program; the cross-scope dimension the LRM exposes is the addressable scope (a
+  named block, not a callable), and within one addressable scope's class MIR has no per-callable
+  visibility to preserve. Modeling each static as a plain member collapses static-local storage and
+  access onto the same paths the rest of MIR already uses for module-level signals (one type of
+  decl, one MemberAccess shape, one render path, no static-frame walker state on the backend).
 - Names are made unique **uniformly** by appending an id to every static member -- not "append only
   on collision". Sibling callables in the same owner class (`static int x;` in two processes) and
   nested blocks repeating an identifier can both claim the same source name; the suffix removes the

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -152,12 +152,17 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       against the wrapper member in the constructor body (`BindVisibleChild` / `BindRoot` followed
       by zero or more `AddSuffixStep`), carrying only flat MIR primitives -- the wrapper type itself
       carries only the element type.
-- [ ] D2e -- An upward reference whose head is a named procedural block (a named `begin`/`end` or
-      `fork`/`join`, LRM 23.9). Unlike a module or generate scope, a named procedural block is not a
-      constructed object today: its static-lifetime locals live as members on the enclosing unit
-      (`docs/decisions/variable-lifetime-storage.md`), so there is no scope to climb to and no
-      by-name signal to fetch. This form needs either named procedural blocks to materialize as
-      navigable scopes or a member-name-aware resolution -- a model question deferred from D2c.
+- [x] D2e -- A hierarchical reference whose head is a named procedural block (a named `begin`/`end`,
+      LRM 9.3.5 / 23.9). A named block whose subtree owns hierarchy-addressable persistent storage
+      is a first-class structural declaration of the compilation unit: it materializes as a child
+      runtime scope on its nearest enclosing addressable scope, its static-lifetime locals live on
+      that scope's class, and the descendant case (`outer.inner.y` where `outer` owns no static of
+      its own) materializes `outer` because navigation through it is needed. Intra-unit access
+      (`outer.x` from a peer process) resolves through the typed-segment route -- the same
+      `OwnedChildBinding` infrastructure that routes instance and generate-block heads. Cross-unit
+      access (`Top.c.outer.x` from another module) resolves through the runtime by-name walk that
+      `GetChild` / `GetSignal` already provide. A named `fork`/`join` block as head is not yet
+      supported; the front-end still rejects it at construction.
 - [x] D3 -- Multi-level dotted paths resolve through the object tree across more than one level.
       Landed for downward paths through scalar instances.
 - [x] D4 -- A combinational process reading a hierarchical reference re-triggers when the referenced

--- a/include/lyra/hir/procedural_body.hpp
+++ b/include/lyra/hir/procedural_body.hpp
@@ -4,6 +4,7 @@
 
 #include "lyra/base/arena.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/stmt.hpp"
 
@@ -13,8 +14,15 @@ namespace lyra::hir {
 // statements, expressions, and local variables index into. Processes and
 // subroutines are both procedural bodies; they differ only in what wraps the
 // body (a process kind and sensitivity, or a subroutine signature).
+//
+// `root_stmt` is the body's execution-semantics entry; `root_scope` is the
+// body's declaration-semantics entry (the implicit process / subroutine
+// root scope that owns top-level locals and any directly-nested begin/end
+// child scopes). The two views are linked by `BlockStmt.scope`, etc.,
+// without either view duplicating the other.
 struct ProceduralBody {
   StmtId root_stmt{};
+  ProceduralScopeId root_scope{};
   base::Arena<Expr, ExprId> exprs;
   base::Arena<Stmt, StmtId> stmts;
   base::Arena<ProceduralVarDecl, ProceduralVarId> procedural_vars;

--- a/include/lyra/hir/procedural_scope.hpp
+++ b/include/lyra/hir/procedural_scope.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "lyra/hir/procedural_var.hpp"
+
+namespace lyra::hir {
+
+struct ProceduralScopeId {
+  std::uint32_t value;
+
+  auto operator<=>(const ProceduralScopeId&) const
+      -> std::strong_ordering = default;
+};
+
+// The lexical declaration scope a procedural body fragment owns. SV gives
+// several constructs their own declaration scope: the body root of a process
+// or subroutine; every `begin ... end` block (named or unnamed, LRM 9.3.4 /
+// 9.3.5); a `fork ... join` block carrying its own locals (LRM 9.3.2); the
+// implicit scope a `foreach` loop introduces for its loop variables (LRM
+// 12.7.3). They differ only in two axes the downstream consumers care about:
+// whether the scope carries a SV identifier (label), and whether the scope
+// is runtime-addressable as a hierarchical-reference head (LRM 23.9). A
+// named begin/end satisfies the latter; the others do not, in the forms
+// supported today.
+enum class ProceduralScopeKind : std::uint8_t {
+  kProcessRoot,
+  kBeginEndBlock,
+  kForkJoin,
+  kForEachLoop,
+};
+
+// A first-class lexical declaration scope in a procedural body. Holds the
+// declarations it directly owns and the immediate child scopes nested
+// inside it -- a downward ownership tree that mirrors SV lexical semantics
+// (LRM 9.3.4 visibility, LRM 23.9 hierarchical-reference addressability).
+// The HIR statement tree carries execution semantics; this scope tree
+// carries declaration semantics. The two views share identity through
+// `BlockStmt.scope` / `ForkStmt.scope` / etc., but neither view duplicates
+// what the other says: a downstream consumer that needs ownership reads it
+// here, not from the statement tree.
+struct ProceduralScopeDecl {
+  ProceduralScopeKind kind;
+  // SV `block_identifier` (LRM 9.3.5). Present for a named begin/end;
+  // absent for a process root, an unnamed begin/end, a fork/join scope, or
+  // a foreach loop scope. Distinct from `Stmt.label` (LRM 6.21 statement
+  // label); the two never share storage.
+  std::optional<std::string> label;
+  std::vector<ProceduralVarId> direct_declarations;
+  std::vector<ProceduralScopeId> direct_child_scopes;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -12,6 +12,7 @@
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/inside_item.hpp"
 #include "lyra/hir/loop_label_id.hpp"
+#include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/value_ref.hpp"
 
@@ -42,6 +43,15 @@ struct ExprStmt {
 
 struct BlockStmt {
   std::vector<StmtId> statements;
+  // The lexical declaration scope this block introduces, when it comes from
+  // a source-level `begin ... end` (LRM 9.3.4). Present for SV-source
+  // blocks (named or unnamed); absent for compiler-synthesized statement
+  // groupings that emit as a block but introduce no SV scope (e.g., the
+  // inner wrappers a foreach lowering produces around its nested for-loops).
+  // The scope record holds the optional SV `block_identifier` and the direct
+  // declarations / child scopes the block owns; runtime addressability is a
+  // separate axis on the scope record.
+  std::optional<ProceduralScopeId> scope;
 };
 
 // LRM 9.3.2 Table 9-1: which join keyword controls when the forking process
@@ -56,11 +66,14 @@ enum class JoinMode : std::uint8_t {
 // (VarDeclStmt) -- initialized at block entry, before any branch spawns, to
 // give each branch a by-value snapshot; they precede the parallel statements in
 // the fork's scope. Each branch in `branches` is a statement run as its own
-// concurrent process; `mode` sets when the parent resumes.
+// concurrent process; `mode` sets when the parent resumes. `scope` is the
+// fork's lexical declaration scope -- distinct from the enclosing scope so
+// `locals` are owned here, not by the parent.
 struct ForkStmt {
   JoinMode mode;
   std::vector<StmtId> locals;
   std::vector<StmtId> branches;
+  ProceduralScopeId scope;
 };
 
 enum class UniquePriorityCheck : std::uint8_t {

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -12,6 +12,7 @@
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/loop_var.hpp"
+#include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_hops.hpp"
@@ -75,7 +76,7 @@ struct GenerateChildRef {
 // the enclosing class's owned-child binding table.
 struct DownwardHead {
   StructuralHops hops = {};
-  std::variant<InstanceMemberId, GenerateChildRef> child;
+  std::variant<InstanceMemberId, GenerateChildRef, ProceduralScopeId> child;
 };
 
 // Where an upward cross-unit reference's navigation starts (LRM 23.8 / 23.9).
@@ -212,6 +213,7 @@ struct StructuralScope {
   std::vector<PortConnection> port_connections;
   base::Arena<CrossUnitRefDecl, CrossUnitRefId> cross_unit_refs;
   base::Arena<SubroutineDecl, StructuralSubroutineId> structural_subroutines;
+  base::Arena<ProceduralScopeDecl, ProceduralScopeId> procedural_scopes;
   std::vector<TypeAliasDecl> type_aliases;
 
   [[nodiscard]] auto NextGenerateId() const -> GenerateId {

--- a/include/lyra/lowering/ast_to_hir/process_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/process_lowerer.hpp
@@ -49,13 +49,16 @@ class ProcessLowerer {
   // creation rather than back-patching it at a later reference.
   void AnalyzeLifetimeExtended(const slang::ast::Statement& body);
 
-  // Composite: appends a `ProceduralVarDecl` to `body` and registers the
-  // slang-to-HIR binding for `var` in the procedural-var registry. The two
-  // halves stay atomic so no caller forgets to register a binding it later
-  // looks up.
+  // Composite: appends a `ProceduralVarDecl` to `body`, registers the
+  // slang-to-HIR binding for `var` in the procedural-var registry, and
+  // attaches the new id to the lexical scope the walk frame is currently
+  // building. The three halves stay atomic so no caller forgets to register
+  // a binding it later looks up, and no var slips out of its declaring
+  // scope's downward-ownership list.
   auto AddProceduralVar(
-      hir::ProceduralBody& body, const slang::ast::VariableSymbol& var,
-      hir::TypeId type) -> hir::ProceduralVarId;
+      const WalkFrame& frame, hir::ProceduralBody& body,
+      const slang::ast::VariableSymbol& var, hir::TypeId type)
+      -> hir::ProceduralVarId;
 
   [[nodiscard]] auto LookupProceduralVar(const slang::ast::VariableSymbol& var)
       const -> std::optional<hir::ProceduralVarId>;

--- a/include/lyra/lowering/ast_to_hir/walk_frame.hpp
+++ b/include/lyra/lowering/ast_to_hir/walk_frame.hpp
@@ -11,6 +11,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/loop_label_id.hpp"
+#include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/with_clause_id.hpp"
 
@@ -110,6 +111,21 @@ struct WalkFrame {
   // foreach loop variables are also slang Iterator symbols, so the match is by
   // symbol identity. Empty outside a with-clause body.
   std::vector<ActiveIterationClause> active_iteration_clauses;
+
+  // Accumulators for the lexical procedural scope currently being built. A
+  // var-decl handler pushes its newly-minted id into the declarations
+  // vector; a nested-scope handler pushes its assembled id into the
+  // children vector. The caller that opened the scope (process root,
+  // begin/end, fork, foreach) owns the vectors and seals their contents
+  // into a `ProceduralScopeDecl` when the recursion returns.
+  //
+  // Contract: every frame that lowers procedural-body content has both
+  // accumulators set; structural-scope frames before any body opens leave
+  // them null. Handlers reached inside a body therefore dereference these
+  // unconditionally -- a null accumulator is a caller bug, not a runtime
+  // branch.
+  std::vector<hir::ProceduralVarId>* current_scope_declarations = nullptr;
+  std::vector<hir::ProceduralScopeId>* current_scope_children = nullptr;
 
   [[nodiscard]] auto Current() const -> ScopeFrameId {
     if (structural_chain.empty()) {
@@ -211,6 +227,20 @@ struct WalkFrame {
       }
     }
     return std::nullopt;
+  }
+
+  // Switches the lexical scope accumulators to the pair the caller owns for
+  // the scope it just opened. The caller appends its assembled
+  // `ProceduralScopeDecl` to the structural scope's arena after the recursion
+  // returns; the resulting id is pushed into the parent scope's accumulators
+  // by the caller, not by the frame.
+  [[nodiscard]] auto WithProceduralScopeAccumulators(
+      std::vector<hir::ProceduralVarId>* declarations,
+      std::vector<hir::ProceduralScopeId>* children) const -> WalkFrame {
+    WalkFrame next = *this;
+    next.current_scope_declarations = declarations;
+    next.current_scope_children = children;
+    return next;
   }
 
   // Establishes `label` as the break target for the body being lowered. `used`

--- a/include/lyra/lowering/hir_to_mir/callable_storage_plan.hpp
+++ b/include/lyra/lowering/hir_to_mir/callable_storage_plan.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <algorithm>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/procedural_scope.hpp"
+#include "lyra/hir/procedural_var.hpp"
+#include "lyra/hir/type_id.hpp"
+#include "lyra/mir/class_id.hpp"
+#include "lyra/mir/member.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Tag for "storage lives directly on the class enclosing the body" -- the
+// `mir::Class` a `ProcessLowerer` is bound to: for a module / generate /
+// package body, the class the surrounding `StructuralScope` lowers to; for
+// an SV class method, the SV class itself. Distinct tag (not an optional
+// procedural-scope id) keeps the `StorageOwner` sum explicit and forbids an
+// overloaded nullopt at every consumer.
+struct EnclosingClass {
+  auto operator==(const EnclosingClass&) const -> bool = default;
+};
+
+// Where one piece of static persistent storage physically lives. Either the
+// body's enclosing class, or a materialized procedural-storage scope
+// (LRM 9.3.5 / 23.9) identified by its HIR id.
+using StorageOwner = std::variant<EnclosingClass, hir::ProceduralScopeId>;
+
+// One materialized procedural-storage scope. It is a runtime hierarchy child
+// of its runtime parent, reachable through `companion_member` on the
+// parent's class. `runtime_parent` is the immediate lexical parent
+// (another procedural scope, or the enclosing structural class).
+struct MaterializedProceduralScope {
+  mir::ClassId class_id{};
+  mir::MemberId companion_member{};
+  StorageOwner runtime_parent;
+};
+
+// Where a static-lifetime body local's persistent storage physically lives:
+// on its own lexical scope's class (a static declared in an unnamed
+// begin/end lives on that unnamed scope's class, not on any enclosing
+// named scope's).
+struct StaticStoragePlacement {
+  StorageOwner owner;
+  mir::MemberId member;
+};
+
+// Registry of materialized procedural-storage scopes for one structural
+// scope. Every `ProceduralScopeDecl` materializes, indexed by HIR
+// `ProceduralScopeId`. Walks from any `StorageOwner` to the body's
+// enclosing class assemble the companion-member chain consumers use to
+// project storage from `self`.
+class ProceduralScopeMaterializationTable {
+ public:
+  void Resize(std::size_t n) {
+    by_scope_id_.assign(n, MaterializedProceduralScope{});
+  }
+
+  void Record(hir::ProceduralScopeId scope, MaterializedProceduralScope entry) {
+    if (scope.value >= by_scope_id_.size()) {
+      throw InternalError(
+          "ProceduralScopeMaterializationTable::Record: scope id out of range");
+    }
+    by_scope_id_[scope.value] = entry;
+  }
+
+  [[nodiscard]] auto Get(hir::ProceduralScopeId scope) const
+      -> const MaterializedProceduralScope& {
+    if (scope.value >= by_scope_id_.size()) {
+      throw InternalError(
+          "ProceduralScopeMaterializationTable::Get: scope id out of range");
+    }
+    return by_scope_id_[scope.value];
+  }
+
+  [[nodiscard]] auto Size() const -> std::size_t {
+    return by_scope_id_.size();
+  }
+
+  // The companion-member path from the body's enclosing class `self` down
+  // to `owner`. Empty when owner is the enclosing class; one entry per
+  // intervening materialized procedural scope otherwise.
+  [[nodiscard]] auto CompanionChainTo(StorageOwner owner) const
+      -> std::vector<mir::MemberId> {
+    std::vector<mir::MemberId> chain;
+    while (const auto* scope_id = std::get_if<hir::ProceduralScopeId>(&owner)) {
+      const auto& entry = Get(*scope_id);
+      chain.push_back(entry.companion_member);
+      owner = entry.runtime_parent;
+    }
+    // Reverse so the chain reads outermost-first (enclosing self toward
+    // owner) -- the order consumers walk when projecting through `self`.
+    std::ranges::reverse(chain);
+    return chain;
+  }
+
+ private:
+  std::vector<MaterializedProceduralScope> by_scope_id_;
+};
+
+// One request to materialize a static declaration's initializer in the
+// Initialize phase. Body lowering emits these instead of lowering the
+// initializer expression itself; the declaration-initializer lowering path
+// consumes the list in the Initialize phase context, lowers the HIR init
+// expression there, and writes an assignment to `placement`. Carrying the
+// HIR expression handle (not a pre-lowered MIR expression) keeps the body's
+// MIR arena separate from the Initialize phase's arena and lets each phase
+// lower in its own context.
+struct PendingStaticInitializer {
+  hir::ProceduralVarId var{};
+  hir::TypeId hir_type{};
+  std::optional<hir::ExprId> init_expr;
+  StaticStoragePlacement placement{};
+  mir::TypeId storage_type{};
+};
+
+// Per-callable storage plan. Holds the static-var placements for one
+// callable's body and a borrowed reference to the structural scope's
+// shared procedural-scope materialization table; chain queries forward to
+// the table because chains are properties of the runtime topology, not of
+// the var.
+class CallableStoragePlan {
+ public:
+  CallableStoragePlan() = default;
+
+  CallableStoragePlan(
+      const ProceduralScopeMaterializationTable& scopes,
+      std::vector<std::optional<StaticStoragePlacement>> placements)
+      : scopes_(&scopes), placements_(std::move(placements)) {
+  }
+
+  [[nodiscard]] auto StaticPlacement(hir::ProceduralVarId var) const
+      -> std::optional<StaticStoragePlacement> {
+    if (var.value >= placements_.size()) return std::nullopt;
+    return placements_[var.value];
+  }
+
+  [[nodiscard]] auto ScopeMaterialization(hir::ProceduralScopeId scope) const
+      -> const MaterializedProceduralScope& {
+    return scopes_->Get(scope);
+  }
+
+  [[nodiscard]] auto CompanionChainTo(StorageOwner owner) const
+      -> std::vector<mir::MemberId> {
+    return scopes_->CompanionChainTo(owner);
+  }
+
+  [[nodiscard]] auto Scopes() const
+      -> const ProceduralScopeMaterializationTable& {
+    return *scopes_;
+  }
+
+ private:
+  const ProceduralScopeMaterializationTable* scopes_ = nullptr;
+  std::vector<std::optional<StaticStoragePlacement>> placements_;
+};
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/declaration_initializer.hpp
+++ b/include/lyra/lowering/hir_to_mir/declaration_initializer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
+#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Materializes one pending static initializer (LRM 13.3.1). The HIR
+// initializer expression is lowered in the caller-chosen frame's context --
+// its arena, its bindings, its `self` -- so the lowered output never carries
+// arena affinity from the body-lowering pass that deferred it. The result
+// lands as an assignment to the storage placement, wrapped in the
+// observable cell protocol when the storage is observable-typed.
+auto IntegratePendingStaticInitializer(
+    ProcessLowerer& process, const hir::ProceduralBody& body,
+    const WalkFrame& init_frame, const PendingStaticInitializer& pending)
+    -> diag::Result<void>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -77,23 +77,29 @@ class ProcessLowerer {
   // enclosing scope chose for this callable (LRM processes are anonymous, so
   // the caller passes `"process_N"`; methods pass `src.name`). The
   // `owner_ctor_frame` is the enclosing class's constructor-time
-  // frame -- the static-local lowering reads it to place per-instance storage
-  // and its init AssignExpr into the owner's constructor body. `visibility` is
-  // the access the produced method declares: a class instance method is public,
-  // a scope's processes and subroutines are internal.
+  // frame -- the static-local lowering reads it to place the init AssignExpr
+  // into the owner's constructor block. `visibility` is the access the produced
+  // method declares: a class instance method is public, a scope's processes
+  // and subroutines are internal. `static_members` is the per-instance storage
+  // the enclosing scope already declared for this body's static-lifetime
+  // locals, indexed by `hir::ProceduralVarId.value` (nullopt for an automatic
+  // local); the body lowering reads it instead of minting members, so the
+  // class's member arena stays settled while peer bodies lower against it.
   ProcessLowerer(
       ModuleLowerer& module,
       const StructuralScopeLowerer* enclosing_scope_lowerer,
       TimeResolution time_resolution, const hir::ProceduralBody& hir_body,
       std::string callable_name, mir::MethodVisibility visibility,
-      WalkFrame owner_ctor_frame)
+      WalkFrame owner_ctor_frame,
+      const std::vector<std::optional<mir::MemberId>>& static_members)
       : module_(&module),
         enclosing_scope_lowerer_(enclosing_scope_lowerer),
         time_resolution_(time_resolution),
         hir_body_(&hir_body),
         callable_name_(std::move(callable_name)),
         visibility_(visibility),
-        owner_ctor_frame_(std::move(owner_ctor_frame)) {
+        owner_ctor_frame_(std::move(owner_ctor_frame)),
+        static_members_(&static_members) {
   }
 
   // Lowers an entire HIR process (initial / final / always / always_ff /
@@ -227,10 +233,9 @@ class ProcessLowerer {
   }
 
   // The synthesized identifier for the callable being lowered (e.g.
-  // `"process_3"`, or a method's user-given name). Consumed by the
-  // static-local lowering to mangle the member name on the owner
-  // class so that sibling callables sharing a source name (`static int x;` in
-  // two processes of the same module) do not collide.
+  // `"process_3"`, or a method's user-given name). Used as the produced
+  // method's name and as a prefix for any per-callable artifact the body
+  // emits (e.g. a lifetime-extended activation box).
   [[nodiscard]] auto CallableName() const -> std::string_view {
     return callable_name_;
   }
@@ -249,6 +254,23 @@ class ProcessLowerer {
   // construction-time vantage.
   [[nodiscard]] auto OwnerCtorFrame() const -> const WalkFrame& {
     return owner_ctor_frame_;
+  }
+
+  // Resolves a HIR static-lifetime body local to the MIR member the
+  // enclosing scope pre-declared for it during shape declaration. The body's
+  // static-local lowering reads this instead of minting a member on the owner
+  // class, so the class's member arena stays settled while peer bodies lower
+  // against it.
+  [[nodiscard]] auto LookupPreDeclaredStaticMember(
+      hir::ProceduralVarId hir_id) const -> mir::MemberId {
+    if (hir_id.value >= static_members_->size() ||
+        !(*static_members_)[hir_id.value].has_value()) {
+      throw InternalError(
+          "ProcessLowerer::LookupPreDeclaredStaticMember: HIR procedural "
+          "var was not pre-declared as a static member by the enclosing "
+          "scope");
+    }
+    return *(*static_members_)[hir_id.value];
   }
 
   // Assembles the completion-payload value a `return` should carry in the
@@ -272,6 +294,10 @@ class ProcessLowerer {
   std::string callable_name_;
   mir::MethodVisibility visibility_;
   WalkFrame owner_ctor_frame_;
+  // Pre-declared MIR member for each static-lifetime body local, indexed by
+  // HIR `ProceduralVarId.value` (nullopt for an automatic local). Owned by the
+  // enclosing scope's lowerer; borrowed here for the body lowering's lifetime.
+  const std::vector<std::optional<mir::MemberId>>* static_members_;
   std::vector<ProceduralVarBinding> bindings_;
 
   // Completion-payload shape of the subroutine being lowered, set by

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -17,6 +17,7 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
+#include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -37,29 +38,24 @@ struct AutomaticVarBinding {
   mir::TypeId type;
 };
 
-struct StaticVarBinding {
-  mir::MemberId var;
-};
-
-// LRM 6.21: an automatic local a detached fork branch borrows and can outlive
-// is lifted into a shared activation object. Its reads / writes reach a member
-// of that object through a handle local (a shared pointer) declared at
-// `handle_depth`; a branch reaches the same member through a by-value copy of
-// the handle. `handle_type` is the handle's `PointerType{kShared}` type.
+// LRM 6.21: an automatic local a detached fork branch borrows and can
+// outlive is lifted into a shared activation object. Its reads / writes
+// reach a member of that object through a shared-pointer handle; a branch
+// captures the handle by value to keep the activation alive across the
+// declaring frame's return.
 struct PromotedVarBinding {
-  // The shared activation handle's cross-body origin: the reading body makes
-  // the handle available (a by-value, owning copy that keeps the activation
-  // alive) and projects the promoted member from it.
   BindingOriginId handle_origin;
   mir::TypeId handle_type;
   mir::MemberId member;
 };
 
-// LRM 13.3.1: a static-lifetime body local is realized as a member on the
-// callable's owner class, so a HIR procedural-var-ref dispatches to a
-// MemberAccess instead of a LocalRef.
+// Body-local environment binding for one HIR procedural var: an in-frame
+// local for an automatic, or a shared-activation handle for a
+// lifetime-extended automatic (LRM 6.21). Static-lifetime locals (LRM
+// 13.3.1) are NOT body-local; their placement is the per-callable storage
+// plan's authority, not this binding registry.
 using ProceduralVarBinding =
-    std::variant<AutomaticVarBinding, StaticVarBinding, PromotedVarBinding>;
+    std::variant<AutomaticVarBinding, PromotedVarBinding>;
 
 // Per-process / method lowering registries. Carries facts to the
 // surrounding module and class, time resolution, the HIR body, and
@@ -69,29 +65,27 @@ using ProceduralVarBinding =
 class ProcessLowerer {
  public:
   // Facts: every parameter is set once at construction and never mutated for
-  // the lowerer's lifetime. `enclosing_scope_lowerer` is the lowering pass for
-  // the structural scope this body sits inside; its registries resolve every
-  // reference to an enclosing-scope declaration. It is null for a class method
-  // body, which sits inside no structural scope. `callable_name` is the
-  // synthesized identifier the
-  // enclosing scope chose for this callable (LRM processes are anonymous, so
-  // the caller passes `"process_N"`; methods pass `src.name`). The
-  // `owner_ctor_frame` is the enclosing class's constructor-time
-  // frame -- the static-local lowering reads it to place the init AssignExpr
-  // into the owner's constructor block. `visibility` is the access the produced
-  // method declares: a class instance method is public, a scope's processes
-  // and subroutines are internal. `static_members` is the per-instance storage
-  // the enclosing scope already declared for this body's static-lifetime
-  // locals, indexed by `hir::ProceduralVarId.value` (nullopt for an automatic
-  // local); the body lowering reads it instead of minting members, so the
-  // class's member arena stays settled while peer bodies lower against it.
+  // the lowerer's lifetime. `enclosing_scope_lowerer` is the lowering pass
+  // for the structural scope this body sits inside; its registries resolve
+  // every reference to an enclosing-scope declaration. It is null for a
+  // class method body, which sits inside no structural scope. `callable_name`
+  // is the synthesized identifier the enclosing scope chose for this
+  // callable (LRM processes are anonymous, so the caller passes
+  // `"process_N"`; methods pass the user-given name). `owner_ctor_frame` is
+  // the enclosing class's constructor-time frame -- the base frame each
+  // body lowering extends with its own block / bindings, carrying the
+  // owner-class context (self pointer type, scope chain) into body lowering.
+  // `visibility` is the access the produced method declares (public for a
+  // class instance method, internal for a scope's processes and
+  // subroutines). `storage_plan` is the planner's per-callable storage plan
+  // -- static placements and the shared scope materialization table that
+  // chain queries route through.
   ProcessLowerer(
       ModuleLowerer& module,
       const StructuralScopeLowerer* enclosing_scope_lowerer,
       TimeResolution time_resolution, const hir::ProceduralBody& hir_body,
       std::string callable_name, mir::MethodVisibility visibility,
-      WalkFrame owner_ctor_frame,
-      const std::vector<std::optional<mir::MemberId>>& static_members)
+      WalkFrame owner_ctor_frame, const CallableStoragePlan& storage_plan)
       : module_(&module),
         enclosing_scope_lowerer_(enclosing_scope_lowerer),
         time_resolution_(time_resolution),
@@ -99,28 +93,29 @@ class ProcessLowerer {
         callable_name_(std::move(callable_name)),
         visibility_(visibility),
         owner_ctor_frame_(std::move(owner_ctor_frame)),
-        static_members_(&static_members) {
+        storage_plan_(&storage_plan) {
   }
 
   // Lowers an entire HIR process (initial / final / always / always_ff /
-  // always_comb / always_latch) into its `mir::MethodDecl` body. Constructs the
-  // process root scope on the stack and walks `src`'s body into it. Binding the
-  // body to its startup / shutdown lifecycle is the caller's concern (it reads
-  // the HIR process kind), not a property of the returned body.
+  // always_comb / always_latch) into its `mir::MethodDecl`. Any static
+  // initializers the body defers to the Initialize phase accumulate on the
+  // lowerer; the caller drains them through `TakePendingStaticInitializers`
+  // after `Run` returns and integrates them into the owning class's
+  // Initialize block.
   auto Run(const hir::Process& src) -> diag::Result<mir::MethodDecl>;
 
   // Lowers a HIR subroutine declaration into a `mir::MethodDecl`.
   // Pre-registers the formal params as body locals so call references resolve,
   // then walks the body. Functions with a non-void result close with a
-  // trailing `return` of the implicit result variable.
+  // trailing `return` of the implicit result variable. Deferred static
+  // initializers are drained the same way as for a process body.
   auto Run(const hir::SubroutineDecl& src) -> diag::Result<mir::MethodDecl>;
 
   // Central expression dispatcher. One switch over `hir::Expr::data` routing
-  // each kind to the per-family handler in `expression/{operators, calls,
-  // references, selects, aggregates, assignment, inside}.cpp`. Handlers
-  // recurse through this method; sub-expressions reach `frame` through it.
-  // An observable-cell leaf is auto-wrapped in an `ObservableMethod{kGet}`
-  // call so the result is a value-typed expression.
+  // each kind to its per-family handler; handlers recurse through this
+  // method, so sub-expressions reach `frame` through it. An observable-cell
+  // leaf is auto-wrapped in an `ObservableMethod{kGet}` call so the result
+  // is a value-typed expression.
   auto LowerExpr(const hir::Expr& expr, WalkFrame frame)
       -> diag::Result<mir::Expr>;
 
@@ -131,8 +126,7 @@ class ProcessLowerer {
       -> diag::Result<mir::Expr>;
 
   // Central statement dispatcher. One switch over `hir::Stmt::data` routing
-  // each kind to the per-family handler in `statement/{blocks, branches,
-  // loops, timing, fork_join, assignment, flow}.cpp`.
+  // each kind to its per-family handler.
   auto LowerStmt(const hir::Stmt& stmt, WalkFrame frame)
       -> diag::Result<mir::Stmt>;
 
@@ -191,22 +185,31 @@ class ProcessLowerer {
 
   void MapProceduralVar(
       hir::ProceduralVarId hir_id, ProceduralVarBinding binding) {
-    if (hir_id.value != bindings_.size()) {
-      throw InternalError(
-          "ProcessLowerer::MapProceduralVar: HIR procedural vars must "
-          "be mapped in HIR id order");
+    if (hir_id.value >= bindings_.size()) {
+      bindings_.resize(hir_id.value + 1);
     }
-    bindings_.push_back(binding);
+    if (bindings_[hir_id.value].has_value()) {
+      throw InternalError(
+          "ProcessLowerer::MapProceduralVar: HIR procedural var already "
+          "registered in the body-local environment");
+    }
+    bindings_[hir_id.value] = binding;
   }
 
+  // Returns the body-local environment binding for an automatic / promoted
+  // var, or nullptr when the var has no body-local binding (it resolves
+  // through `LookupStaticPlacement` against the storage plan instead).
+  // Reference-resolution sites dispatch on this -- presence in the body
+  // env is the authoritative signal, not the HIR lifetime, because
+  // subroutine params / output / result_var get registered here regardless
+  // of the slang-reported lifetime.
   [[nodiscard]] auto LookupProceduralVar(hir::ProceduralVarId hir_id) const
-      -> const ProceduralVarBinding& {
-    if (hir_id.value >= bindings_.size()) {
-      throw InternalError(
-          "ProcessLowerer::LookupProceduralVar: unmapped HIR "
-          "procedural var");
+      -> const ProceduralVarBinding* {
+    if (hir_id.value >= bindings_.size() ||
+        !bindings_[hir_id.value].has_value()) {
+      return nullptr;
     }
-    return bindings_[hir_id.value];
+    return &*bindings_[hir_id.value];
   }
 
   // An activation scope is opened at block entry -- the box and its handle are
@@ -246,32 +249,67 @@ class ProcessLowerer {
     return visibility_;
   }
 
-  // The owner class's constructor-time frame. The static-local
-  // lowering reads it to place the per-instance storage's init AssignExpr
-  // into the owner's constructor block using the owner's own `self` binding,
-  // not the body's. Body-walking edits override `current_block` /
-  // `self_binding` for the body, while this snapshot stays at the owner's
-  // construction-time vantage.
+  // The owner class's constructor-time frame -- the base each body lowering
+  // extends with its own block / bindings. Carries the outer-class context
+  // (self pointer type, scope chain) so a body frame derived from it
+  // resolves `self` to the owner. Body lowering does NOT write into this
+  // frame's block; static initializers are deferred via
+  // `RecordPendingStaticInitializer` and integrated by the caller in the
+  // appropriate lifecycle phase (Initialize for module-level bodies, the
+  // class constructor for SV-class methods).
   [[nodiscard]] auto OwnerCtorFrame() const -> const WalkFrame& {
     return owner_ctor_frame_;
   }
 
-  // Resolves a HIR static-lifetime body local to the MIR member the
-  // enclosing scope pre-declared for it during shape declaration. The body's
-  // static-local lowering reads this instead of minting a member on the owner
-  // class, so the class's member arena stays settled while peer bodies lower
-  // against it.
-  [[nodiscard]] auto LookupPreDeclaredStaticMember(
-      hir::ProceduralVarId hir_id) const -> mir::MemberId {
-    if (hir_id.value >= static_members_->size() ||
-        !(*static_members_)[hir_id.value].has_value()) {
-      throw InternalError(
-          "ProcessLowerer::LookupPreDeclaredStaticMember: HIR procedural "
-          "var was not pre-declared as a static member by the enclosing "
-          "scope");
-    }
-    return *(*static_members_)[hir_id.value];
+  // The callable's storage plan: static placements + scope materialization
+  // table for chain walks. Borrowed for the body lowering's lifetime.
+  [[nodiscard]] auto StoragePlan() const -> const CallableStoragePlan& {
+    return *storage_plan_;
   }
+
+  // Resolves a HIR static-lifetime body local to the placement the planner
+  // produced during shape declaration. A compiler-bug invariant if called
+  // for a var with no placement (an automatic local).
+  [[nodiscard]] auto LookupStaticPlacement(hir::ProceduralVarId hir_id) const
+      -> StaticStoragePlacement {
+    const auto placement = storage_plan_->StaticPlacement(hir_id);
+    if (!placement.has_value()) {
+      throw InternalError(
+          "ProcessLowerer::LookupStaticPlacement: HIR procedural var has "
+          "no pre-declared static placement");
+    }
+    return *placement;
+  }
+
+  // Records that a static declaration's initializer must run in the
+  // Initialize phase. Body lowering calls this from the static-var
+  // declaration handler instead of lowering the initializer itself; the
+  // pending list is returned in the `LoweredCallable` for caller
+  // integration. The HIR `init_expr` is kept as a handle (not pre-lowered)
+  // so the dedicated initializer lowering path can lower it in the
+  // Initialize phase context.
+  void RecordPendingStaticInitializer(PendingStaticInitializer entry) {
+    pending_static_initializers_.push_back(std::move(entry));
+  }
+
+  // Hands the accumulated pending initializers to the caller (Run extracts
+  // them at the end of body lowering to fold into `LoweredCallable`).
+  [[nodiscard]] auto TakePendingStaticInitializers()
+      -> std::vector<PendingStaticInitializer> {
+    return std::move(pending_static_initializers_);
+  }
+
+  // Builds the chained MemberAccess that reaches a static-lifetime body
+  // local's storage from the current frame's `self`: starts at the
+  // enclosing class pointer, walks the placement's companion chain (queried
+  // from the procedural-scope materialization table), and ends with a
+  // MemberAccess to the storage member. The expr's type is the storage
+  // field's type read from the owner class's published shape, so an
+  // observable-wrapped static returns a wrapper Expr the caller routes
+  // through the cell protocol or uses as a write target.
+  [[nodiscard]] auto BuildStaticStorageAccess(
+      const WalkFrame& frame, StaticStoragePlacement placement) const
+      -> mir::Expr;
 
   // Assembles the completion-payload value a `return` should carry in the
   // subroutine being lowered: the function's explicit return value (or its
@@ -294,11 +332,12 @@ class ProcessLowerer {
   std::string callable_name_;
   mir::MethodVisibility visibility_;
   WalkFrame owner_ctor_frame_;
-  // Pre-declared MIR member for each static-lifetime body local, indexed by
-  // HIR `ProceduralVarId.value` (nullopt for an automatic local). Owned by the
-  // enclosing scope's lowerer; borrowed here for the body lowering's lifetime.
-  const std::vector<std::optional<mir::MemberId>>* static_members_;
-  std::vector<ProceduralVarBinding> bindings_;
+  // Per-callable storage plan owned by the enclosing scope's lowerer;
+  // borrowed here for the body lowering's lifetime.
+  const CallableStoragePlan* storage_plan_;
+  // Body-local environment bindings, indexed by HIR procedural var id;
+  // nullopt for a static var (its placement lives on the storage plan).
+  std::vector<std::optional<ProceduralVarBinding>> bindings_;
 
   // Completion-payload shape of the subroutine being lowered, set by
   // Run(subroutine) before its body walks and read by every return site. All
@@ -311,6 +350,11 @@ class ProcessLowerer {
   mir::TypeId completion_payload_type_{};
 
   std::map<hir::ProceduralVarId, PromotedVarBinding> pending_activation_;
+
+  // Static-initializer requests accumulated during body walk; the caller
+  // pulls them out of the returned LoweredCallable and integrates them into
+  // the Initialize phase block.
+  std::vector<PendingStaticInitializer> pending_static_initializers_;
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -16,6 +16,7 @@
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/class_id.hpp"
@@ -289,11 +290,14 @@ class StructuralScopeLowerer {
   // `hir::DownwardHead`) to the MIR member that owns the child. `hops == 0`
   // reads this scope's own table; `hops > 0` walks the parent chain to an
   // enclosing scope, used by the sibling-of-ancestor install when the head
-  // lives outside the referrer's frame.
+  // lives outside the referrer's frame. The procedural-scope arm resolves to
+  // the companion unique-pointer member; subsequent steps follow the typed
+  // segment chain through that pointer's pointee class.
   [[nodiscard]] auto TranslateOwnedChild(
       hir::StructuralHops hops,
-      const std::variant<hir::InstanceMemberId, hir::GenerateChildRef>& child)
-      const -> mir::MemberId {
+      const std::variant<
+          hir::InstanceMemberId, hir::GenerateChildRef, hir::ProceduralScopeId>&
+          child) const -> mir::MemberId {
     return LookupOwnedChildAtHops(hops, child);
   }
 
@@ -317,8 +321,9 @@ class StructuralScopeLowerer {
  private:
   [[nodiscard]] auto LookupOwnedChildAtHops(
       hir::StructuralHops hops,
-      const std::variant<hir::InstanceMemberId, hir::GenerateChildRef>& child)
-      const -> mir::MemberId {
+      const std::variant<
+          hir::InstanceMemberId, hir::GenerateChildRef, hir::ProceduralScopeId>&
+          child) const -> mir::MemberId {
     if (hops.value == 0) {
       return std::visit(
           Overloaded{
@@ -341,6 +346,9 @@ class StructuralScopeLowerer {
                 return generate_map_[g.generate.value]
                     .by_scope_id.at(g.scope.value)
                     .var_id;
+              },
+              [&](const hir::ProceduralScopeId& s) -> mir::MemberId {
+                return scope_materialization_.Get(s).companion_member;
               },
           },
           child);
@@ -427,15 +435,16 @@ class StructuralScopeLowerer {
   std::vector<std::optional<mir::LocalRef>> loop_var_procedural_map_;
   std::vector<mir::MemberId> instance_member_map_;
   std::vector<GenerateBindings> generate_map_;
-  // Pre-declared MIR members for each callable's static-lifetime body locals.
-  // Outer vector parallels the HIR scope's subroutines / processes
-  // respectively; inner vector is indexed by HIR `ProceduralVarId.value`,
-  // nullopt for an automatic local. Populated during shape declaration so the
-  // class's member arena is settled before any body lowers against it.
-  std::vector<std::vector<std::optional<mir::MemberId>>>
-      subroutine_static_members_;
-  std::vector<std::vector<std::optional<mir::MemberId>>>
-      process_static_members_;
+  // Per-structural-scope runtime-topology table for materialized procedural
+  // storage scopes. Populated during shape declaration; consumed by the
+  // per-callable plans and by the runtime-tree construction emitter.
+  ProceduralScopeMaterializationTable scope_materialization_;
+  // Per-callable storage plan. Outer vector parallels the HIR scope's
+  // subroutines / processes arenas; each entry packages the callable's
+  // static placements together with a reference to `scope_materialization_`
+  // so peer bodies query both through the same plan handle.
+  std::vector<CallableStoragePlan> subroutine_storage_plans_;
+  std::vector<CallableStoragePlan> process_storage_plans_;
   mir::ClassId class_id_{};
   std::vector<std::unique_ptr<StructuralScopeLowerer>> children_;
 };

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -427,6 +427,15 @@ class StructuralScopeLowerer {
   std::vector<std::optional<mir::LocalRef>> loop_var_procedural_map_;
   std::vector<mir::MemberId> instance_member_map_;
   std::vector<GenerateBindings> generate_map_;
+  // Pre-declared MIR members for each callable's static-lifetime body locals.
+  // Outer vector parallels the HIR scope's subroutines / processes
+  // respectively; inner vector is indexed by HIR `ProceduralVarId.value`,
+  // nullopt for an automatic local. Populated during shape declaration so the
+  // class's member arena is settled before any body lowers against it.
+  std::vector<std::vector<std::optional<mir::MemberId>>>
+      subroutine_static_members_;
+  std::vector<std::vector<std::optional<mir::MemberId>>>
+      process_static_members_;
   mir::ClassId class_id_{};
   std::vector<std::unique_ptr<StructuralScopeLowerer>> children_;
 };

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -33,6 +33,7 @@ enum class TypeKind {
   kScope,
   kInstance,
   kGenScope,
+  kProceduralStorageScope,
   kServices,
   kFiles,
   kDiagnostic,
@@ -241,6 +242,15 @@ struct InstanceType {
 // generate scope is matched by its block name, not a def-name.
 struct GenScopeType {
   auto operator==(const GenScopeType&) const -> bool = default;
+};
+
+// The runtime object-tree base class `lyra::runtime::ProceduralStorageScope`,
+// the concrete base a named procedural block (LRM 9.3.5 / 23.9) extends when
+// its subtree holds hierarchically-reachable static storage. A tree node
+// matched by block name like GenScopeType, but a distinct kind so backend
+// dispatch and diagnostics see the source kind directly.
+struct ProceduralStorageScopeType {
+  auto operator==(const ProceduralStorageScopeType&) const -> bool = default;
 };
 
 // The engine facade `lyra::runtime::RuntimeServices`. A callable body reaches
@@ -472,10 +482,10 @@ using TypeData = std::variant<
     AssociativeArrayType, WildcardIndexType, StringType, StringViewType,
     MachineIntType, EventType, RealType, ShortRealType, RealTimeType,
     ChandleType, VoidType, ObjectType, ExternalUnitObjectType, ScopeType,
-    InstanceType, GenScopeType, ServicesType, FilesType, DiagnosticType,
-    RuntimeLibraryType, CoroutineType, RefType, PointerType, ManagedRefType,
-    VectorType, TupleType, UnionType, ExternalRefType, ObservableType,
-    ResolvedType, DriverType, CallableType>;
+    InstanceType, GenScopeType, ProceduralStorageScopeType, ServicesType,
+    FilesType, DiagnosticType, RuntimeLibraryType, CoroutineType, RefType,
+    PointerType, ManagedRefType, VectorType, TupleType, UnionType,
+    ExternalRefType, ObservableType, ResolvedType, DriverType, CallableType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -80,13 +80,23 @@ class Scope {
   // string literal.
   void RegisterSignal(std::string_view name, void* address);
 
-  // Wires `child` into this scope's object-tree edge: sets `child.parent_`
-  // to `this`, places `child` in the attached-children relation, and makes
-  // it findable through `GetChild` (key derived from `child.Segment()`).
-  // One write point per child edge; the parent never re-states identity
-  // the child already holds. Called after the typed owner commits the
-  // child, so a thrown ctor leaves no half-attached scope.
+  // Wires `child` into this scope's physical containment edge: sets
+  // `child.parent_` to `this` and places `child` in the attached-children
+  // relation (used by elaboration walks, dump, ForEachChild, and the
+  // SV-visible by-name lookup which recurses through anonymous children).
+  // Called after the typed owner commits the child, so a thrown ctor
+  // leaves no half-attached scope.
   void AttachChild(Scope& child);
+
+  // Whether this scope carries a source-visible SV name. An unnamed
+  // begin/end (synthetic anonymous scope) is emitted with an empty
+  // `HierarchySegment` base name; every other scope kind gets its SV
+  // identifier as the base name. `GetChild` recurses through
+  // non-addressable children so peer by-name lookup transparently walks
+  // past them (LRM 23 hierarchical-name semantics).
+  [[nodiscard]] auto IsAddressable() const -> bool {
+    return !segment_.BaseName().empty();
+  }
 
   // Returns the address of the signal registered under `name`, or the owned
   // child registered at `name` with `indices`; nullptr if none. A cross-unit
@@ -201,10 +211,10 @@ class Scope {
   HierarchySegment segment_;
   // Borrowed; set in the constructor.
   RuntimeServices* services_ = nullptr;
-  // The single object-tree edge: every child this scope owns appears here
-  // once, with its `Segment()` carrying both the LRM display name and the
-  // by-name lookup key. Traversal walks this in deterministic attach order;
-  // by-name lookup scans it and compares each child's segment.
+  // Physical containment: every runtime child scope this object owns
+  // appears here once, in attach order. Includes anonymous scopes
+  // (unnamed begin/ends). `GetChild` scans this and recurses into
+  // anonymous children so SV-visible lookup ignores synthetic wrappers.
   std::vector<Scope*> attached_children_;
   // By-name interface this scope answers cross-unit signal queries from.
   // Filled during construction; scanned only at construction-time
@@ -229,6 +239,15 @@ class Instance : public Scope {
 // A module-local generate naming scope (`if` / `for` / `case` generate block):
 // an intra-unit owned child that crosses no compilation-unit boundary.
 class GenScope : public Scope {
+ public:
+  using Scope::Scope;
+};
+
+// A named procedural block (`begin : outer static int x; ... end`, LRM
+// 9.3.5 / 23.9) holding static-lifetime locals reachable by hierarchical
+// path (`Top.outer.x`): an intra-unit owned child like `GenScope`, separate
+// C++ type so the source kind survives backend dispatch and diagnostics.
+class ProceduralStorageScope : public Scope {
  public:
   using Scope::Scope;
 };

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -128,6 +128,9 @@ auto RenderTypeAsCpp(
           [](const mir::GenScopeType&) -> std::string {
             return std::string{"lyra::runtime::GenScope"};
           },
+          [](const mir::ProceduralStorageScopeType&) -> std::string {
+            return std::string{"lyra::runtime::ProceduralStorageScope"};
+          },
           [](const mir::ServicesType&) -> std::string {
             return std::string{"lyra::runtime::RuntimeServices&"};
           },

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -271,14 +271,16 @@ auto LowerHierarchicalValue(
   if (!path) return std::unexpected(std::move(path.error()));
 
   // Downward: the head is an owned child this unit's scope declares -- an
-  // instance / instance-array member, or a generate block (LRM 27). Both are
-  // bound before any process body is lowered, so a reference resolves
-  // regardless of source order; a missing binding is a compiler-bug invariant.
+  // instance / instance-array member, a generate block (LRM 27), or a named
+  // procedural block (LRM 9.3.5 / 23.9). Each is bound before any process
+  // body is lowered, so a reference resolves regardless of source order; a
+  // missing binding is a compiler-bug invariant.
   const bool head_is_owned_child =
       head_sym.kind == slang::ast::SymbolKind::Instance ||
       head_sym.kind == slang::ast::SymbolKind::InstanceArray ||
       head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
-      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray;
+      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray ||
+      head_sym.kind == slang::ast::SymbolKind::StatementBlock;
   if (!head_is_owned_child) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
@@ -311,7 +313,8 @@ auto LowerHierarchicalValue(
   // unsupported here.
   const bool head_is_intra_unit =
       head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
-      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray;
+      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray ||
+      head_sym.kind == slang::ast::SymbolKind::StatementBlock;
   if (!head_is_intra_unit) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,

--- a/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
@@ -91,12 +91,31 @@ auto ProcessLowerer::Run(
     const slang::ast::ProceduralBlockSymbol& proc, WalkFrame parent_frame)
     -> diag::Result<hir::Process> {
   hir::ProceduralBody body;
-  const WalkFrame frame = parent_frame.WithProceduralBody(&body, &body.exprs);
+
+  // Open the root lexical scope accumulators. Every body-tree var declared
+  // below feeds into these vectors and becomes the root scope's direct
+  // declarations; nested named blocks / forks / foreach scopes push their
+  // ids into the root scope's children list.
+  std::vector<hir::ProceduralVarId> root_declarations;
+  std::vector<hir::ProceduralScopeId> root_children;
+  const WalkFrame frame =
+      parent_frame.WithProceduralBody(&body, &body.exprs)
+          .WithProceduralScopeAccumulators(&root_declarations, &root_children);
 
   AnalyzeLifetimeExtended(proc.getBody());
   auto root_stmt = LowerStmt(proc.getBody(), frame);
   if (!root_stmt) return std::unexpected(std::move(root_stmt.error()));
   body.root_stmt = body.stmts.Add(*std::move(root_stmt));
+
+  if (parent_frame.current_structural_scope != nullptr) {
+    body.root_scope =
+        parent_frame.current_structural_scope->procedural_scopes.Add(
+            hir::ProceduralScopeDecl{
+                .kind = hir::ProceduralScopeKind::kProcessRoot,
+                .label = std::nullopt,
+                .direct_declarations = std::move(root_declarations),
+                .direct_child_scopes = std::move(root_children)});
+  }
 
   const auto& mapper = module_->SourceMapper();
   const auto span = mapper.PointSpanOf(proc.location);
@@ -127,8 +146,9 @@ auto ProcessLowerer::Run(
 }
 
 auto ProcessLowerer::AddProceduralVar(
-    hir::ProceduralBody& body, const slang::ast::VariableSymbol& var,
-    hir::TypeId type) -> hir::ProceduralVarId {
+    const WalkFrame& frame, hir::ProceduralBody& body,
+    const slang::ast::VariableSymbol& var, hir::TypeId type)
+    -> hir::ProceduralVarId {
   const hir::ProceduralVarId id = body.procedural_vars.Add(
       hir::ProceduralVarDecl{
           .name = std::string{var.name},
@@ -143,6 +163,7 @@ auto ProcessLowerer::AddProceduralVar(
         "ProcessLowerer::AddProceduralVar: procedural variable symbol "
         "already mapped");
   }
+  frame.current_scope_declarations->push_back(id);
   return id;
 }
 

--- a/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
@@ -2,6 +2,7 @@
 
 #include <expected>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -12,6 +13,8 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
+#include "lyra/hir/procedural_scope.hpp"
+#include "lyra/hir/structural_scope.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -67,19 +70,25 @@ auto LowerForkStmt(
   // LRM 9.3.2: a fork's block_item_declarations are not parallel statements --
   // they are locals of the fork scope, initialized in the parent at block entry
   // before any branch spawns. The grammar places them before the statements, so
-  // they form a prefix; each remaining statement is a branch. Locals lower in
-  // the enclosing (parent) context; only the branches enter the fork-branch
-  // scope.
+  // they form a prefix; each remaining statement is a branch. The fork
+  // introduces its own lexical declaration scope owning those locals; locals
+  // lower in the parent execution context but attach to the fork scope, and
+  // only the branches enter the fork-branch execution scope.
+  std::vector<hir::ProceduralVarId> fork_declarations;
+  std::vector<hir::ProceduralScopeId> fork_children;
+  const WalkFrame fork_scope_frame =
+      frame.WithProceduralScopeAccumulators(&fork_declarations, &fork_children);
+
   std::vector<hir::StmtId> locals;
   std::vector<const slang::ast::Statement*> branch_stmts;
   for (const auto* child : body_stmts) {
     if (child->kind == slang::ast::StatementKind::VariableDeclaration) {
-      auto local_stmt = proc.LowerStmt(*child, frame);
+      auto local_stmt = proc.LowerStmt(*child, fork_scope_frame);
       if (!local_stmt) {
         return std::unexpected(std::move(local_stmt.error()));
       }
-      locals.push_back(
-          frame.current_procedural_body->stmts.Add(*std::move(local_stmt)));
+      locals.push_back(fork_scope_frame.current_procedural_body->stmts.Add(
+          *std::move(local_stmt)));
     } else {
       branch_stmts.push_back(child);
     }
@@ -87,7 +96,7 @@ auto LowerForkStmt(
 
   std::vector<hir::StmtId> branches;
   branches.reserve(branch_stmts.size());
-  const WalkFrame branch_frame = frame.WithForkBranch();
+  const WalkFrame branch_frame = fork_scope_frame.WithForkBranch();
   for (const auto* child : branch_stmts) {
     auto child_stmt = proc.LowerStmt(*child, branch_frame);
     if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
@@ -95,13 +104,29 @@ auto LowerForkStmt(
         *std::move(child_stmt)));
   }
 
+  if (frame.current_structural_scope == nullptr) {
+    throw InternalError(
+        "LowerForkStmt: fork has no enclosing structural scope to register "
+        "its lexical scope against");
+  }
+  const hir::ProceduralScopeId scope_id =
+      frame.current_structural_scope->procedural_scopes.Add(
+          hir::ProceduralScopeDecl{
+              .kind = hir::ProceduralScopeKind::kForkJoin,
+              .label = std::nullopt,
+              .direct_declarations = std::move(fork_declarations),
+              .direct_child_scopes = std::move(fork_children)});
+
+  frame.current_scope_children->push_back(scope_id);
+
   return hir::Stmt{
       .label = std::nullopt,
       .data =
           hir::ForkStmt{
               .mode = mode,
               .locals = std::move(locals),
-              .branches = std::move(branches)},
+              .branches = std::move(branches),
+              .scope = scope_id},
       .span = span};
 }
 
@@ -111,17 +136,42 @@ auto LowerStatementListStmt(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::StatementList& list, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
+  // A bare slang `StatementList` (multiple statements without a source-level
+  // `begin ... end`) lowers to an unnamed begin/end scope -- semantically
+  // equivalent for declaration ownership, with no SV identifier and no
+  // hierarchical addressability.
+  std::vector<hir::ProceduralVarId> nested_declarations;
+  std::vector<hir::ProceduralScopeId> nested_children;
+  const WalkFrame body_frame = frame.WithProceduralScopeAccumulators(
+      &nested_declarations, &nested_children);
+
   std::vector<hir::StmtId> kids;
   kids.reserve(list.list.size());
   for (const auto* child : list.list) {
-    auto child_stmt = proc.LowerStmt(*child, frame);
+    auto child_stmt = proc.LowerStmt(*child, body_frame);
     if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
     kids.push_back(
-        frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
+        body_frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
   }
+
+  if (frame.current_structural_scope == nullptr) {
+    throw InternalError(
+        "LowerStatementListStmt: statement list has no enclosing structural "
+        "scope to register its lexical scope against");
+  }
+  const hir::ProceduralScopeId scope_id =
+      frame.current_structural_scope->procedural_scopes.Add(
+          hir::ProceduralScopeDecl{
+              .kind = hir::ProceduralScopeKind::kBeginEndBlock,
+              .label = std::nullopt,
+              .direct_declarations = std::move(nested_declarations),
+              .direct_child_scopes = std::move(nested_children)});
+
+  frame.current_scope_children->push_back(scope_id);
+
   return hir::Stmt{
       .label = std::nullopt,
-      .data = hir::BlockStmt{.statements = std::move(kids)},
+      .data = hir::BlockStmt{.statements = std::move(kids), .scope = scope_id},
       .span = span};
 }
 
@@ -132,25 +182,67 @@ auto LowerBlockStmt(
   if (block.blockKind != slang::ast::StatementBlockKind::Sequential) {
     return LowerForkStmt(proc, frame, block, span);
   }
+  // Every `begin ... end` introduces a lexical declaration scope (LRM
+  // 9.3.4); the label (LRM 9.3.5) is optional. The scope's own declarations
+  // and nested child scopes are collected here through a fresh accumulator
+  // pair, then sealed into a `ProceduralScopeDecl` and appended to the
+  // enclosing structural scope's arena when the body walk returns -- the
+  // arena is append-only, so the scope must be assembled before its first
+  // `Add`. A named scope is also registered as a runtime-addressable
+  // owned child so a reference whose leading component slang resolves to
+  // this block's symbol can route through the same head-binding machinery
+  // that instance and generate heads use.
+  std::optional<std::string> label;
+  if (block.blockSymbol != nullptr && !block.blockSymbol->name.empty()) {
+    label = std::string{block.blockSymbol->name};
+  }
+
+  std::vector<hir::ProceduralVarId> nested_declarations;
+  std::vector<hir::ProceduralScopeId> nested_children;
+  const WalkFrame body_frame = frame.WithProceduralScopeAccumulators(
+      &nested_declarations, &nested_children);
+
   std::vector<hir::StmtId> kids;
   if (block.body.kind == slang::ast::StatementKind::List) {
     const auto& list = block.body.as<slang::ast::StatementList>();
     kids.reserve(list.list.size());
     for (const auto* child : list.list) {
-      auto child_stmt = proc.LowerStmt(*child, frame);
+      auto child_stmt = proc.LowerStmt(*child, body_frame);
       if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
-      kids.push_back(
-          frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
+      kids.push_back(body_frame.current_procedural_body->stmts.Add(
+          *std::move(child_stmt)));
     }
   } else {
-    auto child_stmt = proc.LowerStmt(block.body, frame);
+    auto child_stmt = proc.LowerStmt(block.body, body_frame);
     if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
     kids.push_back(
-        frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
+        body_frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
   }
+
+  if (frame.current_structural_scope == nullptr) {
+    throw InternalError(
+        "LowerBlockStmt: begin/end body has no enclosing structural scope "
+        "to register its lexical scope against");
+  }
+  const hir::ProceduralScopeId scope_id =
+      frame.current_structural_scope->procedural_scopes.Add(
+          hir::ProceduralScopeDecl{
+              .kind = hir::ProceduralScopeKind::kBeginEndBlock,
+              .label = label,
+              .direct_declarations = std::move(nested_declarations),
+              .direct_child_scopes = std::move(nested_children)});
+
+  frame.current_scope_children->push_back(scope_id);
+
+  if (label.has_value() && block.blockSymbol != nullptr) {
+    proc.Module().MapOwnedChildBinding(
+        *block.blockSymbol, frame.Current(),
+        hir::DownwardHead{.child = scope_id});
+  }
+
   return hir::Stmt{
       .label = std::nullopt,
-      .data = hir::BlockStmt{.statements = std::move(kids)},
+      .data = hir::BlockStmt{.statements = std::move(kids), .scope = scope_id},
       .span = span};
 }
 

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -100,6 +100,7 @@ auto BuildIntegerLevel(
             .name = std::string{kLastIndexName},
             .type = int32_type,
             .lifetime = hir::VariableLifetime::kAutomatic});
+    frame.current_scope_declarations->push_back(last_var);
     setup.push_back(body.stmts.Add(
         hir::Stmt{
             .label = std::nullopt,
@@ -112,7 +113,7 @@ auto BuildIntegerLevel(
   }
 
   const hir::ProceduralVarId loop_var =
-      proc.AddProceduralVar(body, *dim.loopVar, int32_type);
+      proc.AddProceduralVar(frame, body, *dim.loopVar, int32_type);
   std::vector<hir::ForInit> init;
   init.emplace_back(hir::ForInitDecl{.var = loop_var, .init = first_id});
   const hir::ExprId cond_ref = frame.Exprs().Add(
@@ -166,7 +167,7 @@ auto BuildAssociativeLevel(
   const hir::TypeId key_type = *key_type_or;
 
   const hir::ProceduralVarId key_var =
-      proc.AddProceduralVar(body, *dim.loopVar, key_type);
+      proc.AddProceduralVar(frame, body, *dim.loopVar, key_type);
   setup.push_back(body.stmts.Add(
       hir::Stmt{
           .label = std::nullopt,
@@ -177,6 +178,7 @@ auto BuildAssociativeLevel(
           .name = std::string{kMoreFlagName},
           .type = int32_type,
           .lifetime = hir::VariableLifetime::kAutomatic});
+  frame.current_scope_declarations->push_back(more_var);
 
   auto walk_call = [&](support::BuiltinFn method) -> hir::ExprId {
     const hir::ExprId key_ref = frame.Exprs().Add(
@@ -314,7 +316,10 @@ auto BuildForeachNest(
           : body.stmts.Add(
                 hir::Stmt{
                     .label = std::nullopt,
-                    .data = hir::BlockStmt{.statements = std::move(*inner_or)},
+                    .data =
+                        hir::BlockStmt{
+                            .statements = std::move(*inner_or),
+                            .scope = std::nullopt},
                     .span = span});
 
   stmts.push_back(body.stmts.Add(
@@ -362,7 +367,8 @@ auto ProcessLowerer::LowerForeachStmt(
 
   // All dimensions skipped (`foreach (a[])`): the array reference is still
   // evaluated for side effects and the body runs once. No loop, so a break in
-  // the body is a plain innermost exit.
+  // the body is a plain innermost exit. The synthesized block carries no SV
+  // scope.
   if (levels.empty()) {
     auto array_or = proc.LowerExpr(fs.arrayRef, frame);
     if (!array_or) return std::unexpected(std::move(array_or.error()));
@@ -377,9 +383,22 @@ auto ProcessLowerer::LowerForeachStmt(
     const auto body_stmt_id = body.stmts.Add(*std::move(body_or));
     return hir::Stmt{
         .label = std::nullopt,
-        .data = hir::BlockStmt{.statements = {array_eval_stmt, body_stmt_id}},
+        .data =
+            hir::BlockStmt{
+                .statements = {array_eval_stmt, body_stmt_id},
+                .scope = std::nullopt},
         .span = span};
   }
+
+  // The foreach loop introduces its own lexical declaration scope (LRM
+  // 12.7.3); the loop variables flow into that scope. Open accumulators
+  // here so every loop var the helpers below mint -- via
+  // `proc.AddProceduralVar` -- attaches to the foreach scope rather than
+  // the parent.
+  std::vector<hir::ProceduralVarId> foreach_declarations;
+  std::vector<hir::ProceduralScopeId> foreach_children;
+  const WalkFrame foreach_frame = frame.WithProceduralScopeAccumulators(
+      &foreach_declarations, &foreach_children);
 
   // Thread `arrayRef` into the nest only when some dimension reads it at run
   // time; a purely fixed foreach lowers to plain range loops that never touch
@@ -387,23 +406,37 @@ auto ProcessLowerer::LowerForeachStmt(
   std::optional<hir::ExprId> array;
   const slang::ast::Type* array_type = nullptr;
   if (needs_array) {
-    auto array_or = proc.LowerExpr(fs.arrayRef, frame);
+    auto array_or = proc.LowerExpr(fs.arrayRef, foreach_frame);
     if (!array_or) return std::unexpected(std::move(array_or.error()));
-    array = frame.Exprs().Add(*std::move(array_or));
+    array = foreach_frame.Exprs().Add(*std::move(array_or));
     array_type = fs.arrayRef.type;
   }
 
   const hir::LoopLabelId foreach_label = body.AddLoopLabel();
   bool label_used = false;
   auto top = BuildForeachNest(
-      proc, fs, frame, levels, 0, array, array_type, int32_type, span,
+      proc, fs, foreach_frame, levels, 0, array, array_type, int32_type, span,
       foreach_label, &label_used);
   if (!top) return std::unexpected(std::move(top.error()));
+
+  if (frame.current_structural_scope == nullptr) {
+    throw InternalError(
+        "LowerForeachStmt: foreach has no enclosing structural scope to "
+        "register its lexical scope against");
+  }
+  const hir::ProceduralScopeId scope_id =
+      frame.current_structural_scope->procedural_scopes.Add(
+          hir::ProceduralScopeDecl{
+              .kind = hir::ProceduralScopeKind::kForEachLoop,
+              .label = std::nullopt,
+              .direct_declarations = std::move(foreach_declarations),
+              .direct_child_scopes = std::move(foreach_children)});
+  frame.current_scope_children->push_back(scope_id);
 
   // LRM 12.7.3 implicit begin-end around the foreach.
   return hir::Stmt{
       .label = std::nullopt,
-      .data = hir::BlockStmt{.statements = std::move(*top)},
+      .data = hir::BlockStmt{.statements = std::move(*top), .scope = scope_id},
       .span = span};
 }
 

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -59,8 +59,8 @@ auto LowerVariableDeclStmt(
   auto type_id_or =
       proc.Module().InternType(sym.getType(), mapper.PointSpanOf(sym.location));
   if (!type_id_or) return std::unexpected(std::move(type_id_or.error()));
-  const auto local_id =
-      proc.AddProceduralVar(*frame.current_procedural_body, sym, *type_id_or);
+  const auto local_id = proc.AddProceduralVar(
+      frame, *frame.current_procedural_body, sym, *type_id_or);
   std::optional<hir::ExprId> init_id;
   if (const auto* init_expr = sym.getInitializer()) {
     auto init_or = proc.LowerExpr(*init_expr, frame);

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -64,7 +64,17 @@ auto LowerSubroutineDecl(
   hir::ProceduralBody body;
   ProcessLowerer lowerer(module, sym);
   lowerer.AnalyzeLifetimeExtended(sym.getBody());
-  const WalkFrame body_frame = frame.WithProceduralBody(&body, &body.exprs);
+
+  // Open the root lexical scope accumulators for this subroutine body. The
+  // formal params, the implicit result var, and every body-tree var declared
+  // below feed into these vectors and become the root scope's direct
+  // declarations. Nested begin/end / fork / foreach scopes push their ids
+  // into the root scope's children list.
+  std::vector<hir::ProceduralVarId> root_declarations;
+  std::vector<hir::ProceduralScopeId> root_children;
+  const WalkFrame body_frame =
+      frame.WithProceduralBody(&body, &body.exprs)
+          .WithProceduralScopeAccumulators(&root_declarations, &root_children);
 
   std::vector<hir::SubroutineParam> params;
   params.reserve(sym.getArguments().size());
@@ -75,7 +85,7 @@ auto LowerSubroutineDecl(
       return std::unexpected(std::move(formal_type_or.error()));
     }
     const hir::ProceduralVarId var =
-        lowerer.AddProceduralVar(body, *formal, *formal_type_or);
+        lowerer.AddProceduralVar(body_frame, body, *formal, *formal_type_or);
     params.push_back(
         hir::SubroutineParam{
             .var = var, .direction = ParamDirectionOf(*formal)});
@@ -83,13 +93,26 @@ auto LowerSubroutineDecl(
 
   std::optional<hir::ProceduralVarId> result_var;
   if (sym.returnValVar != nullptr) {
-    result_var =
-        lowerer.AddProceduralVar(body, *sym.returnValVar, *return_type_or);
+    result_var = lowerer.AddProceduralVar(
+        body_frame, body, *sym.returnValVar, *return_type_or);
   }
 
   auto body_stmt_or = lowerer.LowerStmt(sym.getBody(), body_frame);
   if (!body_stmt_or) return std::unexpected(std::move(body_stmt_or.error()));
   body.root_stmt = body.stmts.Add(*std::move(body_stmt_or));
+
+  // Append the assembled root scope to the enclosing structural scope's
+  // procedural-scope arena when one is available (a class method body has
+  // no structural-scope context; its locals are placed directly on the
+  // class and the root-scope record has no consumer).
+  if (frame.current_structural_scope != nullptr) {
+    body.root_scope = frame.current_structural_scope->procedural_scopes.Add(
+        hir::ProceduralScopeDecl{
+            .kind = hir::ProceduralScopeKind::kProcessRoot,
+            .label = std::nullopt,
+            .direct_declarations = std::move(root_declarations),
+            .direct_child_scopes = std::move(root_children)});
+  }
 
   return hir::SubroutineDecl{
       .name = std::string{sym.name},

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -1,8 +1,16 @@
 #include "lyra/lowering/hir_to_mir/class_decl_lowerer.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <expected>
+#include <format>
+#include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/procedural_var.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
@@ -74,17 +82,48 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   ctor_code.result_type = module.Unit().builtins.void_type;
   mir_class.constructor = std::move(ctor_code);
 
+  // Pre-declare each method's static-lifetime body locals as members on this
+  // class before any method body lowers. A static local has per-instance
+  // storage that outlives every activation of its body (LRM 13.3.1), so it
+  // lives on the enclosing class; declaring it here keeps the class's member
+  // arena settled before any body looks a peer up against it. The mangled
+  // name (`<method>__<source>_<hir_id>`) keeps sibling methods sharing a
+  // source identifier from colliding on the member arena, and the
+  // `hir_id` suffix keeps nested-block reuses of the same identifier
+  // distinct.
+  std::vector<std::vector<std::optional<mir::MemberId>>> method_static_members;
+  method_static_members.reserve(hir_class.methods.size());
+  for (const auto& method : hir_class.methods) {
+    std::vector<std::optional<mir::MemberId>> by_hir_id(
+        method.body.procedural_vars.size());
+    for (std::size_t j = 0; j < method.body.procedural_vars.size(); ++j) {
+      const hir::ProceduralVarId var_id{static_cast<std::uint32_t>(j)};
+      const auto& v = method.body.procedural_vars.Get(var_id);
+      if (v.lifetime != hir::VariableLifetime::kStatic) {
+        continue;
+      }
+      const std::string mangled =
+          std::format("{}__{}_{}", method.name, v.name, j);
+      const mir::TypeId type = module.TranslateType(v.type);
+      by_hir_id[j] =
+          mir_class.members.Add(mir::MemberDecl{.name = mangled, .type = type});
+    }
+    method_static_members.push_back(std::move(by_hir_id));
+  }
+
   // Each instance method (LRM 8.6) is lowered as a callable this class owns: it
   // resolves the body's `self` to the managed handle, and the method's
   // declaration-order position becomes its `MethodId`, so a call site naming
   // the index reaches the same method.
-  for (const auto& method : hir_class.methods) {
+  for (std::size_t i = 0; i < hir_class.methods.size(); ++i) {
+    const auto& method = hir_class.methods[i];
     ScopeChainNode method_link{};
     const WalkFrame method_owner_frame =
         WalkFrame{}.WithClass(&mir_class, method_link);
     ProcessLowerer method_lowerer(
         module, nullptr, mir_class.time_resolution, method.body, method.name,
-        mir::MethodVisibility::kPublic, method_owner_frame);
+        mir::MethodVisibility::kPublic, method_owner_frame,
+        method_static_members[i]);
     auto method_or = method_lowerer.Run(method);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     mir_class.methods.Add(*std::move(method_or));

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -13,6 +13,8 @@
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
+#include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
+#include "lyra/lowering/hir_to_mir/declaration_initializer.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
@@ -78,23 +80,23 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
     ctor_block.AppendStmt(mir::ExprStmt{.expr = assign});
   }
 
-  ctor_code.params = {self_id};
-  ctor_code.result_type = module.Unit().builtins.void_type;
-  mir_class.constructor = std::move(ctor_code);
-
-  // Pre-declare each method's static-lifetime body locals as members on this
-  // class before any method body lowers. A static local has per-instance
-  // storage that outlives every activation of its body (LRM 13.3.1), so it
-  // lives on the enclosing class; declaring it here keeps the class's member
-  // arena settled before any body looks a peer up against it. The mangled
-  // name (`<method>__<source>_<hir_id>`) keeps sibling methods sharing a
-  // source identifier from colliding on the member arena, and the
-  // `hir_id` suffix keeps nested-block reuses of the same identifier
-  // distinct.
-  std::vector<std::vector<std::optional<mir::MemberId>>> method_static_members;
-  method_static_members.reserve(hir_class.methods.size());
+  // Pre-declare each method's static-lifetime body locals as members on
+  // this class before any method body lowers. A static local has per-
+  // instance storage that outlives every activation of its body (LRM
+  // 13.3.1); an SV class has no named-procedural-block hierarchy, so every
+  // static lives directly on the enclosing SV class. The mangled name
+  // (`<method>__<source>_<hir_id>`) keeps sibling methods that reuse a
+  // source identifier from colliding on the member arena; the `hir_id`
+  // suffix distinguishes nested-block reuses too.
+  //
+  // The materialization table is empty because there are no procedural-
+  // storage scopes inside class methods; the per-method plans still need a
+  // reference for the API.
+  ProceduralScopeMaterializationTable method_scopes;
+  std::vector<CallableStoragePlan> method_plans;
+  method_plans.reserve(hir_class.methods.size());
   for (const auto& method : hir_class.methods) {
-    std::vector<std::optional<mir::MemberId>> by_hir_id(
+    std::vector<std::optional<StaticStoragePlacement>> placements(
         method.body.procedural_vars.size());
     for (std::size_t j = 0; j < method.body.procedural_vars.size(); ++j) {
       const hir::ProceduralVarId var_id{static_cast<std::uint32_t>(j)};
@@ -105,16 +107,21 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
       const std::string mangled =
           std::format("{}__{}_{}", method.name, v.name, j);
       const mir::TypeId type = module.TranslateType(v.type);
-      by_hir_id[j] =
+      const mir::MemberId mid =
           mir_class.members.Add(mir::MemberDecl{.name = mangled, .type = type});
+      placements[j] = StaticStoragePlacement{
+          .owner = StorageOwner{EnclosingClass{}}, .member = mid};
     }
-    method_static_members.push_back(std::move(by_hir_id));
+    method_plans.emplace_back(method_scopes, std::move(placements));
   }
 
   // Each instance method (LRM 8.6) is lowered as a callable this class owns: it
   // resolves the body's `self` to the managed handle, and the method's
   // declaration-order position becomes its `MethodId`, so a call site naming
-  // the index reaches the same method.
+  // the index reaches the same method. SV classes do not have a separate
+  // Initialize lifecycle phase, so a method's pending static initializers
+  // integrate into this class's constructor block (matching the per-instance
+  // storage shape used for class-method statics).
   for (std::size_t i = 0; i < hir_class.methods.size(); ++i) {
     const auto& method = hir_class.methods[i];
     ScopeChainNode method_link{};
@@ -122,12 +129,20 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
         WalkFrame{}.WithClass(&mir_class, method_link);
     ProcessLowerer method_lowerer(
         module, nullptr, mir_class.time_resolution, method.body, method.name,
-        mir::MethodVisibility::kPublic, method_owner_frame,
-        method_static_members[i]);
+        mir::MethodVisibility::kPublic, method_owner_frame, method_plans[i]);
     auto method_or = method_lowerer.Run(method);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     mir_class.methods.Add(*std::move(method_or));
+    for (const auto& pending : method_lowerer.TakePendingStaticInitializers()) {
+      auto integ = IntegratePendingStaticInitializer(
+          method_lowerer, method.body, frame, pending);
+      if (!integ) return std::unexpected(std::move(integ.error()));
+    }
   }
+
+  ctor_code.params = {self_id};
+  ctor_code.result_type = module.Unit().builtins.void_type;
+  mir_class.constructor = std::move(ctor_code);
 
   return mir_class;
 }

--- a/src/lyra/lowering/hir_to_mir/declaration_initializer.cpp
+++ b/src/lyra/lowering/hir_to_mir/declaration_initializer.cpp
@@ -1,0 +1,53 @@
+#include "lyra/lowering/hir_to_mir/declaration_initializer.hpp"
+
+#include <expected>
+#include <utility>
+
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
+#include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto IntegratePendingStaticInitializer(
+    ProcessLowerer& process, const hir::ProceduralBody& body,
+    const WalkFrame& init_frame, const PendingStaticInitializer& pending)
+    -> diag::Result<void> {
+  auto& init_block = *init_frame.current_block;
+  const mir::TypeId self_ptr_type = init_frame.current_class->self_pointer_type;
+
+  mir::ExprId init_value{};
+  if (pending.init_expr.has_value()) {
+    auto init_or =
+        process.LowerExpr(body.exprs.Get(*pending.init_expr), init_frame);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    init_value = init_block.exprs.Add(*std::move(init_or));
+  } else {
+    init_value = init_block.exprs.Add(BuildDefaultValueFromHir(
+        process.Module(), init_frame, pending.hir_type));
+  }
+
+  const mir::ExprId target = init_block.exprs.Add(
+      process.BuildStaticStorageAccess(init_frame, pending.placement));
+  // Route through the observable cell protocol when the storage is
+  // observable-wrapped (a static owned by a materialized procedural-storage
+  // scope, so a cross-unit pointer slot lines up with the wrapped cell);
+  // plain assignment otherwise (LRM 13.3.1).
+  const mir::ExprId services_self_read =
+      init_block.exprs.Add(MakeSelfRefExpr(init_frame, self_ptr_type));
+  const mir::ExprId services_id = init_block.exprs.Add(
+      mir::MakeServicesCallExpr(
+          services_self_read, process.Module().Unit().builtins.services));
+  const mir::Expr assign_expr = BuildObservableAssignExpr(
+      process.Module().Unit(), init_block, services_id, target, init_value,
+      std::nullopt, pending.storage_type,
+      process.Module().Unit().builtins.void_type);
+  const mir::ExprId assign = init_block.exprs.Add(assign_expr);
+  init_block.AppendStmt(mir::ExprStmt{.expr = assign});
+  return {};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -154,20 +154,22 @@ auto LowerStructuralDataObjectRefExpr(
 auto LowerProceduralVarRefExpr(
     ProcessLowerer& process, const WalkFrame& frame,
     const hir::ProceduralVarRef& l, mir::TypeId type) -> mir::Expr {
-  const auto& binding = process.LookupProceduralVar(l.var);
-  // A static-lifetime local lives as a per-instance member on the
-  // owner class (LRM 13.3.1); the read reaches it through `self` like any
-  // member ref.
-  if (const auto* sb = std::get_if<StaticVarBinding>(&binding)) {
-    return BuildStructuralMemberAccessExpr(
-        frame, process.Module().Unit(), mir::EnclosingHops{.value = 0},
-        sb->var);
+  // Storage placement (static, LRM 13.3.1) and body-local environment
+  // (automatic / promoted) are separate authorities. Presence in the
+  // body-local environment is the authoritative signal: a body-declared
+  // static is not registered there and resolves through the storage plan,
+  // while subroutine params / output / result_var ARE registered (regardless
+  // of their slang-reported lifetime) and resolve through it.
+  const auto* binding = process.LookupProceduralVar(l.var);
+  if (binding == nullptr) {
+    return process.BuildStaticStorageAccess(
+        frame, process.LookupStaticPlacement(l.var));
   }
   // A lifetime-extended automatic (LRM 6.21) lives in a shared activation
   // object; the read / write reaches its member through the handle. The handle
   // is a carrier the resolver makes available in this body (a by-value, owning
   // copy inside a detached branch), and the promoted member projects from it.
-  if (const auto* pb = std::get_if<PromotedVarBinding>(&binding)) {
+  if (const auto* pb = std::get_if<PromotedVarBinding>(binding)) {
     const BodyBindingRef handle =
         frame.bindings->EnsureCarrier(pb->handle_origin);
     const mir::ExprId handle_ref =

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -3,6 +3,7 @@
 #include <expected>
 #include <optional>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
@@ -13,6 +14,7 @@
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/lowering/hir_to_mir/completion_payload.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/statement/assignment.hpp"
 #include "lyra/lowering/hir_to_mir/statement/blocks.hpp"
@@ -90,6 +92,62 @@ auto ProcessLowerer::LowerStmt(const hir::Stmt& stmt, WalkFrame frame)
           },
       },
       stmt.data);
+}
+
+auto ProcessLowerer::BuildStaticStorageAccess(
+    const WalkFrame& frame, StaticStoragePlacement placement) const
+    -> mir::Expr {
+  mir::Block& block = *frame.current_block;
+  const mir::CompilationUnit& unit = module_->Unit();
+  const std::vector<mir::MemberId> chain =
+      storage_plan_->CompanionChainTo(placement.owner);
+  mir::ExprId receiver = block.exprs.Add(
+      MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
+  for (const mir::MemberId step : chain) {
+    const mir::TypeId receiver_type = block.exprs.Get(receiver).type;
+    const auto* ptr =
+        std::get_if<mir::PointerType>(&unit.types.Get(receiver_type).data);
+    if (ptr == nullptr) {
+      throw InternalError(
+          "ProcessLowerer::BuildStaticStorageAccess: companion chain step "
+          "receiver is not a pointer type");
+    }
+    const auto* obj =
+        std::get_if<mir::ObjectType>(&unit.types.Get(ptr->pointee).data);
+    if (obj == nullptr) {
+      throw InternalError(
+          "ProcessLowerer::BuildStaticStorageAccess: companion chain step "
+          "receiver's pointee is not an intra-unit object type");
+    }
+    // The enclosing class is still being built when this lowering runs, so
+    // member types come from the published shape, not the not-yet-committed
+    // mir class.
+    const mir::TypeId step_type =
+        module_->GetClassShape(obj->class_id).members.Get(step).type;
+    receiver = block.exprs.Add(
+        mir::MakeMemberAccessExpr(
+            receiver, mir::MemberRef{.var = step}, step_type));
+  }
+  // Resolve the owner class id from the placement's StorageOwner: the
+  // enclosing class is the one bound to `frame.current_class`; a procedural
+  // scope owner consults the materialization table.
+  const mir::ClassId owner_class_id = std::visit(
+      Overloaded{
+          [&](EnclosingClass) -> mir::ClassId {
+            const mir::TypeId self_ty = frame.current_class->self_pointer_type;
+            const auto& pointee = unit.types.Get(
+                std::get<mir::PointerType>(unit.types.Get(self_ty).data)
+                    .pointee);
+            return std::get<mir::ObjectType>(pointee.data).class_id;
+          },
+          [&](hir::ProceduralScopeId sid) -> mir::ClassId {
+            return storage_plan_->ScopeMaterialization(sid).class_id;
+          }},
+      placement.owner);
+  const mir::TypeId field_type =
+      module_->GetClassShape(owner_class_id).members.Get(placement.member).type;
+  return mir::MakeMemberAccessExpr(
+      receiver, mir::MemberRef{.var = placement.member}, field_type);
 }
 
 namespace {

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -1,7 +1,6 @@
 #include "lyra/lowering/hir_to_mir/statement/flow.hpp"
 
 #include <expected>
-#include <format>
 #include <optional>
 #include <string>
 #include <utility>
@@ -28,13 +27,13 @@ namespace lyra::lowering::hir_to_mir {
 namespace {
 
 // LRM 13.3.1: a static-lifetime body local has per-instance storage that
-// outlives every activation of the body. Realize it as a member on the
-// callable's owner class; the init AssignExpr lands in that owner's
-// constructor body (LRM Table 6-7 variable-initialization). The body
-// declaration itself emits nothing. The mangled name carries
-// `<callable>__<source>_<hir_var_id>` so sibling callables sharing a source
-// name (`static int x;` in two processes of the same module) and nested
-// blocks repeating an identifier do not collide on the owner's member arena.
+// outlives every activation of the body. Its member on the owner class is
+// pre-declared by the enclosing scope during shape declaration (one per
+// static local in source order); the body's declaration statement looks the
+// member up by HIR id, places the init AssignExpr into the owner's
+// constructor body (LRM Table 6-7 variable-initialization), and emits no
+// executable text. The class's member arena stays settled while peer bodies
+// lower against it.
 auto LowerStaticVarDeclStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::VarDeclStmt& v, const hir::ProceduralVarDecl& hir_local,
@@ -44,10 +43,7 @@ auto LowerStaticVarDeclStmt(
   auto& ctor_block = *ctor_frame.current_block;
   const mir::TypeId self_ptr_type = owner_class->self_pointer_type;
 
-  const std::string mangled = std::format(
-      "{}__{}_{}", process.CallableName(), hir_local.name, v.var.value);
-  const mir::MemberId static_var =
-      owner_class->members.Add(mir::MemberDecl{.name = mangled, .type = type});
+  const mir::MemberId static_var = process.LookupPreDeclaredStaticMember(v.var);
   process.MapProceduralVar(v.var, StaticVarBinding{.var = static_var});
 
   mir::ExprId init_value{};

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -9,16 +9,13 @@
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
+#include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
-#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
-#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
-#include "lyra/mir/class.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/local.hpp"
-#include "lyra/mir/member.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/value_ref.hpp"
 
@@ -27,52 +24,22 @@ namespace lyra::lowering::hir_to_mir {
 namespace {
 
 // LRM 13.3.1: a static-lifetime body local has per-instance storage that
-// outlives every activation of the body. Its member on the owner class is
-// pre-declared by the enclosing scope during shape declaration (one per
-// static local in source order); the body's declaration statement looks the
-// member up by HIR id, places the init AssignExpr into the owner's
-// constructor body (LRM Table 6-7 variable-initialization), and emits no
-// executable text. The class's member arena stays settled while peer bodies
-// lower against it.
+// outlives every activation of the body. Body lowering records the
+// initializer as a pending request (var + HIR init expression + placement);
+// the dedicated initializer lowering path runs in the Initialize phase and
+// produces the AssignExpr to the placement. The body's declaration
+// statement itself emits no executable text.
 auto LowerStaticVarDeclStmt(
-    ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
+    ProcessLowerer& process, std::optional<std::string> label,
     const hir::VarDeclStmt& v, const hir::ProceduralVarDecl& hir_local,
     mir::TypeId type) -> diag::Result<mir::Stmt> {
-  auto* owner_class = frame.current_class;
-  const auto& ctor_frame = process.OwnerCtorFrame();
-  auto& ctor_block = *ctor_frame.current_block;
-  const mir::TypeId self_ptr_type = owner_class->self_pointer_type;
-
-  const mir::MemberId static_var = process.LookupPreDeclaredStaticMember(v.var);
-  process.MapProceduralVar(v.var, StaticVarBinding{.var = static_var});
-
-  mir::ExprId init_value{};
-  if (v.init.has_value()) {
-    auto init_or =
-        process.LowerExpr(process.HirBody().exprs.Get(*v.init), ctor_frame);
-    if (!init_or) return std::unexpected(std::move(init_or.error()));
-    init_value = ctor_block.exprs.Add(*std::move(init_or));
-  } else {
-    init_value = ctor_block.exprs.Add(
-        BuildDefaultValueFromHir(process.Module(), ctor_frame, hir_local.type));
-  }
-
-  const mir::ExprId ctor_self_read =
-      ctor_block.exprs.Add(MakeSelfRefExpr(ctor_frame, self_ptr_type));
-  const mir::ExprId target = ctor_block.exprs.Add(
-      mir::MakeMemberAccessExpr(
-          ctor_self_read, mir::MemberRef{.var = static_var}, type));
-  // A static-lifetime local lives as a member on the owner; if its declared
-  // type is an observable cell wrapper the init must route through
-  // `Var<T>::Set` so subscribers fire on its initial value (LRM 13.3.1).
-  const mir::ExprId services_id = ctor_block.exprs.Add(
-      mir::MakeServicesCallExpr(
-          ctor_self_read, process.Module().Unit().builtins.services));
-  const mir::Expr assign_expr = BuildObservableAssignExpr(
-      process.Module().Unit(), ctor_block, services_id, target, init_value,
-      std::nullopt, type, process.Module().Unit().builtins.void_type);
-  const mir::ExprId assign = ctor_block.exprs.Add(assign_expr);
-  ctor_block.AppendStmt(mir::ExprStmt{.expr = assign});
+  process.RecordPendingStaticInitializer(
+      PendingStaticInitializer{
+          .var = v.var,
+          .hir_type = hir_local.type,
+          .init_expr = v.init,
+          .placement = process.LookupStaticPlacement(v.var),
+          .storage_type = type});
   return mir::Stmt{.label = std::move(label), .data = mir::EmptyStmt{}};
 }
 
@@ -150,7 +117,7 @@ auto LowerVarDeclStmt(
   }
   if (hir_local.lifetime == hir::VariableLifetime::kStatic) {
     return LowerStaticVarDeclStmt(
-        process, frame, std::move(label), v, hir_local, type);
+        process, std::move(label), v, hir_local, type);
   }
   return LowerAutomaticVarDeclStmt(
       process, frame, std::move(label), v, hir_local, type);

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -16,6 +16,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
@@ -1724,6 +1725,51 @@ auto StructuralScopeLowerer::DeclareShape(
   // Instance members shape: one MIR slot per child instance.
   DeclareInstanceMemberShapes(lowerer, shape);
 
+  // A static-lifetime body local has per-instance storage that outlives every
+  // activation of its body (LRM 13.3.1), so it lives as a member on the
+  // enclosing class. Declaring it here, in shape phase, keeps the published
+  // shape immutable while peer bodies lower against it; the body lowering
+  // looks the member up by HIR id instead of minting one. The mangled name
+  // (`<callable>__<source>_<hir_id>`) keeps sibling callables sharing a
+  // source identifier from colliding on the member arena, and the
+  // `hir_id` suffix keeps nested-block reuses of the same identifier
+  // distinct.
+  const auto declare_callable_statics = [&](const hir::ProceduralBody& body,
+                                            std::string_view callable_name)
+      -> std::vector<std::optional<mir::MemberId>> {
+    std::vector<std::optional<mir::MemberId>> by_hir_id(
+        body.procedural_vars.size());
+    for (std::size_t j = 0; j < body.procedural_vars.size(); ++j) {
+      const hir::ProceduralVarId var_id{static_cast<std::uint32_t>(j)};
+      const auto& v = body.procedural_vars.Get(var_id);
+      if (v.lifetime != hir::VariableLifetime::kStatic) {
+        continue;
+      }
+      const std::string mangled =
+          std::format("{}__{}_{}", callable_name, v.name, j);
+      const mir::TypeId type = module.TranslateType(v.type);
+      by_hir_id[j] =
+          shape.members.Add(mir::MemberDecl{.name = mangled, .type = type});
+    }
+    return by_hir_id;
+  };
+  subroutine_static_members_.reserve(hir_scope.structural_subroutines.size());
+  for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
+    const auto& s = hir_scope.structural_subroutines.Get(
+        hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
+    subroutine_static_members_.push_back(
+        declare_callable_statics(s.body, s.name));
+  }
+  process_static_members_.reserve(hir_scope.processes.size());
+  for (std::size_t i = 0; i < hir_scope.processes.size(); ++i) {
+    const std::string callable_name =
+        std::format("process_{}", hir_scope.structural_subroutines.size() + i);
+    const auto& p =
+        hir_scope.processes.Get(hir::ProcessId{static_cast<std::uint32_t>(i)});
+    process_static_members_.push_back(
+        declare_callable_statics(p.body, callable_name));
+  }
+
   module.DefineClassShape(class_id_, std::move(shape));
   return class_id_;
 }
@@ -1944,7 +1990,8 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
     ProcessLowerer subroutine_lowerer(
         module, &lowerer, hir_scope.time_resolution, src.body, src.name,
-        mir::MethodVisibility::kInternal, ctor_frame);
+        mir::MethodVisibility::kInternal, ctor_frame,
+        subroutine_static_members_[i]);
     auto decl_or = subroutine_lowerer.Run(src);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId added = mir_class.methods.Add(*std::move(decl_or));
@@ -1955,11 +2002,14 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     }
   }
 
-  for (const auto& p : hir_scope.processes) {
+  for (std::size_t i = 0; i < hir_scope.processes.size(); ++i) {
+    const auto& p =
+        hir_scope.processes.Get(hir::ProcessId{static_cast<std::uint32_t>(i)});
     std::string name = std::format("process_{}", mir_class.methods.size());
     ProcessLowerer process_lowerer(
         module, &lowerer, hir_scope.time_resolution, p.body, std::move(name),
-        mir::MethodVisibility::kInternal, ctor_frame);
+        mir::MethodVisibility::kInternal, ctor_frame,
+        process_static_members_[i]);
     auto decl_or = process_lowerer.Run(p);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -16,12 +16,15 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
 #include "lyra/lowering/hir_to_mir/continuous_assign.hpp"
+#include "lyra/lowering/hir_to_mir/declaration_initializer.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
@@ -846,9 +849,30 @@ void InstallCrossUnitRefs(StructuralScopeLowerer& lowerer, WalkFrame frame) {
     const mir::MemberId slot = member;
     const mir::TypeId slot_type = mir_class.members.Get(slot).type;
     mir::ExprId nav{};
-    if (down->hops.value != 0) {
+    // A procedural-storage scope head is reached through the SV-visible
+    // hierarchy projection: by-name lookup on the enclosing scope walks
+    // transparently past anonymous begin/ends. The compile-time typed
+    // segment is not usable because the scope's companion pointer lives
+    // on whichever anonymous class physically owns it, not on the
+    // structural class that the source-level reference names. Instance
+    // heads at hops > 0 remain typed (they always sit on the structural
+    // class of the referenced generate/module scope).
+    const bool head_is_procedural_scope =
+        std::holds_alternative<hir::ProceduralScopeId>(down->child);
+    if (down->hops.value != 0 && !head_is_procedural_scope) {
       nav = BuildTypedEnclosingNavValue(
           lowerer, frame, *down, cu.path, slot_type);
+    } else if (head_is_procedural_scope) {
+      const auto& scope_decl = hir_scope.procedural_scopes.Get(
+          std::get<hir::ProceduralScopeId>(down->child));
+      if (!scope_decl.label.has_value()) {
+        throw InternalError(
+            "cross-unit ref: procedural-scope head has no SV label; "
+            "peer navigation would have no name to look up");
+      }
+      nav = ctor_block.exprs.Add(BuildDownwardNavValue(
+          module, frame, *scope_decl.label, cu.path, slot_type,
+          scope_ptr_type));
     } else {
       const mir::MemberId head_var =
           lowerer.TranslateOwnedChild(hir::StructuralHops{0}, down->child);
@@ -1227,8 +1251,11 @@ void AppendOwnedChildConstruction(
       module, owner_class, arm_block, target_var, child_scope_id, ctor_args);
 
   const mir::MemberDecl& var = owner_class.members.Get(target_var);
-  const std::string& runtime_label =
-      var.source_name.empty() ? var.name : var.source_name;
+  // The runtime label is the SV-visible identifier. An anonymous scope
+  // (no `source_name`) gets an empty label; the scope's runtime base
+  // treats an empty label as non-addressable, so a peer by-name lookup
+  // walks past it and reaches the addressable descendants underneath.
+  const std::string& runtime_label = var.source_name;
   const auto& builtins = module.Unit().builtins;
   const mir::TypeId self_ptr_type = owner_class.self_pointer_type;
 
@@ -1467,10 +1494,9 @@ auto LowerCaseGenerate(
 
   std::vector<mir::Block> body_scopes;
   body_scopes.reserve(case_gen.items.size());
-  for (std::size_t i = 0; i < case_gen.items.size(); ++i) {
+  for (const auto& item : case_gen.items) {
     body_scopes.push_back(BuildGenerateArmBody(
-        lowerer.Module(), frame, gen_bindings, case_gen.items[i].scope, {},
-        std::nullopt));
+        lowerer.Module(), frame, gen_bindings, item.scope, {}, std::nullopt));
   }
 
   std::optional<mir::Block> default_scope;
@@ -1725,49 +1751,153 @@ auto StructuralScopeLowerer::DeclareShape(
   // Instance members shape: one MIR slot per child instance.
   DeclareInstanceMemberShapes(lowerer, shape);
 
-  // A static-lifetime body local has per-instance storage that outlives every
-  // activation of its body (LRM 13.3.1), so it lives as a member on the
-  // enclosing class. Declaring it here, in shape phase, keeps the published
-  // shape immutable while peer bodies lower against it; the body lowering
-  // looks the member up by HIR id instead of minting one. The mangled name
-  // (`<callable>__<source>_<hir_id>`) keeps sibling callables sharing a
-  // source identifier from colliding on the member arena, and the
-  // `hir_id` suffix keeps nested-block reuses of the same identifier
-  // distinct.
-  const auto declare_callable_statics = [&](const hir::ProceduralBody& body,
-                                            std::string_view callable_name)
-      -> std::vector<std::optional<mir::MemberId>> {
-    std::vector<std::optional<mir::MemberId>> by_hir_id(
-        body.procedural_vars.size());
-    for (std::size_t j = 0; j < body.procedural_vars.size(); ++j) {
-      const hir::ProceduralVarId var_id{static_cast<std::uint32_t>(j)};
-      const auto& v = body.procedural_vars.Get(var_id);
-      if (v.lifetime != hir::VariableLifetime::kStatic) {
-        continue;
-      }
-      const std::string mangled =
-          std::format("{}__{}_{}", callable_name, v.name, j);
-      const mir::TypeId type = module.TranslateType(v.type);
-      by_hir_id[j] =
-          shape.members.Add(mir::MemberDecl{.name = mangled, .type = type});
+  // Procedural-storage scope plan (LRM 9.3.5 / 23.9). Every
+  // `ProceduralScopeDecl` in the HIR scope tree becomes a runtime class,
+  // regardless of kind, label, or contents. Physical containment is
+  // uniform; the SV-visible hierarchy is a projection over it, computed
+  // at lookup time: a scope with an SV label emits its label as the
+  // runtime segment and is addressable by name, while an anonymous scope
+  // emits an empty segment so peer by-name lookup walks past it
+  // transparently (LRM 23 hierarchical-name semantics). Each static lives
+  // on its own lexical scope's class -- no elevation, no
+  // lexical-vs-physical owner distinction.
+  std::vector<mir::ClassId> scope_classes(hir_scope.procedural_scopes.size());
+  std::vector<mir::ClassShape> sub_shapes(hir_scope.procedural_scopes.size());
+  for (std::size_t i = 0; i < hir_scope.procedural_scopes.size(); ++i) {
+    const auto& decl = hir_scope.procedural_scopes.Get(
+        hir::ProceduralScopeId{static_cast<std::uint32_t>(i)});
+    const mir::ClassId class_id = module.Unit().DeclareClass();
+    scope_classes[i] = class_id;
+    const std::string scope_token =
+        decl.label.has_value() ? *decl.label : std::format("anon_{}", i);
+    mir::ClassShape sub_shape;
+    sub_shape.name = std::format("{}__{}", name_, scope_token);
+    sub_shape.base = mir::ClassRef{mir::RuntimeLibraryClassRef{
+        .base_type =
+            module.Unit().types.Intern(mir::ProceduralStorageScopeType{})}};
+    const mir::TypeId sub_self_object =
+        module.Unit().types.Intern(mir::ObjectType{.class_id = class_id});
+    sub_shape.self_pointer_type = module.Unit().types.PointerTo(
+        sub_self_object, mir::PointerOwnership::kBorrowed);
+    sub_shape.time_resolution = hir_scope.time_resolution;
+    const mir::BaseContract sub_contract =
+        mir::ResolveBaseContract(module.Unit(), *sub_shape.base);
+    for (const auto& param : sub_contract.ctor_prefix) {
+      sub_shape.ctor_prefix_params.Add(param);
     }
-    return by_hir_id;
+    // Carry the enclosing structural scope's type aliases (typedefs declared
+    // at module / generate level) so the cpp renderer can name those types
+    // when emitting a static's slot inside this nested class. C++ enclosing-
+    // class scope lookup makes the alias usable unqualified at the use site.
+    sub_shape.type_aliases = shape.type_aliases;
+    sub_shapes[i] = std::move(sub_shape);
+  }
+
+  scope_materialization_.Resize(hir_scope.procedural_scopes.size());
+  std::vector<std::vector<std::optional<StaticStoragePlacement>>>
+      subroutine_placements(hir_scope.structural_subroutines.size());
+  std::vector<std::vector<std::optional<StaticStoragePlacement>>>
+      process_placements(hir_scope.processes.size());
+
+  const auto owner_shape_of = [&](StorageOwner owner) -> mir::ClassShape& {
+    return std::visit(
+        Overloaded{
+            [&](EnclosingClass) -> mir::ClassShape& { return shape; },
+            [&](hir::ProceduralScopeId sid) -> mir::ClassShape& {
+              return sub_shapes[sid.value];
+            }},
+        owner);
   };
-  subroutine_static_members_.reserve(hir_scope.structural_subroutines.size());
+
+  // Every scope materializes; the recursion just threads `runtime_parent`
+  // down. Statics land on their own lexical scope (no elevation).
+  const auto place =
+      [&](const auto& self_ref, const hir::ProceduralBody& body,
+          std::string_view callable_name,
+          std::vector<std::optional<StaticStoragePlacement>>& per_callable,
+          hir::ProceduralScopeId scope_id,
+          StorageOwner runtime_parent) -> void {
+    const auto& scope = hir_scope.procedural_scopes.Get(scope_id);
+    mir::ClassShape& parent_shape = owner_shape_of(runtime_parent);
+    const mir::ClassId my_class = scope_classes[scope_id.value];
+    const std::string scope_token =
+        scope.label.has_value() ? *scope.label
+                                : std::format("anon_{}", scope_id.value);
+    const mir::TypeId companion_type =
+        MakeUniqueObjectPointer(module, my_class);
+    mir::MemberDecl companion_decl{
+        .name = CompanionVarNameFor(scope_token), .type = companion_type};
+    if (scope.label.has_value()) {
+      companion_decl.source_name = *scope.label;
+    }
+    const mir::MemberId companion_id = parent_shape.members.Add(companion_decl);
+    parent_shape.contained.push_back(my_class);
+    scope_materialization_.Record(
+        scope_id, MaterializedProceduralScope{
+                      .class_id = my_class,
+                      .companion_member = companion_id,
+                      .runtime_parent = runtime_parent});
+    const StorageOwner my_owner{scope_id};
+
+    if (per_callable.size() < body.procedural_vars.size()) {
+      per_callable.resize(body.procedural_vars.size());
+    }
+    for (const auto var_id : scope.direct_declarations) {
+      const auto& v = body.procedural_vars.Get(var_id);
+      if (v.lifetime != hir::VariableLifetime::kStatic) continue;
+
+      const std::string mangled =
+          std::format("{}__{}_{}", callable_name, v.name, var_id.value);
+      const mir::TypeId type = module.TranslateType(v.type);
+      const mir::TypeId field_type = MaybeWrapObservable(module, type);
+      mir::MemberDecl member_decl{.name = mangled, .type = field_type};
+      if (scope.label.has_value()) {
+        member_decl.source_name = v.name;
+      }
+      const mir::MemberId mid =
+          sub_shapes[scope_id.value].members.Add(member_decl);
+
+      per_callable[var_id.value] =
+          StaticStoragePlacement{.owner = my_owner, .member = mid};
+    }
+
+    for (const auto child_id : scope.direct_child_scopes) {
+      self_ref(self_ref, body, callable_name, per_callable, child_id, my_owner);
+    }
+  };
+
   for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
     const auto& s = hir_scope.structural_subroutines.Get(
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
-    subroutine_static_members_.push_back(
-        declare_callable_statics(s.body, s.name));
+    place(
+        place, s.body, s.name, subroutine_placements[i], s.body.root_scope,
+        StorageOwner{EnclosingClass{}});
   }
-  process_static_members_.reserve(hir_scope.processes.size());
   for (std::size_t i = 0; i < hir_scope.processes.size(); ++i) {
-    const std::string callable_name =
-        std::format("process_{}", hir_scope.structural_subroutines.size() + i);
     const auto& p =
         hir_scope.processes.Get(hir::ProcessId{static_cast<std::uint32_t>(i)});
-    process_static_members_.push_back(
-        declare_callable_statics(p.body, callable_name));
+    const std::string callable_name =
+        std::format("process_{}", hir_scope.structural_subroutines.size() + i);
+    place(
+        place, p.body, callable_name, process_placements[i], p.body.root_scope,
+        StorageOwner{EnclosingClass{}});
+  }
+
+  subroutine_storage_plans_.reserve(hir_scope.structural_subroutines.size());
+  for (auto& placements : subroutine_placements) {
+    subroutine_storage_plans_.emplace_back(
+        scope_materialization_, std::move(placements));
+  }
+  process_storage_plans_.reserve(hir_scope.processes.size());
+  for (auto& placements : process_placements) {
+    process_storage_plans_.emplace_back(
+        scope_materialization_, std::move(placements));
+  }
+
+  // Publish each procedural-storage scope's shape; the body sweep below
+  // builds each class's constructor against the published shape.
+  for (std::size_t i = 0; i < hir_scope.procedural_scopes.size(); ++i) {
+    module.DefineClassShape(scope_classes[i], std::move(sub_shapes[i]));
   }
 
   module.DefineClassShape(class_id_, std::move(shape));
@@ -1985,13 +2115,118 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     }
   }
 
+  // Build each materialized procedural-storage scope's class: copy its
+  // already-published shape into a `mir::Class`, build a constructor whose
+  // body constructs the immediate-child materialized scopes the same way an
+  // owned-child instance is constructed, and commit. This runs before any
+  // body lowers so static-init lowering against the structural constructor
+  // (which writes `self->companion->...->static = init`) reaches storage the
+  // runtime has already built. The structural constructor then appends
+  // construction calls for top-level materialized scopes below, before the
+  // subroutine and process bodies that initialize their statics.
+  for (std::size_t i = 0; i < scope_materialization_.Size(); ++i) {
+    const hir::ProceduralScopeId scope_id{static_cast<std::uint32_t>(i)};
+    const auto& entry = scope_materialization_.Get(scope_id);
+    const mir::ClassShape& sub_shape = module.GetClassShape(entry.class_id);
+    mir::Class sub_class;
+    sub_class.name = sub_shape.name;
+    sub_class.base = sub_shape.base;
+    sub_class.self_pointer_type = sub_shape.self_pointer_type;
+    sub_class.time_resolution = sub_shape.time_resolution;
+    sub_class.ctor_prefix_params = sub_shape.ctor_prefix_params;
+    sub_class.params = sub_shape.params;
+    sub_class.members = sub_shape.members;
+    sub_class.contained = sub_shape.contained;
+    sub_class.type_aliases = sub_shape.type_aliases;
+
+    mir::CallableCode sub_ctor_code;
+    CallableBindings sub_ctor_bindings(module.Unit(), sub_ctor_code);
+    const mir::LocalId sub_self_id = sub_ctor_bindings.Declare(
+        BindingOriginId::Receiver(),
+        mir::LocalDecl{.name = "self", .type = sub_shape.self_pointer_type});
+    mir::Block& sub_ctor_block = sub_ctor_code.body;
+    ScopeChainNode sub_scope_link{};
+    const WalkFrame sub_ctor_frame =
+        parent_frame.WithClass(&sub_class, sub_scope_link)
+            .WithBlock(&sub_ctor_block)
+            .WithBindings(&sub_ctor_bindings);
+    for (std::size_t j = 0; j < scope_materialization_.Size(); ++j) {
+      const hir::ProceduralScopeId child_id{static_cast<std::uint32_t>(j)};
+      const auto& child_entry = scope_materialization_.Get(child_id);
+      const auto* parent_scope =
+          std::get_if<hir::ProceduralScopeId>(&child_entry.runtime_parent);
+      if (parent_scope == nullptr || parent_scope->value != i) continue;
+      AppendOwnedChildConstruction(
+          module, sub_ctor_frame, child_entry.companion_member,
+          child_entry.class_id, {}, std::nullopt);
+    }
+    // Register each static on this procedural-storage scope as a by-name
+    // signal so a cross-compilation-unit descent (`Top.outer.x` from
+    // another unit) finds it through `GetSignal` once it has navigated to
+    // this scope by `GetChild`. Companion members are pointers to nested
+    // scopes and are registered as children via `AttachChild`, not as
+    // signals, so the pointer kinds are excluded.
+    for (std::size_t mi = 0; mi < sub_class.members.size(); ++mi) {
+      const mir::MemberId mid{static_cast<std::uint32_t>(mi)};
+      const auto& m = sub_class.members.Get(mid);
+      if (m.source_name.empty()) continue;
+      const mir::TypeKind mk = module.Unit().types.Get(m.type).Kind();
+      if (mk == mir::TypeKind::kPointer || mk == mir::TypeKind::kVector ||
+          mk == mir::TypeKind::kObject) {
+        continue;
+      }
+      const mir::ExprId sub_self = sub_ctor_block.exprs.Add(
+          MakeSelfRefExpr(sub_ctor_frame, sub_shape.self_pointer_type));
+      const mir::ExprId member_ref = sub_ctor_block.exprs.Add(
+          mir::MakeMemberAccessExpr(
+              sub_self, mir::MemberRef{.var = mid}, m.type));
+      const mir::TypeId addr_type = module.Unit().types.PointerTo(
+          m.type, mir::PointerOwnership::kBorrowed);
+      const mir::ExprId addr = sub_ctor_block.exprs.Add(
+          mir::MakeAddressOfExpr(member_ref, addr_type));
+      const mir::ExprId name_lit = sub_ctor_block.exprs.Add(
+          mir::Expr{
+              .data = mir::StringLiteral{.value = m.source_name},
+              .type = module.Unit().builtins.string});
+      const mir::ExprId reg_self = sub_ctor_block.exprs.Add(
+          MakeSelfRefExpr(sub_ctor_frame, sub_shape.self_pointer_type));
+      const mir::ExprId call = sub_ctor_block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee =
+                          mir::Direct{
+                              .target = support::BuiltinFn::kRegisterSignal},
+                      .arguments = {reg_self, name_lit, addr}},
+              .type = void_type});
+      sub_ctor_block.AppendStmt(mir::ExprStmt{.expr = call});
+    }
+    sub_ctor_code.params = {sub_self_id};
+    sub_ctor_code.result_type = void_type;
+    sub_class.constructor = std::move(sub_ctor_code);
+    module.Unit().DefineClass(entry.class_id, std::move(sub_class));
+  }
+
+  // Construct every top-level materialized procedural-storage scope in the
+  // structural constructor, before the subroutine and process bodies lower
+  // so static inits that target storage inside one of these scopes write
+  // through an already-built `self->companion->...->static` chain.
+  for (std::size_t i = 0; i < scope_materialization_.Size(); ++i) {
+    const hir::ProceduralScopeId scope_id{static_cast<std::uint32_t>(i)};
+    const auto& entry = scope_materialization_.Get(scope_id);
+    if (!std::holds_alternative<EnclosingClass>(entry.runtime_parent)) continue;
+    AppendOwnedChildConstruction(
+        module, ctor_frame, entry.companion_member, entry.class_id, {},
+        std::nullopt);
+  }
+
   for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
     const auto& src = hir_scope.structural_subroutines.Get(
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
     ProcessLowerer subroutine_lowerer(
         module, &lowerer, hir_scope.time_resolution, src.body, src.name,
         mir::MethodVisibility::kInternal, ctor_frame,
-        subroutine_static_members_[i]);
+        subroutine_storage_plans_[i]);
     auto decl_or = subroutine_lowerer.Run(src);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId added = mir_class.methods.Add(*std::move(decl_or));
@@ -1999,6 +2234,12 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
       throw InternalError(
           "StructuralScopeLowerer::PopulateBodies: subroutine added out of "
           "mapped id order");
+    }
+    for (const auto& pending :
+         subroutine_lowerer.TakePendingStaticInitializers()) {
+      auto integ = IntegratePendingStaticInitializer(
+          subroutine_lowerer, src.body, init_frame, pending);
+      if (!integ) return std::unexpected(std::move(integ.error()));
     }
   }
 
@@ -2009,12 +2250,18 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     ProcessLowerer process_lowerer(
         module, &lowerer, hir_scope.time_resolution, p.body, std::move(name),
         mir::MethodVisibility::kInternal, ctor_frame,
-        process_static_members_[i]);
+        process_storage_plans_[i]);
     auto decl_or = process_lowerer.Run(p);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
     AppendProcessRegistration(
         module, activate_frame, body, p.kind == hir::ProcessKind::kFinal);
+    for (const auto& pending :
+         process_lowerer.TakePendingStaticInitializers()) {
+      auto integ = IntegratePendingStaticInitializer(
+          process_lowerer, p.body, init_frame, pending);
+      if (!integ) return std::unexpected(std::move(integ.error()));
+    }
   }
 
   std::vector<mir::MemberId> driven_nets;

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -210,6 +210,9 @@ class MirDumper {
             [](const ScopeType&) -> std::string { return "Scope"; },
             [](const InstanceType&) -> std::string { return "Instance"; },
             [](const GenScopeType&) -> std::string { return "GenScope"; },
+            [](const ProceduralStorageScopeType&) -> std::string {
+              return "ProceduralStorageScope";
+            },
             [](const ServicesType&) -> std::string { return "Services"; },
             [](const FilesType&) -> std::string { return "Files"; },
             [](const DiagnosticType&) -> std::string { return "Diagnostic"; },

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -80,6 +80,9 @@ auto Type::Kind() const -> TypeKind {
           [](const ScopeType&) { return TypeKind::kScope; },
           [](const InstanceType&) { return TypeKind::kInstance; },
           [](const GenScopeType&) { return TypeKind::kGenScope; },
+          [](const ProceduralStorageScopeType&) {
+            return TypeKind::kProceduralStorageScope;
+          },
           [](const ServicesType&) { return TypeKind::kServices; },
           [](const FilesType&) { return TypeKind::kFiles; },
           [](const DiagnosticType&) { return TypeKind::kDiagnostic; },

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -47,8 +47,8 @@ void Engine::BindDesign(std::span<const TopBinding> tops) {
   for (const auto& top : tops) {
     // A `$root`-anchored absolute path descends from the root by name, so
     // the root answers GetChild for each top under its segment (LRM 23.6).
-    // AttachChild reads the top's own Segment() -- the base name set when
-    // main constructed it -- and uses that as the lookup key.
+    // AttachChild wires physical containment; SV-visible lookup on
+    // `$root` recurses through the attached-children relation.
     root_->AttachChild(*top.scope);
   }
   // Link every top before any phase runs, so an upward climb during resolution

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -50,7 +50,18 @@ auto Scope::GetSignal(std::string_view name) -> void* {
 auto Scope::GetChild(
     std::string_view name, std::span<const lyra::value::PackedArray> indices)
     -> Scope* {
+  // SV-visible child lookup. Named children match on segment name +
+  // indices; anonymous children (unnamed begin/ends emitted with an empty
+  // segment name) are transparent -- the walk recurses into them so a
+  // peer's `top.outer.x` finds `outer` regardless of how many unnamed
+  // begin/ends physically wrap it (LRM 23 hierarchical-name semantics).
   for (Scope* child : attached_children_) {
+    if (!child->IsAddressable()) {
+      if (Scope* found = child->GetChild(name, indices)) {
+        return found;
+      }
+      continue;
+    }
     const HierarchySegment& seg = child->segment_;
     if (seg.BaseName() != name) {
       continue;

--- a/tests/cases/cpp/hierarchy_named_block_head/case.yaml
+++ b/tests/cases/cpp/hierarchy_named_block_head/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.hierarchy_named_block_head
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      intra outer.x=7 outer.inner.y=13
+      x=7 y=13
+      after write x=100

--- a/tests/cases/cpp/hierarchy_named_block_head/main.sv
+++ b/tests/cases/cpp/hierarchy_named_block_head/main.sv
@@ -1,0 +1,42 @@
+// LRM 23.9: a named procedural block is a hierarchical-reference head.
+// `Top.c.outer.x` and `Top.c.outer.inner.y` reach static-lifetime locals
+// declared inside the named blocks of `Child`. A sibling process inside
+// `Child` reads the same statics through an intra-unit typed segment
+// (`outer.x`), and an external write through the hierarchical path is
+// observed at a later time step.
+
+module Child;
+  int intra_x;
+  int intra_inner_y;
+
+  initial begin : outer
+    static int x = 7;
+    begin : inner
+      static int y = 13;
+    end
+  end
+
+  initial begin
+    #1;
+    intra_x = outer.x;
+    intra_inner_y = outer.inner.y;
+    $display("intra outer.x=%0d outer.inner.y=%0d", intra_x, intra_inner_y);
+  end
+endmodule
+
+module Top;
+  Child c();
+  int xread;
+  int yread;
+
+  initial begin
+    #2;
+    xread = c.outer.x;
+    yread = c.outer.inner.y;
+    $display("x=%0d y=%0d", xread, yread);
+
+    c.outer.x = 100;
+    #1;
+    $display("after write x=%0d", c.outer.x);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_named_block_nesting/case.yaml
+++ b/tests/cases/cpp/hierarchy_named_block_nesting/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.hierarchy_named_block_nesting
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      outer internal a=7 b=13
+      Top.outer.a=7
+      Top.c.deep.d=42

--- a/tests/cases/cpp/hierarchy_named_block_nesting/main.sv
+++ b/tests/cases/cpp/hierarchy_named_block_nesting/main.sv
@@ -1,0 +1,43 @@
+// LRM 9.3.5 / 23.6 / 23.9: named begin/end is a hierarchical-reference
+// head; unnamed begin/end is transparent in the hierarchical-name path.
+// This exercises the placement and lookup behaviour that the primary
+// D2e test (`hierarchy_named_block_head`) does not cover:
+//
+//   1. A static declared directly in an unnamed block nested inside a
+//      named block. The static has no hierarchical name from outside;
+//      internally the enclosing body reads it like any local.
+//   2. A named begin/end wrapped in one or more unnamed begin/ends. LRM
+//      lets a peer reach it by its label (`Top.c.deep.d`) as if the
+//      unnamed wrappers did not exist -- the runtime tree must project
+//      the same view.
+//   3. A sibling procedural block in the same module reaching a named
+//      block by its label (`Top.outer.a`), without a cross-instance
+//      hop.
+
+module Inner;
+  initial begin
+    begin
+      begin : deep
+        static int d = 42;
+      end
+    end
+  end
+endmodule
+
+module Top;
+  Inner c();
+
+  initial begin : outer
+    static int a = 7;
+    begin
+      static int b = 13;
+      $display("outer internal a=%0d b=%0d", a, b);
+    end
+  end
+
+  initial begin
+    #1;
+    $display("Top.outer.a=%0d", outer.a);
+    $display("Top.c.deep.d=%0d", c.deep.d);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements LRM 9.3.5 / 23.9: a named `begin : label ... end` becomes a hierarchical-reference head, so peers can reach its static-lifetime locals through paths like `Top.outer.x`. To support this cleanly, every `begin/end` (named or unnamed) materializes as a runtime scope class, and each static-lifetime local lives on its own lexical scope's class -- no elevation, no lexical-vs-physical owner distinction. The SV-visible hierarchy is a projection over the physical containment tree, computed at lookup time: `Scope::GetChild` walks past anonymous scopes transparently, so an unnamed `begin/end` wrapping a named one is invisible to peer navigation (LRM 23 hierarchical-name semantics).

## Design

The two-phase HIR-to-MIR scope lowering was extended so shape declaration owns the full storage plan before any body lowers: `ProceduralScopeMaterializationTable` records one entry per HIR `ProceduralScopeDecl` with its runtime class, companion member on the parent, and immediate lexical parent; `CallableStoragePlan` gives each body its static-var placements and forwards chain queries to that table. Body lowering never mints class members; it looks placements up and defers static initializers as `PendingStaticInitializer` records that the caller drains and integrates into the Initialize phase.

Runtime side, `Scope` gains a `ProceduralStorageScope` subclass (paired with the new `mir::ProceduralStorageScopeType` marker) and `IsAddressable()` (derived from segment-name emptiness). `GetChild` recurses through non-addressable children, so a peer's `top.outer.x` finds `outer` regardless of how many unnamed begin/ends physically wrap it. Cross-unit references to a named procedural block use the runtime by-name walk (the compile-time typed segment does not fit because the scope's companion pointer lives on whichever anonymous class physically owns it).

## Testing

Two new end-to-end test cases:

- `hierarchy_named_block_head` -- the primary D2e case: named block as head reached both intra-unit (sibling process, `outer.x`) and cross-unit (`Top.c.outer.x`, including nested `outer.inner.y` and a hierarchical write).
- `hierarchy_named_block_nesting` -- three corner cases grouped into one module: a static declared directly in an unnamed block nested inside a named one; a named block wrapped in unnamed begin/ends reached through the anonymous chain; a sibling process reaching a named block by its label in the same module.

Full `bazel test //...` passes.