### PR TITLE
Register named block head identity in declaration pass

### DIFF
--- a/docs/decisions/declarations-before-bodies.md
+++ b/docs/decisions/declarations-before-bodies.md
@@ -162,8 +162,8 @@ mechanism.
 - **Procedural storage scope materialization** (`procedural-storage-scope.md`). A named procedural
   block whose subtree owns hierarchy-addressable storage is a structural declaration: its class
   identity, its statics, the parent's owning-pointer companion member, and the contained-class edge
-  are minted by the shape pass. A sibling process's body lowering reads its peer block's members
-  through a typed segment chain; the body never mints any of these.
+  are minted by the shape pass. A sibling process's body lowering reaches its peer block's static
+  through a head the shape pass already registered; the body never mints any of these.
 
 The same invariant applies to future structural concepts that admit cross-reference; new
 applications do not introduce new mechanism.

--- a/docs/decisions/front-end-semantic-boundary.md
+++ b/docs/decisions/front-end-semantic-boundary.md
@@ -144,13 +144,16 @@ one translation; they must not each re-derive it.
   through its enclosing structural scope, so a read nested in a procedural block or a fork branch
   routes from that scope. slang's resolved reference path is provenance only, never a second routing
   authority.
-- Two items remain before the boundary is fully realized. A named procedural block's identity is
-  still assigned during the body pass -- it shares an arena populated by statement traversal, with
-  no source-order position the declaration pass can predict -- so a forward cross-scope reference to
-  a named block is not yet order-independent. And whether value access and change observation share
-  one bound runtime endpoint -- and whether an enclosing reference binds a per-instance handle
-  rather than re-navigating the parent chain on the hot path -- is the endpoint-capability half of
-  the boundary, constrained by it but not settled here.
+- Every addressable structural identity, including a named procedural block's, is registered by the
+  compilation-unit declaration pass before any body lowers. A named block's head identity is its SV
+  label, registered directly from the elaborated scope members, so a forward cross-scope reference
+  to it routes independently of declaration order like every other head kind. Its intra-unit access
+  is a typed layout-visible segment: the enclosing climb reaches the materialized scope's companion,
+  which HIR-to-MIR recovers from the label.
+- One item remains before the boundary is fully realized. Whether value access and change
+  observation share one bound runtime endpoint -- and whether an enclosing reference binds a
+  per-instance handle rather than re-navigating the parent chain on the hot path -- is the
+  endpoint-capability half of the boundary, constrained by it but not settled here.
 
 ## Relation to existing decisions
 

--- a/docs/decisions/procedural-storage-scope.md
+++ b/docs/decisions/procedural-storage-scope.md
@@ -136,14 +136,14 @@ The same owned-child binding registry that routes downward access through an ins
 generate-block head registers named procedural blocks too, so a reference of the form `outer.x` from
 a sibling process routes as a downward head rather than a cross-unit by-name climb. A named
 procedural block is an intra-unit layout-visible structural child (LRM 23.9). Its declaration-time
-hierarchical identity is the SV label -- the stable name slang resolves the reference to, independent
-of source order.
+hierarchical identity is the SV label -- the stable name slang resolves the reference to,
+independent of source order.
 
 Its executable realization is a typed segment. The enclosing climb to the block's owning scope is
 typed, and the block itself is reached through the materialized procedural scope's companion handle
 on the enclosing class -- a typed member access, not a by-name lookup. HIR-to-MIR recovers that
-companion from the label, so the label is the head's declaration-time identity while the companion is
-its realization. The runtime by-name walk serves only a cross-compilation-unit descent past this
+companion from the label, so the label is the head's declaration-time identity while the companion
+is its realization. The runtime by-name walk serves only a cross-compilation-unit descent past this
 head.
 
 ### D8. Ownership is the runtime tree; the companion is navigation only

--- a/docs/decisions/procedural-storage-scope.md
+++ b/docs/decisions/procedural-storage-scope.md
@@ -14,8 +14,8 @@ A named procedural block (LRM 9.3.5 `begin : name ... end`) is a hierarchical-re
 23.9): `Top.outer.x` reaches a static inside `outer` from another scope. The block is therefore not
 statement-tree decoration -- it is part of the compilation unit's hierarchical structure. Once that
 is true, every existing rule for structural declaration applies to it: it has a stable identity, its
