### PR TITLE
Unify continuous-assign write dispatch by LHS type

### DIFF
--- a/include/lyra/lowering/hir_to_mir/continuous_assign.hpp
+++ b/include/lyra/lowering/hir_to_mir/continuous_assign.hpp
@@ -1,29 +1,50 @@
 #pragma once
 
-#include <optional>
 #include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/continuous_assign.hpp"
+#include "lyra/hir/structural_data_object.hpp"
+#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
-#include "lyra/mir/field.hpp"
 #include "lyra/mir/method.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
-// When the continuous-assignment target is a net, the process drives one of the
-// net's driver slots instead of writing a cell: its body updates this driver
-// handle member with the evaluated right-hand side (LRM 6.5).
-struct NetDriver {
-  mir::FieldId driver_field;
-  mir::TypeId driver_type;
-};
+// Stable identity of a resolved-net target reached by a continuous
+// assignment's LHS. Two assignments whose LHS reaches the same net share
+// one identity value (LRM 6.5).
+using ContinuousWriteTarget = std::variant<
+    std::pair<hir::StructuralHops, hir::StructuralDataObjectId>,
+    hir::CrossUnitRefId>;
 
+// Caller-owned record of the resolved-net targets a lowering loop has
+// already installed a driver on. `LowerContinuousAssign` inspects and
+// appends to it: a duplicate at insertion is a same-scope multi-driver
+// (LRM 6.5), which the lowering rejects with a user diagnostic. Callers
+// for whom multi-driver is impossible by construction pass a fresh
+// instance and never inspect it.
+using ContinuousAssignDrivenNets = std::vector<ContinuousWriteTarget>;
+
+// Lowers a continuous assignment fully, including any Resolve- and
+// Initialize-phase side effects the LHS's type demands. A variable-typed
+// LHS produces a body coroutine that writes the cell directly every
+// iteration (LRM 10.3.2). A resolved-net-typed LHS installs a driver-handle
+// field on the enclosing class, attaches the driver at Resolve, seeds it
+// at Initialize, and the body updates the driver every iteration (LRM
+// 6.5). The write protocol is picked by the LHS's MIR type; callers see
+// one API for both cases. The three phase frames all address the same
+// enclosing class; each carries its phase's target block. `driven_nets` is
+// the caller's dedup set: the lowering registers the LHS's target into it
+// and returns `Fail` on a duplicate.
 auto LowerContinuousAssign(
-    const StructuralScopeLowerer& lowerer, WalkFrame frame, std::string name,
-    const hir::ContinuousAssign& src,
-    std::optional<NetDriver> net_driver = std::nullopt)
-    -> diag::Result<mir::MethodDecl>;
+    const StructuralScopeLowerer& lowerer, const WalkFrame& ctor_frame,
+    const WalkFrame& resolve_frame, const WalkFrame& init_frame,
+    std::string name, const hir::ContinuousAssign& src,
+    ContinuousAssignDrivenNets& driven_nets) -> diag::Result<mir::MethodDecl>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -1,11 +1,17 @@
 #include "lyra/lowering/hir_to_mir/continuous_assign.hpp"
 
+#include <algorithm>
 #include <expected>
+#include <format>
 #include <optional>
+#include <string>
 #include <utility>
+#include <variant>
 
 #include "lyra/hir/continuous_assign.hpp"
+#include "lyra/hir/expr.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
@@ -13,80 +19,232 @@
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/callable_code.hpp"
+#include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/field.hpp"
 #include "lyra/mir/method.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+// The MIR value type behind a resolved-net LHS, paired with the LHS target's
