### PR TITLE
Model DPI-C imports as external callables in HIR

### DIFF
--- a/docs/decisions/dpi-foreign-boundary.md
+++ b/docs/decisions/dpi-foreign-boundary.md
@@ -1,0 +1,210 @@
+# DPI-C as a foreign arm of the one callable model
+
+Date: 2026-07-08 Status: accepted
+
+## Context
+
+DPI-C (LRM 35) is the SystemVerilog / C foreign-language boundary: `import "DPI-C"` (SV calls a
+foreign C function) and `export "DPI-C"` (foreign C calls an SV subroutine). It needs a home in the
+post-reset architecture, where the pipeline is HIR -> MIR -> LIR -> LLVM and two backends consume
+MIR: the C++ backend (transitional) and the LLVM/JIT backend.
+
+A pre-reset DPI implementation exists as reference (`archived/`). It was built for an LLVM backend
+and modeled DPI as its own parallel IR subsystem: a dedicated MIR call family (`DpiCall`,
+`DpiImportRef`) separate from ordinary calls, and marshaling logic that lived in the LLVM backend.
+That shape is a good source for the ABI type classification, the export-context mechanism, and the
+header/link design, but its MIR node shape is a forbidden shape after the reset: `mir.md` bans a
+node kind invented to express a runtime-library wrapper, and `callable.md` already defines the right
+home.
+
+This entry fixes how DPI fits the callable model, the value model, and the two-backend boundary
+before implementation begins.
+
+## The model
+
+`callable.md` already states that a callable's implementation form is either an internal body or an
+external symbol. DPI is the first client of the external form; it is not a special case:
+
+```
+Internal callable = signature + body
+External callable = signature + foreign symbol + ABI
+```
+
+DPI marshaling is a value operation of the same kind the value model already uses everywhere else: a
+real value reshape is a call against a runtime primitive (the C++ backend renders it as a runtime
+method call; the JIT renders it as an opaque-handle `extern "C"` runtime-ABI call). A DPI boundary
+conversion is one more such primitive, not backend-special lowering.
+
+## Decisions
+
+### 1. A DPI import is a receiver-less associated callable with an external-symbol implementation form
+
+An imported subroutine lowers to a callable -- not a member of any object, and not a separate DPI
+call family. Three structural facts fix its shape:
+
+- **The implementation form is a variant on the callable.** A callable's code is either an internal
+  body or an external symbol (a foreign linkage name, source language, and calling convention, with
+  no body). External-ness is a structural variant on the callable's code, not a flag on an internal
+  callable and not a separate incompatible declaration type -- `callable.md` invariant 7, mirroring
+  how an object type is intra-unit or external-unit.
+- **It has no receiver, so it is an associated callable, not an instance method.** A DPI import is
+  called by name with no `self`: a non-context import cannot touch SV state, and a context import
+  reaches its scope through the DPI scope handle, never an instance receiver. A receiver-less
+  callable is a type-associated function in the enclosing unit's associated namespace, a category
+  distinct from the instance method set (`object_model.md` invariants 7 and 8). It is stored in a
+  class-level static-callable namespace -- `StaticCallableDecl`, the callable peer of the existing
+  `StaticConstantDecl` -- never in the instance method arena.
+- **It shares one declaration shape with SV class statics.** A DPI external callable and a future SV
+  class static method are the same shape (a receiver-less associated callable, the former with an
+  external-symbol code form, the latter with an internal one), reached through one associated
+  call-target identity. This is the shared callable-declaration shape the callable model
+  anticipates; the associated call-target arm is permanent and serves statics too, so it is added
+  once, never as a temporary DPI-only variant refactored away later.
+
+An import call is an ordinary call whose target is that associated callable.
+
+The internal/external implementation variant is realized at the callable declaration layer -- the
+static-callable declaration is either a bodied callable or an external symbol -- not inside the
+shared callable-code struct. This still realizes the structural variant of `callable.md` invariant 7
+(a variant, not a flag on a method), while leaving every instance-method, constructor, and closure
+consumer of the callable code untouched; moving the variant into the callable code is a later
+unification option, not a prerequisite.
+
+Reason: putting the import in the instance method arena is a category error (it has no receiver and
+is not an instance member); a separate incompatible external-declaration type contradicts the one
+callable-declaration shape the model unifies toward; a DPI-specific target id would be a temporary
+variant. The associated-callable home follows the object model's receiver-less-function category
+directly, reuses the static-constant precedent, and is the home a future static method needs, so it
+is built once.
+
+### 2. Two signatures, separate but linked
+
+DPI keeps the SV semantic signature and its ABI projection as distinct, connected records:
+
+```
+CallableSignature   = the SV semantic signature (type checking, diagnostics; slang already validated it)
+ForeignAbiSignature = the ABI projection of that signature: per parameter an ABI type class,
+                      direction, and passing mode; a return ABI class and return kind
+ExternalSymbol      = foreign name + language + calling convention + ForeignAbiSignature
+```
+
+The ABI type class is a fixed function of an SV type and direction, computed once at lowering and
+carried on the signature; a backend reads it and never re-derives it. Header generation, ABI
+diagnostics, and the foreign-call ABI all read `ForeignAbiSignature`; SV semantic checking stays on
+`CallableSignature`. The import C linkage name (which slang does not persist for imports) and the
+pure/context properties live on `ExternalSymbol`, not on the SV callable.
+
+Reason: conflating the SV signature with the C ABI signature loses the separation that keeps type
+checking, diagnostics, and header emission each reading the surface they need.
+
+### 3. Marshaling is a cross-ABI carrier conversion through runtime primitives, expressed in MIR
+
+The boundary conversion between an SV value and its foreign ABI carrier is an ordinary MIR call
+against a runtime conversion primitive, emitted at HIR-to-MIR. An import call desugars to: marshal
+each input to its carrier, call the external symbol over the carriers, marshal each output carrier
+back to the actual's write path.
+
+The carrier is a **backend-ABI carrier type**, not an SV value-semantic type. It lives in the same
+category as the runtime plumbing types the MIR type system already carries (the services, scope,
+reference, and pointer types) and maps through the per-backend type-mapping dispatch to the target C
+ABI type. Its lifetime is a call-lowering artifact: it is produced by a marshal-in primitive and
+consumed by the foreign call or a marshal-out primitive, never held as a user variable.
+
+Invariant -- the carrier is ABI-temporary. The carrier type is produced only by marshal lowering;
+its only legal occurrences are the result type of a marshal-to-carrier call and the operand or
+result type of a foreign call. It is never a variable's type, never appears in a user expression or
+type check, is never stored to an SV variable, and never escapes the single lowered-call window
+(marshal-in, foreign call, marshal-out, one statement). It is a runtime plumbing type, never a
+member of the SV value-type set.
+
+Reason: the two backends have different runtime ABIs (native value methods vs opaque-handle
+`extern "C"` calls). A conversion expressed as a MIR call renders mechanically on both; a
+backend-realized conversion would be written twice and drift. The carrier being a plumbing type, not
+a value type, keeps it out of the SV value model and adds no new MIR expression primitive -- it is a
+type in an existing category, and the conversion is an ordinary call.
+
+### 4. A DPI export is an internal callable plus foreign-wrapper metadata; context is a thread-local ambient handle
+
+An exported subroutine is an ordinary internal SV callable. The export contributes metadata that
+tells a backend to also materialize a foreign-linkage wrapper: the wrapper marshals the ABI
+arguments, obtains the runtime context, calls the internal callable, and marshals the result back.
+The wrapper is a backend realization; the metadata and the ABI signature are backend-neutral.
+
+The wrapper obtains its context (design object, engine, and, for a module-scoped export, the calling
+instance) from a **thread-local ambient context** installed for the duration of a run, not from the
+foreign caller. Every backend funnels its run through one shared entry (`RunSimulation` over the
+engine), which is the single install point. A module-scoped export resolves its instance from the
+scope the foreign side established (LRM 35.5.3 `svSetScope`); every export is a context function
+(LRM 35.7).
+
+Invariant: the DPI export context is valid only while a Lyra simulation engine is actively running
+on the current thread. Nested foreign entries (an import called from inside an export) push and pop
+a thread-local stack. A foreign callback that runs on a different thread must install its own
+context on that thread; this is a stated constraint, not a supported path today.
+
+Reason: the runtime is otherwise entirely explicit-pointer-threaded with no ambient anchor, so a
+wrapper that receives only plain C arguments has nothing to recover the context from. A thread-local
+handle is the precise scope (it does not outlive the run, and it does not assume a single global
+engine), which keeps a future parallel or multi-engine test from aliasing one global.
+
+### 5. The "SV as a library driven by an external C main" execution model is out of scope
+
+DPI export is supported within the LRM import -> export call chain, under Lyra as the driver: an
+imported C function, called from a running Lyra simulation, calls back an exported SV function. The
+distinct execution model where an external C/C++ program is the `main` and drives a Lyra design as a
+linked library -- which is what a Verilator-style C++ testbench needs -- is a separate roadmap
+capability (it needs standalone/object emission and an embedding entry point), not part of the DPI
+base implementation. A design that declares an export whose only consumer is such an external driver
+is accepted, records its metadata, and can have its ABI header generated, but is not claimed to be
+callable from an external main.
+
+Reason: both backends today run Lyra as the driver (the C++ backend emits a self-contained program;
+the LLVM backend runs in-process). Folding the external-driver model into DPI would drag standalone
+emission, an embedding API, and driver lifecycle into a base feature and let one design's incidental
+usage inflate the scope.
+
+## Rejected alternatives
+
+- **A separate DPI call family (`DpiCall` / `DpiImportRef`), as in the archive.** A DPI-specific
+  bypass around the callable and call vocabulary; a forbidden shape after the reset (`mir.md`). The
+  external-callable arm carries the same information without a parallel subsystem.
+- **Backend-realized marshaling driven by the ABI signature.** Forces DPI-ABI-driven conversion
+  logic into value emission, which `backend_contract.md` forbids, and duplicates the logic across
+  the two backends' different runtime ABIs.
+- **The ABI carrier as an SV value-semantic type or a new MIR expression primitive.** Pollutes the
+  value model with a foreign-ABI shape and opens the closed primitive set. The carrier is a plumbing
+  type in an existing category, materialized only during call lowering.
+- **A process-global (non-thread-local) export context.** Works under a single-threaded engine but
+  assumes one global engine and aliases across concurrent or multi-engine runs; the thread-local
+  form is the precise scope.
+- **The imported callable stored as an instance method (in the per-class method arena).** A DPI
+  import has no receiver and is not an instance member; a receiver-less callable is a
+  type-associated function (`object_model.md` invariants 7, 8), so its home is the
+  associated-callable namespace, not the instance method set.
+- **A temporary DPI-only callable-target variant, unified later.** Leaves a DPI-specific identity in
+  the IR to be refactored away; the unification is done once, consistent with the reset.
+
+## Consequences
+
+- Both backends consume the same MIR for a foreign call and a marshal conversion; only the
+  type-mapping of the ABI carrier and the realization of the foreign-linkage symbol differ.
+- Foreign-symbol linkage must be built per backend: the C++ backend gains a user-link-input seam in
+  its build recipe; the LLVM/JIT backend gains external-symbol resolution in its execution session.
+  Neither exists today.
+- A `chandle` argument needs a runtime representation and a type-mapping entry, which do not exist
+  yet; it is required before `chandle` crosses the boundary.
+- The export-context install composes into the one shared run entry, so it serves both backends from
+  a single place.
+
+## Cross-references
+
+- `docs/architecture/callable.md` (the external-symbol implementation form; direction as data flow)
+- `docs/architecture/mir.md` (closed primitive set; no invented runtime-library node kind)
+- `docs/architecture/backend_contract.md` (mechanical render; runtime-library names only in
+  type-mapping)
+- `docs/architecture/emission_model.md` (per-unit artifact; the runtime SDK as link-time substrate)
+- `docs/decisions/jit-value-realization.md` (the opaque-handle runtime ABI the JIT marshals through)
+- `docs/decisions/generated-behavior-boundary.md` (backend-neutral native-entry ABI; symbol lookup
+  by specialization identity)
+- LRM 35: 35.4 (imports), 35.5 (functions/tasks; type mapping 35.5.6; scope 35.5.3), 35.7 (exports
+  are context functions), 35.9 (disable protocol)

