### PR TITLE
Move unpacked array range from the value to the type

### DIFF
--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -76,6 +76,8 @@ what the construct means.
 
 - Control-flow graphs, basic blocks, branches, or phi nodes.
 - Storage placement, offsets, or memory layout.
+- The resolution of a selector's declared coordinate to a storage position -- the declared-range
+  rebase. A select carries the source-level selector; the selected value resolves the coordinate.
 - Scheduling, dirty tracking, or wakeup filtering.
 - The frontend's symbol or string identity. MIR carries only MIR's own ids.
 - SystemVerilog source-level syntactic sugar. Sugar collapses to MIR's primitives at HIR-to-MIR.
@@ -200,6 +202,11 @@ implies; the diagnostic for any new forbidden shape is "what identity property d
 - Basic blocks, successor lists, or phi nodes in MIR nodes. (MIR is not the machine-execution
   model.)
 - Storage offsets, byte layouts, or alignment data in MIR nodes. (Storage placement belongs to LIR.)
+- A select whose selector is a resolved storage position rather than the source-level coordinate: a
+  lowering that rebases a declared index against the container's range (`i - left`, `left - i`, an
+  indexed-part-select width offset) and hands MIR the resulting position. The rebase is a storage
+  computation the selected value owns; a select carries the source selector. (Coordinate resolution
+  is the value's, not a synthesized MIR operator's.)
 - A secondary hierarchy or identity system that shadows MIR ids (coordinate tuples, ordinals, symbol
   paths used as identity). (Identity is owned by the layer; programming languages do not have two
   parallel name systems for the same thing.)

--- a/docs/decisions/selector-coordinate-resolution.md
+++ b/docs/decisions/selector-coordinate-resolution.md
@@ -1,0 +1,123 @@
+# Array selection is semantic; the selected value resolves its own declared coordinates
+
+## Date
+
+2026-07-02
+
+## Status
+
+Accepted
+
+## Model
+
+A fixed unpacked array is declared over an index range, and the range is part of the array's
+identity, not a size in disguise. `logic a[1:7]`, `logic b[7:1]`, and `logic c[0:6]` all hold seven
+elements, yet `a[1]`, `b[1]`, and `c[1]` name three different elements. A selection `a[i]` is only
+defined relative to the array's own coordinate system: which storage element the source index `i`
+names depends on the declared range and its direction.
+
+The selection model follows. A select expression carries a _semantic_ selection -- the value being
+selected and the source-level selector -- and nothing more. The selected value owns its declared
+coordinate system and resolves a source selector to a storage position. Lowering translates a source
+selection faithfully:
+
+```text
+a[i]       ->  a.Element(i)
+a[hi:lo]   ->  a.Slice(<source selector>)
+```
+
+and never computes `i - 1`, `left - i`, or `base +/- (width - 1)`. Resolving a declared coordinate
+to a storage position is the selected value's job, done once, inside the value.
+
+## Decision
+
+1. **The selected value owns its declared coordinate system.** A selectable value carries its
+   declared range as an immutable descriptor fixed at construction: a packed value carries its
+   dimension stack, an unpacked value carries its `UnpackedRange`. `value.Element(i)` is a complete
+   operation -- the value alone determines which storage position the source index `i` names.
+   Neither the lowering nor a per-selection argument supplies the coordinate system.
+
+   **Amended for the unpacked/container family** by
+   [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md): an unpacked/container
+   payload is ordinal-only and carries no range; the coordinate system is a fact of the receiver
+   expression's static type, materialized at the select as an explicit MIR operand. This packed
+   clause (dimension stack on the value) is unchanged -- packed dims is a storage-representation and
+   `SameRepresentation` identity fact, not pure coordinate naming. Decisions 2, 3, 4 below hold for
+   both families.
+
+2. **Coordinate resolution runs in the value's wide, X/Z-aware domain, never as narrow selector
+   arithmetic.** Rebasing a declared coordinate to a storage position (`i - left`, `left - i`, and
+   the indexed-part-select width offset) happens inside the value in a canonical wide domain that
+   preserves X/Z. It is never a native operator on the selector's own -- possibly narrow, possibly
+   four-state -- type. A narrow rebase can wrap a genuinely out-of-range selector into an apparently
+   valid position, and a four-state selector against a two-state bound shares no storage domain;
+   both are defects of resolving in the selector's type instead of the value's domain.
+
+3. **The value's access surface is coordinate-facing; the storage position is private.** A
+   selectable value exposes element and slice access that take a source-level coordinate. The
+   storage position it resolves to is an internal detail below a single resolution point -- never a
+   public method, never a coordinate that flows between runtime components. A value is reached
+   through its coordinate-facing surface, so no caller re-derives a storage position under the wrong
+   coordinate system.
+
+4. **The declared range is selection-only.** Whole-value movement -- assignment, copy, argument
+   passing, equality -- is position-wise and range-agnostic (LRM 7.6: element correspondence is
+   left-to-right order, so `int a[7:0] = int b[1:8]` assigns `b[1]` to `a[7]`). The range is fixed
+   at construction and never adopted from a source; a semantic store carries the destination's
+   declared range, converting the source at the store boundary (see
+   [value-store-discipline](value-store-discipline.md)). Only element and slice selection consult
+   the range.
+
+## Consequences
+
+- A slice read is a materialized owned value whose storage copies position-wise into any
+  destination, per decision 4. (For the unpacked/container family, that value is ordinal-only
+  payload and carries no declared sub-range -- the result range is non-observable; see
+  [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md). A packed slice value still
+  carries its dimension stack.)
+- Packed, unpacked, and the zero-based families sit under one model. A packed value carries its
+  dimension stack and resolves in its bit domain. A dynamic array and a queue are declared
+  zero-based, so their coordinate system is the identity and resolution is a no-op; a queue's slice
+  bounds are still resolved and clamped inside the value (LRM 7.10.1), not synthesized at lowering.
+- A selector lowering that synthesizes no coordinate arithmetic emits no operator whose operands the
+  frontend did not already unify. The general operand reconciliation a lowering otherwise carries
+  for such synthesized operators has no input and is removed; the invariant that native binary
+  operands share a storage domain is enforced structurally rather than repaired.
+
+## Rejected alternatives
+
+- **Resolve the coordinate at lowering (fold `i - left` into the selector index).** The value
+  becomes storage-only and every caller must remember its coordinate system and pre-rebase. The
+  rebase is synthesized as an operator on the selector's own narrow, possibly four-state type -- the
+  wrap and storage-domain-mismatch defects of decision 2 -- and a select node carries a storage
+  computation rather than a semantic selection.
+- **Pass the declared range alongside the value as a per-selection argument.** The value's
+  `Element(i)` stays under-defined without an external range, so the coordinate system is scattered
+  across every call site rather than owned by the value. This is the "shape passed in alongside the
+  value" shape rejected for the same reason a packed element carries its own shape (see
+  [runtime-shape-and-default-value](runtime-shape-and-default-value.md)). **Superseded for the
+  unpacked/container family** by
+  [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md): there the range is a
+  type-derived MIR operand owned by the receiver's static _type_, not a runtime quantity scattered
+  by callers -- so it is not the rejected shape. It remains rejected for packed, whose dims stay on
+  the value.
+- **A public storage-position access on the value.** Once a zero-based position is a callable
+  protocol, a caller computes one under the wrong coordinate system and the leak returns. The
+  position stays private below the single resolution point.
+
+## Cross-references
+
+- LRM 7.4.5 / 7.4.6 (indexing, slicing, operations on arrays), 7.6 (array assignment element
+  correspondence), 11.5.1 (bit / part / indexed part-select), 7.10.1 (queue operators and clamping).
+- `architecture/mir.md` -- a select is a semantic access primitive; MIR does not own coordinate
+  resolution.
+- [integral-representation](integral-representation.md),
+  [runtime-shape-and-default-value](runtime-shape-and-default-value.md) -- a value carries its own
+  declared shape rather than receiving it alongside.
+- [value-store-discipline](value-store-discipline.md) -- the store boundary that gives an assignment
+  the destination's declared range.
+- [unpacked-array-representation](unpacked-array-representation.md) -- the unpacked value that
+  carries its `UnpackedRange`.
+- [slice-value-semantics](slice-value-semantics.md) -- the slice read that materializes the
+  sub-ranged value.
+- [queue-operators](queue-operators.md) -- the queue access whose bounds resolve inside the value.

--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -123,36 +123,42 @@ Unpacked array support follows these invariants:
    inner `UnpackedArrayType` whose element is `int`. One IR layer per declared dimension. AST -> HIR
    consumes slang's nested `FixedSizeUnpackedArrayType` 1:1.
 
-2. **Backend cpp renders each unpacked type layer as `lyra::value::UnpackedArray<T>`.**
+2. **Backend cpp renders each unpacked type layer as `lyra::value::UnpackedArray<T>`.** _(Amended by
+   [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md): the value is an ordinal-only
+   payload and does NOT carry a declared range; the range is a fact of the receiver's static type,
+   materialized at the select as a MIR operand. The original "the value carries its declared range"
+   is superseded.)_
 
    `mir::UnpackedArrayType { dim, element_type }` -> `lyra::value::UnpackedArray<` +
-   `render(element_type)` + `>`. The wrapper owns a private `std::vector<T>` and exposes a surface
-   symmetric with `PackedArray` -- element access by position, slice, `operator==` and `CaseEqual`
-   returning a 1-bit `PackedArray` -- so the substrate-asymmetric operations (equality with X / Z
-   propagation, range selectors, observability hooks) live behind a single uniform method surface.
-   LRM 7.4.5 invalid-index handling lives in the wrapper too: positional access returns `T&` (or
-   `const T&` from the const overload); on an invalid index the returned reference is to the
-   wrapper's shield slot, restored to canonical state via `T::ResetToDefault` immediately before
-   being handed out so any prior OOB write is erased. Element-level compound semantics live on
-   `PackedArray` directly -- the wrapper carries no per-T forwarder. The write-side slice
-   (`SliceRef`) returns a write-through proxy whose destructor scatters back into the receiver's
-   storage; slice reads on partially-OOB positions handle the in-range and OOB elements per-element
-   rather than at slice granularity, matching the packed array's per-bit OOB treatment in
-   bit-extract and slice-assign. See `docs/decisions/runtime-shape-and-default-value.md` for the
-   shield contract.
+   `render(element_type)` + `>`. The wrapper owns a private `std::vector<T>` plus its declared
+   `UnpackedRange`, seeded at construction alongside the element default, and exposes a surface
+   symmetric with `PackedArray` -- element and slice access by source-declared coordinate,
+   `operator==` and `CaseEqual` returning a 1-bit `PackedArray` -- so the substrate-asymmetric
+   operations (equality with X / Z propagation, range selectors, observability hooks) live behind a
+   single uniform method surface. Element and slice access take a source-level index and resolve it
+   to a storage position against the wrapper's own range (see
+   `docs/decisions/selector-coordinate-resolution.md`); the storage position is internal and never a
+   public argument. LRM 7.4.5 invalid-index handling lives in the wrapper: an index outside the
+   declared range or bearing X / Z returns a reference to the shield slot, restored to canonical
+   state via `T::ResetToDefault` before being handed out so any prior OOB write is erased.
+   Element-level compound semantics live on `PackedArray` directly -- the wrapper carries no per-T
+   forwarder. The write-side slice (`SliceRef`) returns a write-through proxy whose destructor
+   scatters back into the receiver's storage; slice reads on partially-OOB positions handle in-range
+   and OOB elements per-element, matching the packed array's per-bit OOB treatment. See
+   `docs/decisions/runtime-shape-and-default-value.md` for the shield contract.
 
-3. **Default initialization emits a `ConstructExpr` whose first positional argument is the
-   canonical-default element and whose second is an `ArrayLiteralExpr` rendered as
-   `std::array<T, N>{...}`.**
+3. **Default initialization emits a `ConstructExpr` whose arguments are the declared range, the
+   canonical-default element, and an `ArrayLiteralExpr` rendered as `std::array<T, N>{...}`.**
 
    `default_value.cpp` synthesises an `ArrayLiteralExpr` populated with per-element defaults; the
