### PR TITLE
Bind generate heads before lowering iteration bodies

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -188,6 +188,18 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       originating inside a generate block (see D2b); and a reference from an enclosing scope into a
       child instance's generate block (`leaf.g.x`, `leaf.bank[i].y`, and deeper through an instance
       inside the block).
+- [x] D8 -- A loop-generate iteration reads another iteration of the same loop by hierarchical name
+      from inside its own body (`g[i-1].v` -- the systolic / pipeline / carry-chain shape),
+      including a forward read of an iteration constructed after the referrer. The reference binds
+      only after the whole object tree exists, so a sibling not yet constructed when the referrer's
+      own construction runs still resolves; no instance is dereferenced across the boundary during
+      construction. The intra-unit, indexed extension of the sibling reads in D2d.
+- [ ] D9 -- A continuous assignment whose right-hand side reads a cross-instance signal that is
+      itself continuously driven does not re-evaluate when that source settles: it captures the
+      source's pre-settle value once and never updates. The reference resolves to the correct target
+      and reads it, so the gap is the missing reactive subscription on a dynamically-driven
+      cross-instance source, not the routing. This bounds what D4 covers -- a directly-driven source
+      re-triggers; an assign-driven cross-instance source may not.
 
 Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
 

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -49,6 +49,22 @@ auto StructuralScopeLowerer::BuildResolvedGenerateFromArray(
   hir::Generate gen{};
   const hir::GenerateId gen_id =
       frame.current_structural_scope->NextGenerateId();
+
+  // A downward reference `g[k]` heads at the array symbol; the runtime
+  // by-name-and-index child lookup and the reference's own index select the
+  // k-th iteration from among the concrete per-iteration children, which all
+  // share the array's source name, so the head may point at any iteration's
+  // scope -- the first. Registered before any iteration body lowers, so a
+  // reference from inside one iteration to another (`g[i-1].v`) resolves its
+  // head while that body lowers, regardless of source order.
+  if (!array.entries.empty()) {
+    module_->MapOwnedChildBinding(
+        array, frame_,
+        hir::DownwardHead{
+            .child = hir::GenerateChildRef{
+                .generate = gen_id, .scope = hir::StructuralScopeId{0}}});
+  }
+
   std::vector<hir::ResolvedGenerateItem> items;
   items.reserve(array.entries.size());
   for (const auto* entry : array.entries) {
@@ -68,17 +84,6 @@ auto StructuralScopeLowerer::BuildResolvedGenerateFromArray(
             .index = array_index->as<std::int64_t>().value_or(0),
             .scope = scope_id});
   }
-  // A downward reference `g[k]` heads at the array symbol; the runtime
-  // by-name-and-index child lookup selects the k-th iteration from among the
-  // concrete per-iteration children, which all share the array's source name.
-  // The head only carries that name, so it may point at any iteration's scope.
-  if (!items.empty()) {
-    module_->MapOwnedChildBinding(
-        array, frame_,
-        hir::DownwardHead{
-            .child = hir::GenerateChildRef{
-                .generate = gen_id, .scope = items.front().scope}});
-  }
   gen.data = hir::ResolvedGenerate{.items = std::move(items)};
   return gen;
 }
