### PR TITLE
Support $test$plusargs and $value$plusargs

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -111,7 +111,12 @@ full support.
       `id_stage_i.controller_i.exc_req_d` inside `gen_rvfi_no_wb_stage`; `ibex_ex_block` reaches its
       generate-instantiated multiplier and divider the same way). Reached once DPI export above is
       handled or elided.
-- [ ] **`$value$plusargs`** -- runtime plusarg query (ibex_tracer reads the trace-enable plusarg).
+- [ ] **`$value$plusargs` / `$test$plusargs`** -- runtime plusarg query (LRM 21.6). The language
+      surface lowers and executes: `$test$plusargs` probes for a prefix, `$value$plusargs` parses
+      the matched plusarg's remainder under `%d` / `%o` / `%h` / `%x` / `%b` / `%s`. The
+      host-to-simulation plusargs source is still empty, so every query returns 0 and `ibex_tracer`
+      behaves as if no trace-enable plusarg was supplied; wiring the host command line into the
+      simulation is what unlocks a real match.
 - [ ] **A procedural statement form in ibex_cs_registers** -- one unsupported statement shape,
       recorded for follow-up once isolated.
 - [x] **Constant of an unpacked array type** -- an elaboration-time `localparam` array referenced

--- a/include/lyra/lowering/hir_to_mir/expression/system/plusargs.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/plusargs.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// LRM 21.6 `$test$plusargs` / `$value$plusargs`. The value form is modelled
+// as an IIFE: the closure body calls the runtime helper against a temp of
+// the output lvalue's shape and conditionally writes the temp back to the
+// original lvalue. The test form has no output and lowers to a direct call
+// against the services handle. Both yield the SV `int` return.
+auto LowerPlusargsSystemSubroutineCall(
+    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
+    const support::PlusargsSystemSubroutineInfo& info)
+    -> diag::Result<mir::Expr>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -13,6 +13,7 @@
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/diagnostic.hpp"
 #include "lyra/runtime/file_table.hpp"