-   backend wraps it in `ConstructExpr` so the wrapper's `(T canonical_default, std::span<const T>)`
-   constructor receives both the canonical-default seed for `oob_slot_` and the initial elements.
-   The `std::array<T, N>` rvalue produced by the element list implicitly converts to the ctor's
-   `std::span<const T>` parameter. For `int arr[3]`:
+   backend wraps it in `ConstructExpr` so the wrapper's constructor receives the declared range
+   (from the type's `dim`), the canonical-default seed for the shield slot, and the initial
+   elements. The `std::array<T, N>` rvalue produced by the element list implicitly converts to the
+   ctor's `std::span<const T>` parameter. For `int arr[1:3]`:
 
    ```cpp
    lyra::value::UnpackedArray<lyra::value::PackedArray> arr(
+       lyra::value::UnpackedRange{1, 3},
        lyra::value::PackedArray::Int(0),
        std::array<lyra::value::PackedArray, 3>{
            lyra::value::PackedArray::Int(0),
@@ -160,9 +166,9 @@ Unpacked array support follows these invariants:
            lyra::value::PackedArray::Int(0)});
    ```
 
-   Multi-dim composes through the nested element type with the same shape at every layer. The same
-   element-list shape applies to `DynamicArray<T>` -- the only thing that varies is the outer
-   container type.
+   Multi-dim composes through the nested element type with the same shape at every layer.
+   `DynamicArray<T>` uses the same element-list shape without the range argument -- a dynamic array
+   is declared zero-based, so its coordinate system is the identity.
 
 4. **`'{...}` is a first-class IR expression -- `hir::ArrayLiteral` / `mir::ArrayLiteral` --
    rendered as `std::array<T, N>{...}`.**

--- a/docs/decisions/unpacked-range-belongs-to-type.md
+++ b/docs/decisions/unpacked-range-belongs-to-type.md
@@ -1,0 +1,213 @@
+# Unpacked/container range belongs to the type, not the payload
+
+## Date
+
+2026-07-08
+
+## Status
+
+Accepted
+
+## Scope
+
+Fixed unpacked arrays and variable-size containers. Packed arrays are explicitly out of scope (see
+"Packed carve-out"). This decision amends
+[selector-coordinate-resolution](selector-coordinate-resolution.md) decision 1 for the unpacked
+family.
+
+## Decision
+
+For unpacked/container arrays:
+
+- The runtime **payload is ordinal-only** -- vector-like storage sized by element count, with no
+  declared range.
+- The **declared coordinate range is a fact of the receiver expression's static type.**
+- **Coordinate-consuming operations** (element and slice select, and any locator that reports a
+  declared index) **carry the range as an explicit MIR operand**, materialized at HIR-to-MIR from
+  the receiver's static type.
+- A **whole-value store copies the ordinal payload** into the destination and preserves the
+  destination's declaration semantics; it performs no range relabel.
+- **`ConformRange` is removed.**
+
+## Invariants (guardrails)
+
+1. **The range operand is part of the MIR Select node's semantic contract, not a C++ backend
+   artifact.** Every backend sees the same operand. `Element(recv, index, receiver_range)` and
+   `Slice(recv, a, b, form, receiver_range)` are the MIR node shapes; a mechanical LLVM backend
+   consumes them identically to the C++ backend. No backend "adds" the range -- MIR carries it.
+
+2. **`Var<T>::Set` stays ordinary whole-`T` assignment.** After this decision, for an unpacked array
+   `T` _is_ the range-free payload type, so `Set` remains a plain `T` copy and neither `Var`,
+   `ScopedMutation`, `Ref`, nor the scheduler ever knows about a range. This works _only_ because
+   `range_` has been removed from `T`; `Set` must never grow semantic-store behavior.
+
+3. **No legal SV operation may require the declared range label of an unpacked range-select
+   result.** A slice result's payload is range-free (the result range is non-observable: LRM assigns
+   none, and chaining a select after a range-select is illegal). If a future consumer needs a
+   range-select result's declared range, it must define its own result-shape rule explicitly rather
+   than assume the payload carries one.
+
+## Why this beats recursive `ConformRange` (first principles)
+
+SV unpacked assignment is position-wise (LRM 7.6: element correspondence is left-to-right ordinal).
+The declared range is _coordinate naming_ -- which storage ordinal a source index denotes -- not
+payload representation: storage is a `std::vector` sized by count, endpoint- independent; there is
+no `SameRepresentation` over an unpacked range; every whole-value surface (copy, equality,
+`IsBitIdentical`, positional `'{...}` print, sort, reduction) is ordinal. `DynamicArray<T>` already
+carries no range and runs the identical surface.
+
+Putting the range inside the movable payload forces whole-value movement (which must not touch
+coordinate labels) and selection (which must) to share one object copy. A cross-range store then has
+to _repair_ a descriptor a plain copy wrongly carried -- that repair is `ConformRange`. Recursive
+`ConformRange` is the honest, correct consequence of _keeping_ the range in the payload: it re-walks
+the full dim stack on every cross-range store to relabel what the type system already knows. The
+range-free model removes the repair: the store is a payload copy, and the range enters at selection,
+the operation that consumes coordinates. Construction already passes a type-derived `UnpackedRange`
+to size the payload; selection using a type-derived range is the symmetric read- side operation.
+
+## X/Z-aware resolution is preserved
+
+[selector-coordinate-resolution](selector-coordinate-resolution.md) decision 2 (rebase runs in the
+value's wide, X/Z-aware domain, never as narrow selector arithmetic) is unchanged. The runtime
+helper that maps a source index to a storage ordinal still runs in the wide domain and still yields
+the invalid/shield result for an X/Z or out-of-range index. The only change: the range it resolves
+against arrives as an operand instead of a stored field. No rebase moves to the selector's narrow
+type; no `i - left` is synthesized at lowering.
+
+## Backend-contract clean
+
+The range operand is materialized at HIR-to-MIR from the receiver's static type and travels as an
+ordinary MIR value -- the prototype/companion-value pattern (`backend_contract.md`: a shape a
+factory needs travels as a MIR value, never composed by render from a node's type). Render emits it
+mechanically; it does not read another node's type to synthesize it. This mirrors how construction
+already emits `UnpackedRange{l,r}`. Render stays a fixed function of one node (Inv 1); no
+value-emission entry gains a decision (Inv 2); the Inv-5 LLVM falsifier passes.
+
+## Every value boundary works
+
+The governing range is always the local static type at the select site, so no runtime range ever
+travels across a boundary or lives on a cell:
+
+- **Module variable** (`Var<Payload>`): the select receiver node carries the variable's static
+  `UnpackedArrayType`; the operand comes from it.
+- **Automatic local** (plain C++ `T`, no Var/cell): its slot has a static MIR type; the select
+  materializes the range from it. This is why the model lands where a declaration-wrapper approach
+  could not -- an automatic local has no wrapper.
+- **Function return** (bare by-value payload): `f()[i]`'s range comes from the receiver `CallExpr`'s
+  static return type; the function returns no `{payload, shape}` pair.
+- **`ref`/`const ref` formal and `ref` port**: the governing coordinate system is the callee formal
+  / child port local declared static type (LRM 13.5.2 requires only _equivalent_ types),
+  materialized at the callee's select. Only payload crosses the boundary.
+- **By-value / port**: a position-wise copy into the local formal/port, whose own static type
+  governs its selects.
+
+## Exact MIR and C++ shapes
+
+For `int a[1:3][1:4]`, `int b[3:1][4:1]`, `f` returns `int[3:1]`, `s : int[1:7]`:
+
+```
+SV:   a[i]
+MIR:  Element(recv = a, index = i, range = <operand Range{1,3} from a's static type>)
+C++:  a.Get().Element(Int(i), UnpackedRange{1,3})
+
+SV:   a[i][j]
+MIR:  Element(Element(a, i, Range{1,3}), j, Range{1,4})   // inner range from a's element type
+C++:  a.Get().Element(Int(i), UnpackedRange{1,3}).Element(Int(j), UnpackedRange{1,4})
+
+SV:   s[2:5]
+MIR:  Slice(recv = s, a = 2, b = 5, form = const, range = <operand Range{1,7}>)
+C++:  s.Get().Slice(2, 5, /*const*/, UnpackedRange{1,7})   // result payload is range-free
+
+SV:   a = b
+MIR:  Store(dest = a, src = b)                             // no ConformRange
+C++:  a.Set(services, b.Get())                            // plain ordinal payload copy
+
+SV:   f()[i]
+MIR:  Element(recv = f(), index = i, range = <operand Range{3,1} from f's return type>)
+C++:  f().Element(Int(i), UnpackedRange{3,1})
+```
+
+`i`/`j`/`2`/`5` stay raw SV coordinates; the range is a type-derived operand, never `i-1`, never
+render-synthesized, never a payload field.
+
+## Packed carve-out
+
+Packed `dims` stays in the packed value. It is not pure coordinate naming: its product is the flat
+storage width (a representation requirement) and the full stack participates in
+`SameRepresentation`, asserted on every packed store (`[7:0]` and `[3:0][1:0]` share storage yet are
+not same-representation and select differently). A packed value stays self-describing; this decision
+does not touch it. Applying the unpacked split to packed is a category error.
+
+## Performance
+
+No current runtime performance data exists (tracking is pending the execution backends), so this is
+a complexity argument, not a measurement.
+
+- Extra operand to `Element`/`Slice`: a 16-byte `UnpackedRange` by value; no heap, no indirection.
+- No allocation added; the payload move is the same vector copy.
+- No type-tree walk: the range is a flat operand per select level, materialized at lowering --
+  nothing re-derives it by walking a nested descriptor at runtime (which is what recursive
+  `ConformRange` would add on every store).
+- Bounds are an immediate/local value: a folded constant today; forward-compatible with dims
+  becoming constructor-input runtime values (the operand then sources the receiver's runtime dim,
+  not a C++ template parameter -- honoring `parameter-code-shape-over-approximation.md`).
+- Coordinate resolution stays in the wide X/Z-aware runtime helper, taking the range as an argument.
+- Store gets cheaper: `ConformRange` (a whole-value copy plus relabel) becomes a plain payload copy.
+
+## Rejected alternatives
+
+- **Recursive `ConformRange`** -- keep the range in the payload but make the store relabel every
+  dimension. Correct, but wrong-shaped: it re-walks the type tree at runtime on every cross-range
+  store to restate what the type already knows, and it keeps the range on the movable payload, which
+  is the root reason a plain `a = b` needs a repair at all. See "Why this beats recursive
+  `ConformRange`" above -- it is the honest consequence of the payload-range model, not a fix for
+  it.
+
+- **Range as a C++ template parameter** -- `std::array<T, N>`, or a non-type template parameter
+  `Typed<..., Range<1, 3>>` on the value type. Rejected:
+  [parameter-code-shape-over-approximation](parameter-code-shape-over-approximation.md) forbids
+  baking an extent/range into the type, because the committed direction makes unpacked dimensions
+  constructor-input runtime values and anything type-baked would have to be torn out; it would also
+  split every type-erased boundary (format, change detection, a value variant) by range. An unpacked
+  extent is already not in the C++ type today.
+
+- **Range as a per-selection runtime argument the caller computes** -- `a.Element(i, left, right)`
+  where `left` / `right` are values a caller threads in. This is the alternative
+  [selector-coordinate-resolution](selector-coordinate-resolution.md) rejected: the coordinate
+  system is scattered across call sites rather than owned. The chosen model looks similar at the C++
+  call but is not this one -- the range is a MIR operand materialized from the receiver's _static
+  type_ at lowering (the prototype pattern), so the type owns it and no caller computes or threads a
+  runtime coordinate system.
+
+- **Range on a per-declaration cell wrapper** -- the value holds only payload; a wrapper beside each
+  declared variable holds the range; `Var<Payload>` is unchanged. Rejected: it does not land
+  uniformly. An automatic local is a plain C++ value with no cell or wrapper to host a range, and a
+  function return and a temporary have none either. Since the receiver's static type carries the
+  range at every one of those sites anyway, a stored wrapper is both insufficient (locals,
+  temporaries) and unnecessary.
+
+## Consequences / amendments
+
+- Multi-dimensional arrays need no special handling. An unpacked value is `UnpackedArray<...>`
+  nested one layer per dimension; each select consumes exactly one dimension's range from its
+  receiver's static type, so `a[i][j][k]` is three independent single-dimension selects and any rank
+  adds no logic. A whole-array store is a plain nested copy at any rank. (Packed multi-dim is
+  unrelated -- a flat dim stack on one value, per the carve-out.)
+- [selector-coordinate-resolution](selector-coordinate-resolution.md) decision 1: for
+  unpacked/container, the receiver's static type owns the coordinate system, materialized at the
+  select as a MIR operand; the payload owns ordinal data only. Decisions 2, 3, 4 stand. Packed
+  unchanged.
+- [value-store-discipline](value-store-discipline.md): the store still preserves the destination's
+  declared type, but its realization drops `ConformRange` (a payload copy into a destination-typed
+  cell).
+- [unpacked-array-representation](unpacked-array-representation.md) invariant 2: "the value carries
+  its declared range" becomes "the type carries the range; the value carries ordinal payload".
+
+## Confirmed evidence
+
+- Source-build verified defect of the payload-range model: `int a[1:3][1:4] = b[3:1][4:1]` then
+  `a[1][1]` reads 0 (should be 99); `ConformRange` conforms only the outer dim. A symptom of the
+  store-repair this decision eliminates, not the justification.
+- Not defects (retracted): foreach index is correct (declared 1..7); the differing-range `ref` case
+  is a support-policy question (slang accepts, Verilator rejects as requiring matching types), not a
+  confirmed bug.

--- a/docs/decisions/value-store-discipline.md
+++ b/docs/decisions/value-store-discipline.md
@@ -67,6 +67,10 @@ whole-value assignment is the defect this split exists to prevent.
 
 ## Cross-references
 
+- [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md) -- for the unpacked/container
+  family the semantic store is realized as a plain ordinal-payload copy: the payload carries no
+  declared range, so nothing needs conforming at the boundary and the `ConformRange` step is
+  removed. The store-preserves-the-destination-type principle is unchanged.
 - [integral-representation](integral-representation.md) -- the fat-integral representation this
   generalizes.
 - [runtime-shape-and-default-value](runtime-shape-and-default-value.md) -- the container default

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -183,6 +183,14 @@ Tracked in `processes.md`.
 - [ ] processes/generate -- process generate; if / for-generate with `initial` and continuous-assign
       bodies run today, the full generate-form x procedural-block matrix is unverified (P12).
 
+### system functions
+
+- [ ] Query functions -- the data-query and array-query system functions (`$bits`, `$typename`,
+      `$left` / `$right` / `$low` / `$high` / `$increment` / `$size`, `$dimensions` /
+      `$unpacked_dimensions`), as elaboration-time constants for fixed-size operands and runtime
+      queries for dynamically sized ones (`query-functions.md`). The value-computation functions
+      (`$clog2`, `$signed` / `$unsigned`, `$isunknown` / `$countones` / `$onehot`) are supported.
+
 ### system tasks
 
 - [ ] System tasks -- the `$display` / `$write` / `$strobe` / `$monitor` family, file IO,

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -110,7 +110,8 @@ full support.
       structural (continuous-assign) right-hand side that applies a reduction operator to a
       part-select whose width comes from `$bits` (the `ibex_top` parity check,
       `assign unused = ^busy_q[$bits(mubi_t)-1:1]`). This is `ibex_top`'s first stop once its
-      children lower.
+      children lower. The reduction and part-select already lower; the gap is `$bits` of a type,
+      which has no elaboration-constant lowering yet. Unblocked by `query-functions.md` Q1.
 - [ ] Further structural-expression forms surfaced as later passes get deeper (recorded here as
       discovery continues).
 

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -106,12 +106,12 @@ full support.
       (and element-selected) in an expression. An unpacked struct or union constant is still
       blocked, but on unpacked-struct / union _type_ support rather than on constant
       materialization.
-- [ ] **Reduction operator over a `$bits`-derived part-select in a continuous assign** -- a
+- [x] **Reduction operator over a `$bits`-derived part-select in a continuous assign** -- a
       structural (continuous-assign) right-hand side that applies a reduction operator to a
       part-select whose width comes from `$bits` (the `ibex_top` parity check,
-      `assign unused = ^busy_q[$bits(mubi_t)-1:1]`). This is `ibex_top`'s first stop once its
-      children lower. The reduction and part-select already lower; the gap is `$bits` of a type,
-      which has no elaboration-constant lowering yet. Unblocked by `query-functions.md` Q1.
+      `assign unused = ^busy_q[$bits(mubi_t)-1:1]`). `$bits` lowers to an elaboration constant
+      (`query-functions.md` Q1) and the mixed-domain part-select bound reads correctly
+      (`operators.md` W14).
 - [ ] Further structural-expression forms surfaced as later passes get deeper (recorded here as
       discovery continues).
 

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -14,12 +14,11 @@ Done when:
 
 ## Actionable
 
-- W14 -- a range-select read whose two bounds have different state domains aborts at runtime. The
-  rest of the operator surface in scope is complete.
+All items closed; operator surface in scope is complete.
 
 ## Sub-Steps
 
-The numeric IDs (W1..W12) imply execution order; where a cut is independent the text says so.
+The numeric IDs (W1..W14) imply execution order; where a cut is independent the text says so.
 
 ### Membership and equality
 
@@ -54,13 +53,14 @@ merged node.
 - [x] W6 -- Selector lvalue (write side, including NBA + selector). LRM 11.5.1 write rules
       (fully-OOB no-op, partial-OOB only in-range bits, X / Z position no-op) all hold. Closes
       `datatypes/packed/indexed_part_select` for the write half.
-- [ ] W14 -- A range-select read whose two bounds have different state domains aborts at runtime
-      (e.g. `v[$bits(t)-1:1]`, where the `$bits`-derived bound is 4-state and the literal bound is
-      2-state). The endpoint-ordering step compares the two bounds assuming a shared storage domain
-      -- true for the common two-literal case, not when the bounds are typed differently. The fix
-      reconciles the endpoints to a common domain before comparing; a broader audit should cover
-      every comparison the selector lowering synthesizes. Pre-existing (a `localparam integer` bound
-      reaches it too); surfaced by `$bits` in a part-select bound (`query-functions.md` Q1).
+- [x] W14 -- A selector whose bound or index comes from a differently typed expression reads
+      correctly: a range-select `v[$bits(t)-1:1]` mixing a 4-state and a 2-state bound, or a
+      bit-select on a non-zero-based range with a 4-state index. The selector lowering carries only
+      the source-level selection; the selected value resolves a source coordinate to a storage
+      position in its own wide, X/Z-preserving domain (decisions/selector-coordinate-resolution.md),
+      so no coordinate arithmetic is synthesized on the selector's own -- possibly narrow, possibly
+      four-state -- type, and no runtime comparison between the two bounds is emitted. Unblocks
+      `$bits` in a part-select bound (`query-functions.md` Q1) and the `ibex_top` parity reduction.
 
 ### Construction
 

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -14,7 +14,8 @@ Done when:
 
 ## Actionable
 
-All items closed; operator surface in scope is complete.
+- W14 -- a range-select read whose two bounds have different state domains aborts at runtime. The
+  rest of the operator surface in scope is complete.
 
 ## Sub-Steps
 
@@ -53,6 +54,13 @@ merged node.
 - [x] W6 -- Selector lvalue (write side, including NBA + selector). LRM 11.5.1 write rules
       (fully-OOB no-op, partial-OOB only in-range bits, X / Z position no-op) all hold. Closes
       `datatypes/packed/indexed_part_select` for the write half.
+- [ ] W14 -- A range-select read whose two bounds have different state domains aborts at runtime
+      (e.g. `v[$bits(t)-1:1]`, where the `$bits`-derived bound is 4-state and the literal bound is
+      2-state). The endpoint-ordering step compares the two bounds assuming a shared storage domain
+      -- true for the common two-literal case, not when the bounds are typed differently. The fix
+      reconciles the endpoints to a common domain before comparing; a broader audit should cover
+      every comparison the selector lowering synthesizes. Pre-existing (a `localparam integer` bound
+      reaches it too); surfaced by `$bits` in a part-select bound (`query-functions.md` Q1).
 
 ### Construction
 

--- a/docs/progress/query-functions.md
+++ b/docs/progress/query-functions.md
@@ -1,0 +1,59 @@
+# Query functions
+
+Tracks support for the SystemVerilog data-query and array-query system functions (LRM 20.6, 20.7):
+`$bits`, `$typename`, the array dimension queries (`$left`, `$right`, `$low`, `$high`, `$increment`,
+`$size`), and the dimension-count queries (`$dimensions`, `$unpacked_dimensions`). These functions
+report properties of a data type or of an array's shape, not a computation over a value.
+
+Done when the whole 20.6 / 20.7 family lowers and runs for every data type: the fixed-size forms as
+elaboration-time constants, and the dynamically sized forms as runtime queries of the array's
+current state. When the last item lands, this file is deleted.
+
+## Semantic model
+
+These functions split on one axis, fixed by the LRM:
+
+- A query whose operand is a type, or a value of fixed-size type, is an **elaboration-time
+  constant**. The operand is never evaluated (LRM 20.6.2: `$bits` is "determined without actual
+  evaluation of the expression"; 20.6.1: `$typename`'s expression "is never evaluated"). The result
+  is a property of the type, fixed per specialization -- a type cannot depend on a genvar, and any
+  dimension argument is itself a constant expression -- so it is a literal at the query site, not a
+  runtime read. This is distinct from the select-bound rule (a bound may be a genvar-dependent
+  runtime value and is lowered faithfully): a query operand has no runtime form to be faithful to.
+- A query whose operand is a dynamically sized value (dynamic array, queue, associative array,
+  string) reports the array's **current state** and is a genuine runtime query (LRM 20.7: "When used
+  on a dynamic array or queue dimension, these functions return information about the current
+  state"; 20.6.2: `$bits` of a dynamically sized value returns its current bit count, 0 when empty).
+  It is an error to apply these directly to a dynamically sized type identifier.
+
+`$dimensions` and `$unpacked_dimensions` count dimensions, a type property, so they are constant for
+every operand, dynamic included.
+
+## Sub-steps
+
+- [ ] Q1 -- `$bits` of a type or a fixed-size value, as an elaboration-time constant (LRM 20.6.2).
+      The operand is not evaluated; the result is the bit count of the operand's type, usable
+      wherever an integer constant is. Unblocks the `ibex_top` reduction over a `$bits`-derived
+      part-select tracked in `ibex.md`. Used as a part-select bound it lowers and emits, but aborts
+      at runtime until the mixed-state range-bound fix lands (`operators.md` W14).
+- [ ] Q2 -- The array query functions on a fixed-size dimension, as elaboration-time constants (LRM
+      20.7): `$left`, `$right`, `$low`, `$high`, `$increment`, `$size`, with the optional constant
+      dimension argument, plus `$dimensions` and `$unpacked_dimensions` for every type. Covers
+      packed and unpacked, single- and multi-dimensional shapes.
+- [ ] Q3 -- `$typename` as an elaboration-time string constant (LRM 20.6.1), for a type or an
+      expression operand.
+- [ ] Q4 -- The runtime forms over a dynamically sized operand: `$bits` of a dynamically sized value
+      (0 when empty), and the array queries on a dynamic / queue / associative dimension reporting
+      current state (LRM 20.6.2, 20.7).
+
+## Out of scope
+
+- `$isunbounded` (LRM 20.6.3) queries whether a parameter is the unbounded `$`; it belongs with the
+  unbounded-parameter work noted out of scope in `hierarchy.md`, not with the shape queries here.
+- The value-computation system functions -- `$clog2` (LRM 20.8), `$signed` / `$unsigned` (LRM 20.5),
+  `$isunknown` / `$countones` / `$onehot` (LRM 20.9) -- compute over a value rather than query a
+  type or shape. They are a separate family and are already supported.
+
+## Cross-references
+
+- `ibex.md` -- Q1 unblocks the `ibex_top` structural reduction gap.

--- a/docs/progress/query-functions.md
+++ b/docs/progress/query-functions.md
@@ -31,11 +31,10 @@ every operand, dynamic included.
 
 ## Sub-steps
 
-- [ ] Q1 -- `$bits` of a type or a fixed-size value, as an elaboration-time constant (LRM 20.6.2).
+- [x] Q1 -- `$bits` of a type or a fixed-size value, as an elaboration-time constant (LRM 20.6.2).
       The operand is not evaluated; the result is the bit count of the operand's type, usable
-      wherever an integer constant is. Unblocks the `ibex_top` reduction over a `$bits`-derived
-      part-select tracked in `ibex.md`. Used as a part-select bound it lowers and emits, but aborts
-      at runtime until the mixed-state range-bound fix lands (`operators.md` W14).
+      wherever an integer constant is, including as a part-select bound. Unblocks the `ibex_top`
+      reduction over a `$bits`-derived part-select tracked in `ibex.md`.
 - [ ] Q2 -- The array query functions on a fixed-size dimension, as elaboration-time constants (LRM
       20.7): `$left`, `$right`, `$low`, `$high`, `$increment`, `$size`, with the optional constant
       dimension argument, plus `$dimensions` and `$unpacked_dimensions` for every type. Covers

--- a/include/lyra/hir/range_bounds.hpp
+++ b/include/lyra/hir/range_bounds.hpp
@@ -6,9 +6,14 @@
 
 namespace lyra::hir {
 
+// The two endpoints of a constant range-select `[left:right]`, in source syntax
+// order (`sel.left()` / `sel.right()`). Which one is the physical low end is a
+// property of the base container's orientation, decided at lowering -- not of
+// the numeric magnitudes: for an ascending vector `[0:N]` the left endpoint is
+// the least significant, for a descending `[N:0]` it is the most significant.
 struct RangeConstantBounds {
-  ExprId msb_expr;
-  ExprId lsb_expr;
+  ExprId left_bound;
+  ExprId right_bound;
 };
 
 struct RangeIndexedUpBounds {

--- a/include/lyra/lowering/hir_to_mir/case_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/case_cascade.hpp
@@ -48,7 +48,7 @@ template <typename LabelLowerer>
 auto BuildEqualityChain(
     WalkFrame frame, CaseSnapshotRefs snapshot, mir::TypeId bit_type,
     mir::BinaryOp compare_op, std::size_t label_count,
-    LabelLowerer&& lower_label, const mir::CompilationUnit& unit)
+    LabelLowerer&& lower_label, mir::CompilationUnit& unit)
     -> diag::Result<mir::ExprId> {
   auto& enc_scope = *frame.current_block;
   std::optional<mir::ExprId> acc;

--- a/include/lyra/lowering/hir_to_mir/expression/operators.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/operators.hpp
@@ -29,11 +29,13 @@ auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp;
 // `BuiltinFn` realization on the receiver value type; real / string
 // comparison and logical operators wrap in `kFromBool` (with `BoolCastExpr`
 // around the operands for the logical family); the rest produce a native
-// `BinaryExpr` for the backend to render mechanically. Shared between
-// `LowerHirBinaryExpr` and the case-cascade builder so every site that
-// produces a binary operator goes through one lift.
+// `BinaryExpr` for the backend to render mechanically. The single producer of a
+// binary operator, so it is also the one place that guarantees a word-parallel
+// operator's operands share a storage domain (LRM 11.6.1), inserting the
+// reconciling conversion any synthesized site would otherwise have to remember.
+// `unit` is mutable because reconciling may intern the operands' common type.
 auto BuildMirBinaryExpr(
-    const mir::CompilationUnit& unit, mir::Block& block, mir::BinaryOp op,
+    mir::CompilationUnit& unit, mir::Block& block, mir::BinaryOp op,
     mir::ExprId lhs_id, mir::ExprId rhs_id, mir::TypeId result_type)
     -> mir::Expr;
 

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -117,13 +117,52 @@ struct EnumType {
 // existing `TupleType`, not a distinct variant; an unpacked union (overlapping
 // member storage) is a separate representation problem.
 
-// MIR tracks unpacked arrays as plain C++ vectors: element type plus a
-// non-zero element count. The SV declared range (`[left:right]`, descending
-// or with a non-zero base) is resolved at the HIR-to-MIR boundary -- the
-// index translation lives inside ElementSelectExpr.index, not on the type.
+// One declared unpacked dimension, `[left:right]`. Element order runs
+// left-to-right (LRM 7.6), so the leftmost element (index `left`) is storage
+// ordinal 0. Distinct from `PackedRange`, whose ordinal counts from the right
+// (least-significant) end.
+struct UnpackedRange {
+  std::int64_t left;
+  std::int64_t right;
+
+  [[nodiscard]] auto ElementCount() const -> std::uint64_t {
+    // A declared range spans `|left - right| + 1` elements and is never empty.
+    // The synthetic zero-based empty list `[0:-1]` is the one exception -- it
+    // stands in for a zero-length compiler-internal array that a real SV range
+    // cannot express. No real declared range is `[0:-1]`.
+    if (left == 0 && right == -1) {
+      return 0;
+    }
+    return static_cast<std::uint64_t>(
+               left < right ? right - left : left - right) +
+           1U;
+  }
+  [[nodiscard]] auto IsAscending() const -> bool {
+    return left <= right;
+  }
+
+  // The declared range of a compiler-internal zero-based array of `count`
+  // elements, `[0 : count - 1]`. An empty list is `[0:-1]`.
+  [[nodiscard]] static auto ZeroBased(std::uint64_t count) -> UnpackedRange {
+    return UnpackedRange{
+        .left = 0, .right = static_cast<std::int64_t>(count) - 1};
+  }
+
+  auto operator==(const UnpackedRange&) const -> bool = default;
+};
+
+// An unpacked array is an element type plus its declared range. The range is
+// the array's coordinate system: element and range selection resolve a source
+// index against it. The range lives on the type, not the runtime value -- the
+// backend value is ordinal-only payload and selection passes the range as an
+// operand sourced from this type.
 struct UnpackedArrayType {
   TypeId element_type;
-  std::uint64_t size;
+  UnpackedRange dim;
+
+  [[nodiscard]] auto Size() const -> std::uint64_t {
+    return dim.ElementCount();
+  }
 
   auto operator==(const UnpackedArrayType&) const -> bool = default;
 };

--- a/include/lyra/value/array_manipulation.hpp
+++ b/include/lyra/value/array_manipulation.hpp
@@ -271,21 +271,23 @@ auto ArraySortByKey(Seq& data, F key, Compare cmp) -> void {
   }
 }
 
-// LRM 7.4.5 contiguous-range gather. The slice is `count` elements starting at
-// `offset`; an out-of-range position yields `canonical` and an x / z offset
-// (an invalid position) makes the whole result canonical. The flat vector is
-// wrapped by the caller as a fixed-size unpacked array.
+// LRM 7.4.5 contiguous-range gather. `base` is the already-resolved zero-based
+// storage ordinal of the low element; the caller rebases the source selector
+// against its coordinate system before calling. The slice is `count` elements
+// from `base`; an out-of-range position yields `canonical`, and a selector the
+// caller could not resolve (`!anchor_known`, an x / z selector) makes the whole
+// result canonical. The flat vector is wrapped by the caller as a fixed-size
+// unpacked array.
 template <typename T>
 [[nodiscard]] auto ArraySliceGather(
-    const std::vector<T>& data, const T& canonical, const PackedArray& offset,
-    std::uint32_t count) -> std::vector<T> {
+    const std::vector<T>& data, const T& canonical, std::int64_t base,
+    std::uint32_t count, bool anchor_known) -> std::vector<T> {
   std::vector<T> result;
-  if (offset.HasUnknown()) {
+  if (!anchor_known) {
     result.assign(count, canonical);
     return result;
   }
   result.reserve(count);
-  const auto base = offset.ToInt64();
   const auto size = static_cast<std::int64_t>(data.size());
   for (std::uint32_t i = 0; i < count; ++i) {
     const auto pos = base + static_cast<std::int64_t>(i);
@@ -296,17 +298,17 @@ template <typename T>
   return result;
 }
 
-// LRM 7.6 + 7.4.5 whole-slice scatter. Each of the `count` values lands at
-// `offset + i`; an out-of-range position is skipped and an x / z offset
-// performs no operation, matching the invalid-index write contract.
+// LRM 7.6 + 7.4.5 whole-slice scatter. Each of the `count` values lands at the
+// resolved ordinal `base + i`; an out-of-range position is skipped and an
+// unresolved selector (`!anchor_known`) performs no operation, matching the
+// invalid-index write contract.
 template <typename T>
 auto ArraySliceScatter(
-    std::vector<T>& data, const PackedArray& offset, std::uint32_t count,
-    const std::vector<T>& values) -> void {
-  if (offset.HasUnknown()) {
+    std::vector<T>& data, std::int64_t base, std::uint32_t count,
+    const std::vector<T>& values, bool anchor_known) -> void {
+  if (!anchor_known) {
     return;
   }
-  const auto base = offset.ToInt64();
   const auto size = static_cast<std::int64_t>(data.size());
   for (std::uint32_t i = 0; i < count; ++i) {
     const auto pos = base + static_cast<std::int64_t>(i);

--- a/include/lyra/value/concepts.hpp
+++ b/include/lyra/value/concepts.hpp
@@ -137,41 +137,69 @@ concept AssocIndexable = requires(T& t, const K& key) {
   { t.ElementRef(key) };
 };
 
-// Sliceable: extract a sub-window via two integer arguments. Conforming
-// containers: PackedArray, DynamicArray, UnpackedArray, Queue. The shape is
-// uniformly `Slice(PackedArray, PackedArray)`, but the two arguments mean
-// different things per container's LRM contract:
+// Sliceable: extract a fixed-width sub-window (LRM 7.4.5 / 11.5.2). Conforming
+// containers: PackedArray, DynamicArray, UnpackedArray. The shape is
+// `Slice(anchor, count, shift)`:
 //
-// - Queue (LRM 7.10.1): `(lo, hi)` inclusive bounds. The result size is
-//   `hi - lo + 1` clamped against the queue's runtime size; X/Z on either
-//   bound yields an empty queue.
-// - PackedArray / DynamicArray / UnpackedArray (LRM 7.4.5 / 11.5.2):
-//   `(offset, count)`. The result size is the type-fixed `count`; an X/Z
-//   offset canonical-fills the count-wide window. The width MUST flow as a
-//   separate argument because SV semantics canonical-fill at the
-//   type-determined width even when the offset carries X/Z, and that width
-//   is not derivable from `(lo, hi)` alone.
+// - `anchor` is the SV-declared endpoint the slice hangs from; the container
+//   rebases it against its own declared range.
+// - `count` is the type-fixed result width (LRM 7.4.5). It flows separately
+//   because SV canonical-fills at the type-determined width even when the
+//   anchor carries X/Z, and that width is not otherwise recoverable.
+// - `shift` is how far below the rebased anchor the low end sits: zero for a
+//   constant range or an indexed part-select growing toward the MSB, `count-1`
+//   for one growing toward the LSB (LRM 11.5.1).
 //
-// Bare `Slice` returns the value form (an owned snapshot, materialised via
-// gather); a separate `SliceableRef` concept covers the reference form.
-// String's LRM-named sibling is `Substr(i, j)` (LRM 6.16.8); it uses the
-// queue's `(lo, hi)` shape and does not claim Sliceable (the method name
-// differs per LRM 6.16.8).
+// An X/Z anchor canonical-fills the count-wide window. Bare `Slice` returns the
+// value form (an owned snapshot); `SliceableRef` covers the reference form.
+// A queue's slice is dynamic-width, derived from its bounds (LRM 7.10.1), and a
+// string slices by `Substr(i, j)` (LRM 6.16.8); neither is this fixed-width
+// contract, so neither claims Sliceable.
 template <typename T>
-concept Sliceable =
-    requires(const T& t, const PackedArray& p1, const PackedArray& p2) {
-      { t.Slice(p1, p2) };
-    };
+concept Sliceable = requires(
+    const T& t, const PackedArray& p1, const PackedArray& p2,
+    const PackedArray& p3) {
+  { t.Slice(p1, p2, p3) };
+};
 
 // SliceableRef: the reference-form counterpart of `Sliceable`. `SliceRef`
 // returns a write-through proxy that, on `operator=`, scatters the value
 // back into the receiver's storage. Queue does not satisfy this protocol
 // because LRM 7.10 does not define a write-side queue slice.
 template <typename T>
-concept SliceableRef =
-    requires(T& t, const PackedArray& p1, const PackedArray& p2) {
-      { t.SliceRef(p1, p2) };
-    };
+concept SliceableRef = requires(
+    T& t, const PackedArray& p1, const PackedArray& p2, const PackedArray& p3) {
+  { t.SliceRef(p1, p2, p3) };
+};
+
+// The unpacked family supplies its declared coordinate range at the select as a
+// `[left:right]` operand pair sourced from the receiver's static type, rather
+// than carrying it in the value. PackedArray self-describes (its dims are
+// storage representation) and a dynamic array is zero-based, so both stay on
+// `Indexable` / `Sliceable`; the
+// unpacked value pins the range-carrying shape instead.
+template <typename T>
+concept RangedIndexable = requires(
+    T& t, const PackedArray& pos, const PackedArray& left,
+    const PackedArray& right) {
+  { t.Element(pos, left, right) };
+  { t.ElementRef(pos, left, right) };
+};
+
+template <typename T>
+concept RangedSliceable = requires(
+    const T& t, const PackedArray& a, const PackedArray& b,
+    const PackedArray& form, const PackedArray& left,
+    const PackedArray& right) {
+  { t.Slice(a, b, form, left, right) };
+};
+
+template <typename T>
+concept RangedSliceableRef = requires(
+    T& t, const PackedArray& a, const PackedArray& b, const PackedArray& form,
+    const PackedArray& left, const PackedArray& right) {
+  { t.SliceRef(a, b, form, left, right) };
+};
 
 // Ownable: materialise a borrowed view into an owning value. Models Rust's
 // `ToOwned` trait -- the result is the owning sibling type (a ref view

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -17,6 +17,7 @@
 #include "lyra/value/oob_shield.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/queue.hpp"
+#include "lyra/value/slice_selector.hpp"
 #include "lyra/value/unpacked_array.hpp"
 
 namespace lyra::value {
@@ -127,24 +128,27 @@ class DynamicArray {
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
-  // LRM 7.4.5 / 7.4.6 contiguous-range selector. A dynamic array slices the
-  // same way an unpacked array does. Partial-OOB positions and an x / z
-  // offset yield the canonical default at the type-fixed count's width;
-  // see `concepts.hpp` for the `Sliceable` protocol shape.
+  // LRM 7.4.5 / 7.4.6 contiguous-range selector. A dynamic array is zero-based,
+  // so the source index is the storage ordinal (identity rebase); the slice
+  // result is a fixed-size unpacked array over `[base : base + count - 1]`.
+  // Partial-OOB positions and an x / z selector yield the canonical default at
+  // the type-fixed count's width; see `concepts.hpp` for the `Sliceable` shape.
   [[nodiscard]] auto Slice(
-      const PackedArray& offset, const PackedArray& count_pa) const
+      const PackedArray& a, const PackedArray& b, const PackedArray& form) const
       -> UnpackedArray<T> {
-    const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
+    const SliceWindow win = ResolveSliceWindow(a, b, form);
     return UnpackedArray<T>(
         shield_.Default(),
-        detail::ArraySliceGather(data_, shield_.Default(), offset, count));
+        detail::ArraySliceGather(
+            data_, shield_.Default(), win.base, win.count, win.base_known));
   }
 
   [[nodiscard]] auto SliceRef(
-      const PackedArray& offset, const PackedArray& count_pa)
+      const PackedArray& a, const PackedArray& b, const PackedArray& form)
       -> ArraySliceRef<T> {
-    const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
-    return ArraySliceRef<T>{data_, shield_.Default(), offset, count};
+    const SliceWindow win = ResolveSliceWindow(a, b, form);
+    return ArraySliceRef<T>{
+        data_, shield_.Default(), win.base, win.count, win.base_known};
   }
 
   // LRM 11.2.2 + 11.4.5 aggregate equality. Runtime size mismatch yields
@@ -342,8 +346,8 @@ class DynamicArray {
   }
 
  private:
-  // The LRM 7.12 entry stream (decision: array-manipulation-entry-stream): a
-  // lazy view pairing each element with its ordinal index, in storage order.
+  // The LRM 7.12 entry stream: a lazy view pairing each element with its
+  // ordinal index, in storage order.
   [[nodiscard]] auto Entries() const {
     return std::views::enumerate(data_) |
            std::views::transform([](auto&& pair) {
@@ -358,6 +362,42 @@ class DynamicArray {
     const auto v = idx.ToInt64();
     return v < 0 || static_cast<std::uint64_t>(v) >=
                         static_cast<std::uint64_t>(data_.size());
+  }
+
+  // The zero-based declared range of a `count`-element slice at ordinal `base`.
+  struct SliceWindow {
+    std::int64_t base;
+    std::uint32_t count;
+    bool base_known;
+  };
+
+  // A dynamic array is zero-based, so a source coordinate is its own ordinal.
+  // Resolve the raw range selector `(a, b, form)` to the ordinal window: a
+  // constant range passes its two endpoints, an indexed part-select its base
+  // and (constant) width with the direction in `form`.
+  [[nodiscard]] auto ResolveSliceWindow(
+      const PackedArray& a, const PackedArray& b, const PackedArray& form) const
+      -> SliceWindow {
+    const std::int64_t base_coord = a.ToInt64();
+    const std::int64_t extent = b.ToInt64();
+    std::int64_t other = extent;
+    switch (static_cast<SliceForm>(form.ToInt64())) {
+      case SliceForm::kIndexedUp:
+        other = base_coord + extent - 1;
+        break;
+      case SliceForm::kIndexedDown:
+        other = base_coord - extent + 1;
+        break;
+      case SliceForm::kConstant:
+        break;
+    }
+    const std::int64_t lo = base_coord < other ? base_coord : other;
+    const std::int64_t span =
+        base_coord < other ? other - base_coord : base_coord - other;
+    return SliceWindow{
+        .base = lo,
+        .count = static_cast<std::uint32_t>(span + 1),
+        .base_known = !a.HasUnknown()};
   }
 
   detail::OobShield<T> shield_;

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -415,11 +415,11 @@ class PackedArray {
   [[nodiscard]] auto ElementRef(const PackedArray& idx) -> PackedArrayRef;
   [[nodiscard]] auto Element(const PackedArray& idx) const -> PackedArray;
   [[nodiscard]] auto SliceRef(
-      const PackedArray& offset_in_outer_elements,
-      const PackedArray& count_in_outer_elements) -> PackedArrayRef;
+      const PackedArray& a, const PackedArray& b, const PackedArray& form)
+      -> PackedArrayRef;
   [[nodiscard]] auto Slice(
-      const PackedArray& offset_in_outer_elements,
-      const PackedArray& count_in_outer_elements) const -> PackedArray;
+      const PackedArray& a, const PackedArray& b, const PackedArray& form) const
+      -> PackedArray;
   [[nodiscard]] auto operator<(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator<=(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator>(const PackedArray& other) const -> PackedArray;
@@ -620,8 +620,8 @@ class PackedArrayRef {
   // units; the proxy scales internally based on `dims_`.
   [[nodiscard]] auto ElementRef(const PackedArray& idx) const -> PackedArrayRef;
   [[nodiscard]] auto SliceRef(
-      const PackedArray& offset_in_outer_elements,
-      const PackedArray& count_in_outer_elements) const -> PackedArrayRef;
+      const PackedArray& a, const PackedArray& b, const PackedArray& form) const
+      -> PackedArrayRef;
 
  private:
   PackedArray* root_;

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -18,6 +18,7 @@
 #include "lyra/value/format.hpp"
 #include "lyra/value/oob_shield.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/slice_selector.hpp"
 
 namespace lyra::value {
 
@@ -220,20 +221,39 @@ class Queue {
     return shield_.DiscardTarget();
   }
 
-  // LRM 7.10.1 queue slice `q[lo:hi]`. An x/z bound, or `lo > hi` after
-  // clamping, yields the empty queue. `lo` clamps up to 0 and `hi` clamps down
-  // to the last index (`q[a:b]` with `a < 0` is `q[0:b]`, with `b > $` is
-  // `q[a:$]`). The result carries this queue's element shape, seeded from the
-  // shield's default.
-  [[nodiscard]] auto Slice(const PackedArray& lo, const PackedArray& hi) const
-      -> Queue {
+  // LRM 7.10.1 queue slice. `form` selects the source shape from `(anchor,
+  // extent)`: a constant `q[a:b]` is `anchor = a`, `extent = b`; an indexed
+  // `q[base+:w]` is `anchor = base`, `extent = w`, growing upward; `q[base-:w]`
+  // grows downward. The `base +/- (w - 1)` bound is computed here in the wide
+  // int64 domain, never synthesized at lowering. An x/z bound, or `lo > hi`
+  // after clamping, yields the empty queue; `lo` clamps up to 0 and `hi` down
+  // to the last index. The result carries this queue's element shape. `form` is
+  // the shared `value::SliceForm` (`slice_selector.hpp`).
+  [[nodiscard]] auto Slice(
+      const PackedArray& anchor, const PackedArray& extent,
+      const PackedArray& form) const -> Queue {
     Queue out(shield_.Default());
-    if (lo.HasUnknown() || hi.HasUnknown() || data_.empty()) {
+    if (anchor.HasUnknown() || extent.HasUnknown() || data_.empty()) {
       return out;
     }
-    const std::int64_t a = std::max<std::int64_t>(lo.ToInt64(), 0);
+    const std::int64_t an = anchor.ToInt64();
+    const std::int64_t ex = extent.ToInt64();
+    std::int64_t lo = an;
+    std::int64_t hi = ex;
+    switch (static_cast<SliceForm>(form.ToInt64())) {
+      case SliceForm::kIndexedUp:
+        hi = an + ex - 1;
+        break;
+      case SliceForm::kIndexedDown:
+        lo = an - ex + 1;
+        hi = an;
+        break;
+      case SliceForm::kConstant:
+        break;
+    }
+    const std::int64_t a = std::max<std::int64_t>(lo, 0);
     const auto last = static_cast<std::int64_t>(data_.size()) - 1;
-    const std::int64_t b = std::min<std::int64_t>(hi.ToInt64(), last);
+    const std::int64_t b = std::min<std::int64_t>(hi, last);
     for (std::int64_t i = a; i <= b; ++i) {
       out.data_.push_back(data_[static_cast<std::size_t>(i)]);
     }
@@ -529,7 +549,10 @@ struct Formatter<Queue<T>> {
 static_assert(LyraValue<Queue<PackedArray>>);
 static_assert(Sized<Queue<PackedArray>>);
 static_assert(Indexable<Queue<PackedArray>>);
-static_assert(Sliceable<Queue<PackedArray>>);
+// A queue's `Slice(anchor, extent, form)` is dynamic-width -- the runtime
+// derives the element count from the bounds (LRM 7.10.1) -- not the fixed-width
+// `(anchor, count, shift)` contract `Sliceable` names, so despite the matching
+// arity it carries its own `Slice` rather than claiming that concept.
 static_assert(Ownable<Queue<PackedArray>>);
 static_assert(Defaultable<Queue<PackedArray>>);
 static_assert(Sortable<Queue<PackedArray>>);

--- a/include/lyra/value/slice_selector.hpp
+++ b/include/lyra/value/slice_selector.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::value {
+
+// The source-level shape of a range selector, carried raw from lowering to the
+// selected value. The value resolves the coordinate window from this plus the
+// two raw operands and its own declared range: a constant range `[l:r]` passes
+// `(l, r)`; an indexed part-select `[base +: w]` / `[base -: w]` passes
+// `(base, w)` with the direction here. No count, offset, or ordinal is computed
+// at lowering.
+enum class SliceForm : std::int64_t {
+  kConstant = 0,
+  kIndexedUp = 1,
+  kIndexedDown = 2,
+};
+
+}  // namespace lyra::value

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <ranges>
 #include <span>
 #include <string>
@@ -16,6 +17,7 @@
 #include "lyra/value/oob_shield.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/queue.hpp"
+#include "lyra/value/slice_selector.hpp"
 
 namespace lyra::value {
 
@@ -24,17 +26,40 @@ class UnpackedArray;
 template <typename T>
 class ArraySliceRef;
 
+// The declared range of one unpacked dimension, the array's coordinate system.
+// Element order runs left-to-right (LRM 7.6), so the leftmost element (index
+// `left`) is storage ordinal 0. `ToOrdinal` maps a source-declared index onto
+// the storage ordinal; `FromOrdinal` is its inverse. Unlike a packed bit range,
+// the ordinal counts from the left, not the least-significant end.
+struct UnpackedRange {
+  std::int64_t left;
+  std::int64_t right;
+
+  [[nodiscard]] auto IsAscending() const -> bool {
+    return left <= right;
+  }
+  [[nodiscard]] auto ToOrdinal(std::int64_t sv) const -> std::int64_t {
+    return IsAscending() ? sv - left : left - sv;
+  }
+  [[nodiscard]] auto FromOrdinal(std::int64_t ordinal) const -> std::int64_t {
+    return IsAscending() ? ordinal + left : left - ordinal;
+  }
+};
+
 // SystemVerilog fixed-size unpacked array (LRM 7.4.2). One C++ container layer
 // per declared unpacked dimension; multi-dim composes as
 // `UnpackedArray<UnpackedArray<...>>`. Mirrors `PackedArray`'s surface for
-// every op that crosses the SV / C++ boundary: `Element(const PackedArray&)`
-// for indexed access (no `operator[]`), `Slice(offset, count)` for the LRM
-// 7.4.5 contiguous-range selector, and `operator==` / `CaseEqual` returning a
-// 1-bit `PackedArray` so equality on aggregates propagates through the same
+// every op that crosses the SV / C++ boundary: `Element` / `Slice` for indexed
+// and range access (no `operator[]`), and `operator==` / `CaseEqual` returning
+// a 1-bit `PackedArray` so equality on aggregates propagates through the same
 // value-type the integral surface uses.
 //
-// The element default and the invalid-index discard target are carried by an
-// `OobShield`.
+// The payload is ordinal-only: it does not carry a declared range. The declared
+// coordinate range is a fact of the receiver's static type, passed to element
+// and slice access as a `[left:right]` operand pair against which the source
+// index resolves to a storage ordinal. Whole-array movement is ordinal-wise and
+// range-agnostic. The element default and the invalid-index discard target are
+// carried by an `OobShield`.
 template <typename T>
 class UnpackedArray {
  public:
@@ -46,18 +71,19 @@ class UnpackedArray {
   // variable initialization).
   UnpackedArray() = default;
 
-  // Empty container with the shield seeded. Internal use only -- SV fixed-size
-  // arrays are always non-empty; this form serves `Slice` and similar paths
-  // that build a fresh `UnpackedArray` element-by-element.
+  // Empty container with the shield seeded. Internal use only -- a fresh
+  // `UnpackedArray` that a `Slice` fills element-by-element. The payload is
+  // ordinal-only; a declared range is a fact of the receiver's static type, not
+  // of the value.
   explicit UnpackedArray(T element_default)
       : shield_(std::move(element_default)) {
   }
 
-  // Element-list construction: shield seeded, plus the explicit initial
-  // elements (LRM 10.9 assignment pattern lowering). The element list is taken
-  // as a span so the emit side can hand in a `std::array<T, N>{...}` literal
-  // whose self-determined type is unambiguous, rather than relying on
-  // context-dependent braced-init binding.
+  // Shield + element-list construction: the seeded shield and the explicit
+  // initial elements (LRM 10.9 assignment pattern lowering). The element list
+  // is taken as a span so the emit side can hand in a `std::array<T, N>{...}`
+  // literal whose self-determined type is unambiguous; the element count sizes
+  // the payload.
   UnpackedArray(T element_default, std::span<const T> init)
       : shield_(std::move(element_default)), data_(init.begin(), init.end()) {
   }
@@ -103,41 +129,53 @@ class UnpackedArray {
     }
   }
 
-  // LRM 7.4.5: an invalid-index write lands on the shield's discard target.
-  [[nodiscard]] auto ElementRef(const PackedArray& idx) -> T& {
-    if (IsInvalidIndex(idx)) {
+  // LRM 7.4.5: an invalid-index write lands on the shield's discard target. The
+  // declared range `[left:right]` comes from the receiver's static type as a
+  // select operand.
+  [[nodiscard]] auto ElementRef(
+      const PackedArray& sv_index, const PackedArray& left,
+      const PackedArray& right) -> T& {
+    const auto ordinal = ResolveOrdinal(sv_index, left, right);
+    if (!ordinal) {
       return shield_.DiscardTarget();
     }
-    return data_[static_cast<std::size_t>(idx.ToInt64())];
+    return data_[*ordinal];
   }
 
   // LRM 7.4.5: an invalid-index read returns the element default (LRM Table
   // 7-1).
-  [[nodiscard]] auto Element(const PackedArray& idx) const -> const T& {
-    if (IsInvalidIndex(idx)) {
+  [[nodiscard]] auto Element(
+      const PackedArray& sv_index, const PackedArray& left,
+      const PackedArray& right) const -> const T& {
+    const auto ordinal = ResolveOrdinal(sv_index, left, right);
+    if (!ordinal) {
       return shield_.Default();
     }
-    return data_[static_cast<std::size_t>(idx.ToInt64())];
+    return data_[*ordinal];
   }
 
-  // LRM 7.4.5 contiguous-range selector. Partial-OOB positions yield the
-  // canonical default; X / Z offset yields a wholly-default sub-array at
-  // the type-fixed count's width. See `concepts.hpp` for the `Sliceable`
-  // protocol shape.
+  // LRM 7.4.5 contiguous-range selector. The raw selector `(a, b, form)` is
+  // resolved to the storage-ordinal window against the receiver's declared
+  // `[left:right]` range; a partial-OOB position yields the canonical default
+  // and an X/Z base yields a wholly-default sub-array. The result is
+  // ordinal-only payload.
   [[nodiscard]] auto Slice(
-      const PackedArray& offset, const PackedArray& count_pa) const
+      const PackedArray& a, const PackedArray& b, const PackedArray& form,
+      const PackedArray& left, const PackedArray& right) const
       -> UnpackedArray {
-    const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
+    const SliceWindow win = ResolveSliceWindow(a, b, form, left, right);
     return UnpackedArray(
         shield_.Default(),
-        detail::ArraySliceGather(data_, shield_.Default(), offset, count));
+        detail::ArraySliceGather(
+            data_, shield_.Default(), win.base, win.count, win.base_known));
   }
 
   [[nodiscard]] auto SliceRef(
-      const PackedArray& offset, const PackedArray& count_pa)
-      -> ArraySliceRef<T> {
-    const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
-    return ArraySliceRef<T>{data_, shield_.Default(), offset, count};
+      const PackedArray& a, const PackedArray& b, const PackedArray& form,
+      const PackedArray& left, const PackedArray& right) -> ArraySliceRef<T> {
+    const SliceWindow win = ResolveSliceWindow(a, b, form, left, right);
+    return ArraySliceRef<T>{
+        data_, shield_.Default(), win.base, win.count, win.base_known};
   }
 
   // LRM 11.2.2 + 11.4.5 aggregate equality / case-equality. Slang's binding
@@ -302,7 +340,7 @@ class UnpackedArray {
         std::move(proto), detail::ArrayUniqueIndex(Entries(), std::move(key)));
   }
 
-  // LRM 7.12.5 projection into a same-range fixed unpacked array; `proto` seeds
+  // LRM 7.12.5 projection into a same-size fixed unpacked array; `proto` seeds
   // the result element type's canonical default (producer-supplied, since the
   // result element type may differ from this array's).
   template <typename F, typename U>
@@ -312,8 +350,8 @@ class UnpackedArray {
   }
 
  private:
-  // The LRM 7.12 entry stream (decision: array-manipulation-entry-stream): a
-  // lazy view pairing each element with its ordinal index, in declared order.
+  // The LRM 7.12 entry stream: a lazy view pairing each element with its
+  // ordinal index, in declared order.
   [[nodiscard]] auto Entries() const {
     return std::views::enumerate(data_) |
            std::views::transform([](auto&& pair) {
@@ -323,11 +361,61 @@ class UnpackedArray {
            });
   }
 
-  [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
-    if (idx.HasUnknown()) return true;
-    const auto v = idx.ToInt64();
-    return v < 0 || static_cast<std::uint64_t>(v) >=
-                        static_cast<std::uint64_t>(data_.size());
+  // LRM 7.4.5: resolve a source-declared index to a storage ordinal against the
+  // declared range. An X / Z index, or one outside the range, is an invalid
+  // access -- `nullopt`, the read-default / write-discard path.
+  [[nodiscard]] auto ResolveOrdinal(
+      const PackedArray& sv_index, const PackedArray& left,
+      const PackedArray& right) const -> std::optional<std::size_t> {
+    if (sv_index.HasUnknown()) {
+      return std::nullopt;
+    }
+    const UnpackedRange range{.left = left.ToInt64(), .right = right.ToInt64()};
+    const std::int64_t ordinal = range.ToOrdinal(sv_index.ToInt64());
+    if (ordinal < 0 || static_cast<std::uint64_t>(ordinal) >= data_.size()) {
+      return std::nullopt;
+    }
+    return static_cast<std::size_t>(ordinal);
+  }
+
+  struct SliceWindow {
+    std::int64_t base;
+    std::uint32_t count;
+    bool base_known;
+  };
+
+  // Resolve a raw range selector to the storage-ordinal window. `(a, b)` are
+  // source coordinates -- a constant range's two declared endpoints, or an
+  // indexed part-select's base and (constant) width -- and `form` says which.
+  // The receiver's declared range `[left:right]` comes from its static type as
+  // a select operand. The low ordinal and the count fall out of the two source
+  // endpoints rebased against that range; only the base coordinate `a` can
+  // carry a runtime X / Z.
+  [[nodiscard]] auto ResolveSliceWindow(
+      const PackedArray& a, const PackedArray& b, const PackedArray& form,
+      const PackedArray& left, const PackedArray& right) const -> SliceWindow {
+    const std::int64_t base_coord = a.ToInt64();
+    const std::int64_t extent = b.ToInt64();
+    std::int64_t other = extent;
+    switch (static_cast<SliceForm>(form.ToInt64())) {
+      case SliceForm::kIndexedUp:
+        other = base_coord + extent - 1;
+        break;
+      case SliceForm::kIndexedDown:
+        other = base_coord - extent + 1;
+        break;
+      case SliceForm::kConstant:
+        break;
+    }
+    const UnpackedRange range{.left = left.ToInt64(), .right = right.ToInt64()};
+    const std::int64_t o1 = range.ToOrdinal(base_coord);
+    const std::int64_t o2 = range.ToOrdinal(other);
+    const std::int64_t lo = o1 < o2 ? o1 : o2;
+    const std::int64_t span = o1 < o2 ? o2 - o1 : o1 - o2;
+    return SliceWindow{
+        .base = lo,
+        .count = static_cast<std::uint32_t>(span + 1),
+        .base_known = !a.HasUnknown()};
   }
 
   detail::OobShield<T> shield_;
@@ -338,20 +426,23 @@ class UnpackedArray {
 
 // LRM 7.6: an assignment to an unpacked slice is a single assignment to the
 // entire slice. The proxy aliases the source storage (a non-owning pointer to
-// its element vector) plus the (offset, count) window, so a fixed-size unpacked
-// array and a dynamic array share one slice-write surface. X / Z offset makes
-// `ToOwned()` a wholly-default sub-array and `operator=` a no-op; partial-OOB
-// behaves per-element. Move-only so the proxy cannot outlive what it aliases.
+// its element vector) plus the resolved (base ordinal, count) window, so a
+// fixed-size unpacked array and a dynamic array share one slice-write surface.
+// An unresolved selector makes `ToOwned()` a wholly-default sub-array and
+// `operator=` a no-op; partial-OOB behaves per-element. The materialized owned
+// value is ordinal-only payload (no range). Move-only so the proxy cannot
+// outlive what it aliases.
 template <typename T>
 class ArraySliceRef {
  public:
   ArraySliceRef(
-      std::vector<T>& data, T canonical, PackedArray offset,
-      std::uint32_t count)
+      std::vector<T>& data, T canonical, std::int64_t base, std::uint32_t count,
+      bool anchor_known)
       : data_(&data),
         canonical_(std::move(canonical)),
-        offset_(std::move(offset)),
-        count_(count) {
+        base_(base),
+        count_(count),
+        anchor_known_(anchor_known) {
   }
   ArraySliceRef(const ArraySliceRef&) = delete;
   auto operator=(const ArraySliceRef&) -> ArraySliceRef& = delete;
@@ -361,20 +452,22 @@ class ArraySliceRef {
 
   [[nodiscard]] auto ToOwned() const -> UnpackedArray<T> {
     return UnpackedArray<T>(
-        canonical_,
-        detail::ArraySliceGather(*data_, canonical_, offset_, count_));
+        canonical_, detail::ArraySliceGather(
+                        *data_, canonical_, base_, count_, anchor_known_));
   }
 
   auto operator=(const UnpackedArray<T>& value) -> ArraySliceRef& {
-    detail::ArraySliceScatter(*data_, offset_, count_, value.data_);
+    detail::ArraySliceScatter(
+        *data_, base_, count_, value.data_, anchor_known_);
     return *this;
   }
 
  private:
   std::vector<T>* data_;
   T canonical_;
-  PackedArray offset_;
+  std::int64_t base_;
   std::uint32_t count_;
+  bool anchor_known_;
 };
 
 // LRM 21.2.1.6 aggregate format. Per the per-type Formatter trait the
@@ -403,9 +496,9 @@ struct Formatter<UnpackedArray<T>> {
 
 static_assert(LyraValue<UnpackedArray<PackedArray>>);
 static_assert(Sized<UnpackedArray<PackedArray>>);
-static_assert(Indexable<UnpackedArray<PackedArray>>);
-static_assert(Sliceable<UnpackedArray<PackedArray>>);
-static_assert(SliceableRef<UnpackedArray<PackedArray>>);
+static_assert(RangedIndexable<UnpackedArray<PackedArray>>);
+static_assert(RangedSliceable<UnpackedArray<PackedArray>>);
+static_assert(RangedSliceableRef<UnpackedArray<PackedArray>>);
 static_assert(Ownable<UnpackedArray<PackedArray>>);
 static_assert(Defaultable<UnpackedArray<PackedArray>>);
 static_assert(Sortable<UnpackedArray<PackedArray>>);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -676,9 +676,9 @@ class HirDumper {
                       [&](const RangeConstantBounds& b) -> std::string {
                         return std::format(
                             "RangeSelectExpr base=Expr[{}] kind=Constant "
-                            "msb=Expr[{}] lsb=Expr[{}]",
-                            sel.base_value.value, b.msb_expr.value,
-                            b.lsb_expr.value);
+                            "left=Expr[{}] right=Expr[{}]",
+                            sel.base_value.value, b.left_bound.value,
+                            b.right_bound.value);
                       },
                       [&](const RangeIndexedUpBounds& b) -> std::string {
                         return std::format(

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -19,11 +19,13 @@
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
+#include <slang/numeric/SVInt.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
@@ -74,6 +76,32 @@ auto ClassMethodIndex(const slang::ast::SubroutineSymbol& method)
   throw InternalError("ClassMethodIndex: method not found in its class");
 }
 
+// `$bits` of a fixed-size operand is the bit count of its type (LRM 20.6.2),
+// folded to an integer constant here; the operand is never evaluated. A
+// dynamically sized value operand is a runtime query of the current bit count
+// and is not yet supported (a dynamically sized type operand is rejected
+// earlier by the frontend).
+auto LowerBitsQuery(
+    ModuleLowerer& module, WalkFrame frame,
+    const slang::ast::CallExpression& call, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  const slang::ast::Type& operand_type = *call.arguments()[0]->type;
+  if (!operand_type.isFixedSize()) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "$bits of a dynamically sized value is not yet supported");
+  }
+  auto type_id = module.InternType(*call.type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  // slang types `$bits` as `integer` (4-state); coerce the bit count to that
+  // type so the folded constant's state domain matches its declared type rather
+  // than the 2-state value it is built from.
+  const slang::ConstantValue width = call.type->coerceValue(
+      slang::ConstantValue{
+          slang::SVInt(32, operand_type.getBitstreamWidth(), true)});
+  return MakeConstantValueExpr(module.Unit(), frame, width, *type_id, span);
+}
+
 }  // namespace
 
 template <ExprLowerer Lowerer>
@@ -81,6 +109,19 @@ auto LowerCallExpr(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto& module = lowerer.Module();
+
+  // A query whose operand may be a type is resolved before the argument loop: a
+  // `DataType` operand has no value form and cannot be lowered as one. `$bits`
+  // is the first such function (LRM 20.6.2).
+  if (call.isSystemCall()) {
+    const auto& info =
+        std::get<slang::ast::CallExpression::SystemCallInfo>(call.subroutine);
+    if (info.subroutine != nullptr &&
+        info.subroutine->knownNameId == slang::parsing::KnownSystemName::Bits) {
+      return LowerBitsQuery(module, frame, call, span);
+    }
+  }
+
   std::vector<std::optional<hir::ExprId>> arg_ids;
   arg_ids.reserve(call.arguments().size());
   std::optional<hir::TypeId> receiver_type;

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -138,7 +138,7 @@ auto LowerRangeSelectExpr(
     switch (sel.getSelectionKind()) {
       case slang::ast::RangeSelectionKind::Simple:
         return hir::RangeConstantBounds{
-            .msb_expr = left_id, .lsb_expr = right_id};
+            .left_bound = left_id, .right_bound = right_id};
       case slang::ast::RangeSelectionKind::IndexedUp:
         return hir::RangeIndexedUpBounds{
             .base_index = left_id, .width = right_id};

--- a/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
+++ b/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
@@ -206,6 +206,13 @@ auto BuildValueConversion(
         unit, operand_id, support::BuiltinFn::kFromPackedArray);
   }
 
+  // Unpacked -> unpacked: assignment requires equivalent element types and the
+  // same element count (LRM 7.6), so the element representation already matches
+  // and a whole-array store is a plain ordinal-payload copy. The declared range
+  // is a fact of the destination's static type consulted only at selection, not
+  // payload that a store must conform -- so this falls through to the identity
+  // path, no conversion node.
+
   // Queue -> queue: assignment requires equivalent element types (LRM 7.10), so
   // the element representation already matches and only the LRM 7.10.5 bound
   // can differ. Conform the source's contents to the destination's bound, which

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -190,8 +190,8 @@ auto BuildDefaultValueExpr(
           },
           [&](const mir::UnpackedArrayType& ua) -> mir::Expr {
             std::vector<mir::ExprId> elements;
-            elements.reserve(ua.size);
-            for (std::uint64_t i = 0; i < ua.size; ++i) {
+            elements.reserve(ua.Size());
+            for (std::uint64_t i = 0; i < ua.Size(); ++i) {
               elements.push_back(block.exprs.Add(
                   BuildDefaultValueExpr(module, frame, ua.element_type)));
             }
@@ -437,7 +437,7 @@ auto BuildAssociativeConstructionCall(
   const mir::TypeId entries_type = module.Unit().types.Intern(
       mir::UnpackedArrayType{
           .element_type = tuple_type,
-          .size = static_cast<std::uint64_t>(tuple_ids.size())});
+          .dim = mir::UnpackedRange::ZeroBased(tuple_ids.size())});
   const mir::ExprId entries_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(tuple_ids)},

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -94,33 +94,44 @@ auto CloneLhsSelectorChainOntoRef(
                   "CloneLhsSelectorChainOntoRef: CallExpr above the NBA target "
                   "root is not a container access");
             }
+            // Copy the callee, argument ids, and result type up front: the
+            // recursion and `SnapshotIntoClosure` below append to
+            // `outer_block`, which can reallocate its expression storage and
+            // dangle the `outer_expr` reference `c` is bound to.
+            const auto callee = c.callee;
+            const mir::TypeId call_type = outer_expr.type;
+            const std::vector<mir::ExprId> src_args(
+                c.arguments.begin(), c.arguments.end());
             std::vector<mir::ExprId> body_args;
-            body_args.reserve(c.arguments.size());
+            body_args.reserve(src_args.size());
             body_args.push_back(CloneLhsSelectorChainOntoRef(
-                module, outer_frame, closure, c.arguments.front(), root_id,
+                module, outer_frame, closure, src_args.front(), root_id,
                 captured_root));
-            for (std::size_t i = 1; i < c.arguments.size(); ++i) {
+            for (std::size_t i = 1; i < src_args.size(); ++i) {
               body_args.push_back(SnapshotIntoClosure(
-                  module, outer_frame, closure, c.arguments[i],
-                  "_lyra_nba_arg"));
+                  module, outer_frame, closure, src_args[i], "_lyra_nba_arg"));
             }
             return body.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::CallExpr{
-                            .callee = c.callee,
+                            .callee = callee,
                             .arguments = std::move(body_args)},
-                    .type = outer_expr.type});
+                    .type = call_type});
           },
           [&](const mir::TupleGetExpr& g) -> mir::ExprId {
+            const auto index = g.index;
+            const mir::TypeId type = outer_expr.type;
             const mir::ExprId base = CloneLhsSelectorChainOntoRef(
                 module, outer_frame, closure, g.tuple, root_id, captured_root);
             return body.exprs.Add(
                 mir::Expr{
-                    .data = mir::TupleGetExpr{.tuple = base, .index = g.index},
-                    .type = outer_expr.type});
+                    .data = mir::TupleGetExpr{.tuple = base, .index = index},
+                    .type = type});
           },
           [&](const mir::UnionGetRefExpr& g) -> mir::ExprId {
+            const auto index = g.index;
+            const mir::TypeId type = outer_expr.type;
             const mir::ExprId base = CloneLhsSelectorChainOntoRef(
                 module, outer_frame, closure, g.union_value, root_id,
                 captured_root);
@@ -128,8 +139,8 @@ auto CloneLhsSelectorChainOntoRef(
                 mir::Expr{
                     .data =
                         mir::UnionGetRefExpr{
-                            .union_value = base, .index = g.index},
-                    .type = outer_expr.type});
+                            .union_value = base, .index = index},
+                    .type = type});
           },
           [&](const auto&) -> mir::ExprId {
             throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 
+#include <algorithm>
 #include <expected>
 #include <utility>
 #include <variant>
@@ -316,7 +317,7 @@ auto BuildMirUnaryExpr(
 }
 
 auto BuildMirBinaryExpr(
-    const mir::CompilationUnit& unit, mir::Block& block, mir::BinaryOp op,
+    mir::CompilationUnit& unit, mir::Block& block, mir::BinaryOp op,
     mir::ExprId lhs_id, mir::ExprId rhs_id, mir::TypeId result_type)
     -> mir::Expr {
   const auto& lhs_ty = unit.types.Get(block.exprs.Get(lhs_id).type);

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -15,10 +15,8 @@
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
-#include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
-#include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/type.hpp"
 
 // HIR-to-MIR lowering for the three select families (`a[i]`, `a[hi:lo]`,
@@ -120,494 +118,108 @@ auto WrapSliceToDeclaredType(
   return BuildValueConversion(unit, block, owned_id, final_type);
 }
 
-struct RangeLoHi {
-  mir::ExprId lo;
-  mir::ExprId hi;
-};
-
-enum class RangeContainer : std::uint8_t { kPacked, kQueue, kUnpacked };
-
-// Container-specific projection inputs for `UnfoldRangeBoundsToLoHi`. The
-// three container kinds project SV-source `[a:b]` / `[base+:w]` / `[base-:w]`
-// differently; this struct carries the per-container facts needed.
-struct RangeStrategy {
-  RangeContainer container = RangeContainer::kPacked;
-  // Only meaningful for `kUnpacked`. The declared SV range determines whether
-  // the slice's leftmost-in-memory position is the syntactic base or the
-  // upper end derived from it, and supplies the SV-to-vector index
-  // projection. `count` is the result type's element count (LRM 7.4.5 fixed
-  // width).
-  const hir::UnpackedRange* unpacked_declared = nullptr;
-  std::uint32_t unpacked_count = 0;
-  // Only meaningful for `kPacked`. The declared SV range maps each part-select
-  // endpoint to its LSB-relative offset (LRM 11.5.2); a descending zero-based
-  // range is the identity.
-  const hir::PackedRange* packed_declared = nullptr;
-};
-
-auto MirIntegralConstantToInt64(const mir::IntegralConstant& c)
-    -> std::int64_t {
-  if (c.value_words.empty()) {
-    throw InternalError("MirIntegralConstantToInt64: zero width");
+// Append the receiver's declared range `[left:right]` as trailing select
+// operands when the receiver is an unpacked array: the range is a fact of the
+// receiver's static type, materialized here as a MIR operand rather than
+// carried in the value. A packed receiver self-describes (its dims are storage
+// representation) and a dynamic array is zero-based, so neither contributes an
+// operand.
+auto AppendReceiverRange(
+    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
+    std::vector<mir::ExprId>& args) -> void {
+  // The declared range is a fact of the receiver's value type. On the write
+  // path the base is a place -- an observable cell or a reference -- so unwrap
+  // those single-level indirections to reach the underlying value type.
+  mir::TypeId base_type = block.exprs.Get(base_id).type;
+  for (;;) {
+    const auto& ty = module.Unit().types.Get(base_type);
+    if (const auto* obs = std::get_if<mir::ObservableType>(&ty.data)) {
+      base_type = obs->value;
+    } else if (const auto* ref = std::get_if<mir::RefType>(&ty.data)) {
+      base_type = ref->pointee;
+    } else if (const auto* ptr = std::get_if<mir::PointerType>(&ty.data)) {
+      base_type = ptr->pointee;
+    } else {
+      break;
+    }
   }
-  return static_cast<std::int64_t>(c.value_words.front());
-}
-
-auto IntConstFromMirExpr(const mir::Expr& expr) -> std::int64_t {
-  if (const auto* lit = std::get_if<mir::IntegerLiteral>(&expr.data)) {
-    return MirIntegralConstantToInt64(lit->value);
-  }
-  throw InternalError(
-      "IntConstFromMirExpr: expression is not an IntegerLiteral");
-}
-
-// Builds the `base <op> value` expression for a slice-bound offset. The delta
-// literal matches `base`'s state-kind so the runtime arithmetic never mixes a
-// 2-state literal with a 4-state index; an x / z index then propagates into
-// the offset and invalidates the whole slice (LRM 7.4.5). The caller commits
-// the returned expression.
-auto BuildOffsetDeltaExpr(
-    const ModuleLowerer& module, mir::Block& block, mir::ExprId base,
-    std::int64_t value, mir::BinaryOp op) -> mir::Expr {
-  const auto base_type = block.exprs.Get(base).type;
   const auto& base_ty = module.Unit().types.Get(base_type);
-  const bool four_state =
-      base_ty.IsIntegralPacked() && base_ty.AsIntegralPacked().IsFourState();
-  const auto delta_lit = block.exprs.Add(
-      four_state
-          ? mir::MakeIntegerLiteral(module.Unit().builtins.integer, value)
-          : mir::MakeInt32Literal(module.Unit().builtins.int32, value));
-  return mir::Expr{
-      .data = mir::BinaryExpr{.op = op, .lhs = base, .rhs = delta_lit},
-      .type = base_type};
-}
-
-// Translates an SV-declared-range index into a zero-based C++ vector offset
-// for an unpacked array base. `[0:N]` (ascending from zero) needs no rewrite;
-// other ranges fold the base offset into the index expression so the
-// downstream backend can emit a uniform `vec[i]` access. Commits and returns
-// the resulting `ExprId`.
-auto WrapUnpackedIndex(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::UnpackedRange& declared, mir::ExprId raw_idx,
-    mir::TypeId idx_type) -> mir::ExprId {
-  if (declared.left == 0 && declared.right >= 0) {
-    return raw_idx;
+  if (const auto* ua = std::get_if<mir::UnpackedArrayType>(&base_ty.data)) {
+    const mir::TypeId int32_type = module.Unit().builtins.int32;
+    args.push_back(
+        block.exprs.Add(mir::MakeInt32Literal(int32_type, ua->dim.left)));
+    args.push_back(
+        block.exprs.Add(mir::MakeInt32Literal(int32_type, ua->dim.right)));
   }
-  const mir::ExprId literal_id = block.exprs.Add(
-      mir::MakeInt32Literal(module.Unit().builtins.int32, declared.left));
-  const bool descending = declared.left >= declared.right;
-  return block.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::BinaryExpr{
-                  .op = mir::BinaryOp::kSub,
-                  .lhs = descending ? literal_id : raw_idx,
-                  .rhs = descending ? raw_idx : literal_id},
-          .type = idx_type});
 }
 
-// Translates an SV-declared packed bit-select index into the LSB-relative bit
-// offset the runtime element protocol consumes. The packed sibling of
-// `WrapUnpackedIndex`, but folding the `right` bound rather than `left`:
-// packed bit numbering counts from the LSB (the declared `right` end) while
-// unpacked memory order counts from the declared left. A descending
-// zero-based range (`[N:0]`) needs no rewrite. Commits and returns the
-// resulting `ExprId`.
-auto WrapPackedIndex(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::PackedRange& declared, mir::ExprId raw_idx, mir::TypeId idx_type)
-    -> mir::ExprId {
-  const bool descending = declared.left >= declared.right;
-  if (descending && declared.right == 0) {
-    return raw_idx;
-  }
-  const mir::ExprId literal_id = block.exprs.Add(
-      mir::MakeInt32Literal(module.Unit().builtins.int32, declared.right));
-  return block.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::BinaryExpr{
-                  .op = mir::BinaryOp::kSub,
-                  .lhs = descending ? raw_idx : literal_id,
-                  .rhs = descending ? literal_id : raw_idx},
-          .type = idx_type});
-}
-
-// Emits `lo + (count - 1)`, committed. `count == 1` returns `lo` directly
-// (no zero delta). Used by the fixed-width range-bound projections where
-// the slice width is statically known.
-auto BuildHiFromLoAndCount(
-    const ModuleLowerer& module, mir::Block& block, mir::ExprId lo,
-    std::int64_t count) -> mir::ExprId {
-  if (count == 1) return lo;
-  return block.exprs.Add(
-      BuildOffsetDeltaExpr(module, block, lo, count - 1, mir::BinaryOp::kAdd));
-}
-
-enum class IndexedDir : std::uint8_t { kUp, kDown };
-
-// LRM 11.5.1 packed indexed part-select (`base +: w` / `base -: w`). The base
-// index is mapped to its LSB-relative offset; the slice then extends toward
-// the MSB or LSB. The width grows upward exactly when the indexed direction
-// agrees with the declared range direction (`+:` on a descending range, or
-// `-:` on an ascending range), so a declared-ascending range mirrors the
-// growth direction a declared-descending range would take.
-auto PackedIndexedLoHi(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::PackedRange& declared, mir::ExprId base, std::int64_t count,
-    IndexedDir dir) -> RangeLoHi {
-  const bool descending = declared.left >= declared.right;
-  const mir::ExprId pbase = WrapPackedIndex(
-      module, block, declared, base, block.exprs.Get(base).type);
-  const bool extend_up = (dir == IndexedDir::kUp) == descending;
-  if (extend_up) {
-    return RangeLoHi{
-        .lo = pbase, .hi = BuildHiFromLoAndCount(module, block, pbase, count)};
-  }
-  return RangeLoHi{
-      .lo = block.exprs.Add(BuildOffsetDeltaExpr(
-          module, block, pbase, count - 1, mir::BinaryOp::kSub)),
-      .hi = pbase};
-}
-
-// LRM 7.10.1 queue slice projection. `q[a:b]` requires `a <= b`, so slang
-// always puts source-lo on the MSB side and source-hi on the LSB side --
-// no folding or `min/max` needed. Bounds may be arbitrary runtime
-// expressions; indexed forms build `base + (width - 1)` symbolically.
-template <typename LowerOne>
-auto BuildQueueRangeLoHi(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::RangeBounds& bounds, LowerOne lower_one)
-    -> diag::Result<RangeLoHi> {
-  const mir::TypeId int32_type = module.Unit().builtins.int32;
-  // Build `base <op> (width - 1)` symbolically -- `width` is a runtime
-  // expression on the queue path, so the delta cannot be folded to a
-  // literal.
-  auto build_base_at_width_offset = [&](mir::ExprId base, mir::ExprId width,
-                                        mir::BinaryOp op) -> mir::ExprId {
-    const auto base_type = block.exprs.Get(base).type;
-    const auto width_type = block.exprs.Get(width).type;
-    const auto one = block.exprs.Add(mir::MakeInt32Literal(int32_type, 1));
-    const auto w_minus_1 = block.exprs.Add(
-        mir::Expr{
-            .data =
-                mir::BinaryExpr{
-                    .op = mir::BinaryOp::kSub, .lhs = width, .rhs = one},
-            .type = width_type});
-    return block.exprs.Add(
-        mir::Expr{
-            .data = mir::BinaryExpr{.op = op, .lhs = base, .rhs = w_minus_1},
-            .type = base_type});
-  };
-  return std::visit(
-      Overloaded{
-          [&](const hir::RangeConstantBounds& b) -> diag::Result<RangeLoHi> {
-            auto lo = lower_one(b.msb_expr);
-            if (!lo) return std::unexpected(std::move(lo.error()));
-            auto hi = lower_one(b.lsb_expr);
-            if (!hi) return std::unexpected(std::move(hi.error()));
-            return RangeLoHi{.lo = *lo, .hi = *hi};
-          },
-          [&](const hir::RangeIndexedUpBounds& b) -> diag::Result<RangeLoHi> {
-            auto base = lower_one(b.base_index);
-            if (!base) return std::unexpected(std::move(base.error()));
-            auto width = lower_one(b.width);
-            if (!width) return std::unexpected(std::move(width.error()));
-            return RangeLoHi{
-                .lo = *base,
-                .hi = build_base_at_width_offset(
-                    *base, *width, mir::BinaryOp::kAdd)};
-          },
-          [&](const hir::RangeIndexedDownBounds& b) -> diag::Result<RangeLoHi> {
-            auto base = lower_one(b.base_index);
-            if (!base) return std::unexpected(std::move(base.error()));
-            auto width = lower_one(b.width);
-            if (!width) return std::unexpected(std::move(width.error()));
-            return RangeLoHi{
-                .lo = build_base_at_width_offset(
-                    *base, *width, mir::BinaryOp::kSub),
-                .hi = *base};
-          },
-      },
-      bounds);
-}
-
-// LRM 11.5.2 packed-array slice projection. Bounds are constants per the LRM;
-// each declared endpoint maps through `declared` to its LSB-relative offset,
-// then `[min, max]` gives the physical range the runtime Slice consumes. A
-// descending zero-based range is the identity, so this is transparent for the
-// common case.
-// Orders two already-rebased endpoint offsets into `(lo, hi)` at runtime: `lo`
-// is the lower offset, the physical start the Slice protocol consumes. Picked
-// with a conditional rather than a compile-time min / max so a constant slice
-// folds downstream (the optimizer's job) and a genvar slice stays runtime,
-// without assuming a static ordering -- a packed descending range, a
-// dynamic-array ascending range, and a raw `[width-1:0]` projection each order
-// their endpoints differently.
-auto OrderRebasedEndpoints(
-    const ModuleLowerer& module, mir::Block& block, mir::ExprId a,
-    mir::ExprId b) -> RangeLoHi {
-  const mir::TypeId off_type = block.exprs.Get(a).type;
-  // The two endpoints can carry different integral types -- a genvar-derived
-  // bound is four-state while a constant bound is two-state -- and this
-  // synthesized ordering both compares and selects between them. Reconcile the
-  // second endpoint to the first's type; for a source-level operator slang
-  // inserts this conversion, but this comparison is synthesized.
-  if (block.exprs.Get(b).type != off_type) {
-    b = block.exprs.Add(
-        BuildValueConversion(module.Unit(), block, b, off_type));
-  }
-  const mir::ExprId le = block.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::BinaryExpr{
-                  .op = mir::BinaryOp::kLessEqual, .lhs = a, .rhs = b},
-          .type = module.Unit().builtins.bit1});
-  return RangeLoHi{
-      .lo = block.exprs.Add(
-          mir::Expr{
-              .data =
-                  mir::ConditionalExpr{
-                      .condition = le, .then_value = a, .else_value = b},
-              .type = off_type}),
-      .hi = block.exprs.Add(
-          mir::Expr{
-              .data =
-                  mir::ConditionalExpr{
-                      .condition = le, .then_value = b, .else_value = a},
-              .type = off_type})};
-}
-
-template <typename LowerOne>
-auto BuildPackedRangeLoHi(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::RangeBounds& bounds, const hir::PackedRange& declared,
-    LowerOne lower_one) -> diag::Result<RangeLoHi> {
-  return std::visit(
-      Overloaded{
-          [&](const hir::RangeConstantBounds& b) -> diag::Result<RangeLoHi> {
-            auto msb = lower_one(b.msb_expr);
-            if (!msb) return std::unexpected(std::move(msb.error()));
-            auto lsb = lower_one(b.lsb_expr);
-            if (!lsb) return std::unexpected(std::move(lsb.error()));
-            // Rebase each declared endpoint to its LSB-relative offset at
-            // runtime (the same mapping `WrapPackedIndex` applies to an element
-            // index), then order them, so a constant bound folds downstream and
-            // a genvar-dependent bound stays a runtime read.
-            return OrderRebasedEndpoints(
-                module, block,
-                WrapPackedIndex(
-                    module, block, declared, *msb, block.exprs.Get(*msb).type),
-                WrapPackedIndex(
-                    module, block, declared, *lsb, block.exprs.Get(*lsb).type));
-          },
-          [&](const hir::RangeIndexedUpBounds& b) -> diag::Result<RangeLoHi> {
-            auto base = lower_one(b.base_index);
-            if (!base) return std::unexpected(std::move(base.error()));
-            auto width = lower_one(b.width);
-            if (!width) return std::unexpected(std::move(width.error()));
-            const auto count = IntConstFromMirExpr(block.exprs.Get(*width));
-            return PackedIndexedLoHi(
-                module, block, declared, *base, count, IndexedDir::kUp);
-          },
-          [&](const hir::RangeIndexedDownBounds& b) -> diag::Result<RangeLoHi> {
-            auto base = lower_one(b.base_index);
-            if (!base) return std::unexpected(std::move(base.error()));
-            auto width = lower_one(b.width);
-            if (!width) return std::unexpected(std::move(width.error()));
-            const auto count = IntConstFromMirExpr(block.exprs.Get(*width));
-            return PackedIndexedLoHi(
-                module, block, declared, *base, count, IndexedDir::kDown);
-          },
-      },
-      bounds);
-}
-
-// LRM 7.4.5 unpacked-array slice projection. SV positions are projected to
-// zero-based vector positions through the declared range; `count` comes
-// from the slice's result type. The leftmost-in-memory position depends on
-// the declared direction -- for a descending declared range, indexed-up's
-// base is at the high end of the slice and must be offset down to the
-// memory-leftmost position before projecting.
-template <typename LowerOne>
-auto BuildUnpackedRangeLoHi(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::RangeBounds& bounds, const hir::UnpackedRange& declared,
-    std::uint32_t count_u32, LowerOne lower_one) -> diag::Result<RangeLoHi> {
-  const std::int64_t count = count_u32;
-  const bool descending = declared.left >= declared.right;
-  auto project_sv = [&](mir::ExprId sv_expr) -> mir::ExprId {
-    const auto type = block.exprs.Get(sv_expr).type;
-    return WrapUnpackedIndex(module, block, declared, sv_expr, type);
-  };
-  return std::visit(
-      Overloaded{
-          [&](const hir::RangeConstantBounds& b) -> diag::Result<RangeLoHi> {
-            auto msb = lower_one(b.msb_expr);
-            if (!msb) return std::unexpected(std::move(msb.error()));
-            const auto lo = project_sv(*msb);
-            return RangeLoHi{
-                .lo = lo,
-                .hi = BuildHiFromLoAndCount(module, block, lo, count)};
-          },
-          [&](const hir::RangeIndexedUpBounds& b) -> diag::Result<RangeLoHi> {
-            auto base = lower_one(b.base_index);
-            if (!base) return std::unexpected(std::move(base.error()));
-            const auto leftmost_sv =
-                descending
-                    ? block.exprs.Add(BuildOffsetDeltaExpr(
-                          module, block, *base, count - 1, mir::BinaryOp::kAdd))
-                    : *base;
-            const auto lo = project_sv(leftmost_sv);
-            return RangeLoHi{
-                .lo = lo,
-                .hi = BuildHiFromLoAndCount(module, block, lo, count)};
-          },
-          [&](const hir::RangeIndexedDownBounds& b) -> diag::Result<RangeLoHi> {
-            auto base = lower_one(b.base_index);
-            if (!base) return std::unexpected(std::move(base.error()));
-            const auto leftmost_sv = descending
-                                         ? *base
-                                         : block.exprs.Add(BuildOffsetDeltaExpr(
-                                               module, block, *base, count - 1,
-                                               mir::BinaryOp::kSub));
-            const auto lo = project_sv(leftmost_sv);
-            return RangeLoHi{
-                .lo = lo,
-                .hi = BuildHiFromLoAndCount(module, block, lo, count)};
-          },
-      },
-      bounds);
-}
-
-// Project an `hir::RangeBounds` to the `(lo, hi)` pair the runtime Slice
-// protocol consumes. Three container kinds (queue / packed / unpacked) each
-// have their own projection rules per LRM section; the dispatch picks the
-// right helper and forwards.
-template <typename LowerOne>
-auto UnfoldRangeBoundsToLoHi(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::RangeBounds& bounds, const RangeStrategy& strategy,
-    LowerOne lower_one) -> diag::Result<RangeLoHi> {
-  switch (strategy.container) {
-    case RangeContainer::kQueue:
-      return BuildQueueRangeLoHi(module, block, bounds, lower_one);
-    case RangeContainer::kPacked:
-      return BuildPackedRangeLoHi(
-          module, block, bounds, *strategy.packed_declared, lower_one);
-    case RangeContainer::kUnpacked:
-      return BuildUnpackedRangeLoHi(
-          module, block, bounds, *strategy.unpacked_declared,
-          strategy.unpacked_count, lower_one);
-  }
-  throw InternalError("UnfoldRangeBoundsToLoHi: unknown RangeContainer");
-}
-
-// Extract the slice's element count from its MIR result type. For a packed
-// result the count is the outer dim's element count; for an unpacked-array
-// result it is the size field. Used by the slice factories to materialise
-// the `count` argument for fixed-width Slice calls (the `Sliceable`
-// protocol's second argument; see `concepts.hpp`).
-auto SliceResultOuterCount(const mir::Type& result_ty) -> std::uint32_t {
-  if (result_ty.IsIntegralPacked()) {
-    return static_cast<std::uint32_t>(
-        result_ty.AsIntegralPacked().dims.front().ElementCount());
-  }
-  if (std::holds_alternative<mir::UnpackedArrayType>(result_ty.data)) {
-    return static_cast<std::uint32_t>(
-        std::get<mir::UnpackedArrayType>(result_ty.data).size);
-  }
-  throw InternalError(
-      "SliceResultOuterCount: result type is not a fixed-width slice");
-}
-
-// `arr[i]` element access (LRM 7.4.5 / 7.5 / 7.10). The callee carries
-// just read-vs-write (`kElement` / `kElementRef`); the receiver's container
-// kind picks the runtime overload at C++ render time. Projects the SV-source
-// index through the declared range -- to a zero-based vector position for an
-// unpacked array, to an LSB-relative bit offset for a packed one -- so the
-// runtime needs no declared-direction awareness.
+// `arr[i]` element access (LRM 7.4.5 / 7.5 / 7.10). The callee carries just
+// read-vs-write (`kElement` / `kElementRef`); the receiver's container kind
+// picks the runtime overload at C++ render time. The raw source index is passed
+// through, plus the receiver's declared range for the unpacked family; every
+// selectable value resolves the coordinate against that range.
 auto BuildElementAccessCallExpr(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::Type& hir_base_ty, mir::TypeId hir_idx_type, mir::ExprId base_id,
+    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
     mir::ExprId idx_id, AccessSide side, mir::TypeId result_type) -> mir::Expr {
-  mir::ExprId effective_idx = idx_id;
-  if (const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
-    effective_idx =
-        WrapUnpackedIndex(module, block, ua->dim, idx_id, hir_idx_type);
-  } else if (
-      const auto* pa = std::get_if<hir::PackedArrayType>(&hir_base_ty.data)) {
-    effective_idx =
-        WrapPackedIndex(module, block, pa->dim, idx_id, hir_idx_type);
-  } else if (std::holds_alternative<hir::ScalarBitType>(hir_base_ty.data)) {
-    // A bit-select on a single-bit scalar: its declared range is `[0:0]`.
-    static constexpr hir::PackedRange kScalarDim{.left = 0, .right = 0};
-    effective_idx =
-        WrapPackedIndex(module, block, kScalarDim, idx_id, hir_idx_type);
-  }
+  std::vector<mir::ExprId> args = {base_id, idx_id};
+  AppendReceiverRange(module, block, base_id, args);
   return mir::Expr{
       .data =
           mir::CallExpr{
               .callee = ElementAccessCallee(side),
-              .arguments = {base_id, effective_idx}},
+              .arguments = std::move(args)},
       .type = result_type};
 }
 
-// `arr[hi:lo]` / `arr[base+:w]` / `arr[base-:w]` range select. Queue
-// carries `[base, lo, hi]` because LRM 7.10.1 derives the dynamic count
-// from the bounds; every other container carries `[base, offset, count]`
-// because LRM 7.4.5 / 11.5.2 require the runtime to canonical-fill at the
-// type-determined width even when bounds carry X/Z, and that width is not
-// derivable from `(lo, hi)` alone.
+// `arr[hi:lo]` / `arr[base+:w]` / `arr[base-:w]` range select, lowered to a raw
+// selector `(a, b, form)`: a constant range passes its two source endpoints; an
+// indexed part-select passes its base and (constant) width, with the direction
+// in `form` (0 constant, 1 indexed-up, 2 indexed-down -- the runtime
+// `value::SliceForm`). No count, offset, endpoint ordering, or rebase is
+// computed here; the selected value resolves the ordinal window against its own
+// declared range.
 template <typename LowerOne>
 auto BuildRangeSliceCallExpr(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::Type& hir_base_ty, const hir::RangeBounds& bounds,
+    ModuleLowerer& module, mir::Block& block, const hir::RangeBounds& bounds,
     mir::ExprId base_id, mir::TypeId result_type, AccessSide side,
     LowerOne lower_one) -> diag::Result<mir::Expr> {
-  RangeStrategy strategy;
-  const bool is_queue =
-      std::holds_alternative<hir::QueueType>(hir_base_ty.data);
-  if (is_queue) {
-    strategy.container = RangeContainer::kQueue;
-  } else if (
-      const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
-    const auto& result_ty = module.Unit().types.Get(result_type);
-    strategy.container = RangeContainer::kUnpacked;
-    strategy.unpacked_declared = &ua->dim;
-    strategy.unpacked_count = static_cast<std::uint32_t>(
-        std::get<mir::UnpackedArrayType>(result_ty.data).size);
-  } else if (
-      const auto* pa = std::get_if<hir::PackedArrayType>(&hir_base_ty.data)) {
-    strategy.container = RangeContainer::kPacked;
-    strategy.packed_declared = &pa->dim;
-  } else {
-    // A scalar bit, a dynamic array, and a packed struct / union all index by
-    // raw zero-based offset -- their bounds are already physical -- so an
-    // identity declared range leaves them untranslated.
-    static constexpr hir::PackedRange kRawOffset{.left = 0, .right = 0};
-    strategy.container = RangeContainer::kPacked;
-    strategy.packed_declared = &kRawOffset;
-  }
-  auto bounds_or =
-      UnfoldRangeBoundsToLoHi(module, block, bounds, strategy, lower_one);
-  if (!bounds_or) return std::unexpected(std::move(bounds_or.error()));
-  if (is_queue) {
-    // LRM 7.10 defines no write-side queue slice; slang rejects a queue
-    // slice in lvalue context, so the LHS path never reaches here.
-    return mir::Expr{
-        .data =
-            mir::CallExpr{
-                .callee = mir::Direct{.target = support::BuiltinFn::kSlice},
-                .arguments = {base_id, bounds_or->lo, bounds_or->hi}},
-        .type = result_type};
-  }
-  const auto count =
-      SliceResultOuterCount(module.Unit().types.Get(result_type));
-  const auto count_id = block.exprs.Add(
-      mir::MakeInt32Literal(
-          module.Unit().builtins.int32, static_cast<std::int64_t>(count)));
+  struct RawSelector {
+    mir::ExprId a;
+    mir::ExprId b;
+    std::int64_t form;
+  };
+  auto raw_or = std::visit(
+      Overloaded{
+          [&](const hir::RangeConstantBounds& c) -> diag::Result<RawSelector> {
+            auto l = lower_one(c.left_bound);
+            if (!l) return std::unexpected(std::move(l.error()));
+            auto r = lower_one(c.right_bound);
+            if (!r) return std::unexpected(std::move(r.error()));
+            return RawSelector{.a = *l, .b = *r, .form = 0};
+          },
+          [&](const hir::RangeIndexedUpBounds& c) -> diag::Result<RawSelector> {
+            auto base = lower_one(c.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto w = lower_one(c.width);
+            if (!w) return std::unexpected(std::move(w.error()));
+            return RawSelector{.a = *base, .b = *w, .form = 1};
+          },
+          [&](const hir::RangeIndexedDownBounds& c)
+              -> diag::Result<RawSelector> {
+            auto base = lower_one(c.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto w = lower_one(c.width);
+            if (!w) return std::unexpected(std::move(w.error()));
+            return RawSelector{.a = *base, .b = *w, .form = 2};
+          },
+      },
+      bounds);
+  if (!raw_or) return std::unexpected(std::move(raw_or.error()));
+  const mir::TypeId int32_type = module.Unit().builtins.int32;
+  const auto form_id =
+      block.exprs.Add(mir::MakeInt32Literal(int32_type, raw_or->form));
+  std::vector<mir::ExprId> args = {base_id, raw_or->a, raw_or->b, form_id};
+  AppendReceiverRange(module, block, base_id, args);
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -616,7 +228,7 @@ auto BuildRangeSliceCallExpr(
                       .target = side == AccessSide::kLhs
                                     ? support::BuiltinFn::kSliceRef
                                     : support::BuiltinFn::kSlice},
-              .arguments = {base_id, bounds_or->lo, count_id}},
+              .arguments = std::move(args)},
       .type = result_type};
 }
 
@@ -625,14 +237,17 @@ auto BuildRangeSliceCallExpr(
 // range-select emits, so the runtime sees one slice form regardless of
 // whether the source was `s.field` or `s[hi:lo]`.
 auto BuildFieldSliceCallExpr(
-    const ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
+    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
     std::uint32_t bit_offset, std::uint32_t bit_width, mir::TypeId result_type,
     AccessSide side) -> mir::Expr {
   const mir::TypeId int32_type = module.Unit().builtins.int32;
   const auto offset_id = block.exprs.Add(
       mir::MakeInt32Literal(int32_type, static_cast<std::int64_t>(bit_offset)));
-  const auto count_id = block.exprs.Add(
+  const auto width_id = block.exprs.Add(
       mir::MakeInt32Literal(int32_type, static_cast<std::int64_t>(bit_width)));
+  // A field occupies bits `[offset +: width]` -- a raw indexed-up part-select
+  // (`value::SliceForm` `kIndexedUp` == 1); the value resolves the bit window.
+  const auto form_id = block.exprs.Add(mir::MakeInt32Literal(int32_type, 1));
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -641,7 +256,7 @@ auto BuildFieldSliceCallExpr(
                       .target = side == AccessSide::kLhs
                                     ? support::BuiltinFn::kSliceRef
                                     : support::BuiltinFn::kSlice},
-              .arguments = {base_id, offset_id, count_id}},
+              .arguments = {base_id, offset_id, width_id, form_id}},
       .type = result_type};
 }
 
@@ -651,13 +266,11 @@ auto BuildFieldSliceCallExpr(
 // intact for `operator=` to consume.
 
 auto LowerElementSelectInner(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::Type& hir_base_ty, mir::TypeId hir_idx_type, mir::ExprId base_id,
+    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
     mir::ExprId idx_id, AccessSide side, mir::TypeId result_type,
     bool wrap_packed_as_owned) -> mir::Expr {
   mir::Expr access_call = BuildElementAccessCallExpr(
-      module, block, hir_base_ty, hir_idx_type, base_id, idx_id, side,
-      result_type);
+      module, block, base_id, idx_id, side, result_type);
   if (!wrap_packed_as_owned) return access_call;
   return WrapPackedAsOwned(
       module.Unit(), block, std::move(access_call), result_type);
@@ -665,13 +278,11 @@ auto LowerElementSelectInner(
 
 template <typename LowerOne>
 auto LowerRangeSelectInner(
-    const ModuleLowerer& module, mir::Block& block,
-    const hir::Type& hir_base_ty, const hir::RangeBounds& bounds,
+    ModuleLowerer& module, mir::Block& block, const hir::RangeBounds& bounds,
     mir::ExprId base_id, mir::TypeId result_type, LowerOne lower_one,
     AccessSide side) -> diag::Result<mir::Expr> {
   auto slice_or = BuildRangeSliceCallExpr(
-      module, block, hir_base_ty, bounds, base_id, result_type, side,
-      lower_one);
+      module, block, bounds, base_id, result_type, side, lower_one);
   if (!slice_or) return std::unexpected(std::move(slice_or.error()));
   if (side == AccessSide::kLhs) return *std::move(slice_or);
   return WrapPackedAsOwned(
@@ -711,7 +322,7 @@ template <ExprLowerer Lowerer>
 auto LowerHirElementSelectExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = lowerer.Module();
+  auto& module = lowerer.Module();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const bool is_write = frame.is_lvalue_target;
@@ -751,15 +362,14 @@ auto LowerHirElementSelectExpr(
           ? AccessSide::kLhs
           : AccessSide::kRead;
   return LowerElementSelectInner(
-      module, block, hir_base_ty, module.TranslateType(hir_idx.type), base_id,
-      idx_id, side, result_type, true);
+      module, block, base_id, idx_id, side, result_type, true);
 }
 
 template <ExprLowerer Lowerer>
 auto LowerHirRangeSelectExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = lowerer.Module();
+  auto& module = lowerer.Module();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
@@ -773,9 +383,8 @@ auto LowerHirRangeSelectExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return block.exprs.Add(*std::move(lowered));
   };
-  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
   return LowerRangeSelectInner(
-      module, block, hir_base_ty, sel.bounds, base_id, result_type, lower_one,
+      module, block, sel.bounds, base_id, result_type, lower_one,
       AccessSide::kRead);
 }
 
@@ -843,7 +452,7 @@ template <ExprLowerer Lowerer>
 auto LowerHirElementSelectExprLhs(
     Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = lowerer.Module();
+  auto& module = lowerer.Module();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
@@ -871,15 +480,14 @@ auto LowerHirElementSelectExprLhs(
         .type = result_type};
   }
   return LowerElementSelectInner(
-      module, block, hir_base_ty, module.TranslateType(hir_idx.type), base_id,
-      idx_id, AccessSide::kLhs, result_type, false);
+      module, block, base_id, idx_id, AccessSide::kLhs, result_type, false);
 }
 
 template <ExprLowerer Lowerer>
 auto LowerHirRangeSelectExprLhs(
     Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = lowerer.Module();
+  auto& module = lowerer.Module();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
@@ -893,9 +501,8 @@ auto LowerHirRangeSelectExprLhs(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return block.exprs.Add(*std::move(lowered));
   };
-  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
   return LowerRangeSelectInner(
-      module, block, hir_base_ty, sel.bounds, base_id, result_type, lower_one,
+      module, block, sel.bounds, base_id, result_type, lower_one,
       AccessSide::kLhs);
 }
 

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -21,7 +21,7 @@ auto BuildHirInsideItemPredicate(
     -> diag::Result<mir::ExprId> {
   const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  const auto& unit = lowerer.Module().Unit();
+  auto& unit = lowerer.Module().Unit();
   auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
     auto lowered = lowerer.LowerExpr(hir_exprs.Get(id), frame);
     if (!lowered) {

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -340,7 +340,8 @@ auto BuildPrintItemsArray(
   }
   const mir::TypeId array_type = unit.types.Intern(
       mir::UnpackedArrayType{
-          .element_type = unit.builtins.print_item, .size = items.size()});
+          .element_type = unit.builtins.print_item,
+          .dim = mir::UnpackedRange::ZeroBased(items.size())});
   return mir::Expr{
       .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
       .type = array_type};

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -138,6 +138,10 @@ auto LowerDestructuringAssign(
         mir::MakeInt32Literal(
             process.Module().Unit().builtins.int32,
             static_cast<std::int64_t>(w)));
+    // `temp[offset +: w]`: a raw indexed-up part-select (`value::SliceForm`
+    // `kIndexedUp` == 1); the snapshot value resolves the bit window itself.
+    const mir::ExprId form_id = wrapper.exprs.Add(
+        mir::MakeInt32Literal(process.Module().Unit().builtins.int32, 1));
     const mir::ExprId temp_ref =
         wrapper.exprs.Add(mir::MakeLocalRefExpr(snapshot_var, temp_type));
     const mir::TypeId slice_type = process.Module().Unit().types.Intern(
@@ -152,7 +156,7 @@ auto LowerDestructuringAssign(
             .data =
                 mir::CallExpr{
                     .callee = mir::Direct{.target = support::BuiltinFn::kSlice},
-                    .arguments = {temp_ref, offset_id, count_id}},
+                    .arguments = {temp_ref, offset_id, count_id, form_id}},
             .type = slice_type});
     const mir::ExprId slice_id = wrapper.exprs.Add(
         mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -175,7 +175,8 @@ void EmitExternalUnitDimLevel(
     // dim chain (empty for a scalar instance).
     const mir::TypeId indices_type = module.Unit().types.Intern(
         mir::UnpackedArrayType{
-            .element_type = builtins.int32, .size = indices.size()});
+            .element_type = builtins.int32,
+            .dim = mir::UnpackedRange::ZeroBased(indices.size())});
     const mir::ExprId indices_id = block.exprs.Add(
         mir::Expr{
             .data = mir::ArrayLiteralExpr{.elements = indices},
@@ -503,7 +504,8 @@ auto BuildIndicesLiteral(
   }
   const mir::TypeId indices_type = module.Unit().types.Intern(
       mir::UnpackedArrayType{
-          .element_type = builtins.int32, .size = indices.size()});
+          .element_type = builtins.int32,
+          .dim = mir::UnpackedRange::ZeroBased(indices.size())});
   return block.exprs.Add(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(ids)},
@@ -1252,7 +1254,8 @@ void AppendOwnedChildConstruction(
   }
   const mir::TypeId indices_type = module.Unit().types.Intern(
       mir::UnpackedArrayType{
-          .element_type = builtins.int32, .size = index_elems.size()});
+          .element_type = builtins.int32,
+          .dim = mir::UnpackedRange::ZeroBased(index_elems.size())});
   const mir::ExprId indices_id = arm_block.exprs.Add(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(index_elems)},

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -192,12 +192,11 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
             return mir::UnionType{.elements = std::move(elements)};
           },
           [&](const hir::UnpackedArrayType& src) -> mir::TypeData {
-            const std::int64_t span = (src.dim.left >= src.dim.right)
-                                          ? (src.dim.left - src.dim.right)
-                                          : (src.dim.right - src.dim.left);
             return mir::UnpackedArrayType{
                 .element_type = TranslateType(src.element_type),
-                .size = static_cast<std::uint64_t>(span) + 1U,
+                .dim =
+                    mir::UnpackedRange{
+                        .left = src.dim.left, .right = src.dim.right},
             };
           },
           [&](const hir::DynamicArrayType& src) -> mir::TypeData {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -185,8 +185,8 @@ class MirDumper {
             },
             [](const UnpackedArrayType& u) -> std::string {
               return std::format(
-                  "UnpackedArray(elem=Type[{}], size={})", u.element_type.value,
-                  u.size);
+                  "UnpackedArray(elem=Type[{}], dim=[{}:{}])",
+                  u.element_type.value, u.dim.left, u.dim.right);
             },
             [](const DynamicArrayType& d) -> std::string {
               return std::format(

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -60,7 +60,8 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
           }
         } else if constexpr (std::is_same_v<T, UnpackedArrayType>) {
           HashId(seed, t.element_type);
-          HashField(seed, t.size);
+          HashField(seed, t.dim.left);
+          HashField(seed, t.dim.right);
         } else if constexpr (std::is_same_v<T, DynamicArrayType>) {
           HashId(seed, t.element_type);
         } else if constexpr (std::is_same_v<T, QueueType>) {

--- a/src/lyra/runtime/file_table.cpp
+++ b/src/lyra/runtime/file_table.cpp
@@ -571,7 +571,6 @@ auto ReadUnpackedImpl(
   }
   if (dest.RawSize() == 0U) return MakeInt(0);
 
-  const bool ascending = declared_left <= declared_right;
   const auto lowest_sv = std::min(declared_left, declared_right);
   const auto highest_sv = std::max(declared_left, declared_right);
   // LRM 21.3.4.4: out-of-range start has no defined behaviour. Stamp EBADF
@@ -613,11 +612,13 @@ auto ReadUnpackedImpl(
     auto effective = std::span<const char>(buf).first(got_this);
     auto elem_value = value::PackedArray::FromBytes(
         effective, element_width, elem_signed, elem_four_state);
+    // Write by source-declared index; the declared range `[left:right]` is the
+    // receiver's static-type coordinate system, passed as select operands.
     const std::int64_t sv_index = start_sv + static_cast<std::int64_t>(k);
-    const std::int64_t storage_idx =
-        ascending ? (sv_index - declared_left) : (declared_left - sv_index);
     dest.ElementRef(
-        value::PackedArray::Int(static_cast<std::int32_t>(storage_idx))) =
+        value::PackedArray::Int(static_cast<std::int32_t>(sv_index)),
+        value::PackedArray::Int(static_cast<std::int32_t>(declared_left)),
+        value::PackedArray::Int(static_cast<std::int32_t>(declared_right))) =
         std::move(elem_value);
     total_bytes += got_this;
     if (got_this < bytes_per_elem) break;

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -17,6 +17,7 @@
 #include "lyra/value/packed_convert.hpp"
 #include "lyra/value/packed_internal.hpp"
 #include "lyra/value/packed_reduction.hpp"
+#include "lyra/value/slice_selector.hpp"
 
 namespace lyra::value {
 
@@ -1449,6 +1450,25 @@ struct PackedSelection {
   std::vector<PackedRange> dims;
 };
 
+// Maps a declared-coordinate index onto the outer dimension's zero-based
+// position (LRM 11.5.1): a descending range subtracts its right (least-
+// significant) endpoint, an ascending range subtracts the index from it. The
+// arithmetic runs in the canonical 64-bit offset domain, so a caller's index of
+// any width and state domain composes without a storage-domain clash, and an
+// x / z index propagates to an out-of-range offset that reads the element's
+// default. A descending zero-based range is the identity.
+auto RebaseToZeroBased(const PackedArray& idx, const PackedRange& outer)
+    -> PackedArray {
+  const auto canon = Canonicalize(idx);
+  const bool descending = outer.left >= outer.right;
+  if (descending && outer.right == 0) {
+    return canon;
+  }
+  const auto right = PackedArray::FromInt(
+      outer.right, kOffsetBitWidth, kOffsetSigned, kOffsetFourState);
+  return descending ? canon - right : right - canon;
+}
+
 // Scales an outer-element position to a flat-bit offset. One outer element is
 // `element_bw` bits; when that is 1 (selecting the innermost dimension), the
 // position is already a bit offset. X/Z in the position propagates.
@@ -1467,19 +1487,70 @@ auto ResolveElement(
     std::uint64_t source_bit_width, std::span<const PackedRange> source_dims,
     const PackedArray& idx) -> PackedSelection {
   const auto element_bw = OuterElementBitWidth(source_bit_width, source_dims);
+  const auto zero_based = RebaseToZeroBased(idx, source_dims.front());
   return PackedSelection{
-      .bit_offset = ScaledOuterOffset(idx, element_bw),
+      .bit_offset = ScaledOuterOffset(zero_based, element_bw),
       .dims = PopOuterDim(source_dims)};
 }
 
+// `anchor` is the SV-declared endpoint the slice hangs from; `shift` is how
+// many outer elements the low end sits below its rebased position. A constant
+// range and an indexed part-select whose width grows toward the MSB pass `shift
+// == 0` (the anchor rebases straight to the low end); an indexed part-select
+// growing toward the LSB passes `shift == count - 1`, so the anchor rebases to
+// the high end and the low end is `count - 1` below it (LRM 11.5.1). The
+// subtraction runs in the canonical offset domain, so an anchor of any width or
+// state domain composes and an x / z anchor propagates to an out-of-range read.
 auto ResolveSlice(
     std::uint64_t source_bit_width, std::span<const PackedRange> source_dims,
-    const PackedArray& offset_in_outer_elements, std::uint32_t count)
+    const PackedArray& anchor, std::uint32_t count, const PackedArray& shift)
     -> PackedSelection {
   const auto element_bw = OuterElementBitWidth(source_bit_width, source_dims);
+  const auto low =
+      RebaseToZeroBased(anchor, source_dims.front()) - Canonicalize(shift);
   return PackedSelection{
-      .bit_offset = ScaledOuterOffset(offset_in_outer_elements, element_bw),
+      .bit_offset = ScaledOuterOffset(low, element_bw),
       .dims = ReplaceOuterDimCount(source_dims, count)};
+}
+
+struct RawRangeSelector {
+  PackedArray anchor;
+  std::uint32_t count;
+  PackedArray shift;
+};
+
+// Derive the (low-endpoint anchor, count, shift) the bit-level `ResolveSlice`
+// consumes from a raw range selector `(a, b, form)` and the outer dim's
+// orientation. A constant range `[l:r]` gives the oriented-low endpoint and the
+// element count; an indexed part-select's base and width give the anchor and a
+// direction-dependent shift (LRM 11.5.1). No coordinate is rebased here --
+// `ResolveSlice` rebases in the value's own X/Z-aware domain.
+auto ResolveRawRangeSelector(
+    const PackedRange& outer, const PackedArray& a, const PackedArray& b,
+    const PackedArray& form) -> RawRangeSelector {
+  const bool descending = outer.left >= outer.right;
+  if (static_cast<SliceForm>(form.ToInt64()) == SliceForm::kConstant) {
+    const std::int64_t l = a.ToInt64();
+    const std::int64_t r = b.ToInt64();
+    const std::int64_t lo_endpoint = l < r ? l : r;
+    const std::int64_t hi_endpoint = l < r ? r : l;
+    const std::int64_t low = descending ? lo_endpoint : hi_endpoint;
+    const auto count =
+        static_cast<std::uint32_t>((hi_endpoint - lo_endpoint) + 1);
+    return RawRangeSelector{
+        .anchor = PackedArray::Int(static_cast<std::int32_t>(low)),
+        .count = count,
+        .shift = PackedArray::Int(0)};
+  }
+  const auto count = static_cast<std::uint32_t>(b.ToInt64());
+  const bool extend_up = (static_cast<SliceForm>(form.ToInt64()) ==
+                          SliceForm::kIndexedUp) == descending;
+  const std::int64_t shift =
+      extend_up ? 0 : static_cast<std::int64_t>(count) - 1;
+  return RawRangeSelector{
+      .anchor = a,
+      .count = count,
+      .shift = PackedArray::Int(static_cast<std::int32_t>(shift))};
 }
 
 }  // namespace
@@ -1495,22 +1566,20 @@ auto PackedArray::Element(const PackedArray& idx) const -> PackedArray {
 }
 
 auto PackedArray::SliceRef(
-    const PackedArray& offset_in_outer_elements,
-    const PackedArray& count_in_outer_elements) -> PackedArrayRef {
-  const auto count =
-      static_cast<std::uint32_t>(count_in_outer_elements.ToInt64());
+    const PackedArray& a, const PackedArray& b, const PackedArray& form)
+    -> PackedArrayRef {
+  const auto raw = ResolveRawRangeSelector(type_.dims.front(), a, b, form);
   auto sel = ResolveSlice(
-      type_.bit_width, type_.dims, offset_in_outer_elements, count);
+      type_.bit_width, type_.dims, raw.anchor, raw.count, raw.shift);
   return PackedArrayRef{*this, sel.bit_offset, std::move(sel.dims)};
 }
 
 auto PackedArray::Slice(
-    const PackedArray& offset_in_outer_elements,
-    const PackedArray& count_in_outer_elements) const -> PackedArray {
-  const auto count =
-      static_cast<std::uint32_t>(count_in_outer_elements.ToInt64());
+    const PackedArray& a, const PackedArray& b, const PackedArray& form) const
+    -> PackedArray {
+  const auto raw = ResolveRawRangeSelector(type_.dims.front(), a, b, form);
   auto sel = ResolveSlice(
-      type_.bit_width, type_.dims, offset_in_outer_elements, count);
+      type_.bit_width, type_.dims, raw.anchor, raw.count, raw.shift);
   return ExtractBits(sel.bit_offset, sel.dims);
 }
 
@@ -1540,11 +1609,10 @@ auto PackedArrayRef::ElementRef(const PackedArray& idx) const
 }
 
 auto PackedArrayRef::SliceRef(
-    const PackedArray& offset_in_outer_elements,
-    const PackedArray& count_in_outer_elements) const -> PackedArrayRef {
-  const auto count =
-      static_cast<std::uint32_t>(count_in_outer_elements.ToInt64());
-  auto sel = ResolveSlice(bit_width_, dims_, offset_in_outer_elements, count);
+    const PackedArray& a, const PackedArray& b, const PackedArray& form) const
+    -> PackedArrayRef {
+  const auto raw = ResolveRawRangeSelector(dims_.front(), a, b, form);
+  auto sel = ResolveSlice(bit_width_, dims_, raw.anchor, raw.count, raw.shift);
   return PackedArrayRef{
       *root_, bit_offset_ + sel.bit_offset, std::move(sel.dims)};
 }