--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -1,0 +1,134 @@
+# DPI-C (import and export)
+
+Tracks the SystemVerilog Direct Programming Interface (LRM 35): `import "DPI-C"`, where SV calls a
+foreign C function, and `export "DPI-C"`, where foreign C calls an SV subroutine. This is the
+foreign-language-boundary workstream that `functions.md` lists as out of scope for user subroutines.
+
+Under the post-reset architecture a DPI import is not a separate call subsystem: it is the
+**external** implementation form of the one callable concept (`callable.md`) -- a signature plus a
+foreign linkage name and calling convention, with no body -- and an import call is an ordinary call.
+A DPI export is an ordinary internal SV subroutine for which a backend additionally materializes a
+foreign-linkage wrapper; the wrapper obtains its runtime context (design object, engine, and, for a
+module-scoped export, the calling instance) from a runtime-installed context, never from the foreign
+caller. Export is supported within the LRM import -> export call chain, under Lyra as the driver;
+the distinct execution model where an external C program drives a Lyra design as a linked library is
+a separate roadmap capability, out of scope here. The DPI type mapping between an SV type and its C
+ABI type (LRM 35.5.6) is a backend type-mapping concern, so the MIR representation is
+backend-agnostic: the same MIR is materialized by the C++ backend as an `extern "C"` entry linked by
+the emitted build recipe, and by the LLVM / JIT backend as an external-linkage symbol resolved by
+its execution session. Lyra never compiles the user's C; it provides the ABI surface (a generated
+header, resolved symbol names) and orchestrates linkage.
+
+The settled IR, value, and boundary model -- import as the external arm of the one callable,
+marshaling as a cross-ABI carrier conversion through runtime primitives, the export context, and the
+out-of-scope external-driver boundary -- is recorded in `../decisions/dpi-foreign-boundary.md`.
+
+Done when the LRM 35 surface reproduces on both backends: import (pure and context, every argument
+direction, the full DPI type surface including 4-state, wide packed, `chandle`, and open arrays),
+export (package / `$unit`-scoped and module-scoped instance-bound), DPI tasks (non-suspending and
+suspending, both directions), the `svdpi` context surface, a generated ABI header, and link-input
+orchestration.
+
+## Actionable
+
+D1 is the entry point: the thinnest end-to-end vertical -- one pure scalar import, materialized,
+linked against a user-provided C object, and asserted by a mixed-language test -- standing up the
+whole pipeline the later items extend. D1 lands three foundations together (the external-callable IR
+shape, per-backend foreign-call materialization, and per-backend foreign-symbol linkage) and
+completes as one deliverable: scalar import works end to end on both the C++ and the LLVM / JIT
+backend. Every later item leaves the MIR shape backend-agnostic and lands on both backends.
+
+## Sub-Steps
+
+The `D*` IDs are stable references. They do not impose a total order; real dependencies are stated
+inline.
+
+### Import: SV calls foreign C
+
+- [ ] D1 -- Pure scalar import, end to end on both backends: 2-state integral scalars, `real`, and
+      `string`, `input`-only, function kind (LRM 35.4, 35.5.1). An imported subroutine lowers to a
+      callable whose implementation form is an external symbol, and an import call is an ordinary
+      call to it; a user-provided C object is linked in (via the emitted build recipe on the C++
+      backend, resolved through the execution session on the LLVM / JIT backend), asserted by a
+      mixed-language test.
+- [ ] D2 -- General import: `output` and `inout` arguments, non-pure imports, `chandle`, and packed
+      2-state values up to a single machine word (LRM 35.5.5, 35.5.6). Bidirectional boundary
+      temporaries for the copy-out directions.
+- [ ] D3 -- 4-state and wide marshaling: 4-state scalars and vectors across the boundary (the DPI
+      canonical 4-state layout versus Lyra's internal representation) and packed vectors wider than
+      one machine word (LRM 35.5.6).
+
+### Export: foreign C calls SV
+
+Export is scoped to the LRM import -> export call chain under Lyra as the driver (an imported C
+function, called from a running simulation, calls back an exported SV function). The distinct model
+where an external C program is the `main` driving a Lyra design as a linked library is out of scope
+here (see the design record); a design that declares an export only for such an external driver is
+accepted, records its metadata, and can have its ABI header generated, but is not claimed callable
+from an external main.
+
+- [ ] D4 -- Package / `$unit`-scoped export with foreign-linkage wrappers: scalar 2-state, `real`,
+      and `string` (LRM 35.5). Generated ABI header and driver linkage of the user C that calls the
+      export.
+- [ ] D4a -- Module-scoped export with instance-bound dispatch (LRM 35.5.3): the exported subroutine
+      reads the state of the specific instance the foreign call targets, so the wrapper resolves
+      that instance's context from the scope the foreign side set. This is the `mhpmcounter_num` /
+      `mhpmcounter_get` shape in the Ibex bring-up; the pure-SV Ibex run never calls them, so this
+      closes the construct, not the Ibex external-driver usage.
+- [ ] D4b -- 4-state and by-pointer packed export marshaling, including indirect return for return
+      types that need hidden result storage.
+
+### DPI tasks
+
+- [ ] D5 -- Non-suspending DPI tasks (LRM 35.5.2), import and export. Reuses the immediate-call
+      path; a task keeps its task call protocol and is never rewritten into a function.
+- [ ] D6 -- Suspending DPI tasks: a foreign task that consumes simulation time, including the
+      disable protocol (LRM 35.9). Rides on the timing and suspension machinery (`scheduling.md`,
+      `processes.md`).
+
+### Context and the svdpi surface
+
+- [ ] D7 -- `context` imports and exports and the `svdpi` runtime surface: DPI scope handles, set /
+      get scope, the scope registry, and time queries. A context import observes the scope of its
+      call site.
+
+### Open arrays
+
+- [ ] D8 -- Open-array arguments (LRM 35.5.6.1): the introspection and pointer surface (array
+      bounds, size, dimension queries, element pointers) and packed / scalar element access.
+
+### Driver and link
+
+- [ ] D9 -- Link-input orchestration across both backends: a repeatable `--dpi-link` CLI option and
+      a `lyra.toml` DPI link-inputs array, validated before any backend runs. The C++ backend adds
+      the inputs to the emitted build recipe's link line; the LLVM / JIT backend resolves them
+      through its execution session. A generated ABI header lets the user compile their C against
+      the correct signatures.
+
+## Design record and prerequisites
+
+The two questions that gated the design -- where marshaling lives and how an export wrapper recovers
+its context -- are settled in `../decisions/dpi-foreign-boundary.md`, along with the callable model
+and the out-of-scope boundary. Work proceeds against that record.
+
+Prerequisites surfaced during design:
+
+- `chandle` has no runtime representation or type-mapping entry today; it must gain one before D2
+  (where a `chandle` argument first crosses the boundary).
+- Foreign-symbol linkage does not exist on either backend: the C++ backend needs a user-link-input
+  seam in its build recipe, and the LLVM / JIT backend needs external-symbol resolution in its
+  execution session; both are part of D1.
+
+## Cross-references
+
+- Design record: `../decisions/dpi-foreign-boundary.md` (the settled callable / marshaling / export
+  model and the rejected alternatives).
+- LRM 35: 35.4 (imported subroutines), 35.5 (functions and tasks; type mapping 35.5.6; scope
+  35.5.3), 35.9 (disable protocol).
+- Architecture: `callable.md` (the external-symbol callable), `backend_contract.md` (mechanical
+  per-type marshaling), `emission_model.md` (the SDK as link-time-resolution substrate, per-unit
+  artifacts, header and link), `runtime_distribution.md` (link and run model), `scheduling.md`
+  (suspending tasks).
+- Rides on: `scheduling.md` and `processes.md` (suspending DPI tasks, D6).
+- `functions.md` lists DPI as its out-of-scope sibling; the module-scoped export D4a is the
+  `ibex.md` full-top frontier.

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -104,7 +104,8 @@ full support.
       would otherwise become an empty subroutine returning a default on every call). This is the
       current full-top frontier: `ibex_simple_system` exports `mhpmcounter_num` / `mhpmcounter_get`
       to the Verilator C++ testbench -- unneeded by the pure-SV `ibex_simple_system_tb` run, but the