+#include "lyra/runtime/plusargs.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/scope.hpp"
@@ -165,7 +166,8 @@ class Engine {
   StreamDispatcher stream_;
   DiagnosticDispatcher diagnostic_;
   FileTable files_{stream_};
-  RuntimeServices services_{stream_, diagnostic_, files_, *this};
+  PlusArgsSource plusargs_;
+  RuntimeServices services_{stream_, diagnostic_, files_, plusargs_, *this};
   std::unique_ptr<Scope> root_;
   // Processes created during simulation (fork-join branches), owned for their
   // dynamic lifetime. Each is dropped in RunProcess when it completes; static

--- a/include/lyra/runtime/plusargs.hpp
+++ b/include/lyra/runtime/plusargs.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+class RuntimeServices;
+
+// LRM 21.6 command-line plusargs source, held on the engine as design-global
+// state. Stored tokens are the plusarg content (`+` prefix already stripped)
+// so a match compares directly against the user-supplied prefix.
+class PlusArgsSource {
+ public:
+  // Returns the remainder (the portion after `prefix`) of the first stored
+  // token whose content starts with `prefix`, or nullopt if none match. The
+  // tokens are searched in the order given, matching LRM 21.6.
+  [[nodiscard]] auto MatchPrefix(std::string_view prefix) const
+      -> std::optional<std::string_view>;
+
+ private:
+  std::vector<std::string> tokens_;
+};
+
+// LRM 21.6 $test$plusargs. Returns 1 on prefix match, 0 otherwise, as a
+// PackedArray shaped for SV `int` (2-state 32-bit signed).
+auto TestPlusargs(RuntimeServices& services, const value::String& user_string)
+    -> value::PackedArray;
+
+// LRM 21.6 $value$plusargs. `user_string` is `"plusarg_prefix format_spec"`;
+// on prefix match, converts the remainder per the format specifier and
+// writes it to `out`, returning 1. On no match returns 0 and leaves `out`
+// untouched. Legal format specifiers: %d %o %h %x %b %s (uppercase and
+// leading 0 permitted). Real-valued conversions (%e %f %g) are not yet
+// supported; a call with one of them returns 0 without writing.
+auto ValuePlusargs(
+    RuntimeServices& services, const value::String& user_string,
+    value::PackedArray& out) -> value::PackedArray;
+auto ValuePlusargs(
+    RuntimeServices& services, const value::String& user_string,
+    value::String& out) -> value::PackedArray;
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -16,6 +16,7 @@ namespace lyra::runtime {
 class StreamDispatcher;
 class DiagnosticDispatcher;
 class FileTable;
+class PlusArgsSource;
 class Engine;
 class Observable;
 
@@ -23,10 +24,11 @@ class RuntimeServices {
  public:
   RuntimeServices(
       StreamDispatcher& stream, DiagnosticDispatcher& diagnostic,
-      FileTable& files, Engine& engine)
+      FileTable& files, PlusArgsSource& plusargs, Engine& engine)
       : stream_(&stream),
         diagnostic_(&diagnostic),
         files_(&files),
+        plusargs_(&plusargs),
         engine_(&engine) {
   }
 
@@ -49,6 +51,13 @@ class RuntimeServices {
       throw InternalError("RuntimeServices has no FileTable");
     }
     return *files_;
+  }
+
+  auto PlusArgs() -> PlusArgsSource& {
+    if (plusargs_ == nullptr) {
+      throw InternalError("RuntimeServices has no PlusArgsSource");
+    }
+    return *plusargs_;
   }
 
   void SubmitNba(std::function<void(RuntimeServices&)> closure);
@@ -104,6 +113,7 @@ class RuntimeServices {
   StreamDispatcher* stream_ = nullptr;
   DiagnosticDispatcher* diagnostic_ = nullptr;
   FileTable* files_ = nullptr;
+  PlusArgsSource* plusargs_ = nullptr;
   Engine* engine_ = nullptr;
 };
 

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -193,6 +193,13 @@ enum class BuiltinFn : std::uint16_t {
   kFileEof,
   kFileError,
   kFileFlush,
+  // LRM 21.6 command-line plusargs. Free functions on `lyra::runtime` that
+  // take the services handle plus SV `string` operands; the value form also
+  // takes the output lvalue by reference (a `PackedArray` or `String`,
+  // selected by C++ overload from the SV lvalue's declared type). Both
+  // return an SV `int` (1 on prefix match, 0 otherwise).
+  kTestPlusargs,
+  kValuePlusargs,
   // LRM 9.4.1 `#N`. The runtime free function the scheduler suspends on.
   // The call takes the engine handle, the duration in the calling scope's
   // precision steps, and the calling scope's precision power; the runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -147,12 +147,22 @@ struct TimeFormatSystemSubroutineInfo {};
 // precision. Only the no-argument (current scope) form is modeled.
 struct PrintTimescaleSystemSubroutineInfo {};
 
+// LRM 21.6 command-line plusargs: `$test$plusargs` tests whether any plusarg
+// starts with the user-supplied prefix; `$value$plusargs` also converts the
+// matching plusarg's remainder per the format specifier and writes it to the
+// output lvalue. The kind axis is what the HIR-to-MIR dispatcher branches on
+// to pick the runtime helper.
+enum class PlusargsKind : std::uint8_t { kTest, kValue };
+struct PlusargsSystemSubroutineInfo {
+  PlusargsKind kind;
+};
+
 using SystemSubroutineSemantic = std::variant<
     PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo,
     DiagnosticSystemSubroutineInfo, FileIOSystemSubroutineInfo,
     ScanSystemSubroutineInfo, SFormatSystemSubroutineInfo,
     TimeSystemSubroutineInfo, TimeFormatSystemSubroutineInfo,
-    PrintTimescaleSystemSubroutineInfo>;
+    PrintTimescaleSystemSubroutineInfo, PlusargsSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -828,6 +838,24 @@ inline constexpr std::array kSystemSubroutines = {
             DiagnosticSystemSubroutineInfo{.builtin_fn = BuiltinFn::kEmitFatal},
         .suspends = true,
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{54},
+        .name = "$test$plusargs",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kInt32,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 1},
+        .semantic = PlusargsSystemSubroutineInfo{.kind = PlusargsKind::kTest},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{55},
+        .name = "$value$plusargs",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kInt32,
+        .arg_policy = ArgCountPolicy{.min_args = 2, .max_args = 2},
+        .semantic = PlusargsSystemSubroutineInfo{.kind = PlusargsKind::kValue},
+    },
 };
 
 }  // namespace detail