+// stable identity. Only bare structural or cross-unit references may name a
+// net target: a select or other computed LHS is a variable path even if its
+// root sits on a net (whose runtime protocol still forbids a direct write).
+struct ResolvedNetLhs {
+  mir::TypeId value_type;
+  ContinuousWriteTarget target;
+};
+
+// Answers "is this LHS a resolved-net cell" at the type level, without
+// lowering the LHS. Reads the field type of the ancestor class picked by
+// the LHS's `hops` for a same-unit ref, or the pointee of the pre-declared
+// cross-unit slot's type for a cross-unit ref. In both cases, net-versus-
+// variable is a property of the target's MIR type (LRM 6.5).
+auto ClassifyLhsAsResolvedNet(
+    const StructuralScopeLowerer& lowerer, const WalkFrame& frame,
+    hir::ExprId lhs_id) -> std::optional<ResolvedNetLhs> {
+  const mir::CompilationUnit& unit = lowerer.Module().Unit();
+  const auto* prim =
+      std::get_if<hir::PrimaryExpr>(&lowerer.HirScope().exprs.Get(lhs_id).data);
+  if (prim == nullptr) return std::nullopt;
+  if (const auto* ref =
+          std::get_if<hir::StructuralDataObjectRef>(&prim->data)) {
+    const mir::FieldId target =
+        lowerer.TranslateStructuralDataObject(ref->hops, ref->var);
+    const mir::TypeId target_type =
+        frame.EnclosingClassAtHops(mir::EnclosingHops{ref->hops.value})
+            .fields.Get(target)
+            .type;
+    const auto* resolved =
+        std::get_if<mir::ResolvedType>(&unit.types.Get(target_type).data);
+    if (resolved == nullptr) return std::nullopt;
+    return ResolvedNetLhs{
+        .value_type = resolved->value,
+        .target = std::pair{ref->hops, ref->var}};
+  }
+  if (const auto* cuv = std::get_if<hir::CrossUnitVarRef>(&prim->data)) {
+    const auto& meta = lowerer.CrossUnitRefTarget(cuv->id);
+    const auto& ptr =
+        std::get<mir::PointerType>(unit.types.Get(meta.slot_type).data);
+    const auto* resolved =
+        std::get_if<mir::ResolvedType>(&unit.types.Get(ptr.pointee).data);
+    if (resolved == nullptr) return std::nullopt;
+    return ResolvedNetLhs{.value_type = resolved->value, .target = cuv->id};
+  }
+  return std::nullopt;
+}
+
+// The runtime handle a body update writes into for a resolved-net target.
+// A field on the enclosing class holds the handle; the field is attached
+// at Resolve and seeded at Initialize.
+struct AttachedDriver {
+  mir::FieldId driver_field;
+  mir::TypeId driver_type;
+};
+
+// Installs a driver on a net cell reached through a route: a driver-handle
+// member bound at Resolve (`self->driver = net_access.AttachDriver()`) and
+// seeded at Initialize (`self->driver.Update(services, source)`). The
+// caller supplies `net_access` -- the resolve-phase lvalue of the net cell,
+// itself the LHS lowered in `resolve_frame` -- so a same-scope target reads
+// as `self->net`, a cross-scope one as `self->parent()->net`, and a
+// cross-unit target as the routed navigation into the child. The driver
+// handle field is added to the enclosing class under `driver_name` (LRM
+// 6.5).
+auto AttachDriver(
+    const StructuralScopeLowerer& lowerer, mir::ExprId net_access,
+    mir::TypeId value_type, const std::string& driver_name, hir::ExprId source,
+    const WalkFrame& resolve_frame, const WalkFrame& init_frame)
+    -> diag::Result<AttachedDriver> {
+  mir::CompilationUnit& unit = lowerer.Module().Unit();
+  const hir::StructuralScope& hir_scope = lowerer.HirScope();
+  mir::Class& mir_class = *resolve_frame.current_class;
+  const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
+  mir::Block& resolve_block = *resolve_frame.current_block;
+  mir::Block& init_block = *init_frame.current_block;
+
+  const mir::TypeId driver_type =
+      unit.types.Intern(mir::DriverType{.value = value_type});
+  const mir::FieldId driver_field = mir_class.fields.Add(
+      mir::FieldDecl{.name = driver_name, .type = driver_type});
+
+  const mir::ExprId attach = resolve_block.exprs.Add(
+      mir::MakeNetAttachDriverCallExpr(net_access, driver_type));
+  const mir::ExprId resolve_self =
+      resolve_block.exprs.Add(MakeSelfRefExpr(resolve_frame, self_ptr_type));
+  const mir::ExprId driver_lhs = resolve_block.exprs.Add(
+      mir::MakeFieldAccessExpr(resolve_self, driver_field, driver_type));
+  const mir::ExprId attach_assign = resolve_block.exprs.Add(
+      mir::Expr{
+          .data = mir::AssignExpr{.target = driver_lhs, .value = attach},
+          .type = driver_type});
+  resolve_block.AppendStmt(
+      mir::Stmt{
+          .label = std::nullopt, .data = mir::ExprStmt{.expr = attach_assign}});
+
+  auto source_or = lowerer.LowerExpr(hir_scope.exprs.Get(source), init_frame);
+  if (!source_or) return std::unexpected(std::move(source_or.error()));
+  const mir::ExprId seed_value = init_block.exprs.Add(*std::move(source_or));
+  const auto init_self = [&] {
+    return init_block.exprs.Add(MakeSelfRefExpr(init_frame, self_ptr_type));
+  };
+  const mir::ExprId seed_services = init_block.exprs.Add(
+      mir::MakeServicesCallExpr(init_self(), unit.builtins.services));
+  const mir::ExprId seed_driver = init_block.exprs.Add(
+      mir::MakeFieldAccessExpr(init_self(), driver_field, driver_type));
+  const mir::ExprId seed_update = init_block.exprs.Add(
+      mir::MakeNetDriverUpdateCallExpr(
+          seed_driver, seed_services, seed_value, unit.builtins.void_type));
+  init_block.AppendStmt(
+      mir::Stmt{
+          .label = std::nullopt, .data = mir::ExprStmt{.expr = seed_update}});
+
+  return AttachedDriver{
+      .driver_field = driver_field, .driver_type = driver_type};
+}
+
+}  // namespace
 
 // LRM 10.3.2 (continuous assignment) and LRM 9.2.2.2.1 (always_comb) share a
 // runtime mental model: re-evaluate the assignment whenever any RHS read
 // changes. HIR keeps continuous assignment as a distinct scope-level node so
 // source diagnostics retain provenance; at HIR -> MIR we materialise the
