### PR TITLE
Elaborate the design through a synthesized $root unit

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -133,6 +133,11 @@ the detail lives in the entry itself.
   the transient values one generated entry creates -- the JIT counterpart of C++ stack/RAII.
   Physical-layout / in-frame value lowering is a later optimization, not a correctness prerequisite;
   cross-suspension and managed-value lifetime is out of scope for the call scope.
+- [root-unit-elaboration](root-unit-elaboration.md) -- design elaboration is the synthetic `$root`
+  unit's `construct` entry, which builds the top-level modules as its owned children; there is no
+  design-level free function. Engine / bind / run stay host runner policy and never enter MIR; both
+  backends' host shells collapse to creating the engine, calling the root construct, then bind /
+  run.
 
 ### Compile-time model and specialization
 

--- a/docs/decisions/root-unit-elaboration.md
+++ b/docs/decisions/root-unit-elaboration.md
@@ -1,0 +1,141 @@
+# Design elaboration is the synthetic `$root` unit's construct
+
+Date: 2026-07-08 Status: accepted
+
+## Context
+
+Generated behavior reaches the runtime through a per-specialization unit definition
+([generated-behavior-boundary](generated-behavior-boundary.md)): each unit supplies a `construct`
+entry that builds its own owned children top-down, plus lifecycle entries. Construction is
+root-anchored and cascading -- a unit root's `construct` runs once and builds its subtree, assigning
+each created scope its program.
+
+The design's top-level entry sits outside that model. Constructing each top-level module and
+attaching it so the simulation can run is fabricated by the host, twice: the C++ backend emits it as
+bespoke `main` text that names the runtime driver surface directly, and the in-process JIT
+re-implements the same construct-and-bind sequence in its own driver. It is the one place a backend
+invents design structure instead of translating generated behavior, and the invention is duplicated
+per backend.
+
+The runtime already carries half of the answer. `BindDesign` synthesizes an implicit root scope
+`$root` with an all-no-op program and attaches each externally-constructed top to it as an owned
+child; the architecture already states that the object tree has a single implicit `$root` owning
+every top-level block as a child, and that program entry constructs every top-level block under
+`$root` (`runtime_model.md`, `hierarchy_and_generate.md`). So the tops are already `$root`'s owned
+children -- but `$root` has no construct of its own, and the host builds the tops externally and
+hands them in.
+
+The dividing line this decision rests on:
+
+> MIR describes the semantic behavior of a design. The host / engine describes how a design artifact
+> is executed.
+
+The question for any code is not whether the engine could be a MIR builtin -- it could -- but
+whether it is part of what the design _is_. Top-level elaboration is: it is the same "construct my
+owned children" every unit performs, one level up. Engine creation, binding, and running the
+scheduler are runner policy: they change with the execution mode (an AOT executable, an in-process
+JIT runner, a differential test, an embedding API) while the design does not.
+
+## Decision
+
+`$root` is a first-class synthetic generated unit. Its `construct` entry _is_ the design
+elaboration: it constructs the top-level units and attaches them as its owned children, exactly as
+any unit's `construct` builds its children. Design construction becomes uniform end to end:
+
+```
+$root.construct
+  -> Construct Top      -> Top.construct
+                              -> Construct generate scopes / instances / children -> ...
+```
+
+There is no separate "design-level elaboration free function" and no new unit-level free-function
+container in MIR / LIR. The top-level elaboration is the existing `construct` concept anchored at
+`$root`, realized through the existing `UnitDefinition` / `ScopeProgram` machinery. Both backends
+lower `$root.construct` mechanically like any other `construct`; neither fabricates top
+construction.
+
+The host shell keeps only runner policy. It constructs the one `$root` unit -- whose generated
+constructor elaborates the design -- and hands it to the engine:
+
+```
+Engine engine;
+auto root = construct the $root unit (engine.Services());  // its constructor builds the tops
+engine.BindDesign(std::move(root));
+engine.RunSimulation();
+```
+
+Constructing the `$root` unit is backend-specific only in its allocation -- the C++ backend
+allocates its concrete class, another backend allocates a generic instance -- the same Phase 1
+boundary [generated-behavior-boundary](generated-behavior-boundary.md) already draws around
+allocation. The constructor body that runs is generated and backend-neutral. Engine creation,
+`BindDesign`, `RunSimulation`, exit code, stdout capture, exception-to-exit mapping, JIT symbol
+lookup, and AOT `main` policy stay host-side and never enter MIR. Generated code owns design
+elaboration; the runtime / host owns engine lifecycle.
+
+### Invariants
+
+1. **`$root` is a synthetic elaboration root, not a source unit.** It does not pollute source-level
+   name lookup, hierarchical names, or diagnostic identity. It exists so top construction has a
+   receiver whose owned children are the tops; it is not an SV scope a user can name or reach.
+
+2. **`$root` is produced at the design-link / compilation-aggregate level, not by lowering any
+   single source module.** Its construct needs the top list, which no individual module has. It is a
+   link product of the aggregate, referencing the top units' definitions.
+
+3. **The elaboration lifecycle is fixed.** The host constructs the `$root` unit (allocation is a
+   backend concern; its constructor is generated and elaborates the design by building every top and
+   recursively the whole tree); `BindDesign` takes the constructed root and walks the already-built
+   tree (resolve then initialize then activate, each a full top-down pass); `RunSimulation` starts
+   the scheduler. `BindDesign` no longer receives a top list and no longer constructs -- it binds an
+   existing tree.
+
+4. **The host shell is thin and target-specific; the elaboration body is generated and
+   backend-neutral.** The only generated behavior the shell invokes for construction is the `$root`
+   unit's constructor. The C++ and JIT shells differ only in runner policy, never in how the design
+   is built.
+
+5. **Engine, bind, and run are not MIR.** They are runner policy. Modeling them as MIR builtins
+   would make a design artifact a specific runner program, couple it to one execution mode, and
+   invert the responsibility that the runtime drives the design.
+
+## Rejected alternatives
+
+- **`ElaborateDesign` as a loose design-level free function.** The earlier framing. It introduces a
+  new unit-level free-function container in MIR / LIR that duplicates the `construct` concept.
+  `$root.construct` reuses the existing model with no new container and makes top construction a
+  special case of ordinary child construction.
+
+- **The host constructs the tops externally and passes them to `BindDesign` (status quo).** The one
+  place a backend invents design structure; duplicated across the emitted AOT `main` and the JIT
+  driver; top construction is never observed as generated behavior, so the backend cross-check
+  (`backend_contract.md`) does not cover it.
+
+- **`Engine` / `BindDesign` / `RunSimulation` as MIR builtins.** Makes the artifact a specific
+  runner program rather than a design program. It couples the compiled design to one execution mode,
+  forces every runner (AOT `main`, JIT `Execute`, embedding, differential test) to share one
+  generated main policy, and inverts responsibility -- the runtime should drive the design, not the
+  design the runtime.
+
+## Consequences
+
+- `generated-behavior-boundary`'s `construct` is now anchored at `$root`, not only at each source
+  unit root; the root-anchored, cascading construction that doc describes extends one level up to
+  the synthetic root.
+- `BindDesign` takes the constructed `$root` instead of a top list: the host builds `$root`, the
+  engine takes ownership, and binding operates on the already-built tree.
+- The C++ `main` emission and the JIT driver both collapse to the thin runner shell; the
+  construct-and-bind duplication is removed, closing the render-contract gap tracked against
+  `backend_contract.md`.
+- In per-unit emission, `$root` is a synthesized link-level unit referencing the top units'
+  definitions, not a lowered source module.
+
+## Cross-references
+
+- [generated-behavior-boundary](generated-behavior-boundary.md) (the unit definition / scope program
+  / construct model this anchors at `$root`)
+- [elaboration-lifecycle-phases](elaboration-lifecycle-phases.md) (the build / resolve / initialize
+  / activate protocol `BindDesign` walks)
+- [jit-value-realization](jit-value-realization.md) (the generated-call scope wrapping each
+  runtime-to-generated call, including the root construct)
+- `../architecture/runtime_model.md`, `../architecture/hierarchy_and_generate.md` (`$root` owns
+  every top-level block as a child; program entry constructs the tops under `$root`)

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -24,7 +24,11 @@ deleted.
       `../architecture/lir.md`; no source under `src/lyra/lir`.
 - [ ] Execution backend -- MIR / LIR lowered to LLVM IR, consumed as either an AOT binary or a JIT
       image. JIT and AOT are link-time choices over one backend, not separate surfaces. Contracts in