--- a/tests/cases/cpp/container_subroutine_boundary/case.yaml
+++ b/tests/cases/cpp/container_subroutine_boundary/case.yaml
@@ -21,3 +21,6 @@ expect:
     lookup_rt: 200
     bump_existing_rt: 111
     bump_new_rt: 300
+    ua_local_rt: 100
+    uav2_rt: 11
+    uav4_rt: 33

--- a/tests/cases/cpp/container_subroutine_boundary/main.sv
+++ b/tests/cases/cpp/container_subroutine_boundary/main.sv
@@ -39,10 +39,28 @@ module Top;
     m[key] = v;
   endfunction
 
+  // A fixed unpacked array with a non-trivial declared range across the
+  // subroutine boundary: the automatic-local `t` (a plain value, no cell) and
+  // the copy-out formal `a` each resolve their selects against their own
+  // declared range, not a range carried by the value.
+  function automatic int ua_local();
+    int t[1:3];
+    t[1] = 40;
+    t[3] = 60;
+    return t[1] + t[3];
+  endfunction
+
+  function automatic void fill_ua(output int a[2:4]);
+    a[2] = 11;
+    a[3] = 22;
+    a[4] = 33;
+  endfunction
+
   qi_t qv;
   dai_t dav;
   as_t amap;
   qi_t sq;
