### PR TITLE
Reject DPI and fold hierarchical constant references

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -94,11 +94,23 @@ full support.
 
 ### Localized / long tail
 
-- [ ] **Hierarchical / cross-unit reference to a parameter** (reaching a sub-instance's parameter
-      through a dotted path, e.g. the `mhpmcounter` accessor in the DPI block).
-- [ ] **Cross-unit reference resolved through a generate-instantiated child scope** -- a reference
-      that descends into or out of a module instance created inside a generate block (ibex_ex_block
-      instantiates its multiplier and divider this way). Today it aborts during lowering.
+- [x] **Hierarchical / cross-unit reference to a parameter or enum constant** -- reaching a
+      sub-instance's `localparam` or enum value through a dotted path (the `MHPMCounterNum` accessor
+      in the DPI block). A hierarchically reached compile-time constant resolves to its value
+      independent of the path, matching a same-scope reference to the same constant.
+- [ ] **DPI-C import and export** -- `import "DPI-C"` binds an SV subroutine name to a foreign C
+      implementation and `export "DPI-C"` exposes an SV subroutine to C (LRM 35.4, 35.5). Lyra emits
+      no C ABI, so both are rejected with a diagnostic rather than silently lowered (a DPI import
+      would otherwise become an empty subroutine returning a default on every call). This is the
+      current full-top frontier: `ibex_simple_system` exports `mhpmcounter_num` / `mhpmcounter_get`
+      to the Verilator C++ testbench -- unneeded by the pure-SV `ibex_simple_system_tb` run, but the
+      unmodified source still declares them.
+- [ ] **Hierarchical reference reaching a module instance from a nested generate scope** -- a dotted
+      reference, written inside a conditional or loop generate block, that descends into a module
+      instance owned by an enclosing scope (the RVFI trap logic in `ibex_core`,
+      `id_stage_i.controller_i.exc_req_d` inside `gen_rvfi_no_wb_stage`; `ibex_ex_block` reaches its
+      generate-instantiated multiplier and divider the same way). Reached once DPI export above is
+      handled or elided.
 - [ ] **`$value$plusargs`** -- runtime plusarg query (ibex_tracer reads the trace-enable plusarg).
 - [ ] **A procedural statement form in ibex_cs_registers** -- one unsupported statement shape,
       recorded for follow-up once isolated.

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -34,6 +34,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedSubroutineArgument,
   kUnsupportedForkJoinForm,
   kUnsupportedClassFeature,
+  kUnsupportedDpi,
 
   kErrorDelayValueOutOfRange,
   kErrorCaseEqualityOnRealOperand,

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -126,6 +126,10 @@ constexpr std::array kEntries{
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
             .name = "unsupported_class_feature"}},