-// runtime shape directly here as a coroutine body `forever { lhs = rhs;
-// SensitivityWaitStmt(reads); }`, which the caller registers as a startup
-// activation. The body executes once at t=0 (the natural fall-through of the
-// eternal loop) before the first wait, matching LRM 9.2.2.2's "evaluate at
-// time 0" requirement for inferred sensitivity.
+// runtime shape as a coroutine body `forever { <write>; wait on reads; }`,
+// which the caller registers as a startup activation. The body executes once
+// at t=0 (the natural fall-through of the eternal loop) before the first
+// wait, matching LRM 9.2.2.2's "evaluate at time 0" requirement for inferred
+// sensitivity. The write is chosen by LHS type: a resolved-net cell is
+// driven through a driver handle attached at Resolve; every other observable
+// cell is written directly. Same-scope multi-driver on one net is rejected
+// against `driven_nets`, which the caller carries across its loop.
 auto LowerContinuousAssign(
-    const StructuralScopeLowerer& lowerer, WalkFrame frame, std::string name,
-    const hir::ContinuousAssign& src, std::optional<NetDriver> net_driver)
-    -> diag::Result<mir::MethodDecl> {
+    const StructuralScopeLowerer& lowerer, const WalkFrame& ctor_frame,
+    const WalkFrame& resolve_frame, const WalkFrame& init_frame,
+    std::string name, const hir::ContinuousAssign& src,
+    ContinuousAssignDrivenNets& driven_nets) -> diag::Result<mir::MethodDecl> {
   mir::CompilationUnit& unit = lowerer.Module().Unit();
+  const hir::StructuralScope& hir_scope = lowerer.HirScope();
+  const mir::TypeId self_ptr_type = ctor_frame.current_class->self_pointer_type;
+
+  // A resolved-net target acquires a driver handle in Resolve, installed as
+  // a field on the enclosing class; the body updates that handle every
+  // iteration. A non-net LHS falls through to the direct observable write,
+  // with no Resolve-phase acquisition. Multi-driver rejection runs before
+  // the install so a duplicate never leaves side effects behind.
+  std::optional<AttachedDriver> attached;
+  if (const auto net =
+          ClassifyLhsAsResolvedNet(lowerer, resolve_frame, src.lhs)) {
+    if (std::ranges::find(driven_nets, net->target) != driven_nets.end()) {
+      return diag::Fail(
+          src.span, diag::DiagCode::kUnsupportedContinuousAssignForm,
+          "a net with more than one driver is not yet supported");
+    }
+    driven_nets.push_back(net->target);
+    auto net_access_or =
+        lowerer.LowerLhsExpr(hir_scope.exprs.Get(src.lhs), resolve_frame);
+    if (!net_access_or) {
+      return std::unexpected(std::move(net_access_or.error()));
+    }
+    const mir::ExprId net_access =
+        resolve_frame.current_block->exprs.Add(*std::move(net_access_or));
+    const std::string driver_name = std::format("{}__driver", name);
+    auto attached_or = AttachDriver(
+        lowerer, net_access, net->value_type, driver_name, src.rhs,
+        resolve_frame, init_frame);
+    if (!attached_or) return std::unexpected(std::move(attached_or.error()));
+    attached = *attached_or;
+  }
+
   mir::CallableCode code;
   CallableBindings bindings(unit, code);
   const mir::LocalId self_id = bindings.Declare(
       BindingOriginId::Receiver(),
-      mir::LocalDecl{
-          .name = "self", .type = frame.current_class->self_pointer_type});
-  const WalkFrame outer_frame = frame.WithBlock(&code.body)
-                                    .WithBindings(&bindings)
-                                    .WithCoroutineBody(true);
+      mir::LocalDecl{.name = "self", .type = self_ptr_type});
 
   mir::Block body_block;