-      unmodified source still declares them.
+      unmodified source still declares them. Real support is tracked in `dpi.md`; the module-scoped
+      export here is its D4a.
 - [ ] **Hierarchical reference reaching a module instance from a nested generate scope** -- a dotted
       reference, written inside a conditional or loop generate block, that descends into a module
       instance owned by an enclosing scope (the RVFI trap logic in `ibex_core`,

--- a/include/lyra/hir/foreign_import.hpp
+++ b/include/lyra/hir/foreign_import.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "lyra/hir/type_id.hpp"
+#include "lyra/support/dpi_abi.hpp"
+
+namespace lyra::hir {
+
+// One argument of a DPI-C import's ABI projection (LRM 35.5.6): the SV type it
+// was declared with, paired with the C ABI category it crosses the boundary as.
+struct DpiParamAbi {
+  TypeId sv_type{};
+  support::DpiAbiClass abi = support::DpiAbiClass::kVoid;
+};
+
+// A subroutine declared `import "DPI-C"` (LRM 35.4). It has no SV body, so it
+// is a bodyless external callable, not a body-bearing structural subroutine.
+// The foreign linkage name, the pure property, and the ABI projection of the
+// signature are resolved once here (where slang types are available) and are
+// the sole downstream source for the import; no layer below reads slang.
+// Lowered to a MIR static external callable at HIR-to-MIR.
+struct ForeignImportDecl {
+  std::string name;
+  std::string foreign_name;
+  bool is_pure = false;
+  support::DpiAbiClass ret_abi = support::DpiAbiClass::kVoid;
+  TypeId ret_sv_type{};
+  std::vector<DpiParamAbi> params;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/foreign_import_id.hpp
+++ b/include/lyra/hir/foreign_import_id.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+// Identity of a DPI-C import (LRM 35.4) within its structural scope's
+// `foreign_imports` arena. A bodyless external callable, distinct from a
+// body-bearing structural subroutine.
+struct ForeignImportId {
+  std::uint32_t value;
+
+  auto operator<=>(const ForeignImportId&) const
+      -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -11,6 +11,8 @@
 #include "lyra/base/time.hpp"
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/foreign_import.hpp"
+#include "lyra/hir/foreign_import_id.hpp"
 #include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/structural_data_object.hpp"
@@ -219,7 +221,11 @@ struct StructuralScope {
   base::Arena<InstanceMemberDecl, InstanceMemberId> instance_members;
   std::vector<PortConnection> port_connections;
   base::Arena<CrossUnitRefDecl, CrossUnitRefId> cross_unit_refs;
+  // Body-bearing SV subroutines only. A bodyless DPI-C import never enters this
+  // arena; it lives in `foreign_imports` (invariant relied on by the
+  // per-subroutine body lowering, which assumes every entry here has a body).
   base::Arena<SubroutineDecl, StructuralSubroutineId> structural_subroutines;
+  base::Arena<ForeignImportDecl, ForeignImportId> foreign_imports;
   base::Arena<ProceduralScopeDecl, ProceduralScopeId> procedural_scopes;
   std::vector<TypeAliasDecl> type_aliases;
 

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -5,6 +5,7 @@
 
 #include "lyra/hir/class_id.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/foreign_import_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/subroutine_id.hpp"
 #include "lyra/support/builtin_fn.hpp"
@@ -17,6 +18,14 @@ namespace lyra::hir {
 struct StructuralSubroutineRef {
   StructuralHops hops;
   StructuralSubroutineId subroutine;
+};
+
+// Calls a DPI-C import (LRM 35.4) declared in the unit (or an enclosing scope,
+// reached through `hops`). A bodyless external callable, resolved separately
+// from a body-bearing structural subroutine.
+struct ForeignImportRef {
+  StructuralHops hops;
+  ForeignImportId id;
 };
 
 // Calls an instance method (LRM 8.6) on `receiver`, an expression yielding the
@@ -44,6 +53,6 @@ struct BuiltinMethodRef {
 
 using SubroutineRef = std::variant<
     StructuralSubroutineRef, MethodCallRef, SystemSubroutineRef,
-    BuiltinMethodRef>;
+    BuiltinMethodRef, ForeignImportRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -50,6 +50,18 @@ struct SubroutineBinding {
 using SubroutineBindings =
     std::unordered_map<const slang::ast::SubroutineSymbol*, SubroutineBinding>;
 
+// A DPI-C import call resolves to the scope that declares the import, reached
+// through `owner_frame`, and to the import's `foreign_imports` id. A separate
+// binding space from SubroutineBinding: an import is a bodyless external
+// callable, not a body-bearing structural subroutine.
+struct ForeignImportBinding {
+  ScopeFrameId owner_frame{};
+  hir::ForeignImportId import_id{};
+};
+
+using ForeignImportBindings = std::unordered_map<
+    const slang::ast::SubroutineSymbol*, ForeignImportBinding>;
+
 // A downward reference's leading component names an owned child this scope
 // declares: an instance / instance-array member (`c.x`, `c[1].x`), or a
 // generate block (`g[1].x`, LRM 27). The child's slang symbol maps to the
@@ -165,6 +177,13 @@ class ModuleLowerer {
       const slang::ast::SubroutineSymbol& sym) const
       -> std::optional<SubroutineBinding>;
 
+  void MapForeignImportBinding(
+      const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
+      hir::ForeignImportId import_id);
+  [[nodiscard]] auto LookupForeignImportBinding(
+      const slang::ast::SubroutineSymbol& sym) const
+      -> std::optional<ForeignImportBinding>;
+
   void MapOwnedChildBinding(
       const slang::ast::Symbol& child, ScopeFrameId home_frame,
       hir::DownwardHead head);
@@ -249,6 +268,7 @@ class ModuleLowerer {
   std::unordered_map<const slang::ast::ClassType*, hir::ClassId> class_cache_;
   StructuralDataObjectBindings structural_data_object_bindings_;
   SubroutineBindings subroutine_bindings_;
+  ForeignImportBindings foreign_import_bindings_;
   OwnedChildBindings owned_child_bindings_;
   std::unordered_map<const slang::ast::Scope*, ScopeFrameId> scope_frames_;
   // Dedup by (home_frame, target): the slot id is an index within a scope's

--- a/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
@@ -80,6 +80,9 @@ class StructuralScopeLowerer {
   auto PopulateSubroutineMember(
       const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
       -> diag::Result<void>;
+  auto PopulateForeignImportMember(
+      const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
+      -> diag::Result<void>;
   auto PopulateProceduralBlockMember(
       const slang::ast::ProceduralBlockSymbol& proc, WalkFrame frame)
       -> diag::Result<void>;

--- a/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
+++ b/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/foreign_import.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
@@ -22,5 +23,14 @@ class ModuleLowerer;
 auto LowerSubroutineDecl(
     ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym,
     WalkFrame frame) -> diag::Result<hir::SubroutineDecl>;
+
+// Lowers a slang `import "DPI-C"` subroutine (LRM 35.4) into a bodyless
+// hir::ForeignImportDecl: the resolved foreign name, the pure property, and the
+// ABI projection of its signature. Distinct from LowerSubroutineDecl because a
+// DPI import has no SV body; the caller records the result in the scope's
+// `foreign_imports` arena, never in its subroutine arena.
+auto LowerForeignImport(
+    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym)
+    -> diag::Result<hir::ForeignImportDecl>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/support/dpi_abi.hpp
+++ b/include/lyra/support/dpi_abi.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::support {
+
+// The C ABI category an SV type crosses the DPI-C boundary as (LRM 35.5.6).
+// One value per distinct foreign-carrier shape, shared by HIR, MIR, and LIR so
+// no layer re-derives the classification from a type's properties. The SV type
+// is classified into this category once at AST-to-HIR, where slang types are
+// available; every layer below reads the category.
+//
+// The set covers 2-state integral scalars up to one machine word, real, string,
+// and void; four-state, wide packed, chandle, and open-array carriers are not
+// yet represented.
+enum class DpiAbiClass : std::uint8_t {
+  kVoid,
+  kBit,
+  kByte,
+  kShortInt,
+  kInt,
+  kLongInt,
+  kReal,
+  kString,
+};
+
+}  // namespace lyra::support

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -552,6 +552,13 @@ class HirDumper {
               return std::format(
                   "BuiltinFn \"{}\"", support::BuiltinFnName(b.method));
             },
+            [this](const ForeignImportRef& f) -> std::string {
+              const auto& owner = ResolveScope(f.hops);
+              const auto& decl = owner.foreign_imports.Get(f.id);
+              return std::format(
+                  "ForeignImport[{}](hops={}) \"{}\"", f.id.value, f.hops.value,
+                  decl.name);
+            },
         },
         callee);
   }
@@ -875,6 +882,11 @@ class HirDumper {
           s.structural_subroutines.Get(
               StructuralSubroutineId{static_cast<std::uint32_t>(i)}));
     }
+    for (std::size_t i = 0; i < s.foreign_imports.size(); ++i) {
+      DumpForeignImport(
+          i, s.foreign_imports.Get(
+                 ForeignImportId{static_cast<std::uint32_t>(i)}));
+    }
     if (!s.exprs.empty()) {
       Line("Exprs:");
       Indent();
@@ -959,6 +971,45 @@ class HirDumper {
     }
     DumpProceduralBody(d.body);
     Dedent();
+  }
+
+  void DumpForeignImport(std::size_t index, const ForeignImportDecl& fi) {
+    Line(
+        std::format(
+            "ForeignImport[{}] function \"{}\" c_name=\"{}\"{} ret={}", index,
+            fi.name, fi.foreign_name, fi.is_pure ? " pure" : "",
+            FormatDpiAbiClass(fi.ret_abi)));
+    Indent();
+    for (std::size_t i = 0; i < fi.params.size(); ++i) {
+      Line(
+          std::format(
+              "Param[{}] {} : Type[{}]", i, FormatDpiAbiClass(fi.params[i].abi),
+              fi.params[i].sv_type.value));
+    }
+    Dedent();
+  }
+
+  [[nodiscard]] static auto FormatDpiAbiClass(support::DpiAbiClass abi)
+      -> std::string_view {
+    switch (abi) {
+      case support::DpiAbiClass::kVoid:
+        return "void";
+      case support::DpiAbiClass::kBit:
+        return "bit";
+      case support::DpiAbiClass::kByte:
+        return "byte";
+      case support::DpiAbiClass::kShortInt:
+        return "shortint";
+      case support::DpiAbiClass::kInt:
+        return "int";
+      case support::DpiAbiClass::kLongInt:
+        return "longint";
+      case support::DpiAbiClass::kReal:
+        return "real";
+      case support::DpiAbiClass::kString:
+        return "string";
+    }
+    throw InternalError("FormatDpiAbiClass: unknown support::DpiAbiClass");
   }
 
   [[nodiscard]] static auto FormatParamDirection(ParamDirection dir)

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -509,6 +509,34 @@ auto LowerCallExpr(
     };
   }
 
+  // A DPI-C import is a bodyless external callable, bound in a separate space
+  // from body-bearing subroutines. Resolve it to a ForeignImportRef; its ABI
+  // and foreign name were classified once at declaration and are not re-derived
+  // here.
+  if (const auto import_binding = module.LookupForeignImportBinding(*sym)) {
+    const auto import_hops = frame.HopsTo(import_binding->owner_frame);
+    if (!import_hops.has_value()) {
+      throw InternalError(
+          "AST->HIR call: DPI import owner frame is not on the current scope "
+          "stack");
+    }
+    auto import_result_type = module.InternType(*call.type, span);
+    if (!import_result_type) {
+      return std::unexpected(std::move(import_result_type.error()));
+    }
+    return hir::Expr{
+        .type = *import_result_type,
+        .data =
+            hir::CallExpr{
+                .callee =
+                    hir::ForeignImportRef{
+                        .hops = *import_hops, .id = import_binding->import_id},
+                .arguments = std::move(arg_ids),
+            },
+        .span = span,
+    };
+  }
+
   const auto binding = module.LookupSubroutineBinding(*sym);
   if (!binding.has_value()) {
     throw InternalError(

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -183,6 +183,29 @@ auto ModuleLowerer::LookupSubroutineBinding(
   return it->second;
 }
 
+void ModuleLowerer::MapForeignImportBinding(
+    const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
+    hir::ForeignImportId import_id) {
+  const auto [_, inserted] = foreign_import_bindings_.emplace(
+      &sym,
+      ForeignImportBinding{.owner_frame = owner_frame, .import_id = import_id});
+  if (!inserted) {
+    throw InternalError(
+        "ModuleLowerer::MapForeignImportBinding: DPI import symbol already "
+        "mapped");
+  }
+}
+
+auto ModuleLowerer::LookupForeignImportBinding(
+    const slang::ast::SubroutineSymbol& sym) const
+    -> std::optional<ForeignImportBinding> {
+  const auto it = foreign_import_bindings_.find(&sym);
+  if (it == foreign_import_bindings_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
 void ModuleLowerer::MapOwnedChildBinding(
     const slang::ast::Symbol& child, ScopeFrameId home_frame,
     hir::DownwardHead head) {

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -92,11 +92,16 @@ auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
   // recursion, and forward references (LRM 13.4.2). Ids are sequential in
   // source order and match the index `PopulateSubroutineMember` will write to.
   std::uint32_t reserved_subroutine_id = 0;
+  std::uint32_t reserved_foreign_import_id = 0;
   for (const auto& member : slang_scope_->members()) {
-    if (member.kind == slang::ast::SymbolKind::Subroutine) {
+    if (member.kind != slang::ast::SymbolKind::Subroutine) continue;
+    const auto& sub = member.as<slang::ast::SubroutineSymbol>();
+    if (sub.flags.has(slang::ast::MethodFlags::DPIImport)) {
+      module_->MapForeignImportBinding(
+          sub, frame_, hir::ForeignImportId{reserved_foreign_import_id++});
+    } else {
       module_->MapSubroutineBinding(
-          member.as<slang::ast::SubroutineSymbol>(), frame_,
-          hir::StructuralSubroutineId{reserved_subroutine_id++});
+          sub, frame_, hir::StructuralSubroutineId{reserved_subroutine_id++});
     }
   }
 
@@ -165,9 +170,13 @@ auto StructuralScopeLowerer::PopulateMember(
           member.as<slang::ast::VariableSymbol>(), frame);
     case slang::ast::SymbolKind::Net:
       return PopulateNetMember(member.as<slang::ast::NetSymbol>(), frame);
-    case slang::ast::SymbolKind::Subroutine:
-      return PopulateSubroutineMember(
-          member.as<slang::ast::SubroutineSymbol>(), frame);
+    case slang::ast::SymbolKind::Subroutine: {
+      const auto& sub = member.as<slang::ast::SubroutineSymbol>();
+      if (sub.flags.has(slang::ast::MethodFlags::DPIImport)) {
+        return PopulateForeignImportMember(sub, frame);
+      }
+      return PopulateSubroutineMember(sub, frame);
+    }
     case slang::ast::SymbolKind::ProceduralBlock:
       return PopulateProceduralBlockMember(
           member.as<slang::ast::ProceduralBlockSymbol>(), frame);
@@ -312,6 +321,26 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
   }
   frame.current_structural_scope->structural_subroutines.Add(
       *std::move(decl_or));
+  return {};
+}
+
+auto StructuralScopeLowerer::PopulateForeignImportMember(
+    const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
+    -> diag::Result<void> {
+  auto decl_or = LowerForeignImport(*module_, sym);
+  if (!decl_or) return std::unexpected(std::move(decl_or.error()));
+
+  const auto binding = module_->LookupForeignImportBinding(sym);
+  if (!binding.has_value() ||
+      binding->import_id.value !=
+          static_cast<std::uint32_t>(
+              frame.current_structural_scope->foreign_imports.size())) {
+    throw InternalError(
+        "StructuralScopeLowerer::PopulateForeignImportMember: DPI import added "
+        "out of reserved order; the reserve pass must run first in the same "
+        "order");
+  }
+  frame.current_structural_scope->foreign_imports.Add(*std::move(decl_or));
   return {};
 }
 

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -9,12 +9,18 @@
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/AllTypes.h>
+#include <slang/ast/types/Type.h>
+#include <slang/syntax/AllSyntax.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
+#include "lyra/hir/foreign_import.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/support/dpi_abi.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -50,22 +56,71 @@ auto ParamDirectionOf(const slang::ast::FormalArgumentSymbol& formal)
   throw InternalError("ParamDirectionOf: unknown ArgumentDirection");
 }
 
+// Classifies an SV type into its DPI-C carrier category (LRM 35.5.6). This is
+// the one place slang types are inspected for DPI. The supported set is 2-state
+// integral scalars up to one machine word, `real`, `string`, and `void`;
+// anything else is a located Unsupported so the gap is a clean diagnostic.
+auto ClassifyDpiAbi(const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<support::DpiAbiClass> {
+  const auto& t = type.getCanonicalType();
+  if (t.isVoid()) return support::DpiAbiClass::kVoid;
+  if (t.isString()) return support::DpiAbiClass::kString;
+  if (t.isFloating()) {
+    if (t.as<slang::ast::FloatingType>().floatKind ==
+        slang::ast::FloatingType::Real) {
+      return support::DpiAbiClass::kReal;
+    }
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedDpi,
+        "DPI-C shortreal is not yet supported");
+  }
+  if (t.isIntegral()) {
+    if (t.isFourState()) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedDpi,
+          "4-state DPI-C value is not yet supported");
+    }
+    const auto width = t.getBitWidth();
+    if (width == 1) return support::DpiAbiClass::kBit;
+    if (width <= 8) return support::DpiAbiClass::kByte;
+    if (width <= 16) return support::DpiAbiClass::kShortInt;
+    if (width <= 32) return support::DpiAbiClass::kInt;
+    if (width <= 64) return support::DpiAbiClass::kLongInt;
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedDpi,
+        "wide packed DPI-C value is not yet supported");
+  }
+  if (t.isCHandle()) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedDpi,
+        "chandle DPI-C argument is not yet supported");
+  }
+  return diag::Fail(
+      span, diag::DiagCode::kUnsupportedDpi, "DPI-C type is not yet supported");
+}
+
+// The resolved C linkage name of a DPI import (LRM 35.5.4): the explicit
+// `c_identifier` token when present, otherwise the SV subroutine name. slang
+// does not persist this for imports, so it is re-derived from the syntax here.
+auto ResolveImportCName(const slang::ast::SubroutineSymbol& sym)
+    -> std::string {
+  if (const auto* syntax = sym.getSyntax();
+      syntax != nullptr &&
+      syntax->kind == slang::syntax::SyntaxKind::DPIImport) {
+    const auto& dpi = syntax->as<slang::syntax::DPIImportSyntax>();
+    if (dpi.c_identifier) {
+      return std::string{dpi.c_identifier.valueText()};
+    }
+  }
+  return std::string{sym.name};
+}
+
 }  // namespace
 
 auto LowerSubroutineDecl(
     ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym,
     WalkFrame frame) -> diag::Result<hir::SubroutineDecl> {
   const auto& mapper = module.SourceMapper();
-
-  // A DPI-C import (LRM 35.4) binds an SV subroutine name to a foreign C
-  // implementation, so the subroutine has no SV body Lyra can execute.
-  // Rejecting it prevents lowering the empty shell as an ordinary subroutine
-  // that would silently return a default value on every call.
-  if (sym.flags.has(slang::ast::MethodFlags::DPIImport)) {
-    return diag::Fail(
-        mapper.PointSpanOf(sym.location), diag::DiagCode::kUnsupportedDpi,
-        "DPI-C import of a subroutine is not yet supported");
-  }
 
   auto return_type_or =
       module.InternType(sym.getReturnType(), mapper.PointSpanOf(sym.location));
@@ -133,6 +188,57 @@ auto LowerSubroutineDecl(
       .params = std::move(params),
       .result_var = result_var,
       .body = std::move(body)};
+}
+
+// Lowers a DPI-C import declaration (LRM 35.4) to a bodyless external callable.
+// It has no SV body, so it is not a `SubroutineDecl`; the caller records it
+// among the scope's foreign imports, not its subroutines. The ABI
+// classification and the foreign name are resolved once here and never
+// re-derived downstream. Input-only scalar functions are accepted; the
+// remaining forms are located diagnostics.
+auto LowerForeignImport(
+    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym)
+    -> diag::Result<hir::ForeignImportDecl> {
+  const auto& mapper = module.SourceMapper();
+  const auto loc = mapper.PointSpanOf(sym.location);
+  if (sym.subroutineKind == slang::ast::SubroutineKind::Task) {
+    return diag::Fail(
+        loc, diag::DiagCode::kUnsupportedDpi,
+        "DPI-C import task is not yet supported");
+  }
+  if (sym.flags.has(slang::ast::MethodFlags::DPIContext)) {
+    return diag::Fail(
+        loc, diag::DiagCode::kUnsupportedDpi,
+        "DPI-C context import is not yet supported");
+  }
+  auto ret_abi = ClassifyDpiAbi(sym.getReturnType(), loc);
+  if (!ret_abi) return std::unexpected(std::move(ret_abi.error()));
+  auto ret_type = module.InternType(sym.getReturnType(), loc);
+  if (!ret_type) return std::unexpected(std::move(ret_type.error()));
+
+  std::vector<hir::DpiParamAbi> abi_params;
+  abi_params.reserve(sym.getArguments().size());
+  for (const auto* formal : sym.getArguments()) {
+    const auto floc = mapper.PointSpanOf(formal->location);
+    if (formal->direction != slang::ast::ArgumentDirection::In) {
+      return diag::Fail(
+          floc, diag::DiagCode::kUnsupportedDpi,
+          "DPI-C output/inout argument is not yet supported");
+    }
+    auto abi = ClassifyDpiAbi(formal->getType(), floc);
+    if (!abi) return std::unexpected(std::move(abi.error()));
+    auto param_type = module.InternType(formal->getType(), floc);
+    if (!param_type) return std::unexpected(std::move(param_type.error()));
+    abi_params.push_back(hir::DpiParamAbi{.sv_type = *param_type, .abi = *abi});
+  }
+
+  return hir::ForeignImportDecl{
+      .name = std::string{sym.name},
+      .foreign_name = ResolveImportCName(sym),
+      .is_pure = sym.flags.has(slang::ast::MethodFlags::Pure),
+      .ret_abi = *ret_abi,
+      .ret_sv_type = *ret_type,
+      .params = std::move(abi_params)};
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -611,6 +611,11 @@ auto LowerHirCallExpr(
           [&](const hir::BuiltinMethodRef& b) -> diag::Result<mir::Expr> {
             return LowerBuiltinMethodCall(lowerer, frame, c, b, result_type);
           },
+          [&](const hir::ForeignImportRef&) -> diag::Result<mir::Expr> {
+            return diag::Fail(
+                span, diag::DiagCode::kUnsupportedDpi,
+                "a call to a DPI-C import is not yet supported");
+          },
       },
       c.callee);
 }

--- a/tests/cases/errors/dpi_import_four_state/case.yaml
+++ b/tests/cases/errors/dpi_import_four_state/case.yaml
@@ -1,4 +1,4 @@
-id: errors.dpi_import_unsupported
+id: errors.dpi_import_four_state
 tags: [errors, diag]
 input:
   command: [emit, cpp]
@@ -10,9 +10,9 @@ expect:
   exit: 1
   stderr:
     contains:
-      - "main.sv:5:"
+      - "main.sv:2:"
       - "unsupported:"
-      - "a call to a DPI-C import is not yet supported"
+      - "4-state DPI-C value is not yet supported"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/dpi_import_four_state/main.sv
+++ b/tests/cases/errors/dpi_import_four_state/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  import "DPI-C" function int f(input logic [7:0] x);
+endmodule

--- a/tests/cases/errors/dpi_import_output_arg/case.yaml
+++ b/tests/cases/errors/dpi_import_output_arg/case.yaml
@@ -1,4 +1,4 @@
-id: errors.dpi_import_unsupported
+id: errors.dpi_import_output_arg
 tags: [errors, diag]
 input:
   command: [emit, cpp]
@@ -10,9 +10,9 @@ expect:
   exit: 1
   stderr:
     contains:
-      - "main.sv:5:"
+      - "main.sv:2:"
       - "unsupported:"
-      - "a call to a DPI-C import is not yet supported"
+      - "DPI-C output/inout argument is not yet supported"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/dpi_import_output_arg/main.sv
+++ b/tests/cases/errors/dpi_import_output_arg/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  import "DPI-C" function int f(output int x);
+endmodule


### PR DESCRIPTION
## Summary

Model an `import "DPI-C"` subroutine as a bodyless external callable in HIR rather than a hard-rejected subroutine. A DPI import has no SV body, so it lives in its own `StructuralScope.foreign_imports` arena, never in `structural_subroutines` -- which keeps the body-bearing subroutine lowering completely DPI-unaware, with no `if (external) skip` scattered through the per-subroutine body passes. An independent `hir::ForeignImportDecl` replaces the earlier idea of a flag on `SubroutineDecl`; a call to an import resolves to a new `ForeignImportRef` through a separate binding space, and its DPI ABI classification and resolved C linkage name are computed once at declaration lowering and never re-derived at the call site.

Import declarations now normalize instead of being rejected outright, with input-only scalar-function gates (`real`, `string`, and 2-state integral scalars up to one machine word); the remaining forms (`output` / `inout`, `context`, 4-state, wide packed, `chandle`, tasks) produce located diagnostics. Lowering an import call down to MIR is a follow-up, so a call currently reports a located "a call to a DPI-C import is not yet supported".

## Design

The full DPI model this fits into is recorded in `docs/decisions/dpi-foreign-boundary.md`: import as the external arm of the one callable, marshaling as a cross-ABI carrier conversion through runtime primitives, the export-context mechanism, and the out-of-scope external-C-driver boundary. The phased plan lives in `docs/progress/dpi.md`. This PR is the HIR-representation slice of that plan; the MIR lowering, both backends, and the mixed-language end-to-end test are the follow-up work.

## Testing

`bazel test //...` is green. The `errors/` cases cover the call-site "not yet supported" diagnostic and two declaration-time gates (an `output` argument and a 4-state argument).