+  int uav[2:4];
 
   int sum_rt;
   int da0_rt;
@@ -57,6 +75,9 @@ module Top;
   int lookup_rt;
   int bump_existing_rt;
   int bump_new_rt;
+  int ua_local_rt;
+  int uav2_rt;
+  int uav4_rt;
 
   initial begin
     qv.push_back(1);
@@ -92,5 +113,10 @@ module Top;
     bump(amap, "gamma", 300);
     bump_existing_rt = amap["alpha"];
     bump_new_rt = amap["gamma"];
+
+    ua_local_rt = ua_local();
+    fill_ua(uav);
+    uav2_rt = uav[2];
+    uav4_rt = uav[4];
   end
 endmodule

--- a/tests/cases/cpp/packed_range_direction_select/case.yaml
+++ b/tests/cases/cpp/packed_range_direction_select/case.yaml
@@ -15,3 +15,4 @@ expect:
     desc_nonzero_w: "6'b000100"
     asc_pselect_up: "8'b00000011"
     asc_pselect_dn: "8'b00000100"
+    fs_idx_r: "1'b1"

--- a/tests/cases/cpp/packed_range_direction_select/main.sv
+++ b/tests/cases/cpp/packed_range_direction_select/main.sv
@@ -6,8 +6,11 @@ module Top;
   bit [6:1] desc_nonzero_w;
   bit [7:0] asc_pselect_up;
   bit [7:0] asc_pselect_dn;