-  const WalkFrame body_frame = outer_frame.WithBlock(&body_block);
-
-  const hir::StructuralScope& hir_scope = lowerer.HirScope();
+  const WalkFrame body_frame =
+      ctor_frame.WithBindings(&bindings).WithCoroutineBody(true).WithBlock(
+          &body_block);
 
   auto rhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(src.rhs), body_frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::TypeId assign_type = (*rhs_or).type;
   const mir::ExprId rhs_id = body_block.exprs.Add(*std::move(rhs_or));
 
-  // Build `self.Services()` in the body so an observable LHS routes through
-  // `Var<T>::Set` (or `Mutate` for a selector chain) and a net driver routes
-  // through `Driver<T>::Update`. The body's `self` is the receiver binding
-  // seeded above, reached through the same capture machinery a process body's
-  // self read uses.
-  const mir::ExprId body_self_ref = body_block.exprs.Add(
-      MakeSelfRefExpr(body_frame, frame.current_class->self_pointer_type));
+  // Build `self.Services()` in the body: an observable LHS writes through
+  // it, and a net driver updates through it. The body's `self` is the
+  // receiver binding seeded above, reached through the same capture
+  // machinery a process body's self read uses.
+  const mir::ExprId body_self_ref =
+      body_block.exprs.Add(MakeSelfRefExpr(body_frame, self_ptr_type));
   const mir::ExprId body_services_id = body_block.exprs.Add(
-      mir::MakeServicesCallExpr(
-          body_self_ref, lowerer.Module().Unit().builtins.services));
+      mir::MakeServicesCallExpr(body_self_ref, unit.builtins.services));
 
   mir::ExprId effect_id{};
-  if (net_driver.has_value()) {
-    // A net target drives one of the net's driver slots: the body updates the
-    // driver handle member with the evaluated right-hand side, and the net
-    // re-resolves (LRM 6.5).
-    const mir::ExprId driver_self = body_block.exprs.Add(
-        MakeSelfRefExpr(body_frame, frame.current_class->self_pointer_type));
+  if (attached.has_value()) {
+    // Body writes the driver handle; the net re-resolves and publishes on a
+    // real change (LRM 6.5).
+    const mir::ExprId driver_self =
+        body_block.exprs.Add(MakeSelfRefExpr(body_frame, self_ptr_type));
     const mir::ExprId driver_access = body_block.exprs.Add(
         mir::MakeFieldAccessExpr(
-            driver_self, net_driver->driver_field, net_driver->driver_type));
+            driver_self, attached->driver_field, attached->driver_type));
     effect_id = body_block.exprs.Add(
         mir::MakeNetDriverUpdateCallExpr(
-            driver_access, body_services_id, rhs_id,
-            lowerer.Module().Unit().builtins.void_type));
+            driver_access, body_services_id, rhs_id, unit.builtins.void_type));
   } else {
     auto lhs_or =
         lowerer.LowerLhsExpr(hir_scope.exprs.Get(src.lhs), body_frame);
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
     const mir::ExprId lhs_id = body_block.exprs.Add(*std::move(lhs_or));
     const mir::Expr assign_expr = BuildObservableAssignExpr(
-        lowerer.Module().Unit(), body_block, body_services_id, lhs_id, rhs_id,
-        std::nullopt, assign_type, lowerer.Module().Unit().builtins.void_type);
+        unit, body_block, body_services_id, lhs_id, rhs_id, std::nullopt,
+        assign_type, unit.builtins.void_type);
     effect_id = body_block.exprs.Add(assign_expr);
   }
   body_block.AppendStmt(mir::ExprStmt{.expr = effect_id});

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -900,17 +900,6 @@ void AppendProcessRegistration(
   block.AppendStmt(mir::ExprStmt{.expr = reg_call});
 }
 
