### PR TITLE
Wire host argv into the plusargs source

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -111,12 +111,12 @@ full support.
       `id_stage_i.controller_i.exc_req_d` inside `gen_rvfi_no_wb_stage`; `ibex_ex_block` reaches its
       generate-instantiated multiplier and divider the same way). Reached once DPI export above is
       handled or elided.
-- [ ] **`$value$plusargs` / `$test$plusargs`** -- runtime plusarg query (LRM 21.6). The language
-      surface lowers and executes: `$test$plusargs` probes for a prefix, `$value$plusargs` parses
-      the matched plusarg's remainder under `%d` / `%o` / `%h` / `%x` / `%b` / `%s`. The
-      host-to-simulation plusargs source is still empty, so every query returns 0 and `ibex_tracer`
-      behaves as if no trace-enable plusarg was supplied; wiring the host command line into the
-      simulation is what unlocks a real match.
+- [x] **`$value$plusargs` / `$test$plusargs`** -- runtime plusarg query (LRM 21.6). The full surface
+      is live: `$test$plusargs` probes for a prefix, `$value$plusargs` parses the matched plusarg's
+      remainder under `%d` / `%o` / `%h` / `%x` / `%b` / `%s`, and the host command line populates
+      the plusargs source (`+`-prefixed argv entries flow through `lyra run` to the built program).
+      `ibex_tracer` can now be enabled by a real trace-enable plusarg. Real (`%e` / `%f` / `%g`)
+      conversions remain out of scope.
 - [ ] **A procedural statement form in ibex_cs_registers** -- one unsupported statement shape,
       recorded for follow-up once isolated.
 - [x] **Constant of an unpacked array type** -- an elaboration-time `localparam` array referenced

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -805,6 +805,18 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         none identified; pairs with the endpoint-capability decisions
         (`../decisions/net-driver-resolution.md`, `../decisions/reference-as-data-type.md`).
 
+- [ ] R54 -- Move the emitted host-boundary out of the C++ backend. Today the backend renders the
+      program entry point as one raw C++ string blob covering both the invariant host boundary (argv
+      parsing, plusargs collection, engine construction, `BindDesign`, shutdown) and the
+      design-derived tops construction. Every new host-boundary concept -- a seed CLI flag, a VCD
+      sink path, a simulation deadline, verbosity, signal handling -- grows that blob rather than
+      landing as real, type-checked runtime code. Target: the runtime provides a single
+      host-boundary entry that takes `argc` / `argv` and a design-supplied tops constructor; the
+      backend emits only the tops constructor (which is what MIR actually knows) plus a one-line
+      hand-off. New host-boundary concepts are then added by editing runtime C++, not by growing the
+      emitter's string surface. This is a host-execution-model concern, not a semantic-IR one, so it
+      stays outside MIR. **Blocker**: none.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/driver/cpp_build.hpp
+++ b/include/lyra/driver/cpp_build.hpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <span>
+#include <string>
 
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -29,12 +30,15 @@ auto BuildProject(
 
 // Emit `units`' sources into `work_dir`, build them in place against `runtime`
 // (no bundled copy), execute the result streaming its stdout/stderr, and return
-// its exit code. `tops` are the top-level blocks the program constructs. This
-// is the ephemeral path behind `run`: it never materializes a portable project.
+// its exit code. `tops` are the top-level blocks the program constructs.
+// `child_args` are forwarded verbatim as argv to the built program (LRM 21.6
+// plusargs land here). This is the ephemeral path behind `run`: it never
+// materializes a portable project.
 auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
     std::span<const backend::cpp::TopInstance> tops,
     const std::filesystem::path& work_dir, bool format,
-    const pch::Options& pch_opts) -> diag::Result<int>;
+    const pch::Options& pch_opts, std::span<const std::string> child_args)
+    -> diag::Result<int>;
 
 }  // namespace lyra::driver

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -41,6 +42,9 @@ enum class SchedulerPhase : std::uint8_t {
 struct EngineOptions {
   StreamDispatcher::StreamSink stream_sink;
   DiagnosticDispatcher::DiagnosticSink diagnostic_sink;
+  // LRM 21.6 command-line plusarg tokens with the `+` prefix already
+  // stripped, in the order they appeared on the host command line.
+  std::vector<std::string> plusargs;
 };
 
 [[nodiscard]] auto DefaultEngineOptions() -> EngineOptions;

--- a/include/lyra/runtime/plusargs.hpp
+++ b/include/lyra/runtime/plusargs.hpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "lyra/value/packed_array.hpp"
@@ -17,6 +18,11 @@ class RuntimeServices;
 // so a match compares directly against the user-supplied prefix.
 class PlusArgsSource {
  public:
+  PlusArgsSource() = default;
+  explicit PlusArgsSource(std::vector<std::string> tokens)
+      : tokens_(std::move(tokens)) {
+  }
+
   // Returns the remainder (the portion after `prefix`) of the first stored
   // token whose content starts with `prefix`, or nullopt if none match. The
   // tokens are searched in the order given, matching LRM 21.6.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -450,6 +450,9 @@ auto RenderScopeHeaderFile(
 auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   std::string out;
   out += "#include <memory>\n";
+  out += "#include <string>\n";
+  out += "#include <string_view>\n";
+  out += "#include <utility>\n";
   out += "#include <vector>\n";
   out += "\n";
   out += "#include \"lyra/runtime/engine.hpp\"\n";
@@ -460,8 +463,20 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
         "#include \"{}.hpp\"\n", top.unit->GetClass(top.unit->root).name);
   }
   out += "\n";