+  bit [6:1] dn_src;
+  bit fs_idx_r;
   initial begin
     bit [0:7] src;
+    integer fi;
     asc_bit_w = 8'h00;
     asc_bit_w[2] = 1'b1;
     src = 8'b00100000;
@@ -21,5 +24,11 @@ module Top;
     src = 8'b10110010;
     asc_pselect_up = src[1 +: 3];
     asc_pselect_dn = src[5 -: 3];
+    // A four-state index over a non-zero-based range: the LSB-rebase subtracts
+    // the declared `right` (a two-state literal) from the `integer` index, so
+    // the two operands' domains must reconcile.
+    dn_src = 6'b010100;
+    fi = 3;
+    fs_idx_r = dn_src[fi];
   end
 endmodule

--- a/tests/cases/cpp/query_bits/case.yaml
+++ b/tests/cases/cpp/query_bits/case.yaml
@@ -13,3 +13,6 @@ expect:
     bits_struct_rt: 4
     bits_enum_rt: 2
     bits_2d_rt: 16
+    slice_rt: 5
+    red_rt: 0
+    ca_red: 0

--- a/tests/cases/cpp/query_bits/case.yaml
+++ b/tests/cases/cpp/query_bits/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.query_bits
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    bits_type_rt: 4
+    bits_value_rt: 4
+    bits_struct_rt: 4
+    bits_enum_rt: 2
+    bits_2d_rt: 16