-auto AttachNetDriver(
-    const StructuralScopeLowerer& lowerer, mir::Class& mir_class,
-    mir::ExprId net_access, mir::TypeId value_type,
-    const std::string& driver_name, hir::ExprId source,
-    const WalkFrame& resolve_frame, const WalkFrame& init_frame,
-    mir::TypeId self_ptr_type) -> diag::Result<NetDriver>;
-
-auto ContinuousAssignNetTarget(
-    const StructuralScopeLowerer& lowerer, const mir::Class& mir_class,
-    const hir::ContinuousAssign& ca) -> std::optional<mir::FieldId>;
-
 // Realizes each port connection (LRM 23.3.3). An input or output port is the
 // implied continuous assignment between the two cells, materialized as the same
 // synthesized process a scope-level `assign` produces, registered as a process;
@@ -926,8 +915,6 @@ auto InstallPortConnections(
   mir::Block& resolve_block = *resolve_frame.current_block;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   ModuleLowerer& module = lowerer.Module();
-  const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
-  std::size_t net_port_index = 0;
   for (const auto& pc : hir_scope.port_connections) {
     if (pc.direction == hir::PortDirection::kRef) {
       // Bind the child's reference member to the connected variable's cell in
@@ -969,71 +956,25 @@ auto InstallPortConnections(
     const bool is_input = pc.direction == hir::PortDirection::kInput;
     // A port connection is a reactive edge: the source is read, the sink is
     // driven. An input port's source is the parent expression and its sink is
-    // the child cell; an output port's source is the child cell and its sink is
-    // the parent target. The edge body is the same continuous assignment either
-    // way; only the sink's capability picks the write protocol -- a net cell
-    // takes a driver, a variable cell a direct assignment (LRM 23.3.3).
+    // the child cell; an output port's source is the child cell and its sink
+    // is the parent target. The edge is the same continuous assignment either
+    // way; the sink's own MIR type -- resolved-net cell or observable cell --
+    // picks the write protocol (LRM 23.3.3).
     const hir::ContinuousAssign assign{
         .span = pc.span,
         .lhs = is_input ? cell.cell : pc.peer,
         .rhs = is_input ? pc.peer : cell.cell,
         .sensitivity_list = pc.sensitivity};
-
-    // The sink is a net in two shapes: an input port whose child cell is a net
-    // (reached cross-unit), or an output port whose parent target is a net
-    // (local). Either resolves to a driver the edge's process updates; a
-    // non-net sink keeps the direct continuous-assign write.
-    std::optional<NetDriver> net_driver;
-    auto attach_sink_driver = [&](mir::ExprId net_access,
-                                  hir::ExprId source) -> diag::Result<void> {
-      const mir::TypeId value_type =
-          std::get<mir::ResolvedType>(
-              module.Unit()
-                  .types.Get(resolve_block.exprs.Get(net_access).type)
-                  .data)
-              .value;
-      const std::string driver_name =
-          std::format("net_port_{}__driver", net_port_index++);
-      auto driver_or = AttachNetDriver(
-          lowerer, mir_class, net_access, value_type, driver_name, source,
-          resolve_frame, init_frame, self_ptr_type);
-      if (!driver_or) return std::unexpected(std::move(driver_or.error()));
-      net_driver = *driver_or;
-      return {};
-    };
-    if (is_input) {
-      const auto* prim =
-          std::get_if<hir::PrimaryExpr>(&hir_scope.exprs.Get(cell.cell).data);
-      const auto* cuv = prim != nullptr
-                            ? std::get_if<hir::CrossUnitVarRef>(&prim->data)
-                            : nullptr;
-      if (cuv != nullptr &&
-          hir_scope.cross_unit_refs.Get(cuv->id).target_net_type.has_value()) {
-        auto net_or =
-            lowerer.LowerLhsExpr(hir_scope.exprs.Get(cell.cell), resolve_frame);
-        if (!net_or) return std::unexpected(std::move(net_or.error()));
-        const mir::ExprId net_access =
-            resolve_block.exprs.Add(*std::move(net_or));
-        auto r = attach_sink_driver(net_access, pc.peer);
-        if (!r) return std::unexpected(std::move(r.error()));
-      }
-    } else if (
-        const auto net_field =
-            ContinuousAssignNetTarget(lowerer, mir_class, assign)) {
-      const mir::TypeId net_type = mir_class.fields.Get(*net_field).type;
-      const mir::ExprId net_self = resolve_block.exprs.Add(
-          MakeSelfRefExpr(resolve_frame, self_ptr_type));
-      const mir::ExprId net_access = resolve_block.exprs.Add(
-          mir::MakeFieldAccessExpr(net_self, *net_field, net_type));
-      auto r = attach_sink_driver(net_access, assign.rhs);
-      if (!r) return std::unexpected(std::move(r.error()));
-    }
-
     std::string name = std::format("process_{}", mir_class.methods.size());
-    auto decl_or = LowerContinuousAssign(
-        lowerer, frame, std::move(name), assign, net_driver);
-    if (!decl_or) return std::unexpected(std::move(decl_or.error()));
-    const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
+    // A port connection is single-driver by construction (LRM 23.3.3),
+    // so no port pair here can duplicate another's target; a fresh dedup
+    // set per iteration exists only to satisfy the lowering's API.
+    ContinuousAssignDrivenNets driven_nets;
+    auto method_or = LowerContinuousAssign(
+        lowerer, frame, resolve_frame, init_frame, std::move(name), assign,
+        driven_nets);
+    if (!method_or) return std::unexpected(std::move(method_or.error()));
+    const mir::MethodId body = mir_class.methods.Add(std::move(*method_or));
     AppendProcessRegistration(module, activate_frame, body, false);
   }
   return {};
@@ -1059,86 +1000,6 @@ auto AsOwnedGenerateChildClassId(
     return obj->class_id;
   }
   return std::nullopt;
-}
-
-// The net member a continuous assignment drives -- the resolved-net cell its
-// left-hand side names -- or nullopt when the target is a variable (a direct
-// write, not a driver).
-auto ContinuousAssignNetTarget(
-    const StructuralScopeLowerer& lowerer, const mir::Class& mir_class,
-    const hir::ContinuousAssign& ca) -> std::optional<mir::FieldId> {
-  const hir::StructuralScope& hir_scope = lowerer.HirScope();
-  const auto* prim =
-      std::get_if<hir::PrimaryExpr>(&hir_scope.exprs.Get(ca.lhs).data);
-  if (prim == nullptr) return std::nullopt;
-  const auto* ref = std::get_if<hir::StructuralDataObjectRef>(&prim->data);
-  if (ref == nullptr) return std::nullopt;
-  const mir::FieldId target =
-      lowerer.TranslateStructuralDataObject(ref->hops, ref->var);
-  const mir::TypeId target_type = mir_class.fields.Get(target).type;
-  if (!std::holds_alternative<mir::ResolvedType>(
-          lowerer.Module().Unit().types.Get(target_type).data)) {
-    return std::nullopt;
-  }
-  return target;
-}
-
-// Installs a driver on a net cell reached through a route: a driver-handle
-// member bound at Resolve (`self->driver = net_access.AttachDriver()`) and
-// seeded at Initialize (`self->driver.Update(services, source)`). `net_access`
-// is the resolve-phase lvalue of the net cell -- a local member access for a
-// continuous assignment, a cross-unit navigation for a port connection -- and
-// `source` is the driving expression, lowered in the initialize phase. Returns
-// the driver handle the activation process updates whenever the source changes.
-auto AttachNetDriver(
-    const StructuralScopeLowerer& lowerer, mir::Class& mir_class,
-    mir::ExprId net_access, mir::TypeId value_type,
-    const std::string& driver_name, hir::ExprId source,
-    const WalkFrame& resolve_frame, const WalkFrame& init_frame,
-    mir::TypeId self_ptr_type) -> diag::Result<NetDriver> {
-  ModuleLowerer& module = lowerer.Module();
-  const hir::StructuralScope& hir_scope = lowerer.HirScope();
-  mir::Block& resolve_block = *resolve_frame.current_block;
-  mir::Block& init_block = *init_frame.current_block;
-
-  const mir::TypeId driver_type =
-      module.Unit().types.Intern(mir::DriverType{.value = value_type});
-  const mir::FieldId driver_field = mir_class.fields.Add(
-      mir::FieldDecl{.name = driver_name, .type = driver_type});
-
-  const mir::ExprId attach = resolve_block.exprs.Add(
-      mir::MakeNetAttachDriverCallExpr(net_access, driver_type));
-  const mir::ExprId resolve_self =
-      resolve_block.exprs.Add(MakeSelfRefExpr(resolve_frame, self_ptr_type));
-  const mir::ExprId driver_lhs = resolve_block.exprs.Add(
-      mir::MakeFieldAccessExpr(resolve_self, driver_field, driver_type));
-  const mir::ExprId attach_assign = resolve_block.exprs.Add(
-      mir::Expr{
-          .data = mir::AssignExpr{.target = driver_lhs, .value = attach},
-          .type = driver_type});
-  resolve_block.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt, .data = mir::ExprStmt{.expr = attach_assign}});
-
-  auto source_or = lowerer.LowerExpr(hir_scope.exprs.Get(source), init_frame);
-  if (!source_or) return std::unexpected(std::move(source_or.error()));
-  const mir::ExprId seed_value = init_block.exprs.Add(*std::move(source_or));
-  const auto init_self = [&] {
-    return init_block.exprs.Add(MakeSelfRefExpr(init_frame, self_ptr_type));
-  };
-  const mir::ExprId seed_services = init_block.exprs.Add(
-      mir::MakeServicesCallExpr(init_self(), module.Unit().builtins.services));
-  const mir::ExprId seed_driver = init_block.exprs.Add(
-      mir::MakeFieldAccessExpr(init_self(), driver_field, driver_type));
-  const mir::ExprId seed_update = init_block.exprs.Add(
-      mir::MakeNetDriverUpdateCallExpr(
-          seed_driver, seed_services, seed_value,
-          module.Unit().builtins.void_type));
-  init_block.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt, .data = mir::ExprStmt{.expr = seed_update}});
-
-  return NetDriver{.driver_field = driver_field, .driver_type = driver_type};
 }
 
 void ValidateOwnedChildConstruction(
@@ -2020,51 +1881,20 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     }
   }
 