-      `../architecture/backend_contract.md` and `../architecture/runtime_distribution.md`.
+      `../architecture/backend_contract.md` and `../architecture/runtime_distribution.md`. Design
+      elaboration (constructing the top-level units) runs on the C++ backend as the synthesized
+      design-root unit's construct (`../decisions/root-unit-elaboration.md`); the execution backend
+      does not yet lower cross-unit construction, so it constructs each top directly, does not run
+      the design-root's elaboration, and does not run a design whose tops instantiate submodules.
 - [ ] Per-unit artifact emission -- one artifact per unit specialization, assembled by linking,
       replacing the transitional single-`main.cpp` aggregation. Contract in
       `../architecture/emission_model.md` (inv 1).

--- a/docs/progress/emit-readability.md
+++ b/docs/progress/emit-readability.md
@@ -54,17 +54,18 @@ locate-divergence feedback loop; this one owns the readability of what the loop 
       out of scope. The intermediate concise-constructor form above is superseded when this lands.
 - [ ] An expression is parenthesized only where operator precedence requires it; an outermost
       expression carries no enclosing parentheses.
-- [ ] The design's top-level entry -- constructing each top-level unit and binding the assembled
+- [ ] The design's top-level entry -- constructing each top-level unit and attaching the assembled
       hierarchy so the simulation can run -- is a mechanical rendering of ordinary generated
       behavior, shared by every backend, not a hand-fabricated harness. Today the ahead-of-time path
       composes it as bespoke target text that names the runtime driver surface directly, and the
       in-process path re-implements the same construct-and-bind sequence on its own -- the one place
       a backend invents structure instead of translating it (a render-contract gap; see
-      `../architecture/backend_contract.md`). Direction: express the construct-and-bind sequence as
-      generated behavior lowered like any other, so both backends render it through the same path;
-      only the thin outer entry-point shell (a compiled program's entry point, the in-process
-      driver) stays target-specific and merely invokes it. A self-contained follow-up, not part of
-      the current change set.
+      `../architecture/backend_contract.md`). The pinned model is
+      `../decisions/root-unit-elaboration.md`: elaboration is the synthetic `$root` unit's construct
+      entry, lowered like any other and rendered by both backends through the same path; only the
+      thin runner shell (a compiled program's entry point, the in-process driver) stays
+      target-specific, creating the engine and calling the root construct, then bind / run. A
+      self-contained follow-up, not part of the current change set.
 
 ## Out of Scope
 

--- a/include/lyra/backend/cpp/api.hpp
+++ b/include/lyra/backend/cpp/api.hpp
@@ -1,26 +1,24 @@
 #pragma once
 
 #include <span>
-#include <string>
 
 #include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
 namespace lyra::backend::cpp {
 
-// A top-level block the emitted program constructs under $root: its instance
-// name and the compiled unit whose class is instantiated for it.
-struct TopInstance {
-  std::string name;
-  const mir::CompilationUnit* unit;
-};
-
 auto EmitCppDeclarations(const mir::CompilationUnit& unit) -> CppArtifact;
 
-auto EmitCppHostMain(std::span<const TopInstance> tops) -> CppArtifact;
+// The host `main` constructs the design-root unit, whose constructor builds the
+// top-level units as its owned children; the engine then walks that tree. The
+// design has one root, not a list of tops, so the host takes the single root
+// unit.
+auto EmitCppHostMain(const mir::CompilationUnit& root) -> CppArtifact;
 
+// Emit a translation unit per source unit in `units`, plus the design-root
+// unit `root` and the host `main` that constructs it.
 auto EmitCpp(
     std::span<const mir::CompilationUnit> units,
-    std::span<const TopInstance> tops) -> CppArtifactSet;
+    const mir::CompilationUnit& root) -> CppArtifactSet;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/formatting.hpp
+++ b/include/lyra/backend/cpp/formatting.hpp
@@ -1,13 +1,25 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
+#include <string_view>
 
 namespace lyra::backend::cpp {
 
 [[nodiscard]] inline auto Indent(std::size_t level) -> std::string {
   std::string result(level * 2, ' ');
   return result;
+}
+
+// A unit or class name spelled as a C++ identifier. A source name is already a
+// valid identifier, but a synthesized name may carry a `$` (the design-root
+// unit) that C++ does not admit; mapping it to `_` yields the token the emitted
+// class, its constructor, and every reference to its type share.
+[[nodiscard]] inline auto ToCppName(std::string_view name) -> std::string {
+  std::string out{name};
+  std::ranges::replace(out, '$', '_');
+  return out;
 }
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/compiler/compile.hpp
+++ b/include/lyra/compiler/compile.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "lyra/compiler/unit_metadata.hpp"
@@ -13,6 +14,13 @@
 #include "lyra/mir/compilation_unit.hpp"
 
 namespace lyra::compiler {
+
+// The name of the synthesized design-root unit. Its constructor elaborates the
+// design -- it builds the top-level units as its owned children -- so the host
+// constructs this one unit and the runtime walks the tree it builds. A leading
+// `$` keeps it distinct from every source unit (an SV identifier cannot begin
+// with `$`); a backend maps it to a target-language identifier when emitting.
+inline constexpr std::string_view kDesignRootUnitName = "$root";
 
 enum class StopAfter : std::uint8_t { kParse, kHir, kMir, kLir };
 
@@ -25,6 +33,11 @@ struct CompileArtifacts {
   std::optional<frontend::ParseResult> parse;
   std::optional<std::vector<hir::ModuleUnit>> hir_units;
   std::optional<std::vector<mir::CompilationUnit>> mir_units;
+  // The synthesized design-root unit, present exactly when `mir_units` is. Its
+  // constructor elaborates the design by building the top-level units as its
+  // owned children. It is a compiler output distinct from the source units, so
+  // the host constructs it directly rather than searching the source set.
+  std::optional<mir::CompilationUnit> root_unit;
   // Each LIR unit borrows the same-index MIR unit above for types and metadata,
   // so `lir_units` must not outlive `mir_units`. A vector move keeps the MIR
   // elements at their addresses, so the borrow survives moving these artifacts.

--- a/include/lyra/driver/cpp_build.hpp
+++ b/include/lyra/driver/cpp_build.hpp
@@ -4,7 +4,6 @@
 #include <span>
 #include <string>
 
-#include "lyra/backend/cpp/api.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/driver/pch.hpp"
 #include "lyra/driver/runtime_export.hpp"
@@ -13,13 +12,13 @@
 namespace lyra::driver {
 
 // Assemble a self-contained C++ project into `dir`: one translation unit per
-// compiled unit, a program `main` constructing each top in `tops`, a `build.sh`
-// recipe, and a bundled copy of `runtime`. The directory then builds with no
-// external include or link paths.
+// compiled unit, a program `main` constructing the design-root unit `root`, a
+// `build.sh` recipe, and a bundled copy of `runtime`. The directory then builds
+// with no external include or link paths.
 auto AssembleProject(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
-    std::span<const backend::cpp::TopInstance> tops,
-    const std::filesystem::path& dir, bool format) -> diag::Result<void>;
+    const mir::CompilationUnit& root, const std::filesystem::path& dir,
+    bool format) -> diag::Result<void>;
 
 // Build the assembled project in `dir` by invoking the C++ compiler directly
 // (the same recipe `build.sh` carries). Returns the produced executable's path;
@@ -28,17 +27,14 @@ auto BuildProject(
     const std::filesystem::path& dir, const pch::Options& pch_opts)
     -> diag::Result<std::filesystem::path>;
 
-// Emit `units`' sources into `work_dir`, build them in place against `runtime`
-// (no bundled copy), execute the result streaming its stdout/stderr, and return
-// its exit code. `tops` are the top-level blocks the program constructs.
+// its exit code. `root` is the design-root unit the program constructs.
 // `child_args` are forwarded verbatim as argv to the built program (LRM 21.6
 // plusargs land here). This is the ephemeral path behind `run`: it never
 // materializes a portable project.
 auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
-    std::span<const backend::cpp::TopInstance> tops,
-    const std::filesystem::path& work_dir, bool format,
-    const pch::Options& pch_opts, std::span<const std::string> child_args)
-    -> diag::Result<int>;
+    const mir::CompilationUnit& root, const std::filesystem::path& work_dir,
+    bool format, const pch::Options& pch_opts,
+    std::span<const std::string> child_args) -> diag::Result<int>;
 
 }  // namespace lyra::driver

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -62,7 +62,14 @@ class Engine {
   auto operator=(Engine&&) -> Engine& = delete;
   ~Engine() = default;
 
-  void BindDesign(std::vector<std::unique_ptr<Scope>> tops);
+  // Binds the design's already-constructed `$root` -- the parent-less topmost
+  // scope whose owned children are the top-level units -- and runs the
+  // post-construction elaboration phases across the whole tree. The generated
+  // code constructs `$root` (its constructor builds the tops as owned
+  // children); the engine takes ownership here and walks resolve / initialize /
+  // activate over the built tree. Each phase is a full top-down walk, so the
+  // phase barrier holds design-wide.
+  void BindDesign(std::unique_ptr<Scope> root);
   auto Run() -> int;
 
   auto Stream() -> StreamDispatcher& {

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -173,11 +173,12 @@ auto RenderConstructor(
     init_parts.push_back(std::move(f));
   }
 
+  const std::string cpp_name = ToCppName(s.name);
   const std::string sig =
       init_parts.empty()
-          ? std::format("{}({})", s.name, JoinCommaSeparated(sig_args))
+          ? std::format("{}({})", cpp_name, JoinCommaSeparated(sig_args))
           : std::format(
-                "{}({}) : {}", s.name, JoinCommaSeparated(sig_args),
+                "{}({}) : {}", cpp_name, JoinCommaSeparated(sig_args),
                 JoinCommaSeparated(init_parts));
 
   // The C++ constructor is the one shape that is not an ordinary method:
@@ -194,7 +195,7 @@ auto RenderConstructor(
       "{0}static auto init({2}* self) -> void {{\n"
       "{3}"
       "{0}}}\n",
-      Indent(indent), sig, s.name,
+      Indent(indent), sig, cpp_name,
       RenderBlockStatements(scope_view, indent + 1));
 }
 
@@ -254,7 +255,7 @@ auto RenderScopeAsClass(
           : std::nullopt;
 
   std::string out;
-  out += Indent(indent) + "class " + s.name + " final";
+  out += Indent(indent) + "class " + ToCppName(s.name) + " final";
   if (base.has_value()) {
     out += " : public " + RenderTypeAsCpp(unit, s, base->renderable);
   }
@@ -381,7 +382,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/value/dynamic_array.hpp\"\n";
   out += "#include \"lyra/value/union.hpp\"\n";
   for (const auto& name : CollectExternalUnitNames(unit)) {
-    out += std::format("#include \"{}.hpp\"\n", name);
+    out += std::format("#include \"{}.hpp\"\n", ToCppName(name));
   }
   out += "\n";
   bool any_enum = false;
@@ -447,7 +448,7 @@ auto RenderScopeHeaderFile(
   return out;
 }
 
-auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
+auto RenderHostMain(const mir::CompilationUnit& root) -> std::string {
   std::string out;
   out += "#include <memory>\n";
   out += "#include <string>\n";
@@ -458,14 +459,20 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   out += "#include \"lyra/runtime/engine.hpp\"\n";
   out += "#include \"lyra/runtime/scope.hpp\"\n";
   out += "#include \"lyra/runtime/simulation_entry.hpp\"\n";
-  for (const auto& top : tops) {
-    out += std::format(
-        "#include \"{}.hpp\"\n", top.unit->GetClass(top.unit->root).name);
-  }
+  const auto& root_class = root.GetClass(root.root);
+  const std::string root_cpp_name = ToCppName(root_class.name);
+  out += std::format("#include \"{}.hpp\"\n", root_cpp_name);
   out += "\n";
+  // The host constructs the design-root unit and hands it to the engine. The
+  // root's constructor elaborates the design -- it builds the top-level units
+  // as its owned children -- so this harness invokes generated behavior rather
+  // than composing the object tree itself. The engine then walks the built
+  // tree. The segment carries the root's `$root` display name with no
+  // per-dimension indices; its type literal comes from the canonical
+  // RenderTypeAsCpp mapping, so this file does not repeat a type name MIR owns.
   // LRM 21.6: `+`-prefixed argv entries are plusargs; the runtime stores them
-  // with the `+` stripped so a match compares against the user-supplied
-  // prefix directly.
+  // with the `+` stripped so a match compares against the user-supplied prefix
+  // directly.
   out += "auto main(int argc, char** argv) -> int {\n";
   out += "  std::vector<std::string> plusargs;\n";
   out += "  for (int i = 1; i < argc; ++i) {\n";
@@ -477,24 +484,13 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   out += "  auto options = lyra::runtime::DefaultEngineOptions();\n";
   out += "  options.plusargs = std::move(plusargs);\n";
   out += "  lyra::runtime::Engine engine{std::move(options)};\n";
-  out += "  std::vector<std::unique_ptr<lyra::runtime::Scope>> tops;\n";
-  for (const auto& top : tops) {
-    // A top instance's structural identity is fixed at this construction
-    // site: the segment carries the top's source name with no per-dimension
-    // indices, which $root reads back when binding the design. The segment
-    // type name comes from the canonical RenderTypeAsCpp mapping so this
-    // harness file does not repeat a type literal already owned by MIR's
-    // builtin TypeId table. The root owns each top; construction hands it over.
-    const auto& unit = *top.unit;
-    const auto& top_class = unit.GetClass(unit.root);
-    const std::string segment_cpp =
-        RenderTypeAsCpp(unit, top_class, unit.builtins.hierarchy_segment);
-    out += std::format(
-        "  tops.push_back(std::make_unique<{0}>(nullptr, {1}{{\"{2}\", {{}}}}, "
-        "engine.Services()));\n",
-        top_class.name, segment_cpp, top.name);
-  }
-  out += "  engine.BindDesign(std::move(tops));\n";
+  const std::string segment_cpp =
+      RenderTypeAsCpp(root, root_class, root.builtins.hierarchy_segment);
+  out += std::format(
+      "  auto root = std::make_unique<{0}>(nullptr, {1}{{\"{2}\", {{}}}}, "
+      "engine.Services());\n",
+      root_cpp_name, segment_cpp, root_class.name);
+  out += "  engine.BindDesign(std::move(root));\n";
   out += "  return lyra::runtime::RunSimulation(engine);\n";
   out += "}\n";
   return out;
@@ -505,22 +501,23 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
 auto EmitCppDeclarations(const mir::CompilationUnit& unit) -> CppArtifact {
   const auto& root = unit.GetClass(unit.root);
   return {
-      .relpath = std::format("{}.hpp", root.name),
+      .relpath = std::format("{}.hpp", ToCppName(root.name)),
       .content = RenderScopeHeaderFile(unit, root)};
 }
 
-auto EmitCppHostMain(std::span<const TopInstance> tops) -> CppArtifact {
-  return {.relpath = "main.cpp", .content = RenderHostMain(tops)};
+auto EmitCppHostMain(const mir::CompilationUnit& root) -> CppArtifact {
+  return {.relpath = "main.cpp", .content = RenderHostMain(root)};
 }
 
 auto EmitCpp(
     std::span<const mir::CompilationUnit> units,
-    std::span<const TopInstance> tops) -> CppArtifactSet {
+    const mir::CompilationUnit& root) -> CppArtifactSet {
   CppArtifactSet set;
   for (const auto& unit : units) {
     set.files.push_back(EmitCppDeclarations(unit));
   }
-  set.files.push_back(EmitCppHostMain(tops));
+  set.files.push_back(EmitCppDeclarations(root));
+  set.files.push_back(EmitCppHostMain(root));
   return set;
 }
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <variant>
 
+#include "lyra/backend/cpp/formatting.hpp"
 #include "lyra/backend/cpp/render_call.hpp"
 #include "lyra/backend/cpp/render_stmt.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
@@ -428,7 +429,8 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
           [&](const mir::StaticConstantRef& r) -> std::string {
             const mir::Class& cls = view.Class();
             return std::format(
-                "{}::{}", cls.name, cls.static_constants.Get(r.constant).name);
+                "{}::{}", ToCppName(cls.name),
+                cls.static_constants.Get(r.constant).name);
           },
           // HIR-to-MIR lowers an LHS selector chain to write-form nodes -- a
           // container-access `CallExpr` with a write callee (per
@@ -890,12 +892,14 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
           [&](const mir::FunctionRef& fr) -> std::string {
             const mir::Class& cls = view.Class();
             return std::format(
-                "&{}::{}", cls.name, cls.methods.Get(fr.callable).name);
+                "&{}::{}", ToCppName(cls.name),
+                cls.methods.Get(fr.callable).name);
           },
           [&](const mir::StaticConstantRef& r) -> std::string {
             const mir::Class& cls = view.Class();
             return std::format(
-                "{}::{}", cls.name, cls.static_constants.Get(r.constant).name);
+                "{}::{}", ToCppName(cls.name),
+                cls.static_constants.Get(r.constant).name);
           },
           [&](const mir::ClosureExpr& cl) -> std::string {
             return RenderClosureExpr(view, cl);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <variant>
 
+#include "lyra/backend/cpp/formatting.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/mir/class.hpp"
@@ -114,13 +115,13 @@ auto RenderTypeAsCpp(
             return "lyra::value::WildcardKey";
           },
           [&unit](const mir::ObjectType& o) -> std::string {
-            return unit.GetClass(o.class_id).name;
+            return ToCppName(unit.GetClass(o.class_id).name);
           },
           [&unit](const mir::StructType& s) -> std::string {
             return unit.GetStruct(s.struct_id).name;
           },
           [](const mir::ExternalUnitObjectType& e) -> std::string {
-            return e.unit_name;
+            return ToCppName(e.unit_name);
           },
           [](const mir::ScopeType&) -> std::string {
             return std::string{"lyra::runtime::Scope"};

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -1,11 +1,14 @@
 #include "lyra/compiler/compile.hpp"
 
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "lyra/compiler/unit_metadata.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/frontend/load.hpp"
+#include "lyra/hir/module_unit.hpp"
+#include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
@@ -27,6 +30,21 @@ auto BuildUnitMetadata(const mir::CompilationUnit& unit)
   return ElaboratedUnitMetadata{
       .def_name = root.name,
       .time_precision_power = root.time_resolution.precision_power};
+}
+
+// The design-root unit is a module whose only members are the top-level units,
+// instantiated as its owned children. Its constructor then elaborates the
+// design through the same owned-child construction any parent uses for a
+// submodule, so no code path is special-cased for the top level.
+auto BuildRootHirUnit(const std::vector<std::string>& top_names)
+    -> hir::ModuleUnit {
+  hir::ModuleUnit root{std::string{kDesignRootUnitName}};
+  for (const auto& name : top_names) {
+    root.root_scope.instance_members.Add(
+        hir::InstanceMemberDecl{
+            .instance_name = name, .target_unit = name, .array_dims = {}});
+  }
+  return root;
 }
 
 }  // namespace
@@ -113,9 +131,31 @@ auto Compile(
     unit_metadata.push_back(BuildUnitMetadata(mir_units.back()));
   }
 
+  // The design-root unit is synthesized after the source units it instantiates,
+  // so it references them by the same cross-unit-by-name link every submodule
+  // instantiation uses. It is a distinct compiler output, not one of the source
+  // units, so it is held apart rather than mixed into `mir_units`. Its
+  // constructor elaborates the design through cross-unit construction, which
+  // MIR-to-LIR does not yet lower, so it is not carried to LIR; the execution
+  // backend constructs each top unit directly.
+  std::optional<mir::CompilationUnit> root_unit;
+  if (want_mir) {
+    const hir::ModuleUnit root_hir =
+        BuildRootHirUnit(result.artifacts.top_unit_names);
+    lowering::hir_to_mir::ModuleLowerer root_module(
+        root_hir, result.artifacts.parse->diag_sources);
+    auto root_mir = root_module.Run();
+    if (!root_mir) {
+      sink.Report(std::move(root_mir.error()));
+      return result;
+    }
+    root_unit = *std::move(root_mir);
+  }
+
   result.artifacts.hir_units = std::move(hir_units);
   if (want_mir) {
     result.artifacts.mir_units = std::move(mir_units);
+    result.artifacts.root_unit = std::move(root_unit);
   }
   if (want_lir) {
     result.artifacts.lir_units = std::move(lir_units);

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -14,7 +14,6 @@
 
 #include <fmt/core.h>
 
-#include "lyra/backend/cpp/api.hpp"
 #include "lyra/backend/llvm/emit.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/compiler/compile.hpp"
@@ -443,23 +442,12 @@ auto main(int argc, char** argv) -> int {
       return *loc_or;
     };
 
-    auto build_tops = [](const std::vector<lyra::mir::CompilationUnit>& units,
-                         const std::vector<std::string>& top_names) {
-      std::vector<lyra::backend::cpp::TopInstance> tops;
-      for (const auto& unit : units) {
-        const auto& top_class = unit.GetClass(unit.root);
-        if (std::ranges::find(top_names, top_class.name) != top_names.end()) {
-          tops.push_back({.name = top_class.name, .unit = &unit});
-        }
-      }
-      return tops;
-    };
-
     switch (args.cmd) {
       case CommandKind::kDumpMir:
         for (const auto& unit : *result.artifacts.mir_units) {
           fmt::print("{}", lyra::mir::DumpMir(unit));
         }
+        fmt::print("{}", lyra::mir::DumpMir(*result.artifacts.root_unit));
         return 0;
       case CommandKind::kDumpLir:
         for (const auto& unit : *result.artifacts.lir_units) {
@@ -479,9 +467,9 @@ auto main(int argc, char** argv) -> int {
         }
         const std::filesystem::path dir = args.out_dir;
         const auto& units = *result.artifacts.mir_units;
-        const auto tops = build_tops(units, result.artifacts.top_unit_names);
+        const auto& root = *result.artifacts.root_unit;
         auto assembled = lyra::driver::AssembleProject(
-            *runtime, units, tops, dir, args.format);
+            *runtime, units, root, dir, args.format);
         if (!assembled) {
           report(std::move(assembled.error()), mgr);
           return 1;
@@ -496,9 +484,9 @@ auto main(int argc, char** argv) -> int {
         }
         const std::filesystem::path dir = args.out_dir;
         const auto& units = *result.artifacts.mir_units;
-        const auto tops = build_tops(units, result.artifacts.top_unit_names);
+        const auto& root = *result.artifacts.root_unit;
         auto assembled = lyra::driver::AssembleProject(
-            *runtime, units, tops, dir, args.format);
+            *runtime, units, root, dir, args.format);
         if (!assembled) {
           report(std::move(assembled.error()), mgr);
           return 1;
@@ -516,8 +504,18 @@ auto main(int argc, char** argv) -> int {
           case Backend::kJit: {
             const auto& lir_units = *result.artifacts.lir_units;
             const auto& unit_metadata = *result.artifacts.unit_metadata;
+            const auto& top_names = result.artifacts.top_unit_names;
+            // The JIT constructs each top unit directly (it does not yet lower
+            // the synthesized design-root unit's cross-unit construction), so
+            // it runs only the top-level units, skipping `$root` and
+            // submodules.
             int exit_code = 0;
             for (std::size_t i = 0; i < lir_units.size(); ++i) {
+              const auto& name =
+                  lir_units[i].classes.Get(lir_units[i].root).name;
+              if (std::ranges::find(top_names, name) == top_names.end()) {
+                continue;
+              }
               exit_code = lyra::jit::Execute(lir_units[i], unit_metadata[i]);
             }
             return exit_code;
@@ -543,10 +541,9 @@ auto main(int argc, char** argv) -> int {
               return 1;
             }
             const auto& units = *result.artifacts.mir_units;
-            const auto tops =
-                build_tops(units, result.artifacts.top_unit_names);
+            const auto& root = *result.artifacts.root_unit;
             auto exit_code = lyra::driver::RunInPlace(
-                *runtime, units, tops, *tmp_or, args.format, pch_opts,
+                *runtime, units, root, *tmp_or, args.format, pch_opts,
                 args.plusargs);
             if (!exit_code) {
               report(std::move(exit_code.error()), mgr);

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -155,9 +155,9 @@ void FormatSources(
 
 auto EmitAndWriteSources(
     std::span<const mir::CompilationUnit> units,
-    std::span<const backend::cpp::TopInstance> tops,
-    const std::filesystem::path& dir, bool format) -> diag::Result<void> {
-  auto set = backend::cpp::EmitCpp(units, tops);
+    const mir::CompilationUnit& root, const std::filesystem::path& dir,
+    bool format) -> diag::Result<void> {
+  auto set = backend::cpp::EmitCpp(units, root);
   for (const auto& file : set.files) {
     if (auto r = WriteFile(dir / file.relpath, file.content); !r) {
       return r;
@@ -206,9 +206,9 @@ auto CompileProgram(
 
 auto AssembleProject(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
-    std::span<const backend::cpp::TopInstance> tops,
-    const std::filesystem::path& dir, bool format) -> diag::Result<void> {
-  if (auto r = EmitAndWriteSources(units, tops, dir, format); !r) {
+    const mir::CompilationUnit& root, const std::filesystem::path& dir,
+    bool format) -> diag::Result<void> {
+  if (auto r = EmitAndWriteSources(units, root, dir, format); !r) {
     return r;
   }
 
@@ -250,11 +250,10 @@ auto BuildProject(
 
 auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
-    std::span<const backend::cpp::TopInstance> tops,
-    const std::filesystem::path& work_dir, bool format,
-    const pch::Options& pch_opts, std::span<const std::string> child_args)
-    -> diag::Result<int> {
-  if (auto r = EmitAndWriteSources(units, tops, work_dir, format); !r) {
+    const mir::CompilationUnit& root, const std::filesystem::path& work_dir,
+    bool format, const pch::Options& pch_opts,
+    std::span<const std::string> child_args) -> diag::Result<int> {
+  if (auto r = EmitAndWriteSources(units, root, work_dir, format); !r) {
     return std::unexpected(std::move(r.error()));
   }
   const auto program = work_dir / kProgramName;

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <string_view>
 #include <utility>
-#include <vector>
 
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
@@ -136,8 +135,18 @@ auto Execute(
   }
 
   runtime::Engine engine;
+
+  // The design-root unit's constructor elaborates the design by building the
+  // top-level units through the cross-unit construct ABI, which this backend
+  // does not yet lower. The JIT therefore constructs the top unit directly and
+  // adopts it under a no-op `$root`; the engine then walks the built tree
+  // exactly as for any backend.
+  static constexpr runtime::ScopeProgram kRootProgram{};
+  auto root = std::make_unique<runtime::Scope>(
+      nullptr, runtime::HierarchySegment{"$root", {}}, engine.Services(),
+      &kRootProgram);
   auto top = std::make_unique<runtime::Instance>(
-      nullptr, runtime::HierarchySegment{root_class.name, {}},
+      root.get(), runtime::HierarchySegment{root_class.name, {}},
       engine.Services(), &definition);
 
   // Construction runs generated code that allocates opaque value temporaries in
@@ -149,9 +158,8 @@ auto Execute(
     runtime::GeneratedCallScope construct_scope;
     definition.construct(top.get());
   }
-  std::vector<std::unique_ptr<runtime::Scope>> tops;
-  tops.push_back(std::move(top));
-  engine.BindDesign(std::move(tops));
+  root->AddOwnedChild(std::move(top));
+  engine.BindDesign(std::move(root));
   return runtime::RunSimulation(engine);
 }
 

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -38,39 +38,22 @@ Engine::Engine(EngineOptions options)
       plusargs_(std::move(options.plusargs)) {
 }
 
-void Engine::BindDesign(std::vector<std::unique_ptr<Scope>> tops) {
+void Engine::BindDesign(std::unique_ptr<Scope> root) {
   if (bound_) {
     throw InternalError("Engine::BindDesign called more than once");
   }
   bound_ = true;
-  // The synthetic `$root` has no generated behavior; its program is all no-op.
-  static constexpr ScopeProgram kRootProgram{};
-  root_ = std::make_unique<Scope>(
-      nullptr, HierarchySegment{"$root", {}}, services_, &kRootProgram);
-  std::vector<Scope*> top_handles;
-  top_handles.reserve(tops.size());
-  for (auto& top : tops) {
-    // The root owns every top: a `$root`-anchored absolute path descends from
-    // the root by name (LRM 23.6), and SV-visible lookup on `$root` recurses
-    // through the owned-children relation. The returned handle drives the
-    // per-top phases below without re-borrowing the owning collection.
-    top_handles.push_back(root_->AddOwnedChild(std::move(top)));
-  }
-  // Link every top before any phase runs, so an upward climb during resolution
-  // sees the whole tree (the root and all sibling tops already exist). The
-  // phases run design-wide in order: resolve every reference and attachment
-  // across the design, then initialize every scope's variables (so an
-  // initializer observes resolved references), then activate every scope's
-  // processes (so processes start only after all initialization).
-  for (Scope* top : top_handles) {
-    top->Resolve();
-  }
-  for (Scope* top : top_handles) {
-    top->Initialize();
-  }
-  for (Scope* top : top_handles) {
-    top->Activate();
-  }
+  root_ = std::move(root);
+  // The whole tree already exists: the generated `$root` constructor built the
+  // top-level units as its owned children, and each child built its own
+  // subtree. Each phase is one top-down walk from the root that recurses
+  // through the owned-children relation, so the design-wide barrier holds --
+  // every scope resolves before any initializes, and every scope initializes
+  // before any activates (an upward climb during resolution already sees the
+  // whole tree, and an initializer observes only resolved references).
+  root_->Resolve();
+  root_->Initialize();
+  root_->Activate();
 }
 
 auto Engine::Run() -> int {


### PR DESCRIPTION
## Summary

The design's top-level entry -- constructing each top-level unit and attaching the assembled hierarchy so the simulation can run -- was fabricated by the host on both backends: the ahead-of-time path emitted it as bespoke `main` text that named the runtime driver surface directly, and the in-process JIT re-implemented the same construct-and-bind sequence in its own driver. It was the one place a backend invented design structure instead of translating generated behavior, and the invention was duplicated per backend. This change makes that elaboration ordinary generated behavior: a synthesized `$root` compilation unit whose constructor builds the top-level units as its owned children, exactly as any parent module builds a submodule. Both host shells collapse to constructing the one `$root` and handing it to the engine; `BindDesign` takes the built root and walks the tree. Engine creation, binding, and running the scheduler stay host runner policy and never enter MIR.

## Design

`$root` is synthesized at the compilation-aggregate level as an ordinary HIR module whose instance members are the top-level units, then lowered through the normal HIR-to-MIR pipeline. Because constructing a top is the same cross-unit instantiation any module already performs for a submodule, no new MIR primitive, backend entry, or IR container was needed -- the existing `construct` / `UnitDefinition` machinery produces the whole elaboration, and both backends render it like any other unit. The dividing line the decision rests on: MIR describes what a design *is*; the engine and its lifecycle describe how a design artifact is *executed*. Top-level elaboration is the former (it is just "construct my owned children" one level up); engine creation, bind, and run are the latter and stay in the thin host shell. The model is recorded in `docs/decisions/root-unit-elaboration.md`.

`$root` is a distinct compiler output (`root_unit`), not one of the source units. The host constructs it directly rather than searching the compiled set for it -- an output that is always synthesized top-down is never optional or discovered by predicate. The C++ backend maps the `$root` name (which no SV identifier can be) to a C++ identifier at every name-to-token site; the runtime `$root` behaviour is anchored on the parent-less topmost scope, so the name itself is display-only.

The C++ backend realizes the full model. The execution backend (LIR / JIT) does not yet lower cross-unit construction, so it constructs each top directly and does not run the `$root` elaboration or a design whose tops instantiate submodules; wiring `$root` through it is a self-contained follow-up recorded in the architecture-reset tracker.