--- a/tests/cases/cpp/query_bits/main.sv
+++ b/tests/cases/cpp/query_bits/main.sv
@@ -15,6 +15,14 @@ module Top;
   int bits_enum_rt;
   int bits_2d_rt;
 
+  // `$bits` used as a part-select bound: the `$bits`-derived high bound is
+  // `integer` (4-state), the literal low bound is `int` (2-state), so the
+  // endpoint-ordering comparison must reconcile the two domains.
+  logic [2:0] slice_rt;
+  logic red_rt;
+  logic ca_red;
+  assign ca_red = ^q[$bits(mubi_t)-1:1];
+
   initial begin
     q = 4'b1010;
     bits_type_rt = $bits(mubi_t);
@@ -22,5 +30,7 @@ module Top;
     bits_struct_rt = $bits(sp_t);
     bits_enum_rt = $bits(e_t);
     bits_2d_rt = $bits(m2d);
+    slice_rt = q[$bits(mubi_t)-1:1];
+    red_rt = ^q[$bits(mubi_t)-1:1];
   end
 endmodule

--- a/tests/cases/cpp/query_bits/main.sv
+++ b/tests/cases/cpp/query_bits/main.sv
@@ -1,0 +1,26 @@
+module Top;
+  typedef logic [3:0] mubi_t;
+  typedef struct packed {
+    logic a;
+    logic [2:0] b;
+  } sp_t;
+  typedef enum logic [1:0] {E0, E1, E2} e_t;
+
+  mubi_t q;
+  bit [1:0][7:0] m2d;
+
+  int bits_type_rt;
+  int bits_value_rt;
+  int bits_struct_rt;
+  int bits_enum_rt;
+  int bits_2d_rt;
+
+  initial begin
+    q = 4'b1010;
+    bits_type_rt = $bits(mubi_t);
+    bits_value_rt = $bits(q);
+    bits_struct_rt = $bits(sp_t);
+    bits_enum_rt = $bits(e_t);
+    bits_2d_rt = $bits(m2d);
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_whole_assign_different_bounds/case.yaml
+++ b/tests/cases/cpp/unpacked_whole_assign_different_bounds/case.yaml
@@ -9,3 +9,7 @@ expect:
   exit: 0
   variables:
     a: [11, 22, 33, 44, 55, 66, 77, 88]