-layout and storage are settled before any executable lowering, and a peer body that reaches into it
-does so by typed segment, not by re-walking source.
+layout and storage are settled before any executable lowering, and a peer body reaches it through a
+route resolved before any body lowers, not by re-walking source.
 
 This decision pins the named procedural block as a first-class structural concept, separates the
 HIR-side lexical view from the MIR-side runtime realization, and forbids body lowering from creating
@@ -130,14 +130,21 @@ visiting the statement tree:
 The body lowering looks up the planner's resulting binding per static var; it does not re-derive
 placement and does not visit the statement tree for any planner concern.
 
-### D7. Intra-unit access to a procedural-scope static is a typed segment
+### D7. Intra-unit access to a procedural-scope static is a typed layout-visible segment
 
 The same owned-child binding registry that routes downward access through an instance or
-generate-block head registers materialized procedural scopes too. A reference of the form `outer.x`
-from a sibling process resolves through the typed segment chain (`self -> outer_companion -> x`);
-the runtime by-name walk is used only across compilation-unit boundaries. Procedural-scope heads
-share routing mechanism with the other structural-child kinds; the distinction is the head's
-`TypeKind`, not the resolution path.
+generate-block head registers named procedural blocks too, so a reference of the form `outer.x` from
+a sibling process routes as a downward head rather than a cross-unit by-name climb. A named
+procedural block is an intra-unit layout-visible structural child (LRM 23.9). Its declaration-time
+hierarchical identity is the SV label -- the stable name slang resolves the reference to, independent
+of source order.
+
+Its executable realization is a typed segment. The enclosing climb to the block's owning scope is
+typed, and the block itself is reached through the materialized procedural scope's companion handle
+on the enclosing class -- a typed member access, not a by-name lookup. HIR-to-MIR recovers that
+companion from the label, so the label is the head's declaration-time identity while the companion is
+its realization. The runtime by-name walk serves only a cross-compilation-unit descent past this
+head.
 
 ### D8. Ownership is the runtime tree; the companion is navigation only
 
@@ -202,7 +209,7 @@ indexed by-name child lookup downcast to the child's typed class.
   clean passes over a small tree.
 - **Body-lowering mints the scope on encounter.** The procedural-scope class is created when the
   body lowering enters the named begin/end. Rejected: re-binds structural graph to executable
-  traversal even when the class id appears peer-unreferenced; the intra-unit typed segment rule (D7)
+  traversal even when the class id appears peer-unreferenced; the intra-unit downward-head rule (D7)
   shows the id IS peer-referenced.
 - **Reuse the generate-scope MIR `TypeKind` for procedural storage scopes.** The runtime base is
   identical, so use one kind. Rejected: dump, debug, and per-kind semantics (named fork, disable
@@ -218,7 +225,7 @@ indexed by-name child lookup downcast to the child's typed class.
 - `declarations-before-bodies.md` -- the strict-D5 invariant a procedural-scope class respects.
 - `variable-lifetime-storage.md` -- the storage-owner rule for static-lifetime body locals, read
   through the addressable-scope concept this decision provides.
-- `hierarchical-reference-routing.md` -- one routing path per access shape; procedural-scope heads
-  resolve through the same typed-segment route as generate-block heads for intra-unit access, and
-  through the runtime by-name walk for cross-unit access.
+- `hierarchical-reference-routing.md` -- one routing path per access shape; a named-block head
+  routes as a downward head, a typed enclosing climb into the materialized scope's companion handle
+  recovered from the block label; the runtime by-name walk serves cross-unit access.
 - `object-model-storage.md` -- the unit's class registry that holds the procedural-scope classes.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -776,7 +776,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
 - [ ] R53 -- Finish the front-end reference / sensitivity translation boundary
       (`../decisions/front-end-semantic-boundary.md`). The correctness repairs and the move to route
       cross-scope references by layout visibility (order-independent, from a whole-unit declaration
-      pass) have landed. Three items remain before the boundary is fully realized:
+      pass) have landed. The boundary is realized in three staged sub-items:
   - [x] R53a -- One route translation for every reference consumer. Value read, value write, and
         change observation (including a dependency read only inside a called function) route through
         one translator keyed on the reader's elaborated position and the target symbol; each segment
