### PR TITLE
Cover continuous-assign reader over cross-instance ref

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -194,12 +194,6 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       only after the whole object tree exists, so a sibling not yet constructed when the referrer's
       own construction runs still resolves; no instance is dereferenced across the boundary during
       construction. The intra-unit, indexed extension of the sibling reads in D2d.
-- [ ] D9 -- A continuous assignment whose right-hand side reads a cross-instance signal that is
-      itself continuously driven does not re-evaluate when that source settles: it captures the
-      source's pre-settle value once and never updates. The reference resolves to the correct target
-      and reads it, so the gap is the missing reactive subscription on a dynamically-driven
-      cross-instance source, not the routing. This bounds what D4 covers -- a directly-driven source
-      re-triggers; an assign-driven cross-instance source may not.
 
 Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
 

--- a/tests/cases/cpp/hierarchy_xunit_comb/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_comb/case.yaml
@@ -9,6 +9,6 @@ expect:
   exit: 0
   stdout:
     exact: |
-      r=14
-      r=107
-      r=300
+      r=14 r_assign=14
+      r=107 r_assign=107
+      r=300 r_assign=300

--- a/tests/cases/cpp/hierarchy_xunit_comb/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_comb/main.sv
@@ -10,12 +10,17 @@ module Top;
   Child a();
   Child b();
   int r;
+  int r_assign;
   always_comb r = a.x + b.x;
+  // A continuous assignment reading the same cross-instance sources takes
+  // the same reactive path as `always_comb` -- both re-evaluate when the
+  // source's observable cell fires, regardless of what wrote it.
+  assign r_assign = a.x + b.x;
   initial begin
-    #2 $display("r=%0d", r);
+    #2 $display("r=%0d r_assign=%0d", r, r_assign);
     a.x = 100;
-    #1 $display("r=%0d", r);
+    #1 $display("r=%0d r_assign=%0d", r, r_assign);
     b.x = 200;
-    #1 $display("r=%0d", r);
+    #1 $display("r=%0d r_assign=%0d", r, r_assign);
   end
 endmodule


### PR DESCRIPTION
## Summary

Extends the existing cross-instance combinational-reader case to cover a continuous-assign reader alongside `always_comb`, and drops a hierarchy tracking item whose described failure had no correlate in the current code path.

## Design

The tracking entry described a case where an `assign` reader over a cross-instance signal whose driver is itself a continuous assignment would capture a pre-settle value once and never update. Tracing the paths that back this behavior -- `Var::Set` fires waiters unconditionally on change regardless of caller, and `sensitivity_wait` handles a cross-unit reference through the same subscribe path as a local field, binding to the target `Var` through the resolve-phase-filled borrowed pointer -- there is no code path that treats an assign-driven source differently from a procedurally-driven one. The item was recorded when three parallel install mechanisms coexisted; the unification into one route removed the failure surface. Rather than leaving a checked item as historical noise, the entry is removed and the invariant is anchored by a test.

The case was already exercising `always_comb` reading two cross-instance sources. Adding an `assign r_assign = a.x + b.x;` alongside the existing reader keeps the two combinational-reader syntactic variants in one file (matching the existing test-consolidation guidance) and asserts that the continuous-assign reader tracks the same source changes at every checkpoint the case already validates.