@@ -880,6 +908,11 @@ inline constexpr std::array kSystemSubroutines = {
 [[nodiscard]] inline auto GetTimeInfo(const SystemSubroutineDesc& desc)
     -> const TimeSystemSubroutineInfo* {
   return std::get_if<TimeSystemSubroutineInfo>(&desc.semantic);
+}
+
+[[nodiscard]] inline auto GetPlusargsInfo(const SystemSubroutineDesc& desc)
+    -> const PlusargsSystemSubroutineInfo* {
+  return std::get_if<PlusargsSystemSubroutineInfo>(&desc.semantic);
 }
 
 }  // namespace lyra::support

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -80,6 +80,10 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "PeekBuffered";
     case support::BuiltinFn::kAdvanceFd:
       return "AdvanceFd";
+    case support::BuiltinFn::kTestPlusargs:
+      return "TestPlusargs";
+    case support::BuiltinFn::kValuePlusargs:
+      return "ValuePlusargs";
     case support::BuiltinFn::kTrigger:
       return "Trigger";
     case support::BuiltinFn::kAwait:
@@ -348,6 +352,8 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
     case support::BuiltinFn::kForkWaitAll:
     case support::BuiltinFn::kForkWaitFirst:
     case support::BuiltinFn::kSpawnAll:
+    case support::BuiltinFn::kTestPlusargs:
+    case support::BuiltinFn::kValuePlusargs:
       return "lyra::runtime";
     default:
       return "";

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -20,6 +20,7 @@
 #include "lyra/lowering/hir_to_mir/expression/system/control.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/file_io.hpp"
+#include "lyra/lowering/hir_to_mir/expression/system/plusargs.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/print.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/scan.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/sformat.hpp"
@@ -314,6 +315,11 @@ auto LowerSystemSubroutineCall(
           [&](const support::PrintTimescaleSystemSubroutineInfo&)
               -> diag::Result<mir::Expr> {
             return LowerPrintTimescaleSystemSubroutineCall(process, frame);
+          },
+          [&](const support::PlusargsSystemSubroutineInfo& plusargs)
+              -> diag::Result<mir::Expr> {
+            return LowerPlusargsSystemSubroutineCall(
+                process, frame, call, plusargs);
           },
       },
       desc.semantic);