+    std::pair{
+        DiagCode::kUnsupportedDpi,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported, .name = "unsupported_dpi"}},
 
     std::pair{
         DiagCode::kErrorDelayValueOutOfRange,

--- a/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
@@ -8,7 +8,9 @@
 #include <slang/ast/Compilation.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
+#include <slang/ast/symbols/SubroutineSymbols.h>
 
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
@@ -53,6 +55,9 @@ class CompilationLowerer {
   }
 
   auto Run() -> diag::Result<std::vector<hir::ModuleUnit>> {
+    if (auto ok = RejectDpiExports(); !ok) {
+      return std::unexpected(std::move(ok.error()));
+    }
     const auto unit_bodies = CollectUnits();
     std::vector<hir::ModuleUnit> units;
     units.reserve(unit_bodies.size());
@@ -66,6 +71,22 @@ class CompilationLowerer {
   }
 
  private:
+  // A DPI-C export (LRM 35.5) makes an SV subroutine callable from C. Lyra
+  // emits no C-export ABI, so an exported subroutine cannot be honored;
+  // rejecting it is what keeps it from lowering as an ordinary subroutine that
+  // silently drops the export contract. slang collects exports only from
+  // elaborated scopes, so every entry belongs to the design under compilation.
+  auto RejectDpiExports() -> diag::Result<void> {
+    for (const auto& dpi : facts_.Compilation().getDPIExports()) {
+      if (dpi.subroutine == nullptr) continue;
+      return diag::Fail(
+          facts_.SourceMapper().PointSpanOf(dpi.subroutine->location),
+          diag::DiagCode::kUnsupportedDpi,
+          "DPI-C export of a subroutine is not yet supported");
+    }
+    return {};
+  }
+
   auto CollectUnits() -> std::vector<const slang::ast::InstanceBodySymbol*> {
     const auto& root = facts_.Compilation().getRoot();
     UnitCollector collector;

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -34,6 +34,143 @@ namespace lyra::lowering::ast_to_hir {
 
 namespace {
 
+// What a value reference to a symbol lowers to, independent of whether the
+// reference is written by simple name or by a hierarchical path (LRM 6, 8.4,
+// 23.6). A parameter or enum value is a compile-time constant whose value does
+// not depend on the path used to reach it; a variable or net binds to a runtime
+// storage cell; a class property reaches the invoking object's field. One
+// classification serves every reference-lowering entry so a symbol cannot be
+// read as a constant through one syntax and rejected through another.
+enum class Referent {
+  kParameterConstant,
+  kEnumConstant,
+  kClassProperty,
+  kVariableStorage,
+  kNetStorage,
+  kUnsupported,
+};
+
+// Total over slang's symbol kinds with no `default`: a kind that ought to lower
+// to a real referent must not hide in a catch-all and surface as a spurious
+// "unsupported" -- the failure mode that let a hierarchically reached parameter
+// read as an unsupported reference. Listing every kind forces a deliberate
+// classification of each (a plausible referent like a specparam is a conscious
+// entry, not a silent omission), and a kind added by a future slang release
+// fails to compile until it is classified here.
+auto ClassifyReferent(const slang::ast::Symbol& sym) -> Referent {
+  using slang::ast::SymbolKind;
+  switch (sym.kind) {
+    case SymbolKind::Parameter:
+      return Referent::kParameterConstant;
+    case SymbolKind::EnumValue:
+      return Referent::kEnumConstant;
+    case SymbolKind::ClassProperty:
+      return Referent::kClassProperty;
+    case SymbolKind::Variable:
+    case SymbolKind::FormalArgument:
+    case SymbolKind::Iterator:
+      return Referent::kVariableStorage;
+    case SymbolKind::Net:
+      return Referent::kNetStorage;
+    case SymbolKind::Unknown:
+    case SymbolKind::Root:
+    case SymbolKind::Definition:
+    case SymbolKind::CompilationUnit:
+    case SymbolKind::DeferredMember:
+    case SymbolKind::TransparentMember:
+    case SymbolKind::EmptyMember:
+    case SymbolKind::PredefinedIntegerType:
+    case SymbolKind::ScalarType:
+    case SymbolKind::FloatingType:
+    case SymbolKind::EnumType:
+    case SymbolKind::PackedArrayType:
+    case SymbolKind::FixedSizeUnpackedArrayType:
+    case SymbolKind::DynamicArrayType:
+    case SymbolKind::DPIOpenArrayType:
+    case SymbolKind::AssociativeArrayType:
+    case SymbolKind::QueueType:
+    case SymbolKind::PackedStructType:
+    case SymbolKind::UnpackedStructType:
+    case SymbolKind::PackedUnionType:
+    case SymbolKind::UnpackedUnionType:
+    case SymbolKind::ClassType:
+    case SymbolKind::CovergroupType:
+    case SymbolKind::VoidType:
+    case SymbolKind::NullType:
+    case SymbolKind::CHandleType:
+    case SymbolKind::StringType:
+    case SymbolKind::EventType:
+    case SymbolKind::UnboundedType:
+    case SymbolKind::TypeRefType:
+    case SymbolKind::UntypedType:
+    case SymbolKind::SequenceType:
+    case SymbolKind::PropertyType:
+    case SymbolKind::VirtualInterfaceType:
+    case SymbolKind::TypeAlias:
+    case SymbolKind::ErrorType:
+    case SymbolKind::ForwardingTypedef:
+    case SymbolKind::NetType:
+    case SymbolKind::TypeParameter:
+    case SymbolKind::Port:
+    case SymbolKind::MultiPort:
+    case SymbolKind::InterfacePort:
+    case SymbolKind::Modport:
+    case SymbolKind::ModportPort:
+    case SymbolKind::ModportClocking:
+    case SymbolKind::Instance:
+    case SymbolKind::InstanceBody:
+    case SymbolKind::InstanceArray:
+    case SymbolKind::Package:
+    case SymbolKind::ExplicitImport:
+    case SymbolKind::WildcardImport:
+    case SymbolKind::Attribute:
+    case SymbolKind::Genvar:
+    case SymbolKind::GenerateBlock:
+    case SymbolKind::GenerateBlockArray:
+    case SymbolKind::ProceduralBlock:
+    case SymbolKind::StatementBlock:
+    case SymbolKind::Field:
+    case SymbolKind::Subroutine:
+    case SymbolKind::ContinuousAssign:
+    case SymbolKind::ElabSystemTask:
+    case SymbolKind::GenericClassDef:
+    case SymbolKind::MethodPrototype:
+    case SymbolKind::UninstantiatedDef:
+    case SymbolKind::PatternVar:
+    case SymbolKind::ConstraintBlock:
+    case SymbolKind::DefParam:
+    case SymbolKind::Specparam:
+    case SymbolKind::Primitive:
+    case SymbolKind::PrimitivePort:
+    case SymbolKind::PrimitiveInstance:
+    case SymbolKind::SpecifyBlock:
+    case SymbolKind::Sequence:
+    case SymbolKind::Property:
+    case SymbolKind::AssertionPort:
+    case SymbolKind::ClockingBlock:
+    case SymbolKind::ClockVar:
+    case SymbolKind::LocalAssertionVar:
+    case SymbolKind::LetDecl:
+    case SymbolKind::Checker:
+    case SymbolKind::CheckerInstance:
+    case SymbolKind::CheckerInstanceBody:
+    case SymbolKind::RandSeqProduction:
+    case SymbolKind::CovergroupBody:
+    case SymbolKind::Coverpoint:
+    case SymbolKind::CoverCross:
+    case SymbolKind::CoverCrossBody:
+    case SymbolKind::CoverageBin:
+    case SymbolKind::TimingPath:
+    case SymbolKind::PulseStyle:
+    case SymbolKind::SystemTimingCheck:
+    case SymbolKind::AnonymousProgram:
+    case SymbolKind::NetAlias:
+    case SymbolKind::ConfigBlock:
+      return Referent::kUnsupported;
+  }
+  throw InternalError("ClassifyReferent: unknown slang SymbolKind");
+}
+
 auto MakeEnumValueExpr(
     const slang::ast::EnumValueSymbol& sym, hir::TypeId type,
     diag::SourceSpan span) -> hir::Expr {
@@ -42,6 +179,48 @@ auto MakeEnumValueExpr(
     throw InternalError("MakeEnumValueExpr: enum value is not integral");
   }
   return MakeIntegralLiteralExpr(cv.integer(), type, span);
+}
+
+auto MakeParameterConstantExpr(
+    ModuleLowerer& module, WalkFrame frame, const slang::ast::Symbol& sym,
+    const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = module.InternType(type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return MakeConstantValueExpr(
+      module.Unit(), frame, sym.as<slang::ast::ParameterSymbol>().getValue(),
+      *type_id, span);
+}
+
+auto MakeEnumConstantExpr(
+    ModuleLowerer& module, const slang::ast::Symbol& sym,
+    const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = module.InternType(type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return MakeEnumValueExpr(
+      sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
+}
+
+// A static data object (LRM 6.21) reached through the structural scope, by the
+// hop distance from the referrer's frame to the frame that owns it.
+auto BindStructuralDataObject(
+    ModuleLowerer& module, WalkFrame frame, const slang::ast::ValueSymbol& sym,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  const auto binding = module.LookupStructuralDataObjectBinding(sym);
+  if (!binding.has_value()) {
+    throw InternalError(
+        "BindStructuralDataObject: value was not bound during scope lowering");
+  }
+  const auto hops = frame.HopsTo(binding->home_frame);
+  if (!hops.has_value()) {
+    throw InternalError(
+        "BindStructuralDataObject: value home frame is not on the current "
+        "scope stack");
+  }
+  return hir::MakeRefExpr(
+      hir::StructuralDataObjectRef{.hops = *hops, .var = binding->var_id},
+      binding->type, span);
 }
 
 // LRM 7.12.4: a reference to an array-method `with`-clause iteration element
@@ -61,6 +240,19 @@ auto MakeIterationElementRefExpr(
       *type_id, span);
 }
 
+auto MakeClassPropertyRefExpr(
+    ModuleLowerer& module, const slang::ast::Symbol& sym,
+    const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = module.InternType(type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::MakeRefExpr(
+      hir::ClassPropertyRef{
+          .field_index =
+              ClassPropertyIndex(sym.as<slang::ast::ClassPropertySymbol>())},
+      *type_id, span);
+}
+
 }  // namespace
 
 auto LowerNamedValueProc(
@@ -75,70 +267,41 @@ auto LowerNamedValueProc(
     return MakeIterationElementRefExpr(module, named, *clause, span);
   }
 
-  if (sym.kind == slang::ast::SymbolKind::EnumValue) {
-    auto type_id = module.InternType(*named.type, span);
-    if (!type_id) return std::unexpected(std::move(type_id.error()));
-    return MakeEnumValueExpr(
-        sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
-  }
-
-  // Inside an instance method, a class property named without an explicit
-  // handle (LRM 8.4) reaches the invoking object through the method's receiver,
-  // so it lowers to a receiver-relative property reference, not a body local.
-  if (sym.kind == slang::ast::SymbolKind::ClassProperty) {
-    auto type_id = module.InternType(*named.type, span);
-    if (!type_id) return std::unexpected(std::move(type_id.error()));
-    return hir::MakeRefExpr(
-        hir::ClassPropertyRef{
-            .field_index =
-                ClassPropertyIndex(sym.as<slang::ast::ClassPropertySymbol>())},
-        *type_id, span);
-  }
-
-  if (sym.kind == slang::ast::SymbolKind::Parameter) {
-    auto type_id = module.InternType(*named.type, span);
-    if (!type_id) return std::unexpected(std::move(type_id.error()));
-    return MakeConstantValueExpr(
-        module.Unit(), frame, sym.as<slang::ast::ParameterSymbol>().getValue(),
-        *type_id, span);
-  }
-
-  // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
-  // VariableSymbol subclasses and route through the same procedural-var
-  // binding as ordinary body locals.
-  // A net (LRM 6.5) is always a structural signal; the variable family may
-  // also be a procedural body local, so try that binding for them first. A net
-  // never has a procedural binding.
-  if (sym.kind == slang::ast::SymbolKind::Variable ||
-      sym.kind == slang::ast::SymbolKind::FormalArgument ||
-      sym.kind == slang::ast::SymbolKind::Iterator) {
-    const auto& var = sym.as<slang::ast::VariableSymbol>();
-    if (auto local = proc.LookupProceduralVar(var)) {
-      const hir::TypeId type =
-          frame.current_procedural_body->procedural_vars.Get(*local).type;
-      return hir::MakeRefExpr(hir::ProceduralVarRef{.var = *local}, type, span);
+  switch (ClassifyReferent(sym)) {
+    case Referent::kParameterConstant:
+      return MakeParameterConstantExpr(module, frame, sym, *named.type, span);
+    case Referent::kEnumConstant:
+      return MakeEnumConstantExpr(module, sym, *named.type, span);
+    // Inside an instance method, a class property named without an explicit
+    // handle (LRM 8.4) reaches the invoking object through the method's
+    // receiver, so it lowers to a receiver-relative property reference.
+    case Referent::kClassProperty:
+      return MakeClassPropertyRefExpr(module, sym, *named.type, span);
+    // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
+    // variable-family symbols; each binds to procedural-var storage when the
+    // enclosing process declares it, otherwise to the static data object of the
+    // same name reached through the structural scope.
+    case Referent::kVariableStorage: {
+      const auto& var = sym.as<slang::ast::VariableSymbol>();
+      if (auto local = proc.LookupProceduralVar(var)) {
+        const hir::TypeId type =
+            frame.current_procedural_body->procedural_vars.Get(*local).type;
+        return hir::MakeRefExpr(
+            hir::ProceduralVarRef{.var = *local}, type, span);
+      }
+      return BindStructuralDataObject(
+          module, frame, sym.as<slang::ast::ValueSymbol>(), span);
     }
-  } else if (sym.kind != slang::ast::SymbolKind::Net) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
-        "reference to non-variable declaration is not supported");
+    // A net (LRM 6.5) is always a structural signal, never a procedural local.
+    case Referent::kNetStorage:
+      return BindStructuralDataObject(
+          module, frame, sym.as<slang::ast::ValueSymbol>(), span);
+    case Referent::kUnsupported:
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
+          "reference to non-variable declaration is not supported");
   }
-
-  const auto binding = module.LookupStructuralDataObjectBinding(
-      sym.as<slang::ast::ValueSymbol>());
-  if (!binding.has_value()) {
-    throw InternalError(
-        "LowerNamedValueProc: value was not bound during scope lowering");
-  }
-  const auto hops = frame.HopsTo(binding->home_frame);
-  if (!hops.has_value()) {
-    throw InternalError(
-        "LowerNamedValueProc: variable home frame is not on the current scope "
-        "stack");
-  }
-  return hir::MakeRefExpr(
-      hir::StructuralDataObjectRef{.hops = *hops, .var = binding->var_id},
-      binding->type, span);
+  throw InternalError("LowerNamedValueProc: unknown Referent");
 }
 
 // LRM 23.6 hierarchical reference. A downward path is rooted in a local
@@ -160,11 +323,28 @@ auto LowerHierarchicalValue(
   }
 
   const auto& target = hve.symbol;
-  if (target.kind != slang::ast::SymbolKind::Variable) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "cross-unit reference to a non-variable declaration is not yet "
-        "supported");
+  switch (ClassifyReferent(target)) {
+    // A hierarchically reached constant folds to its value; the path is not
+    // navigated because the value is fixed at elaboration.
+    case Referent::kParameterConstant:
+      return MakeParameterConstantExpr(module, frame, target, *hve.type, span);
+    case Referent::kEnumConstant:
+      return MakeEnumConstantExpr(module, target, *hve.type, span);
+    case Referent::kClassProperty:
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "hierarchical reference to a class property is not yet supported");
+    case Referent::kNetStorage:
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "hierarchical reference to a net is not yet supported");
+    case Referent::kUnsupported:
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "hierarchical reference to this declaration kind is not yet "
+          "supported");
+    case Referent::kVariableStorage:
+      break;
   }
 
   auto type_id = module.InternType(*hve.type, span);
@@ -340,41 +520,25 @@ auto LowerNamedValueStructural(
   if (auto clause = frame.FindIterationClause(sym)) {
     return MakeIterationElementRefExpr(module, named, *clause, span);
   }
-  if (sym.kind == slang::ast::SymbolKind::EnumValue) {
-    auto type_id = module.InternType(*named.type, span);
-    if (!type_id) return std::unexpected(std::move(type_id.error()));
-    return MakeEnumValueExpr(
-        sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
+  switch (ClassifyReferent(sym)) {
+    case Referent::kParameterConstant:
+      return MakeParameterConstantExpr(module, frame, sym, *named.type, span);
+    case Referent::kEnumConstant:
+      return MakeEnumConstantExpr(module, sym, *named.type, span);
+    case Referent::kVariableStorage:
+    case Referent::kNetStorage:
+      return BindStructuralDataObject(
+          module, frame, sym.as<slang::ast::ValueSymbol>(), span);
+    // A class property has no structural (non-procedural) meaning: it is only
+    // reachable through a method receiver, so outside a method it is rejected
+    // alongside the genuinely unsupported kinds.
+    case Referent::kClassProperty:
+    case Referent::kUnsupported:
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
+          "reference to non-variable declaration is not supported");
   }
-  if (sym.kind == slang::ast::SymbolKind::Parameter) {
-    auto type_id = module.InternType(*named.type, span);
-    if (!type_id) return std::unexpected(std::move(type_id.error()));
-    return MakeConstantValueExpr(
-        module.Unit(), frame, sym.as<slang::ast::ParameterSymbol>().getValue(),
-        *type_id, span);
-  }
-  if (sym.kind != slang::ast::SymbolKind::Variable &&
-      sym.kind != slang::ast::SymbolKind::Net) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
-        "reference to non-variable declaration is not supported");
-  }
-  const auto binding = module.LookupStructuralDataObjectBinding(
-      sym.as<slang::ast::ValueSymbol>());
-  if (!binding.has_value()) {
-    throw InternalError(
-        "LowerNamedValueStructural: value was not bound during scope "
-        "lowering");
-  }
-  const auto hops = frame.HopsTo(binding->home_frame);
-  if (!hops.has_value()) {
-    throw InternalError(
-        "LowerNamedValueStructural: variable home frame is not on the current "
-        "scope stack");
-  }
-  return hir::MakeRefExpr(
-      hir::StructuralDataObjectRef{.hops = *hops, .var = binding->var_id},
-      binding->type, span);
+  throw InternalError("LowerNamedValueStructural: unknown Referent");
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -11,6 +11,7 @@
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
@@ -55,6 +56,17 @@ auto LowerSubroutineDecl(
     ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym,
     WalkFrame frame) -> diag::Result<hir::SubroutineDecl> {
   const auto& mapper = module.SourceMapper();
+
+  // A DPI-C import (LRM 35.4) binds an SV subroutine name to a foreign C
+  // implementation, so the subroutine has no SV body Lyra can execute.
+  // Rejecting it prevents lowering the empty shell as an ordinary subroutine
+  // that would silently return a default value on every call.
+  if (sym.flags.has(slang::ast::MethodFlags::DPIImport)) {
+    return diag::Fail(
+        mapper.PointSpanOf(sym.location), diag::DiagCode::kUnsupportedDpi,
+        "DPI-C import of a subroutine is not yet supported");
+  }
+
   auto return_type_or =
       module.InternType(sym.getReturnType(), mapper.PointSpanOf(sym.location));
   if (!return_type_or) {

--- a/tests/cases/cpp/hierarchy_downward_into_generate/case.yaml
+++ b/tests/cases/cpp/hierarchy_downward_into_generate/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stdout:
-    exact: "11 207 42 5\n"
+    exact: "11 207 42 5 12 9\n"

--- a/tests/cases/cpp/hierarchy_downward_into_generate/main.sv
+++ b/tests/cases/cpp/hierarchy_downward_into_generate/main.sv
@@ -1,9 +1,11 @@
 module Leaf;
+  localparam int W = 12;
+  typedef enum int {Red = 3, Green = 9} color_e;
   int x;
 endmodule
 
 module Top;
-  int a, b, c, d;
+  int a, b, c, d, e, f;
   initial begin
     g[2].u.x = 207;
     #1;
@@ -11,7 +13,9 @@ module Top;
     b = g[2].u.x;
     c = bk.v;
     d = bp.w;
-    $display("%0d %0d %0d %0d", a, b, c, d);
+    e = g[0].u.W;
+    f = g[0].u.Green;
+    $display("%0d %0d %0d %0d %0d %0d", a, b, c, d, e, f);
   end
   genvar i;
   generate

--- a/tests/cases/errors/dpi_export_unsupported/case.yaml
+++ b/tests/cases/errors/dpi_export_unsupported/case.yaml
@@ -1,0 +1,18 @@
+id: errors.dpi_export_unsupported
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "main.sv:4:"
+      - "unsupported:"
+      - "DPI-C export of a subroutine is not yet supported"
+    not_contains:
+      - "internal error"
+      - "\x1b["

--- a/tests/cases/errors/dpi_export_unsupported/main.sv
+++ b/tests/cases/errors/dpi_export_unsupported/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  export "DPI-C" function get_val;
+
+  function automatic int unsigned get_val();
+    return 42;
+  endfunction
+endmodule

--- a/tests/cases/errors/dpi_import_unsupported/case.yaml
+++ b/tests/cases/errors/dpi_import_unsupported/case.yaml
@@ -1,0 +1,18 @@
+id: errors.dpi_import_unsupported
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "main.sv:2:"
+      - "unsupported:"
+      - "DPI-C import of a subroutine is not yet supported"
+    not_contains:
+      - "internal error"
+      - "\x1b["

--- a/tests/cases/errors/dpi_import_unsupported/main.sv
+++ b/tests/cases/errors/dpi_import_unsupported/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  import "DPI-C" function int c_add(int a, int b);
+  int x;
+  initial begin
+    x = c_add(3, 4);
+  end
+endmodule


### PR DESCRIPTION
## Summary

At the AST-to-HIR boundary, "what does a reference to this symbol lower to" was answered in three separate places -- the procedural named reference, the structural named reference, and the hierarchical reference -- and they had drifted. A same-scope reference to a `parameter` or enum value folded to its constant, but the hierarchical path rejected the identical symbol as "cross-unit reference to a non-variable declaration", so `a.b.SomeParam` failed while `SomeParam` worked. This PR routes all three entries through a single `ClassifyReferent`, so a symbol is classified once and cannot be read as a constant through one syntax and rejected through another. A hierarchically reached compile-time constant (parameter or enum value) now folds to its value independent of the path, exactly like a same-scope reference.

The classifier switches over slang's `SymbolKind` with no `default`: a kind that ought to lower to a real referent cannot hide in a catch-all and surface as a spurious "unsupported" (the exact shape of the bug above), and a kind added by a future slang release fails to compile until it is classified. The small Lyra-owned `Referent` enum is likewise matched exhaustively at each call site.

Separately, DPI-C import and export were silently mishandled: an `import "DPI-C"` function lowered to an empty subroutine that returned a default value on every call, and an `export "DPI-C"` directive was dropped while its subroutine lowered as ordinary SV. Both are now rejected with an explicit unsupported diagnostic -- imports at the single subroutine-lowering entry, exports at the compilation level -- under one `kUnsupportedDpi` code.

## Testing

`bazel test //...` is green. The hierarchical constant fold is covered by extending the existing downward-into-generate hierarchy case to read a child `localparam` and enum value alongside its variable reads (the standalone probe case it replaced was removed to avoid a redundant case). Two error cases assert the DPI diagnostics (`errors/dpi_import_unsupported`, `errors/dpi_export_unsupported`); an `errors` case can only assert the first diagnostic, so import and export are necessarily separate.

## Context

Surfaced while re-aligning the Ibex frontier: `ibex_simple_system` reaches a deep `localparam` (`MHPMCounterNum`) through a hierarchical path inside a DPI-C export accessor. The hierarchical-constant fold clears that reference; the DPI diagnostic then makes the export itself the honest frontier rather than silently compiling an accessor that cannot work. `docs/progress/ibex.md` is updated accordingly.