-  std::vector<mir::FieldId> driven_nets;
+  // Scope-local multi-driver dedup. Two continuous assigns in this scope
+  // whose LHS reaches the same resolved-net target address the same net;
+  // the lowering registers each net target into `driven_nets` and rejects
+  // a duplicate. Design-global driver-count validation is a Seal-barrier
+  // concern; this set catches only the trivially detectable same-scope
+  // case.
+  ContinuousAssignDrivenNets driven_nets;
   for (const auto& ca : hir_scope.continuous_assigns) {
-    // A continuous assignment to a net is a driver (LRM 6.5): it attaches a
-    // driver slot at Resolve, seeds it at Initialize, and the activation
-    // process updates it. A variable target keeps the direct continuous-assign
-    // write.
-    std::optional<NetDriver> net_driver;
-    if (const auto net_field =
-            ContinuousAssignNetTarget(lowerer, mir_class, ca)) {
-      // A net carries one driver; a second driver on the same net is rejected
-      // at lowering rather than left to fail at runtime.
-      const bool already_driven = std::ranges::any_of(
-          driven_nets,
-          [&](mir::FieldId m) { return m.value == net_field->value; });
-      if (already_driven) {
-        return diag::Fail(
-            ca.span, diag::DiagCode::kUnsupportedContinuousAssignForm,
-            "a net with more than one driver is not yet supported");
-      }
-      driven_nets.push_back(*net_field);
-      // The net cell is a local member; its resolve-phase lvalue is a member
-      // access off `self`.
-      mir::Block& resolve_block = *resolve_frame.current_block;
-      const mir::TypeId net_type = mir_class.fields.Get(*net_field).type;
-      const mir::TypeId value_type =
-          std::get<mir::ResolvedType>(module.Unit().types.Get(net_type).data)
-              .value;
-      const mir::ExprId net_self = resolve_block.exprs.Add(
-          MakeSelfRefExpr(resolve_frame, self_ptr_type));
-      const mir::ExprId net_access = resolve_block.exprs.Add(
-          mir::MakeFieldAccessExpr(net_self, *net_field, net_type));
-      const std::string driver_name =
-          std::format("{}__driver", mir_class.fields.Get(*net_field).name);
-      auto driver_or = AttachNetDriver(
-          lowerer, mir_class, net_access, value_type, driver_name, ca.rhs,
-          resolve_frame, init_frame, self_ptr_type);
-      if (!driver_or) return std::unexpected(std::move(driver_or.error()));
-      net_driver = *driver_or;
-    }
-
     std::string name = std::format("process_{}", mir_class.methods.size());
-    auto decl_or = LowerContinuousAssign(
-        lowerer, ctor_frame, std::move(name), ca, net_driver);
-    if (!decl_or) return std::unexpected(std::move(decl_or.error()));
-    const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
+    auto method_or = LowerContinuousAssign(
+        lowerer, ctor_frame, resolve_frame, init_frame, std::move(name), ca,
+        driven_nets);
+    if (!method_or) return std::unexpected(std::move(method_or.error()));
+    const mir::MethodId body = mir_class.methods.Add(std::move(*method_or));
     AppendProcessRegistration(module, activate_frame, body, false);
   }
 