@@ -785,13 +785,12 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         or cross-unit-slot dedup. The reader's elaborated position is recovered from its enclosing
         structural scope, so a read nested in a procedural block or fork branch routes from that
         scope. The frontend's resolved reference path is provenance only, not a routing authority.
-  - [ ] R53b -- The declaration pass covers every addressable identity. Generate and instance
-        identities are registered before any body lowers, so a forward cross-scope reference to them
-        is order-independent. A named procedural block's identity is still assigned while its body
-        lowers -- it shares an arena populated by statement traversal, with no source-order position
-        the declaration pass can predict -- so a forward cross-scope reference to a named block is
-        not yet order-independent. Give the named block a declaration-time identity so the invariant
-        holds for it too.
+  - [x] R53b -- The declaration pass covers every addressable identity. Generate, instance, and
+        named procedural block identities are all registered before any body lowers, so a forward
+        cross-scope reference to any of them resolves the same layout-visible route regardless of
+        declaration order. A named block's head identity is its SV label (a hierarchical-reference
+        head, LRM 23.9), registered directly from the elaborated scope members; the body pass grows
+        no structural identity.
   - [ ] R53c -- Endpoint binding. Whether a value read, a value write, and a change observation of
         one target ultimately share one bound runtime endpoint -- and whether an enclosing reference
         binds a per-instance handle rather than re-navigating the parent chain on the hot path -- is

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -67,6 +67,20 @@ struct GenerateChildRef {
   GenerateId generate;
   StructuralScopeId scope;
 };
+// A named procedural block head (LRM 9.3.5 / 23.9), identified by its SV
+// label. A named block is a layout-visible structural child of its enclosing
+// scope; the label is its stable declaration-time identity, not a by-name
+// runtime lookup. The label is meaningful only relative to the `DownwardHead`
+// owner reached by `hops` -- the enclosing structural scope directly
+// containing the block, where sibling block labels are unique (LRM 23.9) -- and
+// is not a unit-global name. HIR-to-MIR resolves it against that owner's
+// materialized scopes to a typed companion handle, so the realization is a
+// typed segment.
+struct NamedBlockRef {
+  std::string label;
+
+  auto operator==(const NamedBlockRef&) const -> bool = default;
+};
 // A downward head can sit in the current scope (`hops == 0`) or in an
 // enclosing scope (`hops > 0`). The enclosing case covers references that
 // reach an owned child of an ancestor scope without leaving the compilation
@@ -75,10 +89,10 @@ struct GenerateChildRef {
 // the owning scope's HIR-level identities; the install resolves it through
 // the enclosing class's owned-child binding table. `head_indices` selects an
 // element when the head is an instance / generate array; empty for a scalar
-// head.
+// head or a named-block head.
 struct DownwardHead {
   StructuralHops hops = {};
-  std::variant<InstanceMemberId, GenerateChildRef, ProceduralScopeId> child;
+  std::variant<InstanceMemberId, GenerateChildRef, NamedBlockRef> child;
   std::vector<std::uint32_t> head_indices = {};
 };
 

--- a/include/lyra/lowering/hir_to_mir/callable_storage_plan.hpp
+++ b/include/lyra/lowering/hir_to_mir/callable_storage_plan.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -85,6 +86,27 @@ class ProceduralScopeMaterializationTable {
           "ProceduralScopeMaterializationTable::Get: scope id out of range");
     }
     return by_scope_id_[scope.value];