+    hi: 11
+    lo: 88
+    nx: 99
+    ny: 7

--- a/tests/cases/cpp/unpacked_whole_assign_different_bounds/main.sv
+++ b/tests/cases/cpp/unpacked_whole_assign_different_bounds/main.sv
@@ -1,7 +1,32 @@
 // LRM 7.6: source/target may differ in range bounds; correspondence is
-// left-to-right, so b[1] -> a[7], b[2] -> a[6], ..., b[8] -> a[0].
+// left-to-right ordinal order, so b[1] -> a[7], b[2] -> a[6], ..., b[8] -> a[0].
+// The destination keeps its declared [7:0] range across the store, so a select
+// after the assignment resolves against [7:0], not the source's [1:8].
+//
+// Multi-dimensional: correspondence is position-wise at every level, and the
+// destination keeps its own declared ranges at each level. With both the outer
+// and inner ranges differing, d[3][4] (storage (0,0)) lands at c's (0,0), which
+// c[1][1] names -- a select after the store resolves against c's ranges, not d's.
 module Top;
   int a [7:0];
   int b [1:8] = '{11, 22, 33, 44, 55, 66, 77, 88};
-  initial a = b;
+  int hi;
+  int lo;
+
+  int c [1:3][1:4];
+  int d [3:1][4:1];
+  int nx;
+  int ny;
+
+  initial begin
+    a = b;
+    hi = a[7];  // a's leftmost (ordinal 0) = b[1] = 11
+    lo = a[0];  // a's rightmost (ordinal 7) = b[8] = 88
+
+    d[3][4] = 99;  // storage position (0,0)
+    d[1][1] = 7;   // storage position (2,3)
+    c = d;
+    nx = c[1][1];  // c storage (0,0) = 99
+    ny = c[3][4];  // c storage (2,3) = 7
+  end
 endmodule