--- a/src/lyra/lowering/hir_to_mir/expression/system/plusargs.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/plusargs.cpp
@@ -1,0 +1,172 @@
+#include "lyra/lowering/hir_to_mir/expression/system/plusargs.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <utility>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
+#include "lyra/lowering/hir_to_mir/closure_builder.hpp"
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
+#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
+#include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/support/builtin_fn.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto LowerTestPlusargs(
+    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call)
+    -> diag::Result<mir::Expr> {
+  const auto& hir_proc = process.HirBody();
+  auto& unit = process.Module().Unit();
+  auto& body = *frame.current_block;
+
+  auto user_or =
+      process.LowerExpr(hir_proc.exprs.Get(*call.arguments[0]), frame);
+  if (!user_or) return std::unexpected(std::move(user_or.error()));
+  const mir::ExprId raw_user_id = body.exprs.Add(*std::move(user_or));
+  // A packed literal / integral variable is a legal user_string here
+  // (LRM 21.6); the runtime signature is on SV `string`, so the operand
+  // gets the value-layer conversion.
+  const mir::ExprId user_id =
+      ConvertToType(unit, body, raw_user_id, unit.builtins.string);
+  const mir::ExprId services_id =
+      body.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::Direct{.target = support::BuiltinFn::kTestPlusargs},
+              .arguments = {services_id, user_id}},
+      .type = unit.builtins.int32};
+}
+
+auto LowerValuePlusargs(
+    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call)
+    -> diag::Result<mir::Expr> {
+  const auto& hir_proc = process.HirBody();
+  auto& module = process.Module();
+  auto& unit = module.Unit();
+  const mir::TypeId int32_t_id = unit.builtins.int32;
+  const mir::TypeId bit_t = unit.builtins.bit1;
+  const mir::TypeId void_t = unit.builtins.void_type;
+
+  const auto& hir_target = hir_proc.exprs.Get(*call.arguments[1]);
+  const mir::TypeId target_type = module.TranslateType(hir_target.type);
+
+  // A match writes the parsed remainder into the caller's lvalue and returns
+  // 1; a no-match leaves the lvalue untouched and returns 0. Both effects
+  // sit in an IIFE so the call fits in expression position (LRM 21.6).
+  ClosureBuilder closure(unit, frame);
+  mir::Block& body = closure.Body();
+  const WalkFrame& closure_frame = closure.Frame();
+
+  auto user_or =
+      process.LowerExpr(hir_proc.exprs.Get(*call.arguments[0]), closure_frame);
+  if (!user_or) return std::unexpected(std::move(user_or.error()));
+  const mir::ExprId raw_user_id = body.exprs.Add(*std::move(user_or));
+  // A packed literal / integral variable is a legal user_string here
+  // (LRM 21.6); the runtime signature is on SV `string`, so the operand
+  // gets the value-layer conversion.
+  const mir::ExprId user_id =
+      ConvertToType(unit, body, raw_user_id, unit.builtins.string);
+
+  const mir::ExprId temp_init =
+      body.exprs.Add(BuildDefaultValueExpr(module, closure_frame, target_type));
+  const mir::LocalId temp_var = closure.Bindings().DeclareAnonymous(
+      mir::LocalDecl{.name = "_lyra_plusargs_out", .type = target_type});
+  body.AppendStmt(mir::LocalDeclStmt{.target = temp_var, .init = temp_init});
+
+  const mir::ExprId services_id =
+      body.exprs.Add(BuildServicesCallExpr(module, closure_frame));
+  const mir::ExprId temp_ref =
+      body.exprs.Add(mir::MakeLocalRefExpr(temp_var, target_type));
+  const mir::ExprId hit_call = body.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::Direct{.target = support::BuiltinFn::kValuePlusargs},
+                  .arguments = {services_id, user_id, temp_ref}},
+          .type = int32_t_id});
+  const mir::LocalId hit_var = closure.Bindings().DeclareAnonymous(
+      mir::LocalDecl{.name = "_lyra_plusargs_hit", .type = int32_t_id});
+  body.AppendStmt(mir::LocalDeclStmt{.target = hit_var, .init = hit_call});
+
+  const mir::ExprId hit_read =
+      body.exprs.Add(mir::MakeLocalRefExpr(hit_var, int32_t_id));
+  const mir::ExprId one_lit = body.exprs.Add(
+      mir::MakeInt32Literal(int32_t_id, static_cast<std::int64_t>(1)));
+  const mir::ExprId cond_id = body.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::BinaryExpr{
+                  .op = mir::BinaryOp::kGreaterEqual,
+                  .lhs = hit_read,
+                  .rhs = one_lit},
+          .type = bit_t});
+
+  mir::Block then_body;
+  const WalkFrame then_frame = closure_frame.WithBlock(&then_body);
+  auto lvalue_or =
+      process.LowerLhsExpr(hir_proc.exprs.Get(*call.arguments[1]), then_frame);
+  if (!lvalue_or) return std::unexpected(std::move(lvalue_or.error()));
+  const mir::ExprId lvalue_id = then_body.exprs.Add(*std::move(lvalue_or));
+  const mir::ExprId temp_read_then =
+      then_body.exprs.Add(mir::MakeLocalRefExpr(temp_var, target_type));
+  const mir::ExprId services_id_then =
+      then_body.exprs.Add(BuildServicesCallExpr(module, then_frame));
+  const mir::Expr assign_expr = BuildObservableAssignExpr(
+      unit, then_body, services_id_then, lvalue_id, temp_read_then,
+      std::nullopt, target_type, void_t);
+  const mir::ExprId assign_id = then_body.exprs.Add(assign_expr);
+  then_body.AppendStmt(mir::ExprStmt{.expr = assign_id});
+
+  body.AppendIfThen(cond_id, std::move(then_body));
+
+  const mir::ExprId final_hit =
+      body.exprs.Add(mir::MakeLocalRefExpr(hit_var, int32_t_id));
+  return BuildClosureCallExpr(
+      unit, *frame.current_block, closure.Build(final_hit));
+}
+
+}  // namespace
+
+auto LowerPlusargsSystemSubroutineCall(
+    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
+    const support::PlusargsSystemSubroutineInfo& info)
+    -> diag::Result<mir::Expr> {
+  switch (info.kind) {
+    case support::PlusargsKind::kTest: {
+      if (call.arguments.size() != 1 || !call.arguments[0].has_value()) {
+        throw InternalError(
+            "LowerPlusargsSystemSubroutineCall: $test$plusargs expects exactly "
+            "one non-elided argument");
+      }
+      return LowerTestPlusargs(process, frame, call);
+    }
+    case support::PlusargsKind::kValue: {
+      if (call.arguments.size() != 2 || !call.arguments[0].has_value() ||
+          !call.arguments[1].has_value()) {
+        throw InternalError(
+            "LowerPlusargsSystemSubroutineCall: $value$plusargs expects two "
+            "non-elided arguments");
+      }
+      return LowerValuePlusargs(process, frame, call);
+    }
+  }
+  throw InternalError(
+      "LowerPlusargsSystemSubroutineCall: unknown PlusargsKind");
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/runtime/plusargs.cpp
+++ b/src/lyra/runtime/plusargs.cpp
@@ -1,0 +1,134 @@
+#include "lyra/runtime/plusargs.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "lyra/runtime/runtime_services.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+namespace {
+
+// LRM 21.6 user_string carries "plusarg_prefix format_spec". The prefix is
+// everything up to the first `%`; the letter after `%` (with an optional
+// leading `0`) is the conversion specifier.
+struct ParsedUserString {
+  std::string_view prefix;
+  char format_letter;
+};
+
+auto ParseUserString(std::string_view user) -> ParsedUserString {
+  const auto pct = user.find('%');
+  if (pct == std::string_view::npos) {
+    return {.prefix = user, .format_letter = '\0'};
+  }
+  std::size_t letter_pos = pct + 1;
+  if (letter_pos < user.size() && user[letter_pos] == '0') {
+    ++letter_pos;
+  }
+  const char letter = letter_pos < user.size() ? user[letter_pos] : '\0';
+  return {.prefix = user.substr(0, pct), .format_letter = letter};
+}
+
+auto BaseForFormat(char letter) -> std::optional<int> {
+  switch (letter) {
+    case 'd':
+    case 'D':
+      return 10;
+    case 'o':
+    case 'O':
+      return 8;
+    case 'h':
+    case 'H':
+    case 'x':
+    case 'X':
+      return 16;
+    case 'b':
+    case 'B':
+      return 2;
+    default:
+      return std::nullopt;
+  }
+}
+
+auto ConvertIntegralRemainder(std::string_view remainder, int base)
+    -> std::int64_t {
+  // LRM 21.6: an empty remainder stores zero rather than being a parse error.
+  // Illegal characters mid-parse stop the scan and the accumulated value
+  // stands; LRM 21.6's `'bx` outcome for "illegal characters for the specified
+  // conversion" needs the target's shape and is not yet modeled here.
+  std::int64_t value = 0;
+  for (const char c : remainder) {
+    int digit = 0;
+    if (c >= '0' && c <= '9') {
+      digit = c - '0';
+    } else if (c >= 'a' && c <= 'z') {
+      digit = (c - 'a') + 10;
+    } else if (c >= 'A' && c <= 'Z') {
+      digit = (c - 'A') + 10;
+    } else {
+      return value;
+    }
+    if (digit >= base) return value;
+    value = (value * base) + digit;
+  }
+  return value;
+}
+
+auto MakeIntResult(std::int64_t value) -> value::PackedArray {
+  // SV `int` shape: 32-bit signed, 2-state (LRM 6.11.1).
+  return value::PackedArray::FromInt(value, 32, true, false);
+}
+
+}  // namespace
+
+auto PlusArgsSource::MatchPrefix(std::string_view prefix) const
+    -> std::optional<std::string_view> {
+  for (const std::string& token : tokens_) {
+    const std::string_view content{token};
+    if (content.starts_with(prefix)) {
+      return content.substr(prefix.size());
+    }
+  }
+  return std::nullopt;
+}
+
+auto TestPlusargs(RuntimeServices& services, const value::String& user_string)
+    -> value::PackedArray {
+  const auto match = services.PlusArgs().MatchPrefix(user_string.View());
+  return MakeIntResult(match.has_value() ? 1 : 0);
+}
+
+auto ValuePlusargs(
+    RuntimeServices& services, const value::String& user_string,
+    value::PackedArray& out) -> value::PackedArray {
+  const auto parsed = ParseUserString(user_string.View());
+  const auto base = BaseForFormat(parsed.format_letter);
+  if (!base.has_value()) {
+    // %s / %e / %f / %g on an integral target: no match, out untouched.
+    return MakeIntResult(0);
+  }
+  const auto match = services.PlusArgs().MatchPrefix(parsed.prefix);
+  if (!match.has_value()) return MakeIntResult(0);
+  const std::int64_t converted = ConvertIntegralRemainder(*match, *base);
+  out = value::PackedArray::FromInt(converted, out);
+  return MakeIntResult(1);
+}
+
+auto ValuePlusargs(
+    RuntimeServices& services, const value::String& user_string,
+    value::String& out) -> value::PackedArray {
+  const auto parsed = ParseUserString(user_string.View());
+  const char letter = parsed.format_letter;
+  if (letter != 's' && letter != 'S') return MakeIntResult(0);
+  const auto match = services.PlusArgs().MatchPrefix(parsed.prefix);
+  if (!match.has_value()) return MakeIntResult(0);
+  out = value::String(std::string(*match));
+  return MakeIntResult(1);
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -282,6 +282,10 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "peek_buffered";
     case BuiltinFn::kAdvanceFd:
       return "advance_fd";
+    case BuiltinFn::kTestPlusargs:
+      return "test_plusargs";
+    case BuiltinFn::kValuePlusargs:
+      return "value_plusargs";
     case BuiltinFn::kDelay:
       return "delay";
     case BuiltinFn::kSimTime:

--- a/tests/cases/cpp/plusargs_empty/case.yaml
+++ b/tests/cases/cpp/plusargs_empty/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.plusargs_empty
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    test_hit: 0
+    value_hit_s: 0
+    value_hit_d: 0
+    value_hit_b: 0
+    s_out: "sentinel"
+    d_out: 42
+    b_out: 0xA5

--- a/tests/cases/cpp/plusargs_empty/main.sv
+++ b/tests/cases/cpp/plusargs_empty/main.sv
@@ -1,0 +1,26 @@
+// LRM 21.6 command-line plusargs, no CLI tokens available: every query
+// returns 0 and $value$plusargs leaves its output untouched. Covers both
+// system functions and the format-specifier surface the test can reach
+// without CLI plumbing (which arrives in a later cut).
+module Top;
+  int    test_hit;
+  int    value_hit_s;
+  int    value_hit_d;
+  int    value_hit_b;
+  string s_out;
+  int    d_out;
+  logic [7:0] b_out;
+
+  initial begin
+    // Sentinels prove no write occurs on 0 return (LRM 21.6: "the
+    // variable provided is not modified").
+    s_out = "sentinel";
+    d_out = 42;
+    b_out = 8'hA5;
+
+    test_hit    = $test$plusargs("nothing_matches");
+    value_hit_s = $value$plusargs("nothing_matches=%s", s_out);
+    value_hit_d = $value$plusargs("nothing_matches=%d", d_out);
+    value_hit_b = $value$plusargs("nothing_matches=%b", b_out);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds LRM 21.6 command-line plusargs to the system-function registry, wired through HIR-to-MIR onto a new engine-owned `PlusArgsSource` reached through runtime services. `$test$plusargs` probes for a prefix; `$value$plusargs` also parses the matched plusarg's remainder under `%d` / `%o` / `%h` / `%x` / `%b` / `%s` and writes it to the caller's output. Both yield the SV `int` return that slang classifies for them.

## Design

The two ids mirror `$sscanf`'s call shape end-to-end: a new semantic variant in the descriptor variant, a per-family lowering entry, and a runtime helper whose signature is stated on SV value types (`value::String`, `value::PackedArray`) at the API boundary. `$value$plusargs` sits in an IIFE so the writeback is a real assignment to the SV lvalue, gated on the match count -- LRM 21.6's "the variable provided is not modified" on a miss falls out for free.

The store itself lives on the engine (a new `PlusArgsSource` peer to `FileTable` in the services fanout). It starts empty; wiring the host command line into it is the natural second step, so every query returns 0 until then. That is enough to unblock the ibex_tracer usage shape at parse and lower time -- the SV compiles cleanly and behaves as if no plusarg were supplied.

## Testing

- `tests/cases/cpp/plusargs_empty` covers the no-match path across `%s` / `%d` / `%b`: return is 0, and outputs keep their sentinel values.
- Ibex-tracer's two live shapes (`%b` into a `bit`, `%s` into a `string`) build and run end-to-end against a playground fixture.
- `bazel test //...` green (pre-commit run).