--- a/tests/cases/cpp/continuous_assign_generate_outer_lhs/case.yaml
+++ b/tests/cases/cpp/continuous_assign_generate_outer_lhs/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.continuous_assign_generate_outer_lhs
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    out: 42
+    seen_w: 43

--- a/tests/cases/cpp/continuous_assign_generate_outer_lhs/main.sv
+++ b/tests/cases/cpp/continuous_assign_generate_outer_lhs/main.sv
@@ -1,0 +1,33 @@
+// A continuous assignment inside a generate block whose left-hand side is a
+// bare reference to a data object declared in the enclosing scope. The LRM
+// makes no distinction between an `assign` written in the module body and one
+// written in a `generate` branch (LRM 10.3.2, 27.4): both are the same
+// reactive edge. The bare-reference LHS makes the target's storage cell live
+// one hop out, which the LHS lowering handles the same way any cross-scope
+// hierarchical reference does (`docs/architecture/reference_resolution.md`).
+//
+// Covers both target kinds so the type-driven dispatch that decides "install a
+// driver" versus "write the cell" exercises the same route on each side
+// (`docs/architecture/net_resolution.md`).
+module Top;
+  logic [7:0] a;
+  int         out;
+  wire [7:0]  w;
+  logic [7:0] seen_w;
+  generate
+    if (1) begin : g
+      // Variable target reached across the generate boundary: LHS lowers to
+      // the outer variable's cell, written directly.
+      assign out = a + 8'd1;
+      // Net target reached across the generate boundary: LHS lowers to the
+      // outer net's cell, driven through a driver installed on this generate
+      // scope.
+      assign w = a + 8'd2;
+    end
+  endgenerate
+  initial begin
+    a = 8'd41;
+    #1;
+    seen_w = w;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Continuous assignments dispatched on net-versus-variable through a caller-side peek at the LHS's HIR shape and a hardcoded `self->field` install for the driver. The peek looked up the field's type in the current `mir::Class` no matter which scope the LHS actually lived in, so an `assign` inside a `generate if` whose LHS is a bare reference to an outer variable crashed with `Arena::Get: id 1 is out of range`. The install path additionally hardcoded `self->local_field`, silently wrong for any cross-scope net. This PR internalizes the whole thing: `LowerContinuousAssign` reads the LHS's MIR type, installs a driver through the LHS's own resolved expression when it names a net, and writes the observable cell directly otherwise. Callers see one API and pass a `ContinuousAssignDrivenNets` set the lowering registers into and dedups against.

## Design

Reads, sensitivity subscribe, and hierarchical routing were already type-driven via `IsObservableCellType` and the route infra; only the continuous-assign write leaked net-vs-variable to every call site. Moving the split inside preserves the real asymmetry (a net has driver-contribution identity that a variable does not, per LRM 6.5) but stops each caller from having to know. The port-connection input-net case previously ran through a separate HIR-flag peek (`target_net_type.has_value()`) and the output-net case through a broken arena peek; both collapse into the shared entry.

Registering the target identity into a caller-owned dedup set (rather than returning a wrapper struct with the identity alongside the `MethodDecl`) keeps the lowering's return the real IR object, per architecture policy A011. Multi-driver rejection now runs before the driver install so a rejected assign never leaves side effects behind.

## Testing

New case `continuous_assign_generate_outer_lhs` covers both a variable target and a net target reached from inside a `generate if` in the enclosing scope -- exercises the exact code path the arena crash hit, plus its net counterpart (which the driver-install hardcode would have miscompiled). Full suite green.