### PR TITLE
Unify reference and sensitivity route translation

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -118,6 +118,10 @@ the detail lives in the entry itself.
   allocates; elaboration is a staged build / resolve / initialize / activate protocol.
 - [net-driver-resolution](net-driver-resolution.md) -- a net is a resolution node with node-owned
   driver slots and capability-handle drivers, validated at a Seal barrier; single-driver is N=1.
+- [front-end-semantic-boundary](front-end-semantic-boundary.md) -- slang owns semantic resolution
+  and sensitivity extraction; Lyra translates resolved facts to executable route and endpoint
+  capability; sensitivity uses the correct per-consumer slang surface and never reclassifies from
+  `ValueSymbol + global table + HopsTo`.
 
 ### Compile-time model and specialization
 

--- a/docs/decisions/front-end-semantic-boundary.md
+++ b/docs/decisions/front-end-semantic-boundary.md
@@ -133,10 +133,21 @@ one translation; they must not each re-derive it.
 
 - The order-dependent stale-value defect and the function-body-read defect are both closed by moving
   to the correct front-end surfaces and refusing to reclassify from degraded information.
-- Removing the parallel classifier entirely -- so sensitivity never asks "is this enclosing /
-  sibling / routed" and instead consumes one `(reader context, target)` translation shared with the
-  body -- is the architecture reset this boundary enables; it is staged after the correctness
-  repairs above.
+- Sensitivity no longer decides whether to keep a dependency, or how to reach it, from the CU-global
+  table's membership plus a `HopsTo`, and neither the value read nor the observation classifies its
+  route by slang's lexical up/down. A compilation-unit declaration pass (D3,
+  `declarations-before-bodies.md`) registers a generate's owned-child identity before any body
+  lowers, so both operations route a cross-scope target by layout visibility from its elaborated
+  position -- a typed climb-and-descent while the segments stay in this unit, a by-name segment only
+  across a unit boundary -- independent of the order the target and referrer appear in source. The
+  observation supplies its own route for a dependency the reader's body never resolved (a signal
+  read only inside a called function) and otherwise reuses the endpoint the body produced.
+- Two gaps remain before this boundary is fully realized. The value read and the observation are
+  built by two routines that duplicate the layout-visibility routing rather than one shared
+  translation. And the declaration pass covers generate identities; instance and named-block
+  identities are still registered during the body pass, so a forward cross-scope reference to one of
+  those is not yet order-independent. Consolidating the routing onto one translation over every
+  addressable identity is the remaining step.
 - Whether value access and change observation ultimately share one bound runtime endpoint (and
   whether an enclosing reference binds a per-instance handle rather than re-navigating the parent
   chain on the hot path) is a later endpoint-capability decision, constrained by this boundary but

--- a/docs/decisions/front-end-semantic-boundary.md
+++ b/docs/decisions/front-end-semantic-boundary.md
@@ -133,25 +133,24 @@ one translation; they must not each re-derive it.
 
 - The order-dependent stale-value defect and the function-body-read defect are both closed by moving
   to the correct front-end surfaces and refusing to reclassify from degraded information.
-- Sensitivity no longer decides whether to keep a dependency, or how to reach it, from the CU-global
-  table's membership plus a `HopsTo`, and neither the value read nor the observation classifies its
-  route by slang's lexical up/down. A compilation-unit declaration pass (D3,
-  `declarations-before-bodies.md`) registers a generate's owned-child identity before any body
-  lowers, so both operations route a cross-scope target by layout visibility from its elaborated
-  position -- a typed climb-and-descent while the segments stay in this unit, a by-name segment only
-  across a unit boundary -- independent of the order the target and referrer appear in source. The
-  observation supplies its own route for a dependency the reader's body never resolved (a signal
-  read only inside a called function) and otherwise reuses the endpoint the body produced.
-- Two gaps remain before this boundary is fully realized. The value read and the observation are
-  built by two routines that duplicate the layout-visibility routing rather than one shared
-  translation. And the declaration pass covers generate identities; instance and named-block
-  identities are still registered during the body pass, so a forward cross-scope reference to one of
-  those is not yet order-independent. Consolidating the routing onto one translation over every
-  addressable identity is the remaining step.
-- Whether value access and change observation ultimately share one bound runtime endpoint (and
-  whether an enclosing reference binds a per-instance handle rather than re-navigating the parent
-  chain on the hot path) is a later endpoint-capability decision, constrained by this boundary but
-  not settled here.
+- Value read, value write, and change observation reach a target through one route translator (D3),
+  keyed on the reader's elaborated position and the target symbol. Neither re-derives the route, and
+  no route depends on which consumer lowers first or on cross-unit-slot dedup. The translator
+  classifies each segment by layout visibility from the target's elaborated position -- a typed
+  enclosing climb or typed downward head while the segments stay in this unit, a by-name head where
+  the route crosses the compilation-unit boundary -- so enclosing, downward-child, sibling,
+  cross-module, and upward-out-of-unit references all route the same way, independent of the order
+  the target and referrer appear in source. The reader is located in the elaborated hierarchy
+  through its enclosing structural scope, so a read nested in a procedural block or a fork branch
+  routes from that scope. slang's resolved reference path is provenance only, never a second routing
+  authority.
+- Two items remain before the boundary is fully realized. A named procedural block's identity is
+  still assigned during the body pass -- it shares an arena populated by statement traversal, with
+  no source-order position the declaration pass can predict -- so a forward cross-scope reference to
+  a named block is not yet order-independent. And whether value access and change observation share
+  one bound runtime endpoint -- and whether an enclosing reference binds a per-instance handle
+  rather than re-navigating the parent chain on the hot path -- is the endpoint-capability half of
+  the boundary, constrained by it but not settled here.
 
 ## Relation to existing decisions
 

--- a/docs/decisions/front-end-semantic-boundary.md
+++ b/docs/decisions/front-end-semantic-boundary.md
@@ -1,0 +1,155 @@
+# Front-End Semantic Facts and Lyra Route/Endpoint Translation Boundary
+
+## Date
+
+2026-07-08
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+Two sensitivity defects share one root cause: Lyra reconstructs semantic facts that the front-end
+(slang) has already resolved, from degraded information, instead of translating the resolved facts.
+
+- A combinational reader of a same-unit cross-scope signal (a sibling or child generate block, a
+  named block) silently loses its change subscription when the target was lowered before the reader:
+  `TranslateSensitivityReads` finds the target in the compilation-unit-global structural-data-object
+  table, computes `HopsTo` to it, and -- because a sibling/child scope is not on the reader's
+  enclosing chain -- drops the dependency instead of routing it. The result is order-dependent: the
+  same design compiles to a working or a broken sensitivity depending on declaration order.
+- A reader whose dependency is read only inside a called function (`always_comb y = f();`, `f` reads
+  a signal) has no subscription at all, so it never re-evaluates. LRM 9.2.2.2.1 requires an
+  `always_comb` to be sensitive to signals read within any function it calls.
+
+Both are consequences of the same boundary being crossed the wrong way. This entry fixes the
+boundary so subsequent reference and sensitivity work inherits it.
+
+## The model that shaped the decision
+
+The front-end has already performed SystemVerilog semantic resolution. For every reference and every
+sensitivity dependency, slang objectively provides:
+
+- The resolved target: a `ValueSymbol*` that is an elaborated-instance-member identity (distinct per
+  elaborated instance; the same symbol for one target across spellings; one symbol for a reference
+  authored once inside a reused unit).
+- For a hierarchical reference, the complete route: `HierarchicalReference` carries `target`, the
+  originating expression, a per-hop `path` (each hop's traversed symbol plus its index/range/name
+  selector), `upwardCount`, `isUpward()`, and `isViaIfacePort()`.
+- The sensitivity dependency shape: `(ValueSymbol* target, bit range)` per read, plus a per-term
+  edge for explicit event controls. The correct read set per consumer is a specific slang surface
+  (below), not one lowered surface for all.
+- The target's semantic kind: net vs variable (`SymbolKind::Net` with its net kind), and driver kind
+  flags for ports and `ref` (`InputPort`, `OutputPort`, `ViaIndirectPort`).
+
+Both the reader scope and the target symbol self-locate in slang's elaborated hierarchy
+(`getHierarchicalParent()` / `getHierarchicalPath()`; the instance-body transition is the
+compilation-unit boundary, which is exactly where `getHierarchicalParent` differs from
+`getParentScope`). Therefore the route from a reader to a target is a structural relationship
+between two already-resolved tree positions -- a translation, never a re-resolution of names. This
+holds identically for a direct read (where a caller-side reference expression also exists) and a
+function-body indirect read (where it does not); the general input is
+`(reader context, target symbol, footprint/edge)`, of which the direct read is the special case.
+
+## The decision
+
+### D1. slang owns semantic resolution and sensitivity extraction; Lyra owns translation
+
+Lyra does not re-resolve SystemVerilog names, does not re-derive up/down/root classification, and
+does not classify a reference from degraded information. slang is the authority for which symbol a
+reference denotes, what its hierarchy route is, which dependencies form a procedure's sensitivity,
+and whether a target is a net, a variable, a port, or a `ref`.
+
+Forbidden shape: deciding how to reach or whether to keep a dependency from
+`ValueSymbol* + compilation-unit-global table + HopsTo`. The CU-global structural-data-object table
+is a legitimate declaration-identity registry (see `declarations-before-bodies.md`); using its
+membership, or a failed `HopsTo`, as a routing classifier is the defect. A failed `HopsTo` means
+only "the target is not on the reader's enclosing chain" (a sibling or child, or another unit); it
+never means "drop," and it is never the classifier for local vs cross-scope vs cross-unit.
+
+### D2. Sensitivity source is consumer-specific
+
+Inferred sensitivity is not one raw `DefaultDFA.getRValues()` for every consumer. `getRValues()` is
+the `@*` surface (call arguments only); it does not satisfy the `always_comb` requirement that
+function-body reads contribute. Each consumer reads the surface slang defines for it (this realigns
+the code with `read-set-inference.md`, whose intent the current code diverged from):
+
+- `always_comb` / `always_latch` (LRM 9.2.2.2.1, 9.2.2.3): `AnalyzedProcedure::getSensitivityList()`
+  -- the implicit list with function-body reads inlined and locally/function-driven bits subtracted.
+- `always @*` (LRM 9.4.2.2): the implicit-event region read set (function arguments only, no
+  function-body reads).
+- explicit event control (`always @(...)`, `always_ff`): the explicit timing-control terms, carrying
+  per-term edges.
+- continuous assign / implied port assign (LRM 10.3, 23.3.3): the continuous-assign surface;
+  function-read inlining follows the chosen policy flag (the LRM leaves it unspecified).
+- `wait(cond)` (LRM 9.4.3): a fresh sub-expression analysis of the condition.
+
+Every inferred surface normalizes to the same dependency shape:
+`(elaborated target ValueSymbol*, bit range)`, with an edge only for explicit event controls. The
+target is a semantic target, not a route and not a runtime endpoint.
+
+### D3. Translation is two orthogonal axes, keyed on objective slang facts
+
+Given a semantic dependency `(reader context, target ValueSymbol*, footprint, optional edge)`, Lyra
+translates it with no name resolution:
+
+- Navigation-segment classification (per intermediate hop): a segment is layout-visible typed
+  navigation when its source and target classes are both owned by the emitting unit, and opaque
+  by-name navigation when it crosses into another compilation unit's body. The classifier is the
+  slang scope kind at each hop: a module/interface/package body, a `GenerateBlock` /
+  `GenerateBlockArray`, or a `StatementBlock` stays in the unit (typed); descending into an
+  `Instance` / `InstanceArray` body, or climbing out through the reader's own instance, crosses the
+  boundary (opaque). This is the per-segment rule of `reference_resolution.md`.
+- Endpoint-capability binding (at the leaf and any forwarding point): the target's access protocol
+  is bound from the target symbol kind and driver flags -- a variable to a plain observable cell, a
+  net to a resolved-net node, a `ref` to a collapsed alias of the connected cell, a port to its own
+  cell plus the implied continuous-assign edge -- narrowed by the footprint. This is
+  `reference_resolution.md`'s "the endpoint inherits the target's access protocol."
+
+Value read, value write, and change observation of one dependency reach the same target through this
+one translation; they must not each re-derive it.
+
+## Immediate changes
+
+1. `TranslateSensitivityReads` stops dropping on a failed `HopsTo`: a dependency whose target is not
+   an enclosing structural object is routed through the reference the body resolved, never
+   discarded. This removes the order-dependent loss for every consumer that infers a read set
+   (`always_comb`, `always @*`, continuous assign, `wait`, port connection). Interim correctness
+   repair; it does not yet remove the parallel classifier.
+2. `always_comb` / `always_latch` read `AnalyzedProcedure::getSensitivityList()` rather than raw
+   `getRValues()`, so function-body reads contribute per LRM 9.2.2.2.1. The other consumers already
+   read the surface their semantics require -- `always @*` and `wait` the reads of their controlled
+   region (function arguments only, LRM 9.2.2.2.2 / 9.4.3), continuous assign its RHS read set --
+   subject to one ordering correction: an `always @*` now infers its sensitivity after its body
+   lowers, so a read's cross-unit reference is resolved before the subscription is built, the same
+   order the other consumers already used.
+3. Regression tests cover: a same-unit cross-scope read in both declaration orders with a mutation
+   at t > 0 (order independence and real re-trigger, not t = 0 settling); an `always_comb` whose
+   dependency is read only inside a called function; and an `always @*` reading a cross-scope signal
+   declared before it.
+
+## Consequences
+
+- The order-dependent stale-value defect and the function-body-read defect are both closed by moving
+  to the correct front-end surfaces and refusing to reclassify from degraded information.
+- Removing the parallel classifier entirely -- so sensitivity never asks "is this enclosing /
+  sibling / routed" and instead consumes one `(reader context, target)` translation shared with the
+  body -- is the architecture reset this boundary enables; it is staged after the correctness
+  repairs above.
+- Whether value access and change observation ultimately share one bound runtime endpoint (and
+  whether an enclosing reference binds a per-instance handle rather than re-navigating the parent
+  chain on the hot path) is a later endpoint-capability decision, constrained by this boundary but
+  not settled here.
+
+## Relation to existing decisions
+
+- `read-set-inference.md` chose these per-consumer surfaces; this entry makes the consumer-specific
+  selection binding and records that the implementation must not collapse them onto `getRValues()`.
+- `reference_resolution.md` / `hierarchical-reference-routing.md` own the per-segment route
+  classification this entry translates onto; sensitivity observation rides the same route as value
+  access.
+- `declarations-before-bodies.md` owns the CU-global declaration-identity registry; this entry
+  forbids using that registry's membership as a routing classifier.
+- `net-driver-resolution.md`, `reference-as-data-type.md` own the endpoint capabilities (net, `ref`)
+  the translation binds to.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -773,6 +773,38 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
 
     **Interacts with**: R47 (object model), R51 (a class with a body), R8 (callable model).
 