-  out += "auto main() -> int {\n";
-  out += "  lyra::runtime::Engine engine;\n";
+  // LRM 21.6: `+`-prefixed argv entries are plusargs; the runtime stores them
+  // with the `+` stripped so a match compares against the user-supplied
+  // prefix directly.
+  out += "auto main(int argc, char** argv) -> int {\n";
+  out += "  std::vector<std::string> plusargs;\n";
+  out += "  for (int i = 1; i < argc; ++i) {\n";
+  out += "    const std::string_view arg{argv[i]};\n";
+  out += "    if (arg.starts_with(\"+\")) {\n";
+  out += "      plusargs.emplace_back(arg.substr(1));\n";
+  out += "    }\n";
+  out += "  }\n";
+  out += "  auto options = lyra::runtime::DefaultEngineOptions();\n";
+  out += "  options.plusargs = std::move(plusargs);\n";
+  out += "  lyra::runtime::Engine engine{std::move(options)};\n";
   out += "  std::vector<std::unique_ptr<lyra::runtime::Scope>> tops;\n";
   for (const auto& top : tops) {
     // A top instance's structural identity is fixed at this construction

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -62,6 +62,10 @@ struct ParsedArgs {
   std::string pch_cache_dir;
   lyra::frontend::CompilationInput input;
   std::string out_dir;
+  // LRM 21.6 plusarg pass-through: `+`-prefixed positional entries collected
+  // from the trailing bucket at parse time. `run` forwards them verbatim to
+  // the built program's argv; other subcommands never consult them.
+  std::vector<std::string> plusargs;
 };
 
 void AddCompilationFlags(argparse::ArgumentParser& cmd) {
@@ -126,7 +130,16 @@ void BindCompilationFlags(
   out.input.disable_assertions = cmd.get<bool>("--disable-assertions");
   out.format = cmd.get<bool>("--format");
   if (auto files = cmd.present<std::vector<std::string>>("files")) {
-    out.input.files = std::move(*files);
+    // argparse collects `.sv` paths and `+`-prefixed plusargs in the same
+    // remaining-bucket; sort them here so downstream stages see the natural
+    // shape (source files vs runtime tokens).
+    for (auto& f : *files) {
+      if (!f.empty() && f.front() == '+') {
+        out.plusargs.push_back(std::move(f));
+      } else {
+        out.input.files.push_back(std::move(f));
+      }
+    }
   }
 }
 
@@ -533,7 +546,8 @@ auto main(int argc, char** argv) -> int {
             const auto tops =
                 build_tops(units, result.artifacts.top_unit_names);
             auto exit_code = lyra::driver::RunInPlace(
-                *runtime, units, tops, *tmp_or, args.format, pch_opts);
+                *runtime, units, tops, *tmp_or, args.format, pch_opts,
+                args.plusargs);
             if (!exit_code) {
               report(std::move(exit_code.error()), mgr);
               return 1;

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -252,7 +252,8 @@ auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
     std::span<const backend::cpp::TopInstance> tops,
     const std::filesystem::path& work_dir, bool format,
-    const pch::Options& pch_opts) -> diag::Result<int> {
+    const pch::Options& pch_opts, std::span<const std::string> child_args)
+    -> diag::Result<int> {
   if (auto r = EmitAndWriteSources(units, tops, work_dir, format); !r) {
     return std::unexpected(std::move(r.error()));
   }
@@ -263,7 +264,7 @@ auto RunInPlace(
       !r) {
     return std::unexpected(std::move(r.error()));
   }
-  auto exit_or = support::RunProcessStreaming(program, {});
+  auto exit_or = support::RunProcessStreaming(program, child_args);
   if (!exit_or) {
     return IoError(std::move(exit_or.error()));
   }

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -25,7 +25,8 @@ namespace lyra::runtime {
 auto DefaultEngineOptions() -> EngineOptions {
   return EngineOptions{
       .stream_sink = [](std::string_view text) { std::cout << text; },
-      .diagnostic_sink = [](std::string_view text) { std::cerr << text; }};
+      .diagnostic_sink = [](std::string_view text) { std::cerr << text; },
+      .plusargs = {}};
 }
 
 Engine::Engine() : Engine(DefaultEngineOptions()) {
@@ -33,7 +34,8 @@ Engine::Engine() : Engine(DefaultEngineOptions()) {
 
 Engine::Engine(EngineOptions options)
     : stream_(std::move(options.stream_sink)),
-      diagnostic_(std::move(options.diagnostic_sink)) {
+      diagnostic_(std::move(options.diagnostic_sink)),
+      plusargs_(std::move(options.plusargs)) {
 }
 
 void Engine::BindDesign(std::vector<std::unique_ptr<Scope>> tops) {

--- a/tests/cases/cpp/plusargs_match/case.yaml
+++ b/tests/cases/cpp/plusargs_match/case.yaml
@@ -1,0 +1,30 @@
+id: cpp.plusargs_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args:
+    - "+BOOL_ONLY"
+    - "+INT=42"
+    - "+HEX=FF"
+    - "+OCT=17"
+    - "+BIN=10101"
+    - "+STR=hello"
+expect:
+  exit: 0
+  variables:
+    test_hit_bool: 1
+    test_hit_prefix: 1
+    test_hit_miss: 0
+    hit_d: 1
+    hit_h: 1
+    hit_o: 1
+    hit_b: 1
+    hit_s: 1
+    d_out: 42
+    h_out: 0xFF
+    o_out: 15
+    b_out: 0x15
+    s_out: "hello"

--- a/tests/cases/cpp/plusargs_match/main.sv
+++ b/tests/cases/cpp/plusargs_match/main.sv
@@ -1,0 +1,31 @@
+// LRM 21.6 command-line plusargs, with CLI tokens supplied. Cover the
+// prefix-only $test$plusargs form, the value form across every integral
+// conversion (%d, %h, %o, %b) and %s, and a $test$plusargs miss to prove
+// no false-positive against unrelated tokens.
+module Top;
+  int    test_hit_bool;
+  int    test_hit_prefix;
+  int    test_hit_miss;
+  int    hit_d;
+  int    hit_h;
+  int    hit_o;
+  int    hit_b;
+  int    hit_s;
+  int    d_out;
+  int    h_out;
+  int    o_out;
+  logic [7:0] b_out;
+  string s_out;
+
+  initial begin
+    test_hit_bool   = $test$plusargs("BOOL_ONLY");
+    test_hit_prefix = $test$plusargs("INT=");
+    test_hit_miss   = $test$plusargs("NOT_HERE");
+
+    hit_d = $value$plusargs("INT=%d", d_out);
+    hit_h = $value$plusargs("HEX=%h", h_out);
+    hit_o = $value$plusargs("OCT=%o", o_out);
+    hit_b = $value$plusargs("BIN=%b", b_out);
+    hit_s = $value$plusargs("STR=%s", s_out);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Populates `PlusArgsSource` from the host command line so LRM 21.6 `$test$plusargs` / `$value$plusargs` can actually match. Before this cut the language surface lowered and executed, but the source was empty on every run, so every query returned 0. The emitted `main` now accepts `argc` / `argv`, filters `+`-prefixed entries (with the `+` stripped to match `PlusArgsSource`'s storage), and hands them to `EngineOptions`. `lyra run test.sv +ibex_tracer_enable=1 +ibex_tracer_file_base=trace_` now enables the tracer.

## Design

Two parts flow through: on the host side, argparse's remaining-bucket collects both `.sv` files and `+`-tokens; the CLI layer sorts them at `BindCompilationFlags`, and `RunInPlace` forwards the tokens verbatim as child argv. On the runtime side, `EngineOptions.plusargs` carries the token list, `PlusArgsSource` gains a token-taking ctor, and the `Engine` ctor plumbs it in the initializer list. No changes to `PlusArgsSource::MatchPrefix` semantics or to the HIR-to-MIR lowering that landed in the prior cut.

While rendering the emitted `main` I noticed the host-boundary rendering is now a raw C++ string blob that mixes an invariant boundary (argv parsing, engine construction, `BindDesign`, `RunSimulation`) with the design-derived tops construction. New host-boundary concepts -- a seed CLI flag, a VCD sink path, a simulation deadline -- would keep growing the blob rather than landing as real, type-checked runtime code. Tracked as R54 in `docs/progress/refactor.md` for a follow-up cut; the target is a runtime `LyraHostMain(argc, argv, tops_constructor)` entry and a one-line hand-off in the emitted `main`. Deliberately out of MIR (it is a host-execution-model concern, not a semantic-IR one).

## Testing

New `tests/cases/cpp/plusargs_match` covers `$test$plusargs` (bool-only, prefix, miss) and `$value$plusargs` across every integral base (`%d` / `%h` / `%o` / `%b`) plus `%s`, driven by `args:` in the yaml so the test framework passes real `+`-tokens on the CLI. The existing `plusargs_empty` case still verifies the "no CLI args" path (empty argv filter → empty `PlusArgsSource`). `bazel test //...` green.