### PR TITLE
Install representation on static-local cells

### DIFF
--- a/src/lyra/lowering/hir_to_mir/declaration_initializer.cpp
+++ b/src/lyra/lowering/hir_to_mir/declaration_initializer.cpp
@@ -9,6 +9,7 @@
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -17,7 +18,31 @@ auto IntegratePendingStaticInitializer(
     const WalkFrame& init_frame, const PendingStaticInitializer& pending)
     -> diag::Result<void> {
   auto& init_block = *init_frame.current_block;
+  const mir::CompilationUnit& unit = process.Module().Unit();
   const mir::TypeId self_ptr_type = init_frame.current_class->self_pointer_type;
+
+  const mir::ExprId target = init_block.exprs.Add(
+      process.BuildStaticStorageAccess(init_frame, pending.placement));
+  const bool target_is_observable_cell = mir::IsObservableCellType(
+      unit.types.Get(init_block.exprs.Get(target).type));
+
+  // An observable cell installs its declared representation and default
+  // contents once at construction (LRM 10.5); a later user initializer stores
+  // through Set, which verifies the value against the installed
+  // representation. The default-only case is fully expressed by Initialize
+  // and needs no Set.
+  if (target_is_observable_cell) {
+    const mir::ExprId prototype = init_block.exprs.Add(BuildDefaultValueFromHir(
+        process.Module(), init_frame, pending.hir_type));
+    init_block.AppendStmt(
+        mir::ExprStmt{
+            .expr = init_block.exprs.Add(
+                mir::MakeObservableInitializeCallExpr(
+                    target, prototype, unit.builtins.void_type))});
+    if (!pending.init_expr.has_value()) {
+      return {};
+    }
+  }
 
   mir::ExprId init_value{};
   if (pending.init_expr.has_value()) {
@@ -30,23 +55,15 @@ auto IntegratePendingStaticInitializer(
         process.Module(), init_frame, pending.hir_type));
   }
 
-  const mir::ExprId target = init_block.exprs.Add(
-      process.BuildStaticStorageAccess(init_frame, pending.placement));
-  // Route through the observable cell protocol when the storage is
-  // observable-wrapped (a static owned by a materialized procedural-storage
-  // scope, so a cross-unit pointer slot lines up with the wrapped cell);
-  // plain assignment otherwise (LRM 13.3.1).
   const mir::ExprId services_self_read =
       init_block.exprs.Add(MakeSelfRefExpr(init_frame, self_ptr_type));
   const mir::ExprId services_id = init_block.exprs.Add(
-      mir::MakeServicesCallExpr(
-          services_self_read, process.Module().Unit().builtins.services));
+      mir::MakeServicesCallExpr(services_self_read, unit.builtins.services));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
-      process.Module().Unit(), init_block, services_id, target, init_value,
-      std::nullopt, pending.storage_type,
-      process.Module().Unit().builtins.void_type);
-  const mir::ExprId assign = init_block.exprs.Add(assign_expr);
-  init_block.AppendStmt(mir::ExprStmt{.expr = assign});
+      unit, init_block, services_id, target, init_value, std::nullopt,
+      pending.storage_type, unit.builtins.void_type);
+  init_block.AppendStmt(
+      mir::ExprStmt{.expr = init_block.exprs.Add(assign_expr)});
   return {};
 }
 


### PR DESCRIPTION
## Summary

Static-lifetime body locals (LRM 13.3.1) stored via `.Set(...)` on their observable cell without first calling `.Initialize(prototype)` to install the cell's declared representation. The store-boundary check added in #1002 (`Var<PackedArray>::Set: store into a cell that was never initialized`) then aborted at runtime the first time any such static was written. Every module-level variable already followed the two-step pattern; the pending-static-initializer drain introduced in #1007 was the only path that skipped it. All 11 broken cases in `//tests:cpp_tests` (`bit_select_signed`, `do_while_single_stmt`, `function_static_sibling_same_name`, and eight others) shared this exact failure.

## Design

`IntegratePendingStaticInitializer` now mirrors the instance-member path in `StructuralScopeLowerer::PopulateBodies`: when the storage target is an observable cell, it emits `MakeObservableInitializeCallExpr(target, default)` first, and then emits the `Set` only when the source has a user-provided initializer (a default-only static is fully expressed by `Initialize`). Non-observable storage keeps the single-assign path unchanged.

## Testing

`bazel test //...` clean locally, including all 11 previously failing `cpp_tests` cases. CI's `Test` job filters out `requires-host-cxx` and so does not exercise `//tests:cpp_tests` — that's why this regression landed on main; worth a follow-up to reinstate an end-to-end check job.