### PR DESCRIPTION
## Summary

An unpacked array's runtime value was doing two jobs that pull in opposite directions: it was the movable data that `a = b` copies position-wise, and it was the typed thing that `a[i]` selects from. A whole-array assignment must move ordinal data and leave the destination's own declared range alone; a selection needs that range to map a source index to a storage slot. Because the range lived inside the value, `a = b` copied the source's range onto the destination, so a `ConformRange` step had to patch it back afterward -- and it only patched the outermost dimension, so a nested cross-range assignment silently read the wrong element. This PR splits the two roles: the declared range becomes a fact of the array's static type, the runtime value becomes pure ordinal payload, and selection takes the range as an operand sourced from the receiver's static type -- exactly the way construction already passes it. `ConformRange` is deleted.

## What changes, concretely

```text
SV                         before                              after
a = b                      a.Set(.., b.Get().ConformRange(..)) a.Set(services, b.Get())   // plain payload copy
a[i]                       a.Get().Element(i)                  a.Get().Element(i, 1, 3)   // range 1,3 from a's type
int a[1:3][1:4]=b[3:1][4:1]; a[1][1]   ->  read 0 (bug)        ->  reads 99
```

Multi-dimensional arrays need no special handling: an unpacked value nests one container layer per dimension, and each select consumes exactly one dimension's range, so `a[i][j][k]` is three independent single-dimension selects. Packed arrays are deliberately untouched -- a packed value's dimension stack is real storage representation (it sets the flat width and participates in same-representation identity), not pure coordinate naming, so it stays self-describing.

## Why this shape

SystemVerilog unpacked assignment is position-wise (LRM 7.6), and an unpacked array's declared range is coordinate naming -- which storage ordinal a source index denotes -- not part of how the payload is stored: the backing store is a vector sized by element count, endpoint-independent, and every whole-value operation (copy, equality, change detection, positional print, sort, reduction) already works in ordinal terms. Keeping the range on the movable value is what forced assignment and selection to share one object and made a plain `a = b` need a repair. Sourcing the range from the receiver's static type puts it where selection already looks and where construction already reads it, and it keeps the wide X/Z-aware coordinate resolution unchanged. The full derivation, the per-boundary analysis (module variable, automatic local, function return, ref/port), and the rejected alternatives are in `docs/decisions/unpacked-range-belongs-to-type.md`.

## Testing

`bazel test //...` is green. New regression coverage: a nested cross-range whole-array store (`int a[1:3][1:4] = b[3:1][4:1]`, the bug above), selection in cell-less contexts (an automatic-local unpacked array and a copy-out subroutine formal, which have no cell to hold a range and so must resolve against the local declared type), and a packed direction-select guard proving packed selection is unaffected.

## Notes for the reviewer

Two things ride along that are not the core change. This branch already carried a `$bits`-fold-to-constant commit (fixed-size operands); it squashes in with the range work. And rebasing onto main reconciled this branch's selector rework with a hierarchical-reference refactor that landed there: member access was ported to main's new `MakeFieldAccessExpr` API, and a pre-existing use-after-reallocation in the NBA deferred-writeback closure was fixed -- it held a reference into a block's expression storage across calls that append to that block, and the two new select operands grew the vector past capacity and exposed it (an emitted `SliceRef` lost its last argument).