@@ -89,17 +94,20 @@ auto StructuralScopeLowerer::BuildResolvedGenerateFromBlock(
   hir::Generate gen{};
   const hir::GenerateId gen_id =
       frame.current_structural_scope->NextGenerateId();
+
+  // A downward reference `blk.x` heads at this block symbol; it carries no
+  // index. Registered before the block body lowers, so a reference from inside
+  // the block to its own name resolves while that body lowers.
+  module_->MapOwnedChildBinding(
+      block, frame_,
+      hir::DownwardHead{
+          .child = hir::GenerateChildRef{
+              .generate = gen_id, .scope = hir::StructuralScopeId{0}}});
+
   auto scope_or = LowerGenerateScope(*module_, block, block.name, frame);
   if (!scope_or) return std::unexpected(std::move(scope_or.error()));
   const hir::StructuralScopeId scope_id =
       AddChildStructuralScope(gen, *std::move(scope_or));
-  // A downward reference `blk.x` heads at this block symbol; it carries no
-  // index.
-  module_->MapOwnedChildBinding(
-      block, frame_,
-      hir::DownwardHead{
-          .child =
-              hir::GenerateChildRef{.generate = gen_id, .scope = scope_id}});
   gen.data = hir::ResolvedGenerate{
       .items = {
           hir::ResolvedGenerateItem{.index = std::nullopt, .scope = scope_id}}};

--- a/tests/cases/cpp/hierarchy_upward_visible_child/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_visible_child/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stdout:
-    exact: "up=7 down=33 deep=22 a=11 b_inst=99\n"
+    exact: "up=7 down=33 deep=22 a=11 b_inst=99 own=4,8,12 fwd=8,12,4\n"

--- a/tests/cases/cpp/hierarchy_upward_visible_child/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_visible_child/main.sv
@@ -23,6 +23,13 @@
 //     name. `reader` (declared before foo_a/foo_b so the references are
 //     forward, upward) reads `foo_a.v == 11` and `foo_b.v == 99`; a
 //     def-name-based climb would collapse both onto the same Foo.
+//
+//   - Indexed loop-generate iterations reading each other. `ring[i].own` reads
+//     its own `ring[i].v` -- the constant index selects the same heterogeneous
+//     member; `ring[i].fwd` reads `ring[(i+1)%3].v`, a wrap that includes a
+//     forward read of a later-built sibling, which resolves only because the
+//     reference binds after the whole tree is built. Asserting the self and
+//     forward routes separately keeps a coincidental total from hiding either.
 module Foo;
   int v;
 endmodule
@@ -60,6 +67,14 @@ module Top;
   Foo foo_a();
   Foo foo_b();
 
+  for (genvar i = 0; i < 3; i = i + 1) begin : ring
+    int v = (i + 1) * 4;
+    int own;
+    int fwd;
+    always_comb own = ring[i].v;
+    always_comb fwd = ring[(i + 1) % 3].v;
+  end
+
   initial begin
     b.bx = 7;
     a.ax = 33;
@@ -67,8 +82,10 @@ module Top;
     foo_a.v = 11;
     foo_b.v = 99;
     #1;
-    $display("up=%0d down=%0d deep=%0d a=%0d b_inst=%0d",
+    $display("up=%0d down=%0d deep=%0d a=%0d b_inst=%0d own=%0d,%0d,%0d fwd=%0d,%0d,%0d",
              a.from_b, b.from_a, mid.leaf.from_top_my_foo,
-             reader.from_a, reader.from_b);
+             reader.from_a, reader.from_b,
+             ring[0].own, ring[1].own, ring[2].own,
+             ring[0].fwd, ring[1].fwd, ring[2].fwd);
   end
 endmodule


### PR DESCRIPTION
## Summary

A loop-generate iteration that references another iteration of the same loop by hierarchical name from inside its own body -- the systolic / pipeline / carry-chain shape, `g[i-1].v` -- crashed during lowering with `downward owned-child head has no binding`. The generate's owned-child head binding was registered only after every iteration body had already lowered, so when one iteration's body resolved a reference to a sibling iteration the head was not yet bound. This registers the head binding before any iteration body lowers, mirroring the subroutine forward-declare already in the same pass, so an intra-array reference resolves regardless of source order. The reference itself then rides the existing route model, which resolves cross-instance references in the resolve phase after the whole object tree is built, so a forward read of a later-constructed sibling resolves too.

## Testing

Extends `hierarchy_upward_visible_child` with an indexed loop-generate ring that reads both its own iteration (self index) and a neighbour (forward index, wrapping), asserting the two routes separately so a coincidental total cannot hide either. Full `//...` build and test gate green.