+- [ ] R53 -- Finish the front-end reference / sensitivity translation boundary
+      (`../decisions/front-end-semantic-boundary.md`). The correctness repairs and the move to route
+      cross-scope references by layout visibility (order-independent, from a whole-unit declaration
+      pass) have landed. Three items remain before the boundary is fully realized:
+  - [x] R53a -- One route translation for every reference consumer. Value read, value write, and
+        change observation (including a dependency read only inside a called function) route through
+        one translator keyed on the reader's elaborated position and the target symbol; each segment
+        is classified by layout visibility, so enclosing, downward-child, sibling, cross-module, and
+        upward-out-of-unit references all resolve the same way with no dependence on lowering order
+        or cross-unit-slot dedup. The reader's elaborated position is recovered from its enclosing
+        structural scope, so a read nested in a procedural block or fork branch routes from that
+        scope. The frontend's resolved reference path is provenance only, not a routing authority.
+  - [ ] R53b -- The declaration pass covers every addressable identity. Generate and instance
+        identities are registered before any body lowers, so a forward cross-scope reference to them
+        is order-independent. A named procedural block's identity is still assigned while its body
+        lowers -- it shares an arena populated by statement traversal, with no source-order position
+        the declaration pass can predict -- so a forward cross-scope reference to a named block is
+        not yet order-independent. Give the named block a declaration-time identity so the invariant
+        holds for it too.
+  - [ ] R53c -- Endpoint binding. Whether a value read, a value write, and a change observation of
+        one target ultimately share one bound runtime endpoint -- and whether an enclosing reference
+        binds a per-instance handle rather than re-navigating the parent chain on the hot path -- is
+        the endpoint-capability half of the boundary, constrained by it but not settled. The
+        endpoint binds from the target's semantic kind (variable / net / `ref` / port) narrowed by
+        the footprint. A port connection is the other construct that reaches a cross-unit cell: it
+        constructs its child-cell reference and, for a `ref` port, its alias, independently of the
+        one route translator, because the alias binds from the raw navigation recipe rather than a
+        resolved slot -- exactly the port / `ref` endpoint-capability question this entry settles,
+        so that construction unifies here rather than in the route-translation cut. **Blocker**:
+        none identified; pairs with the endpoint-capability decisions
+        (`../decisions/net-driver-resolution.md`, `../decisions/reference-as-data-type.md`).
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -201,7 +201,7 @@ enum class EventEdge : std::uint8_t {
 // event control `@(posedge ...)` / `@(negedge ...)` / `@(edge ...)` set the
 // per-leaf edge.
 struct SensitivityEntry {
-  SensitivityRef ref;
+  ReferenceRoute ref;
   std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint;
   EventEdge edge_kind = EventEdge::kAnyChange;
 };

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -79,7 +79,7 @@ struct GenerateChildRef {
 struct DownwardHead {
   StructuralHops hops = {};
   std::variant<InstanceMemberId, GenerateChildRef, ProceduralScopeId> child;
-  std::vector<std::uint32_t> head_indices;
+  std::vector<std::uint32_t> head_indices = {};
 };
 
 // Where an upward cross-unit reference's navigation starts (LRM 23.8 / 23.9).

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -62,9 +62,11 @@ struct IterationBindingRef {
   auto operator==(const IterationBindingRef&) const -> bool = default;
 };
 
-// A sensitivity leaf observes either a this-unit structural data object or a
-// cross-unit member; both resolve to a stored `Observable` the scheduler
-// subscribes to.
-using SensitivityRef = std::variant<StructuralDataObjectRef, CrossUnitVarRef>;
+// A reader-relative route to a referenced value: either a this-unit structural
+// data object reached by a typed enclosing climb, or a cross-unit member
+// reached through a resolved slot. One route serves every consumer of the
+// reference -- value read, value write, and change observation -- so the name
+// is neutral to the consumer, not owned by sensitivity.
+using ReferenceRoute = std::variant<StructuralDataObjectRef, CrossUnitVarRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/instance_array_shape.hpp
+++ b/include/lyra/lowering/ast_to_hir/instance_array_shape.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include <slang/ast/Symbol.h>
+#include <slang/ast/symbols/InstanceSymbols.h>
+
+namespace lyra::lowering::ast_to_hir {
+
+// The resolved shape of an instance array: per-dimension element counts,
+// outermost first, and the per-element leaf instance that names the target
+// unit.
+struct InstanceArrayShape {
+  std::vector<std::uint32_t> dims;
+  const slang::ast::InstanceSymbol* leaf;
+};
+
+// Resolves a (possibly multi-dimensional) instance array to its shape. A
+// zero-element dimension (`Child c[0:-1]`, LRM 23.3.2) has no element to
+// descend into or to name the unit from and constructs nothing, so the array
+// contributes no member: nullopt. The declaration pass (which assigns each
+// array member its identity) and the member-population pass (which builds the
+// member) resolve the shape through this one predicate, so the identity a
+// reference resolves through and the member the body builds cannot drift.
+inline auto ResolveInstanceArrayShape(
+    const slang::ast::InstanceArraySymbol& array)
+    -> std::optional<InstanceArrayShape> {
+  std::vector<std::uint32_t> dims;
+  const slang::ast::Symbol* level = &array;
+  while (level->kind == slang::ast::SymbolKind::InstanceArray) {
+    const auto& arr = level->as<slang::ast::InstanceArraySymbol>();
+    if (arr.elements.empty()) {
+      return std::nullopt;
+    }
+    dims.push_back(static_cast<std::uint32_t>(arr.elements.size()));
+    level = arr.elements.front();
+  }
+  return InstanceArrayShape{
+      .dims = std::move(dims),
+      .leaf = &level->as<slang::ast::InstanceSymbol>()};
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -223,24 +223,20 @@ class ModuleLowerer {
       const std::vector<SensitivityRead>& reads, const WalkFrame& frame)
       -> std::vector<hir::SensitivityEntry>;
 
- private:
-  // Resolves one read target to the reader-relative access form: a typed climb
-  // when the target sits directly on an enclosing scope, otherwise a routed
-  // reference whose head and descent are reconstructed from the target's
-  // elaborated owner chain. Returns nullopt when the target is unreachable
-  // (a form not yet supported).
-  [[nodiscard]] auto TranslateReadTarget(
+  // The one route translator for every reference consumer -- value read, value
+  // write, and change observation. From the reader's elaborated position
+  // (`frame.reader_scope` and its unit-local chain) and the target symbol it
+  // computes the reader-relative route and classifies each segment by layout
+  // visibility: a typed enclosing climb when the target is a this-unit
+  // structural data object, a typed downward head when the head's class this
+  // unit emits, and a by-name head where the route crosses the compilation-unit
+  // boundary. Returns nullopt when the target is not an addressable signal or
+  // its form is not yet supported.
+  [[nodiscard]] auto TranslateReferenceRoute(
       const WalkFrame& frame, const slang::ast::ValueSymbol& value)
-      -> std::optional<hir::SensitivityRef>;
+      -> std::optional<hir::ReferenceRoute>;
 
-  // The cross-unit slot the body already resolved for `target` in `frame`, if
-  // any. An upward reference to an ancestor unit is reached by name across that
-  // unit's boundary (an opaque segment); the reader-relative downward
-  // reconstruction does not apply, so the observation reuses the body's slot.
-  [[nodiscard]] auto LookupCrossUnitRef(
-      ScopeFrameId frame, const slang::ast::ValueSymbol& target) const
-      -> std::optional<hir::CrossUnitRefId>;
-
+ private:
   // Facts.
   LoweringFacts facts_;
   const slang::ast::InstanceBodySymbol* body_;

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -25,6 +25,7 @@
 namespace slang::ast {
 class Expression;
 class ClassType;
+class Scope;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
@@ -183,6 +184,20 @@ class ModuleLowerer {
   auto TakeCrossUnitRefsForFrame(ScopeFrameId slot_owner_frame)
       -> std::vector<hir::CrossUnitRefDecl>;
 
+  // The compilation-unit structural declaration pass (LRM 27, 23.6): before any
+  // executable body lowers, walk the whole unit's scope tree, assign each
+  // addressable scope its frame, and register every owned-child head (instance,
+  // generate block, generate array). A body or sensitivity read resolves an
+  // owned child regardless of which sibling scope lowered first. Registers no
+  // executable HIR.
+  void DeclareStructuralIdentities(const slang::ast::Scope& scope);
+
+  // The frame assigned to `scope` by the declaration pass. Every scope a
+  // structural lowerer is built for was assigned one, so absence is a
+  // compiler-bug invariant.
+  [[nodiscard]] auto LookupScopeFrame(const slang::ast::Scope& scope) const
+      -> ScopeFrameId;
+
   // Frame minting for scope entry.
   [[nodiscard]] auto NextScopeFrameId() -> ScopeFrameId;
 
@@ -200,15 +215,28 @@ class ModuleLowerer {
       hir::CrossUnitRefHead head, std::vector<hir::PathSegment> path,
       hir::TypeId type, diag::SourceSpan span) -> hir::Expr;
 
-  // Translates slang-side reads to HIR SensitivityEntries via this module's
-  // binding tables, using the current walk frame to compute hops.
+  // Translates slang-side reads to HIR SensitivityEntries. Each read resolves
+  // to the same reader-relative route the reader would use to reach the target,
+  // derived from the target's elaborated position -- not reclassified from a
+  // global table lookup.
   [[nodiscard]] auto TranslateSensitivityReads(
-      const std::vector<SensitivityRead>& reads, const WalkFrame& frame) const
+      const std::vector<SensitivityRead>& reads, const WalkFrame& frame)
       -> std::vector<hir::SensitivityEntry>;
 
  private:
-  // Cross-unit ref dedup lookup. Private: TranslateSensitivityReads is the
-  // only caller; external code uses MapOrGetCrossUnitRef.
+  // Resolves one read target to the reader-relative access form: a typed climb
+  // when the target sits directly on an enclosing scope, otherwise a routed
+  // reference whose head and descent are reconstructed from the target's
+  // elaborated owner chain. Returns nullopt when the target is unreachable
+  // (a form not yet supported).
+  [[nodiscard]] auto TranslateReadTarget(
+      const WalkFrame& frame, const slang::ast::ValueSymbol& value)
+      -> std::optional<hir::SensitivityRef>;
+
+  // The cross-unit slot the body already resolved for `target` in `frame`, if
+  // any. An upward reference to an ancestor unit is reached by name across that
+  // unit's boundary (an opaque segment); the reader-relative downward
+  // reconstruction does not apply, so the observation reuses the body's slot.
   [[nodiscard]] auto LookupCrossUnitRef(
       ScopeFrameId frame, const slang::ast::ValueSymbol& target) const
       -> std::optional<hir::CrossUnitRefId>;
@@ -226,6 +254,7 @@ class ModuleLowerer {
   StructuralDataObjectBindings structural_data_object_bindings_;
   SubroutineBindings subroutine_bindings_;
   OwnedChildBindings owned_child_bindings_;
+  std::unordered_map<const slang::ast::Scope*, ScopeFrameId> scope_frames_;
   // Dedup by (home_frame, target): the slot id is an index within a scope's
   // own `cross_unit_refs`, so two scopes referencing the same member each need
   // their own slot.

--- a/include/lyra/lowering/ast_to_hir/sensitivity.hpp
+++ b/include/lyra/lowering/ast_to_hir/sensitivity.hpp
@@ -17,6 +17,7 @@ class Expression;
 class Statement;
 class Symbol;
 class ValueSymbol;
+class ProceduralBlockSymbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
@@ -66,6 +67,16 @@ class SensitivityAnalyzer {
       const slang::ast::Symbol& containing_symbol)
       -> const std::vector<SensitivityRead>&;
 
+  // The effective sensitivity of an `always_comb` / `always_latch` procedure
+  // (LRM 9.2.2.2.1, 9.2.2.3): the reads that wake it, including reads inside
+  // any function it calls, with locally-declared symbols and self-driven bit
+  // ranges already excluded. This is the procedure-level surface, distinct from
+  // the raw read set of a single node, which reflects only call arguments
+  // across a function boundary (the `always @*` rule).
+  [[nodiscard]] auto AnalyzeProcedureSensitivity(
+      const slang::ast::ProceduralBlockSymbol& proc)
+      -> const std::vector<SensitivityRead>&;
+
  private:
   std::unique_ptr<slang::analysis::AnalysisManager> manager_;
   std::unique_ptr<slang::analysis::AnalysisContext> context_;
@@ -74,6 +85,9 @@ class SensitivityAnalyzer {
       expression_cache_;
   std::unordered_map<const slang::ast::Statement*, std::vector<SensitivityRead>>
       statement_cache_;
+  std::unordered_map<
+      const slang::ast::ProceduralBlockSymbol*, std::vector<SensitivityRead>>
+      procedure_cache_;
 };
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
@@ -92,10 +92,10 @@ class StructuralScopeLowerer {
   auto PopulateGenerateBlockMember(
       const slang::ast::GenerateBlockSymbol& block, WalkFrame frame)
       -> diag::Result<void>;
-  auto PopulateInstanceMember(
+  static auto PopulateInstanceMember(
       const slang::ast::InstanceSymbol& inst, WalkFrame frame)
       -> diag::Result<void>;
-  auto PopulateInstanceArrayMember(
+  static auto PopulateInstanceArrayMember(
       const slang::ast::InstanceArraySymbol& array, WalkFrame frame)
       -> diag::Result<void>;
   auto PopulatePortConnections(

--- a/include/lyra/lowering/ast_to_hir/walk_frame.hpp
+++ b/include/lyra/lowering/ast_to_hir/walk_frame.hpp
@@ -23,6 +23,7 @@ struct ProceduralBody;
 
 namespace slang::ast {
 class Symbol;
+class Scope;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
@@ -66,6 +67,16 @@ struct WalkFrame {
   // by ModuleLowerer when a scope is entered. Used to compute structural
   // hops: HopsTo(target) walks back to find target in the chain.
   std::vector<ScopeFrameId> structural_chain;
+
+  // The reader's position in slang's elaborated hierarchy: the slang scope of
+  // the innermost structural scope on the chain. The structural_chain gives
+  // hops only within this compilation unit; this locates the reader in the
+  // whole-design hierarchy (across unit boundaries at the InstanceBody
+  // transition), so a reference route to any target -- including one that
+  // climbs out of this unit -- is computed as a reader-to-target relationship
+  // rather than reclassified from a lexical form. Null before the root scope
+  // is entered.
+  const slang::ast::Scope* reader_scope = nullptr;
 
   // The current expression write target: the expr arena every expression
   // handler appends lowered sub-expressions into, regardless of procedural or
@@ -166,10 +177,12 @@ struct WalkFrame {
   // passed by the caller (which holds the complete scope type) so this header
   // stays free of the HIR scope definition.
   [[nodiscard]] auto WithStructuralFrame(
-      ScopeFrameId child_frame, hir::StructuralScope* scope,
+      ScopeFrameId child_frame, const slang::ast::Scope* slang_scope,
+      hir::StructuralScope* scope,
       base::Arena<hir::Expr, hir::ExprId>* exprs) const -> WalkFrame {
     WalkFrame next = *this;
     next.structural_chain.push_back(child_frame);
+    next.reader_scope = slang_scope;
     next.current_structural_scope = scope;
     next.current_exprs = exprs;
     return next;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -423,7 +423,7 @@ class HirDumper {
         p);
   }
 
-  static auto FormatSensitivityRef(const SensitivityRef& ref) -> std::string {
+  static auto FormatReferenceRoute(const ReferenceRoute& ref) -> std::string {
     return std::visit(
         Overloaded{
             [](const StructuralDataObjectRef& r) -> std::string {
@@ -482,7 +482,7 @@ class HirDumper {
                   if (j != 0) out += ", ";
                   const auto& r = e.triggers[i].sensitivity_list[j];
                   out += std::format(
-                      "{{{} bits={} edge={}}}", FormatSensitivityRef(r.ref),
+                      "{{{} bits={} edge={}}}", FormatReferenceRoute(r.ref),
                       FormatFootprint(r.footprint),
                       FormatEventEdge(r.edge_kind));
                 }
@@ -497,7 +497,7 @@ class HirDumper {
                 if (i != 0) out += ", ";
                 const auto& r = ie.sensitivity_list[i];
                 out += std::format(
-                    "{{{} bits={} edge={}}}", FormatSensitivityRef(r.ref),
+                    "{{{} bits={} edge={}}}", FormatReferenceRoute(r.ref),
                     FormatFootprint(r.footprint), FormatEventEdge(r.edge_kind));
               }
               out += "]";
@@ -1006,7 +1006,7 @@ class HirDumper {
       for (const auto& r : p.implicit_sensitivity_list) {
         Line(
             std::format(
-                "{} bits={}", FormatSensitivityRef(r.ref),
+                "{} bits={}", FormatReferenceRoute(r.ref),
                 FormatFootprint(r.footprint)));
       }
       Dedent();
@@ -1058,7 +1058,7 @@ class HirDumper {
       for (const auto& r : ca.sensitivity_list) {
         Line(
             std::format(
-                "{} bits={}", FormatSensitivityRef(r.ref),
+                "{} bits={}", FormatReferenceRoute(r.ref),
                 FormatFootprint(r.footprint)));
       }
       Dedent();
@@ -1434,7 +1434,7 @@ class HirDumper {
                 if (i != 0) sens += ", ";
                 const auto& r = w.sensitivity_list[i];
                 sens += std::format(
-                    "{{{} bits={}}}", FormatSensitivityRef(r.ref),
+                    "{{{} bits={}}}", FormatReferenceRoute(r.ref),
                     FormatFootprint(r.footprint));
               }
               sens += "]";

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -406,109 +406,64 @@ auto LowerHierarchicalValue(
     return indices;
   };
 
-  if (ref.isUpward()) {
-    // The named arm carries the canonical head name plus any per-dimension
-    // index that immediately follows it in `ref.path` (e.g. `bank[2].x`); the
-    // root arm carries no key. The suffix is `ref.path` strictly past the
-    // head element(s). Synthesizing the extern member on the referrer's own
-    // structural scope keeps the lexical lookup origin coincident with the
-    // structural class that owns this member, including for references
-    // written inside a generate block.
-    hir::CrossUnitRefHead anchor;
-    std::span<const slang::ast::HierarchicalReference::Element> suffix_steps =
-        ref.path.subspan(1);
-    switch (head_sym.kind) {
-      case slang::ast::SymbolKind::Instance:
-      case slang::ast::SymbolKind::GenerateBlock: {
-        std::vector<std::uint32_t> head_indices =
-            extract_head_indices(suffix_steps);
-        anchor = hir::UpwardNamedHead{
-            .head_name = std::string{head_sym.name},
-            .head_indices = std::move(head_indices)};
-        break;
-      }
-      case slang::ast::SymbolKind::Root:
-        anchor = hir::UpwardRootHead{};
-        break;
-      default:
-        return diag::Fail(
-            span, diag::DiagCode::kUnsupportedExpressionForm,
-            "upward hierarchical reference whose head is not a module "
-            "instance, "
-            "a named generate block, or $root is not yet supported");
-    }
-    auto path = build_path(suffix_steps);
-    if (!path) return std::unexpected(std::move(path.error()));
-    return module.MakeCrossUnitMemberRef(
-        var, frame.Current(), std::move(anchor), std::move(*path), *type_id,
-        span);
-  }
-
   std::span<const slang::ast::HierarchicalReference::Element> suffix_steps =
       ref.path.subspan(1);
   std::vector<std::uint32_t> head_indices = extract_head_indices(suffix_steps);
   auto path = build_path(suffix_steps);
   if (!path) return std::unexpected(std::move(path.error()));
 
-  // Downward: the head is an owned child this unit's scope declares -- an
-  // instance / instance-array member, a generate block (LRM 27), or a named
-  // procedural block (LRM 9.3.5 / 23.9). Each is bound before any process
-  // body is lowered, so a reference resolves regardless of source order; a
-  // missing binding is a compiler-bug invariant.
-  const bool head_is_owned_child =
-      head_sym.kind == slang::ast::SymbolKind::Instance ||
-      head_sym.kind == slang::ast::SymbolKind::InstanceArray ||
-      head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
-      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray ||
-      head_sym.kind == slang::ast::SymbolKind::StatementBlock;
-  if (!head_is_owned_child) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference through this scope kind is not yet supported");
-  }
+  // Route by segment layout visibility (LRM 23.6), not slang's lexical up/down
+  // classification. A head that is an owned child of an enclosing scope in this
+  // unit -- a generate block reachable by a typed climb, or any owned child in
+  // the referrer's own scope -- takes the typed downward route, regardless of
+  // the order the child and the referrer appear in source. A head this unit
+  // does not own (an ancestor-unit instance, `$root`, or an owned module
+  // instance reached from a nested generate whose body is another unit) is
+  // reached by name across the boundary.
   const auto binding = module.LookupOwnedChildBinding(head_sym);
-  if (!binding.has_value()) {
-    throw InternalError(
-        "LowerHierarchicalValue: downward owned-child head has no binding");
-  }
-
-  const auto hops = frame.HopsTo(binding->home_frame);
-  if (!hops.has_value()) {
-    throw InternalError(
-        "LowerHierarchicalValue: downward owned-child head's home frame is not "
-        "on the current scope stack");
-  }
-  if (hops->value == 0) {
-    hir::DownwardHead head_at_home = binding->head;
-    head_at_home.head_indices = std::move(head_indices);
-    return module.MakeCrossUnitMemberRef(
-        var, binding->home_frame, std::move(head_at_home), std::move(*path),
-        *type_id, span);
-  }
-
-  // Sibling-of-ancestor: the head sits in an enclosing scope of the referrer.
-  // For an intra-unit owned child (a generate block; its layout is part of
-  // this unit's emitted artifact) the install climbs the runtime parent edge
-  // and composes a typed downward MemberAccess chain on the enclosing class.
-  // A module-instance head with `hops > 0` would require a hybrid typed-climb
-  // / by-name-descent because the instance's body is in another unit;
-  // unsupported here.
   const bool head_is_intra_unit =
       head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
       head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray ||
       head_sym.kind == slang::ast::SymbolKind::StatementBlock;
-  if (!head_is_intra_unit) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference reaching an owned module instance from a "
-        "nested generate scope is not yet supported");
+  std::optional<hir::StructuralHops> down_hops;
+  if (binding.has_value()) {
+    if (const auto hops = frame.HopsTo(binding->home_frame);
+        hops.has_value() && (hops->value == 0 || head_is_intra_unit)) {
+      down_hops = hops;
+    }
   }
-  hir::DownwardHead enclosing_head = binding->head;
-  enclosing_head.hops = *hops;
-  enclosing_head.head_indices = std::move(head_indices);
+
+  if (!down_hops.has_value()) {
+    hir::CrossUnitRefHead anchor;
+    switch (head_sym.kind) {
+      case slang::ast::SymbolKind::Instance:
+      case slang::ast::SymbolKind::InstanceArray:
+      case slang::ast::SymbolKind::GenerateBlock:
+        anchor = hir::UpwardNamedHead{
+            .head_name = std::string{head_sym.name},
+            .head_indices = std::move(head_indices)};
+        break;
+      case slang::ast::SymbolKind::Root:
+        anchor = hir::UpwardRootHead{};
+        break;
+      default:
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedExpressionForm,
+            "hierarchical reference whose head is not a module instance, a "
+            "named generate block, or $root is not yet supported");
+    }
+    return module.MakeCrossUnitMemberRef(
+        var, frame.Current(), std::move(anchor), std::move(*path), *type_id,
+        span);
+  }
+
+  hir::DownwardHead head = binding->head;
+  head.hops = *down_hops;
+  head.head_indices = std::move(head_indices);
+  const ScopeFrameId slot_owner =
+      down_hops->value == 0 ? binding->home_frame : frame.Current();
   return module.MakeCrossUnitMemberRef(
-      var, frame.Current(), std::move(enclosing_head), std::move(*path),
-      *type_id, span);
+      var, slot_owner, std::move(head), std::move(*path), *type_id, span);
 }
 
 auto LowerNamedValueStructural(

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -1,22 +1,16 @@
 #include "lyra/lowering/ast_to_hir/expression/references.hpp"
 
-#include <cstdint>
 #include <expected>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <variant>
-#include <vector>
 
 #include <slang/ast/Expression.h>
 #include <slang/ast/HierarchicalReference.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/symbols/ClassSymbols.h>
-#include <slang/ast/symbols/CompilationUnitSymbols.h>
-#include <slang/ast/symbols/InstanceSymbols.h>
-#include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -202,27 +196,6 @@ auto MakeEnumConstantExpr(
       sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
 }
 
-// A static data object (LRM 6.21) reached through the structural scope, by the
-// hop distance from the referrer's frame to the frame that owns it.
-auto BindStructuralDataObject(
-    ModuleLowerer& module, WalkFrame frame, const slang::ast::ValueSymbol& sym,
-    diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  const auto binding = module.LookupStructuralDataObjectBinding(sym);
-  if (!binding.has_value()) {
-    throw InternalError(
-        "BindStructuralDataObject: value was not bound during scope lowering");
-  }
-  const auto hops = frame.HopsTo(binding->home_frame);
-  if (!hops.has_value()) {
-    throw InternalError(
-        "BindStructuralDataObject: value home frame is not on the current "
-        "scope stack");
-  }
-  return hir::MakeRefExpr(
-      hir::StructuralDataObjectRef{.hops = *hops, .var = binding->var_id},
-      binding->type, span);
-}
-
 // LRM 7.12.4: a reference to an array-method `with`-clause iteration element
 // (`item`) lowers to an `IterationBindingRef` naming `clause` and the element
 // role, typed by its own reference type. The element is one of the clause's two
@@ -253,6 +226,39 @@ auto MakeClassPropertyRefExpr(
       *type_id, span);
 }
 
+// Wraps a resolved reader-relative route as a reference Expr. A route is one of
+// two primaries -- a typed enclosing structural-data-object reference or a
+// cross-unit slot reference -- and each wraps identically.
+auto RouteRefExpr(
+    const hir::ReferenceRoute& route, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr {
+  return std::visit(
+      [&](const auto& primary) -> hir::Expr {
+        return hir::MakeRefExpr(primary, type, span);
+      },
+      route);
+}
+
+// Lowers a reference to a structural signal (a variable or net of an enclosing
+// scope) through the one reference-route translator. Shared by the procedural
+// and structural named-value paths once each has ruled out the non-signal forms
+// its context admits. A simple name is always lexically enclosing, so the route
+// is always available and its absence is a compiler-bug invariant.
+auto LowerStructuralSignalRef(
+    ModuleLowerer& module, WalkFrame frame,
+    const slang::ast::ValueSymbol& value, const slang::ast::Type& type,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto type_id = module.InternType(type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  auto route = module.TranslateReferenceRoute(frame, value);
+  if (!route) {
+    throw InternalError(
+        "LowerStructuralSignalRef: structural signal has no reader-relative "
+        "route");
+  }
+  return RouteRefExpr(*route, *type_id, span);
+}
+
 }  // namespace
 
 auto LowerNamedValueProc(
@@ -279,8 +285,8 @@ auto LowerNamedValueProc(
       return MakeClassPropertyRefExpr(module, sym, *named.type, span);
     // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
     // variable-family symbols; each binds to procedural-var storage when the
-    // enclosing process declares it, otherwise to the static data object of the
-    // same name reached through the structural scope.
+    // enclosing process declares it, otherwise to the structural signal of the
+    // same name reached through the reference-route translator.
     case Referent::kVariableStorage: {
       const auto& var = sym.as<slang::ast::VariableSymbol>();
       if (auto local = proc.LookupProceduralVar(var)) {
@@ -289,13 +295,13 @@ auto LowerNamedValueProc(
         return hir::MakeRefExpr(
             hir::ProceduralVarRef{.var = *local}, type, span);
       }
-      return BindStructuralDataObject(
-          module, frame, sym.as<slang::ast::ValueSymbol>(), span);
+      return LowerStructuralSignalRef(
+          module, frame, sym.as<slang::ast::ValueSymbol>(), *named.type, span);
     }
     // A net (LRM 6.5) is always a structural signal, never a procedural local.
     case Referent::kNetStorage:
-      return BindStructuralDataObject(
-          module, frame, sym.as<slang::ast::ValueSymbol>(), span);
+      return LowerStructuralSignalRef(
+          module, frame, sym.as<slang::ast::ValueSymbol>(), *named.type, span);
     case Referent::kUnsupported:
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
@@ -304,19 +310,17 @@ auto LowerNamedValueProc(
   throw InternalError("LowerNamedValueProc: unknown Referent");
 }
 
-// LRM 23.6 hierarchical reference. A downward path is rooted in a local
-// owned child identified by binding; an upward path carries an anchor (a
-// `$root` token or a canonical named head with any per-dimension index) and
-// a descent suffix that walks by name from the anchor down to the leaf
-// signal.
+// LRM 23.6 hierarchical reference. A reached constant folds to its value; a
+// reached signal's route is produced by the one canonical route translator from
+// the reader's elaborated position and the target symbol. slang's resolved
+// `ref.path` is provenance, not a routing authority, so it is not consulted.
 auto LowerHierarchicalValue(
     ModuleLowerer& module, WalkFrame frame,
     const slang::ast::HierarchicalValueExpression& hve)
     -> diag::Result<hir::Expr> {
   const auto span = module.SourceMapper().SpanOf(hve.sourceRange);
-  const auto& ref = hve.ref;
 
-  if (ref.isViaIfacePort()) {
+  if (hve.ref.isViaIfacePort()) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "interface-port hierarchical reference is not yet supported");
@@ -334,136 +338,26 @@ auto LowerHierarchicalValue(
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
           "hierarchical reference to a class property is not yet supported");
-    case Referent::kNetStorage:
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "hierarchical reference to a net is not yet supported");
     case Referent::kUnsupported:
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
           "hierarchical reference to this declaration kind is not yet "
           "supported");
     case Referent::kVariableStorage:
-      break;
-  }
-
-  auto type_id = module.InternType(*hve.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-
-  const auto& var = target.as<slang::ast::VariableSymbol>();
-  const slang::ast::Symbol& head_sym = *ref.path.front().symbol;
-
-  // ref.path is slang's resolved top-down navigation: path.front() is the
-  // head, path.back() is `target`, and each name selector is the resolved
-  // symbol's canonical name. Carrying those selectors verbatim into the HIR
-  // descent makes the runtime by-name navigation hit each scope by the same
-  // key the parent registered under. Index selectors on the head itself are
-  // extracted by the caller (into the head struct's `head_indices`) before
-  // `build_path` runs, so every path segment here starts with a name selector.
-  const auto build_path =
-      [&](std::span<const slang::ast::HierarchicalReference::Element> steps)
-      -> diag::Result<std::vector<hir::PathSegment>> {
-    std::vector<hir::PathSegment> path;
-    path.reserve(steps.size());
-    for (const auto& step : steps) {
-      if (std::holds_alternative<std::string_view>(step.selector)) {
-        path.push_back(
-            hir::PathSegment{
-                .name = std::string{std::get<std::string_view>(step.selector)},
-                .indices = {}});
-      } else if (std::holds_alternative<std::int32_t>(step.selector)) {
-        if (path.empty()) {
-          throw InternalError(
-              "build_path: index selector precedes any named segment; head "
-              "indices must be extracted by the caller before invoking");
-        }
-        path.back().indices.push_back(
-            static_cast<std::uint32_t>(std::get<std::int32_t>(step.selector)));
-      } else {
+    case Referent::kNetStorage: {
+      auto type_id = module.InternType(*hve.type, span);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      auto route = module.TranslateReferenceRoute(
+          frame, target.as<slang::ast::ValueSymbol>());
+      if (!route) {
         return diag::Fail(
             span, diag::DiagCode::kUnsupportedExpressionForm,
-            "instance-array range select in a hierarchical path is not yet "
-            "supported");
+            "hierarchical reference to this target form is not yet supported");
       }
-    }
-    return path;
-  };
-
-  // Consumes the run of index selectors that immediately follows the head
-  // element; each such index selects a per-dimension element on the head
-  // itself (e.g. `g[2]` when `g` is an instance / generate array).
-  const auto extract_head_indices =
-      [](std::span<const slang::ast::HierarchicalReference::Element>&
-             suffix_steps) -> std::vector<std::uint32_t> {
-    std::vector<std::uint32_t> indices;
-    while (!suffix_steps.empty() && std::holds_alternative<std::int32_t>(
-                                        suffix_steps.front().selector)) {
-      indices.push_back(
-          static_cast<std::uint32_t>(
-              std::get<std::int32_t>(suffix_steps.front().selector)));
-      suffix_steps = suffix_steps.subspan(1);
-    }
-    return indices;
-  };
-
-  std::span<const slang::ast::HierarchicalReference::Element> suffix_steps =
-      ref.path.subspan(1);
-  std::vector<std::uint32_t> head_indices = extract_head_indices(suffix_steps);
-  auto path = build_path(suffix_steps);
-  if (!path) return std::unexpected(std::move(path.error()));
-
-  // Route by segment layout visibility (LRM 23.6), not slang's lexical up/down
-  // classification. A head that is an owned child of an enclosing scope in this
-  // unit -- a generate block reachable by a typed climb, or any owned child in
-  // the referrer's own scope -- takes the typed downward route, regardless of
-  // the order the child and the referrer appear in source. A head this unit
-  // does not own (an ancestor-unit instance, `$root`, or an owned module
-  // instance reached from a nested generate whose body is another unit) is
-  // reached by name across the boundary.
-  const auto binding = module.LookupOwnedChildBinding(head_sym);
-  const bool head_is_intra_unit =
-      head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
-      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray ||
-      head_sym.kind == slang::ast::SymbolKind::StatementBlock;
-  std::optional<hir::StructuralHops> down_hops;
-  if (binding.has_value()) {
-    if (const auto hops = frame.HopsTo(binding->home_frame);
-        hops.has_value() && (hops->value == 0 || head_is_intra_unit)) {
-      down_hops = hops;
+      return RouteRefExpr(*route, *type_id, span);
     }
   }
-
-  if (!down_hops.has_value()) {
-    hir::CrossUnitRefHead anchor;
-    switch (head_sym.kind) {
-      case slang::ast::SymbolKind::Instance:
-      case slang::ast::SymbolKind::InstanceArray:
-      case slang::ast::SymbolKind::GenerateBlock:
-        anchor = hir::UpwardNamedHead{
-            .head_name = std::string{head_sym.name},
-            .head_indices = std::move(head_indices)};
-        break;
-      case slang::ast::SymbolKind::Root:
-        anchor = hir::UpwardRootHead{};
-        break;
-      default:
-        return diag::Fail(
-            span, diag::DiagCode::kUnsupportedExpressionForm,
-            "hierarchical reference whose head is not a module instance, a "
-            "named generate block, or $root is not yet supported");
-    }
-    return module.MakeCrossUnitMemberRef(
-        var, frame.Current(), std::move(anchor), std::move(*path), *type_id,
-        span);
-  }
-
-  hir::DownwardHead head = binding->head;
-  head.hops = *down_hops;
-  head.head_indices = std::move(head_indices);
-  const ScopeFrameId slot_owner =
-      down_hops->value == 0 ? binding->home_frame : frame.Current();
-  return module.MakeCrossUnitMemberRef(
-      var, slot_owner, std::move(head), std::move(*path), *type_id, span);
+  throw InternalError("LowerHierarchicalValue: unknown Referent");
 }
 
 auto LowerNamedValueStructural(
@@ -482,8 +376,8 @@ auto LowerNamedValueStructural(
       return MakeEnumConstantExpr(module, sym, *named.type, span);
     case Referent::kVariableStorage:
     case Referent::kNetStorage:
-      return BindStructuralDataObject(
-          module, frame, sym.as<slang::ast::ValueSymbol>(), span);
+      return LowerStructuralSignalRef(
+          module, frame, sym.as<slang::ast::ValueSymbol>(), *named.type, span);
     // A class property has no structural (non-procedural) meaning: it is only
     // reachable through a method receiver, so outside a method it is rejected
     // alongside the genuinely unsupported kinds.

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -47,24 +47,6 @@ auto StructuralScopeLowerer::BuildResolvedGenerateFromArray(
     const slang::ast::GenerateBlockArraySymbol& array, WalkFrame frame)
     -> diag::Result<hir::Generate> {
   hir::Generate gen{};
-  const hir::GenerateId gen_id =
-      frame.current_structural_scope->NextGenerateId();
-
-  // A downward reference `g[k]` heads at the array symbol; the runtime
-  // by-name-and-index child lookup and the reference's own index select the
-  // k-th iteration from among the concrete per-iteration children, which all
-  // share the array's source name, so the head may point at any iteration's
-  // scope -- the first. Registered before any iteration body lowers, so a
-  // reference from inside one iteration to another (`g[i-1].v`) resolves its
-  // head while that body lowers, regardless of source order.
-  if (!array.entries.empty()) {
-    module_->MapOwnedChildBinding(
-        array, frame_,
-        hir::DownwardHead{
-            .child = hir::GenerateChildRef{
-                .generate = gen_id, .scope = hir::StructuralScopeId{0}}});
-  }
-
   std::vector<hir::ResolvedGenerateItem> items;
   items.reserve(array.entries.size());
   for (const auto* entry : array.entries) {
@@ -92,18 +74,6 @@ auto StructuralScopeLowerer::BuildResolvedGenerateFromBlock(
     const slang::ast::GenerateBlockSymbol& block, WalkFrame frame)
     -> diag::Result<hir::Generate> {
   hir::Generate gen{};
-  const hir::GenerateId gen_id =
-      frame.current_structural_scope->NextGenerateId();
-
-  // A downward reference `blk.x` heads at this block symbol; it carries no
-  // index. Registered before the block body lowers, so a reference from inside
-  // the block to its own name resolves while that body lowers.
-  module_->MapOwnedChildBinding(
-      block, frame_,
-      hir::DownwardHead{
-          .child = hir::GenerateChildRef{
-              .generate = gen_id, .scope = hir::StructuralScopeId{0}}});
-
   auto scope_or = LowerGenerateScope(*module_, block, block.name, frame);
   if (!scope_or) return std::unexpected(std::move(scope_or.error()));
   const hir::StructuralScopeId scope_id =

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -28,6 +29,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/ast_to_hir/instance_array_shape.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
@@ -64,11 +66,14 @@ void ModuleLowerer::DeclareStructuralIdentities(
     const slang::ast::Scope& scope) {
   const ScopeFrameId frame = NextScopeFrameId();
   scope_frames_.emplace(&scope, frame);
-  // A generate id is the source-order position of the generate among this
-  // scope's instantiated generates, matching the arena index the body pass
-  // assigns; an uninstantiated `if` / `case` arm carries no runtime object
-  // (LRM 27.5) and consumes no id.
+  // Each owned-child id is the source-order position of that child among its
+  // own kind in this scope, matching the arena index the body pass assigns.
+  // A generate id counts instantiated generates -- an uninstantiated `if` /
+  // `case` arm carries no runtime object (LRM 27.5) and consumes no id. An
+  // instance-member id counts instances and non-empty instance arrays -- a
+  // zero-element array (LRM 23.3.2) constructs nothing and consumes no id.
   std::uint32_t generate_count = 0;
+  std::uint32_t instance_count = 0;
   for (const auto& member : scope.members()) {
     if (member.kind == slang::ast::SymbolKind::GenerateBlock) {
       const auto& block = member.as<slang::ast::GenerateBlockSymbol>();
@@ -92,6 +97,19 @@ void ModuleLowerer::DeclareStructuralIdentities(
       for (const auto* entry : array.entries) {
         DeclareStructuralIdentities(*entry);
       }
+    } else if (member.kind == slang::ast::SymbolKind::Instance) {
+      MapOwnedChildBinding(
+          member, frame,
+          hir::DownwardHead{.child = hir::InstanceMemberId{instance_count++}});
+    } else if (member.kind == slang::ast::SymbolKind::InstanceArray) {
+      if (!ResolveInstanceArrayShape(
+               member.as<slang::ast::InstanceArraySymbol>())
+               .has_value()) {
+        continue;
+      }
+      MapOwnedChildBinding(
+          member, frame,
+          hir::DownwardHead{.child = hir::InstanceMemberId{instance_count++}});
     }
   }
 }
@@ -221,20 +239,6 @@ auto ModuleLowerer::MapOrGetCrossUnitRef(
   return id;
 }
 
-auto ModuleLowerer::LookupCrossUnitRef(
-    ScopeFrameId frame, const slang::ast::ValueSymbol& target) const
-    -> std::optional<hir::CrossUnitRefId> {
-  const auto fit = cross_unit_ref_dedup_.find(frame);
-  if (fit == cross_unit_ref_dedup_.end()) {
-    return std::nullopt;
-  }
-  const auto it = fit->second.find(&target);
-  if (it == fit->second.end()) {
-    return std::nullopt;
-  }
-  return it->second;
-}
-
 auto ModuleLowerer::TakeCrossUnitRefsForFrame(ScopeFrameId slot_owner_frame)
     -> std::vector<hir::CrossUnitRefDecl> {
   const auto it = cross_unit_refs_by_frame_.find(slot_owner_frame);
@@ -259,35 +263,46 @@ auto ModuleLowerer::MakeCrossUnitMemberRef(
   };
 }
 
-auto ModuleLowerer::TranslateReadTarget(
+auto ModuleLowerer::TranslateReferenceRoute(
     const WalkFrame& frame, const slang::ast::ValueSymbol& value)
-    -> std::optional<hir::SensitivityRef> {
-  // Only an observable structural signal -- a variable or a net -- is a
-  // sensitivity target. A genvar or parameter read folds to an elaboration
-  // constant that cannot change, so it is never observed.
+    -> std::optional<hir::ReferenceRoute> {
+  // Only a variable or a net is an addressable, observable signal. A genvar or
+  // parameter folds to an elaboration constant with no cell to reach.
   if (value.kind != slang::ast::SymbolKind::Variable &&
       value.kind != slang::ast::SymbolKind::Net) {
     return std::nullopt;
   }
-  // Pure enclosing lexical access: the target sits directly on the reader's own
-  // scope or an ancestor, reached by a typed climb of `hops` parent edges.
+
+  // Enclosing within this unit: the target sits directly on the reader's own
+  // scope or an ancestor scope of the same unit, reached by a typed climb of
+  // `hops` parent edges.
   if (const auto binding = LookupStructuralDataObjectBinding(value)) {
     if (const auto hops = frame.HopsTo(binding->home_frame)) {
-      return hir::SensitivityRef{
+      return hir::ReferenceRoute{
           hir::StructuralDataObjectRef{.hops = *hops, .var = binding->var_id}};
     }
   }
 
-  // Otherwise reconstruct the reader-relative route from the target's
-  // elaborated position. Walking up its owner chain, the head is the first
-  // scope owned by an ancestor of the reader (the child of the deepest common
-  // scope) and the scopes below it form the descent. A generate-loop iteration
-  // or an instance-array element is addressed as an index on its array member,
-  // which is the registered owned child.
   const auto type =
       InternType(value.getType(), SourceMapper().PointSpanOf(value.location));
   if (!type) return std::nullopt;
 
+  // The reader's elaborated ancestor scopes, across unit boundaries (slang's
+  // `getHierarchicalParent` crosses the boundary at the instance-body
+  // transition). The route meets the target at the deepest scope shared with
+  // the reader; a target-side hop whose parent is one of these scopes is the
+  // named child that shared ancestor exposes -- the head an out-of-unit or
+  // sibling-subtree reference climbs to and descends from.
+  std::unordered_set<const slang::ast::Scope*> reader_ancestors;
+  for (const slang::ast::Scope* s = frame.reader_scope; s != nullptr;
+       s = s->asSymbol().getHierarchicalParent()) {
+    reader_ancestors.insert(s);
+  }
+
+  // Walk the target's owner chain, building the descent bottom-up. Each hop's
+  // addressable owned child is resolved: the instance member (not its body)
+  // across a unit boundary, the array member for a generate-loop iteration or
+  // instance-array element with the elaborated index attached.
   std::vector<hir::PathSegment> descent;
   descent.push_back(
       hir::PathSegment{.name = std::string{value.name}, .indices = {}});
@@ -296,11 +311,6 @@ auto ModuleLowerer::TranslateReadTarget(
     const slang::ast::Symbol* owned = &scope->asSymbol();
     const slang::ast::Scope* next = owned->getHierarchicalParent();
     std::vector<std::uint32_t> indices;
-    // Resolve the addressable owned child this hierarchy step corresponds to,
-    // and its per-dimension indices when it is an array element. Crossing a
-    // unit boundary, the instance member -- not its body -- is the owned child;
-    // a generate-loop iteration or instance-array element is indexed on its
-    // enclosing array member, which is the registered child.
     if (owned->kind == slang::ast::SymbolKind::InstanceBody) {
       const auto* inst =
           owned->as<slang::ast::InstanceBodySymbol>().parentInstance;
@@ -308,8 +318,17 @@ auto ModuleLowerer::TranslateReadTarget(
       if (inst->arrayPath.empty()) {
         owned = inst;
       } else {
+        // A multi-dimensional instance array nests one InstanceArray symbol per
+        // dimension, but the unit registers a single array member spanning all
+        // dimensions and `arrayPath` already carries every index. Climb to the
+        // outermost array symbol so the head is that registered member.
         indices.assign(inst->arrayPath.begin(), inst->arrayPath.end());
         owned = &inst->getParentScope()->asSymbol();
+        while (owned->getParentScope() != nullptr &&
+               owned->getParentScope()->asSymbol().kind ==
+                   slang::ast::SymbolKind::InstanceArray) {
+          owned = &owned->getParentScope()->asSymbol();
+        }
       }
       next = owned->getHierarchicalParent();
     } else if (const auto* gb = owned->as_if<slang::ast::GenerateBlockSymbol>();
@@ -320,30 +339,52 @@ auto ModuleLowerer::TranslateReadTarget(
       owned = &owned->getHierarchicalParent()->asSymbol();
       next = owned->getHierarchicalParent();
     }
-    if (const auto obinding = LookupOwnedChildBinding(*owned)) {
-      if (const auto hops = frame.HopsTo(obinding->home_frame)) {
-        hir::DownwardHead head = obinding->head;
-        head.hops = *hops;
-        head.head_indices = std::move(indices);
-        std::ranges::reverse(descent);
-        const ScopeFrameId slot_owner =
-            hops->value == 0 ? obinding->home_frame : frame.Current();
-        const hir::CrossUnitRefId id = MapOrGetCrossUnitRef(
-            value, slot_owner, hir::CrossUnitRefHead{std::move(head)},
-            std::move(descent), *type);
-        return hir::SensitivityRef{hir::CrossUnitVarRef{.id = id}};
+
+    // The head is the child of the deepest scope shared with the reader: the
+    // first hop whose parent scope is a reader ancestor. Everything already
+    // accumulated is the descent below it. Stopping at the shared-scope child
+    // rather than the first bound owned child is what makes a procedurally
+    // nested head (a named block inside another) head at the block the shared
+    // scope directly exposes, not the inner one.
+    if (next != nullptr && reader_ancestors.contains(next)) {
+      std::ranges::reverse(descent);
+      // Typed climb when this unit's own layout reaches the head: at hops 0 a
+      // member of the reader's own class, or at any depth a head whose class
+      // this unit emits (a generate block / array, a named block). An instance
+      // head at hops > 0 is excluded -- crossing an instance body crosses into
+      // another compilation unit, so the climb cannot stay typed and the head
+      // is reached by name.
+      const bool head_is_intra_unit =
+          owned->kind == slang::ast::SymbolKind::GenerateBlock ||
+          owned->kind == slang::ast::SymbolKind::GenerateBlockArray ||
+          owned->kind == slang::ast::SymbolKind::StatementBlock;
+      if (const auto obinding = LookupOwnedChildBinding(*owned)) {
+        if (const auto hops = frame.HopsTo(obinding->home_frame);
+            hops.has_value() && (hops->value == 0 || head_is_intra_unit)) {
+          hir::DownwardHead head = obinding->head;
+          head.hops = *hops;
+          head.head_indices = std::move(indices);
+          const ScopeFrameId slot_owner =
+              hops->value == 0 ? obinding->home_frame : frame.Current();
+          const hir::CrossUnitRefId id = MapOrGetCrossUnitRef(
+              value, slot_owner, hir::CrossUnitRefHead{std::move(head)},
+              std::move(descent), *type);
+          return hir::ReferenceRoute{hir::CrossUnitVarRef{.id = id}};
+        }
       }
+      const hir::CrossUnitRefId id = MapOrGetCrossUnitRef(
+          value, frame.Current(),
+          hir::CrossUnitRefHead{hir::UpwardNamedHead{
+              .head_name = std::string{owned->name},
+              .head_indices = std::move(indices)}},
+          std::move(descent), *type);
+      return hir::ReferenceRoute{hir::CrossUnitVarRef{.id = id}};
     }
+
     descent.push_back(
         hir::PathSegment{
             .name = std::string{owned->name}, .indices = std::move(indices)});
     scope = next;
-  }
-  // No reader-relative downward route: an upward reference climbs out to an
-  // ancestor unit, reached by name across the boundary and already resolved by
-  // the body.
-  if (const auto slot = LookupCrossUnitRef(frame.Current(), value)) {
-    return hir::SensitivityRef{hir::CrossUnitVarRef{.id = *slot}};
   }
   return std::nullopt;
 }
@@ -369,7 +410,7 @@ auto ModuleLowerer::TranslateSensitivityReads(
     const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
         read_type.isIntegral() && !read_type.isEnum() ? read.footprint
                                                       : std::nullopt;
-    if (auto ref = TranslateReadTarget(frame, *value)) {
+    if (auto ref = TranslateReferenceRoute(frame, *value)) {
       out.push_back(
           hir::SensitivityEntry{
               .ref = *std::move(ref), .footprint = footprint});

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -228,20 +228,23 @@ auto ModuleLowerer::TranslateSensitivityReads(
     const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
         read_type.isIntegral() && !read_type.isEnum() ? read.footprint
                                                       : std::nullopt;
+    // Reachability decides the access form. An enclosing structural object (the
+    // reader's own scope or an ancestor) is reached by typed navigation; a
+    // target not on the reader's enclosing chain -- a sibling or child scope in
+    // this unit, or another unit -- is reached through the reference resolved
+    // for the body. A failed enclosing lookup therefore routes the read, never
+    // drops it, so the result does not depend on which scope lowered first.
     if (const auto binding = LookupStructuralDataObjectBinding(*value)) {
-      const auto hops = frame.HopsTo(binding->home_frame);
-      if (!hops.has_value()) continue;
-      out.push_back(
-          hir::SensitivityEntry{
-              .ref =
-                  hir::StructuralDataObjectRef{
-                      .hops = *hops, .var = binding->var_id},
-              .footprint = footprint});
-      continue;
+      if (const auto hops = frame.HopsTo(binding->home_frame)) {
+        out.push_back(
+            hir::SensitivityEntry{
+                .ref =
+                    hir::StructuralDataObjectRef{
+                        .hops = *hops, .var = binding->var_id},
+                .footprint = footprint});
+        continue;
+      }
     }
-    // A read of a cross-unit member resolves to the slot that body lowering
-    // created for it; subscribing through the slot is what makes always_comb
-    // re-trigger on a child's signal.
     if (const auto slot = LookupCrossUnitRef(frame.Current(), *value)) {
       out.push_back(
           hir::SensitivityEntry{

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <expected>
 #include <map>
@@ -10,13 +11,16 @@
 #include <vector>
 
 #include <slang/ast/Expression.h>
+#include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
+#include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/NetType.h>
 #include <slang/ast/types/Type.h>
+#include <slang/numeric/SVInt.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -38,6 +42,7 @@ ModuleLowerer::ModuleLowerer(
 
 auto ModuleLowerer::Run() -> diag::Result<hir::ModuleUnit> {
   WalkFrame frame;
+  DeclareStructuralIdentities(*body_);
   StructuralScopeLowerer root(*this, *body_);
   auto root_scope_or = root.Run(frame);
   if (!root_scope_or) {
@@ -53,6 +58,53 @@ auto ModuleLowerer::NextScopeFrameId() -> ScopeFrameId {
 
 auto ModuleLowerer::NextWithClauseId() -> hir::WithClauseId {
   return hir::WithClauseId{.value = next_with_clause_++};
+}
+
+void ModuleLowerer::DeclareStructuralIdentities(
+    const slang::ast::Scope& scope) {
+  const ScopeFrameId frame = NextScopeFrameId();
+  scope_frames_.emplace(&scope, frame);
+  // A generate id is the source-order position of the generate among this
+  // scope's instantiated generates, matching the arena index the body pass
+  // assigns; an uninstantiated `if` / `case` arm carries no runtime object
+  // (LRM 27.5) and consumes no id.
+  std::uint32_t generate_count = 0;
+  for (const auto& member : scope.members()) {
+    if (member.kind == slang::ast::SymbolKind::GenerateBlock) {
+      const auto& block = member.as<slang::ast::GenerateBlockSymbol>();
+      if (block.isUninstantiated) continue;
+      MapOwnedChildBinding(
+          block, frame,
+          hir::DownwardHead{
+              .child = hir::GenerateChildRef{
+                  .generate = hir::GenerateId{generate_count++},
+                  .scope = hir::StructuralScopeId{0}}});
+      DeclareStructuralIdentities(block);
+    } else if (member.kind == slang::ast::SymbolKind::GenerateBlockArray) {
+      const auto& array = member.as<slang::ast::GenerateBlockArraySymbol>();
+      if (array.entries.empty()) continue;
+      MapOwnedChildBinding(
+          array, frame,
+          hir::DownwardHead{
+              .child = hir::GenerateChildRef{
+                  .generate = hir::GenerateId{generate_count++},
+                  .scope = hir::StructuralScopeId{0}}});
+      for (const auto* entry : array.entries) {
+        DeclareStructuralIdentities(*entry);
+      }
+    }
+  }
+}
+
+auto ModuleLowerer::LookupScopeFrame(const slang::ast::Scope& scope) const
+    -> ScopeFrameId {
+  const auto it = scope_frames_.find(&scope);
+  if (it == scope_frames_.end()) {
+    throw InternalError(
+        "ModuleLowerer::LookupScopeFrame: scope frame was not declared before "
+        "body lowering");
+  }
+  return it->second;
 }
 
 void ModuleLowerer::MapStructuralDataObjectBinding(
@@ -207,8 +259,97 @@ auto ModuleLowerer::MakeCrossUnitMemberRef(
   };
 }
 
+auto ModuleLowerer::TranslateReadTarget(
+    const WalkFrame& frame, const slang::ast::ValueSymbol& value)
+    -> std::optional<hir::SensitivityRef> {
+  // Only an observable structural signal -- a variable or a net -- is a
+  // sensitivity target. A genvar or parameter read folds to an elaboration
+  // constant that cannot change, so it is never observed.
+  if (value.kind != slang::ast::SymbolKind::Variable &&
+      value.kind != slang::ast::SymbolKind::Net) {
+    return std::nullopt;
+  }
+  // Pure enclosing lexical access: the target sits directly on the reader's own
+  // scope or an ancestor, reached by a typed climb of `hops` parent edges.
+  if (const auto binding = LookupStructuralDataObjectBinding(value)) {
+    if (const auto hops = frame.HopsTo(binding->home_frame)) {
+      return hir::SensitivityRef{
+          hir::StructuralDataObjectRef{.hops = *hops, .var = binding->var_id}};
+    }
+  }
+
+  // Otherwise reconstruct the reader-relative route from the target's
+  // elaborated position. Walking up its owner chain, the head is the first
+  // scope owned by an ancestor of the reader (the child of the deepest common
+  // scope) and the scopes below it form the descent. A generate-loop iteration
+  // or an instance-array element is addressed as an index on its array member,
+  // which is the registered owned child.
+  const auto type =
+      InternType(value.getType(), SourceMapper().PointSpanOf(value.location));
+  if (!type) return std::nullopt;
+
+  std::vector<hir::PathSegment> descent;
+  descent.push_back(
+      hir::PathSegment{.name = std::string{value.name}, .indices = {}});
+  const slang::ast::Scope* scope = value.getHierarchicalParent();
+  while (scope != nullptr) {
+    const slang::ast::Symbol* owned = &scope->asSymbol();
+    const slang::ast::Scope* next = owned->getHierarchicalParent();
+    std::vector<std::uint32_t> indices;
+    // Resolve the addressable owned child this hierarchy step corresponds to,
+    // and its per-dimension indices when it is an array element. Crossing a
+    // unit boundary, the instance member -- not its body -- is the owned child;
+    // a generate-loop iteration or instance-array element is indexed on its
+    // enclosing array member, which is the registered child.
+    if (owned->kind == slang::ast::SymbolKind::InstanceBody) {
+      const auto* inst =
+          owned->as<slang::ast::InstanceBodySymbol>().parentInstance;
+      if (inst == nullptr) return std::nullopt;
+      if (inst->arrayPath.empty()) {
+        owned = inst;
+      } else {
+        indices.assign(inst->arrayPath.begin(), inst->arrayPath.end());
+        owned = &inst->getParentScope()->asSymbol();
+      }
+      next = owned->getHierarchicalParent();
+    } else if (const auto* gb = owned->as_if<slang::ast::GenerateBlockSymbol>();
+               gb != nullptr && gb->getArrayIndex() != nullptr) {
+      indices.push_back(
+          static_cast<std::uint32_t>(
+              gb->getArrayIndex()->as<std::int64_t>().value_or(0)));
+      owned = &owned->getHierarchicalParent()->asSymbol();
+      next = owned->getHierarchicalParent();
+    }
+    if (const auto obinding = LookupOwnedChildBinding(*owned)) {
+      if (const auto hops = frame.HopsTo(obinding->home_frame)) {
+        hir::DownwardHead head = obinding->head;
+        head.hops = *hops;
+        head.head_indices = std::move(indices);
+        std::ranges::reverse(descent);
+        const ScopeFrameId slot_owner =
+            hops->value == 0 ? obinding->home_frame : frame.Current();
+        const hir::CrossUnitRefId id = MapOrGetCrossUnitRef(
+            value, slot_owner, hir::CrossUnitRefHead{std::move(head)},
+            std::move(descent), *type);
+        return hir::SensitivityRef{hir::CrossUnitVarRef{.id = id}};
+      }
+    }
+    descent.push_back(
+        hir::PathSegment{
+            .name = std::string{owned->name}, .indices = std::move(indices)});
+    scope = next;
+  }
+  // No reader-relative downward route: an upward reference climbs out to an
+  // ancestor unit, reached by name across the boundary and already resolved by
+  // the body.
+  if (const auto slot = LookupCrossUnitRef(frame.Current(), value)) {
+    return hir::SensitivityRef{hir::CrossUnitVarRef{.id = *slot}};
+  }
+  return std::nullopt;
+}
+
 auto ModuleLowerer::TranslateSensitivityReads(
-    const std::vector<SensitivityRead>& reads, const WalkFrame& frame) const
+    const std::vector<SensitivityRead>& reads, const WalkFrame& frame)
     -> std::vector<hir::SensitivityEntry> {
   std::vector<hir::SensitivityEntry> out;
   out.reserve(reads.size());
@@ -228,28 +369,10 @@ auto ModuleLowerer::TranslateSensitivityReads(
     const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
         read_type.isIntegral() && !read_type.isEnum() ? read.footprint
                                                       : std::nullopt;
-    // Reachability decides the access form. An enclosing structural object (the
-    // reader's own scope or an ancestor) is reached by typed navigation; a
-    // target not on the reader's enclosing chain -- a sibling or child scope in
-    // this unit, or another unit -- is reached through the reference resolved
-    // for the body. A failed enclosing lookup therefore routes the read, never
-    // drops it, so the result does not depend on which scope lowered first.
-    if (const auto binding = LookupStructuralDataObjectBinding(*value)) {
-      if (const auto hops = frame.HopsTo(binding->home_frame)) {
-        out.push_back(
-            hir::SensitivityEntry{
-                .ref =
-                    hir::StructuralDataObjectRef{
-                        .hops = *hops, .var = binding->var_id},
-                .footprint = footprint});
-        continue;
-      }
-    }
-    if (const auto slot = LookupCrossUnitRef(frame.Current(), *value)) {
+    if (auto ref = TranslateReadTarget(frame, *value)) {
       out.push_back(
           hir::SensitivityEntry{
-              .ref = hir::CrossUnitVarRef{.id = *slot},
-              .footprint = footprint});
+              .ref = *std::move(ref), .footprint = footprint});
     }
   }
   return out;

--- a/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
@@ -1,13 +1,11 @@
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 
-#include <algorithm>
 #include <expected>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
@@ -46,33 +44,6 @@ auto FromSlangProceduralBlockKind(slang::ast::ProceduralBlockKind kind)
   }
   throw InternalError(
       "FromSlangProceduralBlockKind: unknown ProceduralBlockKind");
-}
-
-// LRM 9.2.2.2.1: a symbol is local to `proc` if it is an automatic-lifetime
-// variable, or if it is declared inside one of `proc`'s statement blocks.
-// `ProceduralBlockSymbol` itself is not a `Scope`, so its statement blocks
-// hang off the surrounding scope -- we walk the symbol's parent-scope chain
-// up to the outermost `StatementBlockSymbol` and check whether that block is
-// one of `proc.getBlocks()`.
-auto IsLocalTo(
-    const slang::ast::ValueSymbol& sym,
-    const slang::ast::ProceduralBlockSymbol& proc) -> bool {
-  if (const auto* var = sym.as_if<slang::ast::VariableSymbol>();
-      var != nullptr &&
-      var->lifetime == slang::ast::VariableLifetime::Automatic) {
-    return true;
-  }
-  const slang::ast::Scope* scope = sym.getParentScope();
-  const slang::ast::StatementBlockSymbol* root_block = nullptr;
-  while (scope != nullptr &&
-         scope->asSymbol().kind == slang::ast::SymbolKind::StatementBlock) {
-    root_block = &scope->asSymbol().as<slang::ast::StatementBlockSymbol>();
-    scope = root_block->getParentScope();
-  }
-  if (root_block == nullptr) return false;
-  const auto blocks = proc.getBlocks();
-  return std::ranges::any_of(
-      blocks, [&](const auto* block) { return block == root_block; });
 }
 
 }  // namespace
@@ -128,19 +99,12 @@ auto ProcessLowerer::Run(
       .implicit_sensitivity_list = {}};
   if (kind == hir::ProcessKind::kAlwaysComb ||
       kind == hir::ProcessKind::kAlwaysLatch) {
-    // LRM 9.2.2.2.1: implicit sensitivity is a property of the always_comb /
-    // always_latch procedure itself (no `@*` token in source). Compute the
-    // procedure-body read set excluding locals.
-    const auto& raw = module_->Sensitivity().AnalyzeReads(proc.getBody(), proc);
-    std::vector<SensitivityRead> filtered;
-    filtered.reserve(raw.size());
-    for (const auto& read : raw) {
-      if (!IsLocalTo(*read.symbol, proc)) {
-        filtered.push_back(read);
-      }
-    }
-    out.implicit_sensitivity_list =
-        module_->TranslateSensitivityReads(filtered, frame);
+    // LRM 9.2.2.2.1 / 9.2.2.3: an always_comb / always_latch wakes on the reads
+    // of its whole procedure, including reads inside any function it calls --
+    // the procedure-level sensitivity, not the raw read set of the body node,
+    // which reflects only call arguments across a function boundary.
+    out.implicit_sensitivity_list = module_->TranslateSensitivityReads(
+        module_->Sensitivity().AnalyzeProcedureSensitivity(proc), frame);
   }
   return out;
 }

--- a/src/lyra/lowering/ast_to_hir/sensitivity.cpp
+++ b/src/lyra/lowering/ast_to_hir/sensitivity.cpp
@@ -5,11 +5,13 @@
 
 #include <slang/analysis/AbstractFlowAnalysis.h>
 #include <slang/analysis/AnalysisManager.h>
+#include <slang/analysis/AnalyzedProcedure.h>
 #include <slang/analysis/DFAResults.h>
 #include <slang/analysis/DataFlowAnalysis.h>
 #include <slang/ast/Expression.h>
 #include <slang/ast/Statement.h>
 #include <slang/ast/Symbol.h>
+#include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
 namespace lyra::lowering::ast_to_hir {
@@ -40,6 +42,19 @@ auto RunDfa(
   dfa.slang::analysis::AbstractFlowAnalysis<
       slang::analysis::DefaultDFA, slang::analysis::DataFlowState>::run(node);
   return FlattenReadSet(dfa.getRValues());
+}
+
+// Flattens slang's procedure-level sensitivity list (LRM 9.2.2.2.1) into the
+// same `(symbol, [lo, hi])` shape as a raw read set. slang has already narrowed
+// each entry's bit range to the bits that wake the procedure and excluded the
+// procedure's locals and self-driven bits.
+auto FlattenSensitivityList(const slang::analysis::AnalyzedProcedure& analyzed)
+    -> std::vector<SensitivityRead> {
+  std::vector<SensitivityRead> out;
+  for (const auto& read : analyzed.getSensitivityList().reads) {
+    out.push_back({.symbol = read.symbol, .footprint = read.bitRange});
+  }
+  return out;
 }
 
 }  // namespace
@@ -78,6 +93,22 @@ auto SensitivityAnalyzer::AnalyzeReads(
   }
   auto [inserted_it, _] = statement_cache_.emplace(
       &stmt, RunDfa(*context_, containing_symbol, stmt));
+  return inserted_it->second;
+}
+
+auto SensitivityAnalyzer::AnalyzeProcedureSensitivity(
+    const slang::ast::ProceduralBlockSymbol& proc)
+    -> const std::vector<SensitivityRead>& {
+  if (const auto it = procedure_cache_.find(&proc);
+      it != procedure_cache_.end()) {
+    return it->second;
+  }
+  slang::analysis::DefaultDFA dfa(*context_, proc, false);
+  dfa.run();
+  const slang::analysis::AnalyzedProcedure analyzed(
+      *context_, proc, nullptr, dfa);
+  auto [inserted_it, _] =
+      procedure_cache_.emplace(&proc, FlattenSensitivityList(analyzed));
   return inserted_it->second;
 }
 

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -180,19 +180,19 @@ auto LowerTimedStmt(
     diag::SourceSpan span) -> diag::Result<hir::Stmt> {
   auto timing = LowerTimingControl(proc, frame, ts.timing, span);
   if (!timing) return std::unexpected(std::move(timing.error()));
-  // LRM 9.4.2.2: `@*` watches every read in the controlled body. Analyze
-  // the body statement directly; the TimingControl shell came back empty
-  // from LowerTimingControl.
+  auto inner_stmt = proc.LowerStmt(ts.stmt, frame);
+  if (!inner_stmt) return std::unexpected(std::move(inner_stmt.error()));
+  const hir::StmtId inner_id =
+      frame.current_procedural_body->stmts.Add(*std::move(inner_stmt));
+  // LRM 9.4.2.2: `@*` watches every read in the controlled body. Inferred after
+  // the body lowers so a read's cross-unit reference is already resolved when
+  // its subscription is built.
   if (auto* ie = std::get_if<hir::ImplicitEventControl>(&*timing)) {
     const auto& reads = proc.Module().Sensitivity().AnalyzeReads(
         ts.stmt, proc.ContainingSymbol());
     ie->sensitivity_list =
         proc.Module().TranslateSensitivityReads(reads, frame);
   }
-  auto inner_stmt = proc.LowerStmt(ts.stmt, frame);
-  if (!inner_stmt) return std::unexpected(std::move(inner_stmt.error()));
-  const hir::StmtId inner_id =
-      frame.current_procedural_body->stmts.Add(*std::move(inner_stmt));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::TimedStmt{.timing = *std::move(timing), .stmt = inner_id},

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -43,7 +43,7 @@ StructuralScopeLowerer::StructuralScopeLowerer(
     ModuleLowerer& module, const slang::ast::Scope& slang_scope)
     : module_(&module),
       slang_scope_(&slang_scope),
-      frame_(module.NextScopeFrameId()) {
+      frame_(module.LookupScopeFrame(slang_scope)) {
   // A `ref` / `const ref` port's internal variable aliases the connected
   // variable rather than owning storage (LRM 23.3.3.2); record which of this
   // body's variables those are so their members lower to a reference type. Only

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -3,10 +3,8 @@
 #include <cstdint>
 #include <expected>
 #include <optional>
-#include <span>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include <slang/ast/Scope.h>
 #include <slang/ast/SemanticFacts.h>
@@ -30,6 +28,7 @@
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
+#include "lyra/lowering/ast_to_hir/instance_array_shape.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/specialization_name.hpp"
@@ -84,8 +83,8 @@ auto StructuralScopeLowerer::ReferenceBindingFor(
 auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
     -> diag::Result<hir::StructuralScope> {
   hir::StructuralScope scope;
-  const WalkFrame frame =
-      parent_frame.WithStructuralFrame(frame_, &scope, &scope.exprs);
+  const WalkFrame frame = parent_frame.WithStructuralFrame(
+      frame_, slang_scope_, &scope, &scope.exprs);
   scope.time_resolution = ResolveTimeResolution(slang_scope_->getTimeScale());
 
   // Forward-declare every subroutine's binding before lowering any body so a
@@ -101,10 +100,11 @@ auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
     }
   }
 
-  // Instance members are lowered ahead of process bodies so a downward
-  // cross-unit reference (`c.x`) resolves its leading `c` even when the
-  // referencing process precedes the instance in source order (declarations
-  // are scope-wide).
+  // Instance member decls are built ahead of the port-connection synthesis
+  // below, which reads them to wire each connection. The owned-child binding a
+  // reference resolves through is established earlier still, by the whole-unit
+  // declaration pass, so this population order is a decl-availability concern,
+  // not a reference-resolution one.
   for (const auto& member : slang_scope_->members()) {
     if (member.kind == slang::ast::SymbolKind::Instance) {
       auto r = PopulateInstanceMember(
@@ -369,47 +369,26 @@ auto StructuralScopeLowerer::PopulateGenerateBlockMember(
 auto StructuralScopeLowerer::PopulateInstanceMember(
     const slang::ast::InstanceSymbol& inst, WalkFrame frame)
     -> diag::Result<void> {
-  const hir::InstanceMemberId member_id =
-      frame.current_structural_scope->instance_members.Add(
-          hir::InstanceMemberDecl{
-              .instance_name = std::string{inst.name},
-              .target_unit = SpecializationName(inst),
-              .array_dims = {}});
-  // A downward cross-unit reference (`c.x`) resolves the leading `c` to
-  // this member; the binding lets process-body lowering find it regardless
-  // of source order.
-  module_->MapOwnedChildBinding(
-      inst, frame_, hir::DownwardHead{.child = member_id});
+  frame.current_structural_scope->instance_members.Add(
+      hir::InstanceMemberDecl{
+          .instance_name = std::string{inst.name},
+          .target_unit = SpecializationName(inst),
+          .array_dims = {}});
   return {};
 }
 
 auto StructuralScopeLowerer::PopulateInstanceArrayMember(
     const slang::ast::InstanceArraySymbol& array, WalkFrame frame)
     -> diag::Result<void> {
-  // Each nested InstanceArray level contributes one dimension; the descent
-  // bottoms out at the per-element instance, which names the target unit.
-  // A zero-element level (`Child c[0:-1]`, LRM 23.3.2) has no element to
-  // descend into or to name the unit from and constructs nothing, so it
-  // contributes no member.
-  std::vector<std::uint32_t> dims;
-  const slang::ast::Symbol* level = &array;
-  while (level->kind == slang::ast::SymbolKind::InstanceArray) {
-    const auto& arr = level->as<slang::ast::InstanceArraySymbol>();
-    if (arr.elements.empty()) {
-      return {};
-    }
-    dims.push_back(static_cast<std::uint32_t>(arr.elements.size()));
-    level = arr.elements.front();
+  auto shape = ResolveInstanceArrayShape(array);
+  if (!shape) {
+    return {};
   }
-  const auto& leaf = level->as<slang::ast::InstanceSymbol>();
-  const hir::InstanceMemberId member_id =
-      frame.current_structural_scope->instance_members.Add(
-          hir::InstanceMemberDecl{
-              .instance_name = std::string{array.name},
-              .target_unit = SpecializationName(leaf),
-              .array_dims = std::move(dims)});
-  module_->MapOwnedChildBinding(
-      array, frame_, hir::DownwardHead{.child = member_id});
+  frame.current_structural_scope->instance_members.Add(
+      hir::InstanceMemberDecl{
+          .instance_name = std::string{array.name},
+          .target_unit = SpecializationName(*shape->leaf),
+          .array_dims = std::move(shape->dims)});
   return {};
 }
 

--- a/tests/cases/cpp/always_comb_function_read_in_generate/case.yaml
+++ b/tests/cases/cpp/always_comb_function_read_in_generate/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_comb_function_read_in_generate
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    obs: 9

--- a/tests/cases/cpp/always_comb_function_read_in_generate/main.sv
+++ b/tests/cases/cpp/always_comb_function_read_in_generate/main.sv
@@ -1,0 +1,33 @@
+// LRM 9.2.2.2.1: an always_comb inside a generate block is sensitive to a
+// signal read only inside a function it calls, even when that function is
+// declared in an enclosing scope and the signal lives in a sibling generate
+// block. Reaching the signal's subscription depends on the target's elaborated
+// position, not on which scope lowered first: the reader (in `rdr`) and the
+// function (`read_tgt`, at module scope) occupy different scopes, and the
+// target (`tgt.v`) is a sibling of the reader's enclosing block.
+module Test;
+  logic [7:0] src;
+  logic [7:0] obs;
+
+  if (1) begin : tgt
+    logic [7:0] v;
+    always_comb v = src;
+  end
+
+  function automatic logic [7:0] read_tgt();
+    return tgt.v;
+  endfunction
+
+  if (1) begin : rdr
+    logic [7:0] o;
+    always_comb o = read_tgt();
+  end
+
+  initial begin
+    src = 8'd1;
+    #1;
+    src = 8'd9;
+    #1;
+    obs = rdr.o;
+  end
+endmodule

--- a/tests/cases/cpp/always_comb_nonlocal_sensitivity/case.yaml
+++ b/tests/cases/cpp/always_comb_nonlocal_sensitivity/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_comb_nonlocal_sensitivity
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "p=4 q=3 fn_a=1 fn_c=2\n"

--- a/tests/cases/cpp/always_comb_nonlocal_sensitivity/main.sv
+++ b/tests/cases/cpp/always_comb_nonlocal_sensitivity/main.sv
@@ -1,0 +1,57 @@
+// LRM 9.2.2.2.1: an always_comb's inferred sensitivity covers every non-local
+// signal it reads -- a sibling scope's signal named hierarchically, in either
+// declaration order, and a signal read inside a function it calls -- and wakes
+// the block when any of them changes. Every source changes after time zero, so
+// a subscription that only settled at time zero, that dropped a non-enclosing
+// target, or that saw only a function's arguments would miss the update.
+//
+//   p.got reads q.sig, with q declared after p; q.got reads p.sig, with p
+//   declared before q -- both cross-scope directions and declaration orders.
+//   fn_a reads an enclosing signal through a called function; fn_c reads a
+//   sibling block's signal through a called function.
+module Test;
+  logic [7:0] a;
+
+  if (1) begin : p
+    logic [7:0] sig;
+    logic [7:0] got;
+    always_comb got = q.sig;
+  end
+
+  if (1) begin : q
+    logic [7:0] sig;
+    logic [7:0] got;
+    always_comb got = p.sig;
+  end
+
+  if (1) begin : c
+    logic [7:0] sig;
+  end
+
+  function automatic logic [7:0] read_a();
+    return a;
+  endfunction
+
+  function automatic logic [7:0] read_c();
+    return c.sig;
+  endfunction
+
+  logic [7:0] fn_a;
+  logic [7:0] fn_c;
+  always_comb fn_a = read_a();
+  always_comb fn_c = read_c();
+
+  initial begin
+    a = 8'd0;
+    p.sig = 8'd0;
+    q.sig = 8'd0;
+    c.sig = 8'd0;
+    #1;
+    a = 8'd1;
+    p.sig = 8'd3;
+    q.sig = 8'd4;
+    c.sig = 8'd2;
+    #1;
+    $display("p=%0d q=%0d fn_a=%0d fn_c=%0d", p.got, q.got, fn_a, fn_c);
+  end
+endmodule

--- a/tests/cases/cpp/always_star_reacts_to_change/case.yaml
+++ b/tests/cases/cpp/always_star_reacts_to_change/case.yaml
@@ -14,3 +14,5 @@ expect:
     result_at_t1: 0
     result_after_a_change: 7
     result_after_b_change: 15
+    # A change to the cross-scope signal g.v (5 + 10 + 20) also wakes the block.
+    result_after_xscope_change: 35

--- a/tests/cases/cpp/always_star_reacts_to_change/main.sv
+++ b/tests/cases/cpp/always_star_reacts_to_change/main.sv
@@ -1,10 +1,19 @@
 module Top;
   int a, b, sum;
   int result_at_t1, result_after_a_change, result_after_b_change;
+  int result_after_xscope_change;
+
+  // Declared before the `always @*` that reads it, so its cross-unit reference
+  // is only resolved when the body lowers; the sensitivity must still subscribe
+  // to it.
+  if (1) begin : g
+    int v;
+  end
 
   initial begin
     a = 1;
     b = 2;
+    g.v = 0;
     #1;
     // result_at_t1 captures sum BEFORE the @* body has run -- LRM 9.4.2.2
     // says @* never runs at time zero, only on subsequent changes.
@@ -15,7 +24,10 @@ module Top;
     b = 10;
     #1;
     result_after_b_change = sum;
+    g.v = 20;
+    #1;
+    result_after_xscope_change = sum;
   end
 
-  always @* sum = a + b;
+  always @* sum = a + b + g.v;
 endmodule

--- a/tests/cases/cpp/hierarchy_xunit_read/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_read/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stdout:
-    exact: "r=42\n"
+    exact: "r=42 rw=5\n"

--- a/tests/cases/cpp/hierarchy_xunit_read/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_read/main.sv
@@ -1,14 +1,18 @@
 module Child;
   int x;
+  wire [7:0] w;
+  assign w = 8'd5;
   initial x = 42;
 endmodule
 
 module Top;
   Child c();
   int r;
+  logic [7:0] rw;
   initial begin
     #1;
     r = c.x;
-    $display("r=%0d", r);
+    rw = c.w;
+    $display("r=%0d rw=%0d", r, rw);
   end
 endmodule


### PR DESCRIPTION
## Summary

This branch reworks how the front end translates SystemVerilog references and inferred sensitivity into HIR routes. A reference and its change observation both answer the same question -- from the reader's position, what is the route to the target signal -- but the value read and the observation each computed that route through separate rules, kept consistent only by lowering order and cross-unit-slot de-duplication. The end state is one canonical route translator, keyed on the reader's elaborated hierarchical position and the target symbol, shared by every consumer: value read, value write, change observation, and a dependency read only inside a called function.

## Design

The translator classifies each route segment by layout visibility from the target's elaborated position: a typed enclosing climb when the target is a this-unit structural data object, a typed downward head when the head's class this unit emits (a generate block, a generate array, or a named block), and a by-name head where the route crosses a compilation-unit boundary (an ancestor-unit signal, a sibling-subtree instance, or an instance head reached by climbing). Because the route is derived from elaborated positions rather than the reference's lexical form, enclosing, downward-child, sibling, cross-module, and upward-out-of-unit references all resolve the same way, independent of the order the target and referrer appear in source. The front end's resolved reference path is used only as provenance, never as a routing authority. Completing the translator's input required carrying the reader's elaborated scope on the walk frame; with that in place, upward-out-of-unit stops being a special per-consumer case and becomes one more reader-to-target route.

## Testing

Full suite green. Coverage includes cross-scope sensitivity in both declaration orders with a mutation at t > 0, an always_comb whose dependency is read only inside a called function, cross-unit reads of both a variable and a net, hierarchical reads of a localparam and an enum constant, nested named-block heads, and multi-dimensional instance arrays.