+  }
+
+  // The materialized head named block this structural scope directly owns with
+  // SV label `label`. A named-block hierarchical head (LRM 23.9) is a direct
+  // child of the structural scope, so its runtime parent is the enclosing
+  // class; a nested block sharing the label is reached by descent, never as a
+  // head, and is excluded. A head that a reference reaches owns addressable
+  // storage and therefore materializes, so absence is a compiler-bug invariant.
+  [[nodiscard]] auto FindHead(std::string_view label) const
+      -> const MaterializedProceduralScope& {
+    for (const auto& entry : by_scope_id_) {
+      if (entry.materialized &&
+          std::holds_alternative<EnclosingClass>(entry.runtime_parent) &&
+          entry.label == label) {
+        return entry;
+      }
+    }
+    throw InternalError(
+        "ProceduralScopeMaterializationTable::FindHead: no materialized head "
+        "named block with label '" +
+        std::string(label) + "'");
   }
 
   [[nodiscard]] auto Size() const -> std::size_t {

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -195,14 +195,16 @@ class StructuralScopeLowerer {
   // Resolves an owned-child reference (the `child` field of a
   // `hir::DownwardHead`) to how the route reaches it: its label, the parent's
   // borrowed companion handle when scalar, and its intra-unit target class when
-  // the artifact owns the child's body. `hops == 0` reads this scope's own
+  // the artifact owns the child's body. A named-block head carries only its SV
+  // label; its companion and target class are recovered from the materialized
+  // procedural scope the label names. `hops == 0` reads this scope's own
   // tables; `hops > 0` walks the parent chain to an enclosing scope, used by
   // the sibling-of-ancestor install when the head lives outside the referrer's
   // frame.
   [[nodiscard]] auto TranslateOwnedChild(
       hir::StructuralHops hops,
       const std::variant<
-          hir::InstanceMemberId, hir::GenerateChildRef, hir::ProceduralScopeId>&
+          hir::InstanceMemberId, hir::GenerateChildRef, hir::NamedBlockRef>&
           child) const -> OwnedChildAnchor {
     return LookupOwnedChildAnchorAtHops(hops, child);
   }
@@ -247,7 +249,7 @@ class StructuralScopeLowerer {
   [[nodiscard]] auto LookupOwnedChildAnchorAtHops(
       hir::StructuralHops hops,
       const std::variant<
-          hir::InstanceMemberId, hir::GenerateChildRef, hir::ProceduralScopeId>&
+          hir::InstanceMemberId, hir::GenerateChildRef, hir::NamedBlockRef>&
           child) const -> OwnedChildAnchor {
     if (hops.value == 0) {
       return std::visit(
@@ -276,8 +278,8 @@ class StructuralScopeLowerer {
                     .companion = b.companion,
                     .target = b.scope_id};
               },
-              [&](const hir::ProceduralScopeId& s) -> OwnedChildAnchor {
-                const auto& e = scope_materialization_.Get(s);
+              [&](const hir::NamedBlockRef& nb) -> OwnedChildAnchor {
+                const auto& e = scope_materialization_.FindHead(nb.label);
                 return OwnedChildAnchor{
                     .label = e.label,
                     .companion = e.companion_field,

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -66,12 +66,17 @@ void ModuleLowerer::DeclareStructuralIdentities(
     const slang::ast::Scope& scope) {
   const ScopeFrameId frame = NextScopeFrameId();
   scope_frames_.emplace(&scope, frame);
-  // Each owned-child id is the source-order position of that child among its
-  // own kind in this scope, matching the arena index the body pass assigns.
-  // A generate id counts instantiated generates -- an uninstantiated `if` /
-  // `case` arm carries no runtime object (LRM 27.5) and consumes no id. An
-  // instance-member id counts instances and non-empty instance arrays -- a
-  // zero-element array (LRM 23.3.2) constructs nothing and consumes no id.
+  // A generate or instance owned-child id is the source-order position of that
+  // child among its own kind in this scope, matching the arena index the body
+  // pass assigns. A generate id counts instantiated generates -- an
+  // uninstantiated `if` / `case` arm carries no runtime object (LRM 27.5) and
+  // consumes no id. An instance-member id counts instances and non-empty
+  // instance arrays -- a zero-element array (LRM 23.3.2) constructs nothing and
+  // consumes no id. A named procedural block (LRM 9.3.5 / 23.9) is keyed by its
+  // SV label instead of a position, so it needs no counter; slang exposes it as
+  // a direct scope member (unnamed begin/ends are transparent), and a reference
+  // heads at it only from the structural scope that owns it, never at a deeper
+  // named block nested inside it.
   std::uint32_t generate_count = 0;
   std::uint32_t instance_count = 0;
   for (const auto& member : scope.members()) {
@@ -110,6 +115,13 @@ void ModuleLowerer::DeclareStructuralIdentities(
       MapOwnedChildBinding(
           member, frame,
           hir::DownwardHead{.child = hir::InstanceMemberId{instance_count++}});
+    } else if (member.kind == slang::ast::SymbolKind::StatementBlock) {
+      const auto& block = member.as<slang::ast::StatementBlockSymbol>();
+      if (block.name.empty()) continue;
+      MapOwnedChildBinding(
+          block, frame,
+          hir::DownwardHead{
+              .child = hir::NamedBlockRef{.label = std::string{block.name}}});
     }
   }
 }
@@ -348,12 +360,14 @@ auto ModuleLowerer::TranslateReferenceRoute(
     // scope directly exposes, not the inner one.
     if (next != nullptr && reader_ancestors.contains(next)) {
       std::ranges::reverse(descent);
-      // Typed climb when this unit's own layout reaches the head: at hops 0 a
-      // member of the reader's own class, or at any depth a head whose class
-      // this unit emits (a generate block / array, a named block). An instance
-      // head at hops > 0 is excluded -- crossing an instance body crosses into
-      // another compilation unit, so the climb cannot stay typed and the head
-      // is reached by name.
+      // A head whose owning scope this unit emits routes as a downward head:
+      // the enclosing climb stays typed, and the head step is a typed member of
+      // the enclosing class. A generate block / array names that member
+      // directly; a named block (LRM 23.9) names it by the block's SV label,
+      // from which HIR-to-MIR recovers the materialized scope's companion. An
+      // instance head at hops > 0 is excluded -- crossing an instance body
+      // crosses into another compilation unit, so the climb cannot stay typed
+      // and the head is reached by name.
       const bool head_is_intra_unit =
           owned->kind == slang::ast::SymbolKind::GenerateBlock ||
           owned->kind == slang::ast::SymbolKind::GenerateBlockArray ||
@@ -372,6 +386,13 @@ auto ModuleLowerer::TranslateReferenceRoute(
           return hir::ReferenceRoute{hir::CrossUnitVarRef{.id = id}};
         }
       }
+      // No owned-child binding: this unit does not declare the head, so it
+      // lives in an ancestor compilation unit (an upward reference climbs out
+      // through the reader's own instance to reach it). A generate block or a
+      // named block in that other unit is reached by name across the boundary,
+      // the same as an instance head. When this unit does own the head the
+      // typed branch above always takes it -- a missing companion or
+      // materialization then surfaces downstream, never a silent by-name.
       const hir::CrossUnitRefId id = MapOrGetCrossUnitRef(
           value, frame.Current(),
           hir::CrossUnitRefHead{hir::UpwardNamedHead{

--- a/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
@@ -188,10 +188,9 @@ auto LowerBlockStmt(
   // pair, then sealed into a `ProceduralScopeDecl` and appended to the
   // enclosing structural scope's arena when the body walk returns -- the
   // arena is append-only, so the scope must be assembled before its first
-  // `Add`. A named scope is also registered as a runtime-addressable
-  // owned child so a reference whose leading component slang resolves to
-  // this block's symbol can route through the same head-binding machinery
-  // that instance and generate heads use.
+  // `Add`. A named block's hierarchical-reference head identity (LRM 23.9) is
+  // registered in the compilation-unit declaration pass, before any body
+  // lowers; the body pass grows no structural identity.
   std::optional<std::string> label;
   if (block.blockSymbol != nullptr && !block.blockSymbol->name.empty()) {
     label = std::string{block.blockSymbol->name};
@@ -233,12 +232,6 @@ auto LowerBlockStmt(
               .direct_child_scopes = std::move(nested_children)});
 
   frame.current_scope_children->push_back(scope_id);
-
-  if (label.has_value() && block.blockSymbol != nullptr) {
-    proc.Module().MapOwnedChildBinding(
-        *block.blockSymbol, frame.Current(),
-        hir::DownwardHead{.child = scope_id});
-  }
 
   return hir::Stmt{
       .label = std::nullopt,

--- a/tests/cases/cpp/hierarchy_named_block_head/main.sv
+++ b/tests/cases/cpp/hierarchy_named_block_head/main.sv
@@ -1,26 +1,29 @@
 // LRM 23.9: a named procedural block is a hierarchical-reference head.
 // `Top.c.outer.x` and `Top.c.outer.inner.y` reach static-lifetime locals
 // declared inside the named blocks of `Child`. A sibling process inside
-// `Child` reads the same statics through an intra-unit typed segment
-// (`outer.x`), and an external write through the hierarchical path is
-// observed at a later time step.
+// `Child` reads the same statics by the block's label. That reader is placed
+// before the named block in source, so the read exercises the
+// declaration-time head identity that makes routing independent of source
+// order (`hierarchy_named_block_nesting` covers the reader-after order). An
+// external write through the hierarchical path is observed at a later time
+// step.
 
 module Child;
   int intra_x;
   int intra_inner_y;
-
-  initial begin : outer
-    static int x = 7;
-    begin : inner
-      static int y = 13;
-    end
-  end
 
   initial begin
     #1;
     intra_x = outer.x;
     intra_inner_y = outer.inner.y;
     $display("intra outer.x=%0d outer.inner.y=%0d", intra_x, intra_inner_y);
+  end
+
+  initial begin : outer
+    static int x = 7;
+    begin : inner
+      static int y = 13;
+    end
   end
 endmodule
 

--- a/tests/cases/cpp/hierarchy_named_block_shadow/case.yaml
+++ b/tests/cases/cpp/hierarchy_named_block_shadow/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.hierarchy_named_block_shadow
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      local=222 outer=111

--- a/tests/cases/cpp/hierarchy_named_block_shadow/main.sv
+++ b/tests/cases/cpp/hierarchy_named_block_shadow/main.sv
@@ -1,0 +1,30 @@
+// LRM 23.9: a named-block head resolves by the layout-visible downward route
+// relative to the reader's scope, not by a unit-global label search. A block
+// label reused in different structural scopes must resolve to the block in the
+// reader's own scope for a bare name, and to the named scope's block for a
+// hierarchical path. Generate block `g` and the module both declare a `blk`;
+// a process inside `g` reads its own `g.blk` by bare name (must be 222) and the
+// module's `blk` by absolute path (must be 111). Neither may bind the other's
+// block. The module-level `blk` is declared after `g`, so its head identity
+// must already exist when the reference inside `g` is lowered.
+
+module Test;
+  int local_read;
+  int outer_read;
+
+  if (1) begin : g
+    initial begin : blk
+      static int x = 222;
+    end
+    initial begin
+      #1;
+      local_read = blk.x;
+      outer_read = Test.blk.x;
+      $display("local=%0d outer=%0d", local_read, outer_read);
+    end
+  end
+
+  initial begin : blk
+    static int x = 111;
+  end
+endmodule


### PR DESCRIPTION
## Summary

A named procedural block (`begin : blk ... end`, LRM 9.3.5 / 23.9) is a hierarchical-reference head, so its identity belongs in the compilation-unit declaration pass alongside generate and instance identities. Previously it was registered while its body lowered, off an arena populated by statement traversal, so a forward cross-scope reference to a named block routed differently depending on source order. This registers the head in the declaration pass and makes its routing order-independent for every reference consumer, closing the last order-dependent head kind for the front-end reference translation boundary.

## Design

A named block's hierarchical head identity is its SV label, which slang resolves stably and independently of source order. The head payload carries that label (`NamedBlockRef`) rather than a procedural-scope arena id; the arena id remains the procedural-scope and materialization identity, but is no longer used as the hierarchical head identity. The label is owner-relative: it is meaningful only against the `DownwardHead` owner reached by hops -- the enclosing structural scope directly containing the block, where sibling block labels are unique -- not as a unit-global name. HIR-to-MIR resolves the label against that owner's materialized procedural scopes to the scope's typed companion handle, so intra-unit access is a typed layout-visible segment, not a by-name lookup. A named block reached across a compilation-unit boundary (an upward reference into an ancestor unit) has no local owned-child binding and routes by name, the same as an instance head; symbol kind alone does not imply the emitting unit owns the head.

## Testing

Full suite green. Coverage: a named-block cross-scope read placed before the block in source (order independence, flat and nested `outer.inner.y`); label shadowing across enclosing scopes, where a generate block and the module both declare `blk` and a reader inside the generate resolves its own `blk` by bare name and the module's `blk` by absolute path to distinct blocks; plus the existing named-block head and nesting cases.