### PR TITLE
Consolidate host boundary in a runtime entry

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -804,17 +804,15 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         none identified; pairs with the endpoint-capability decisions
         (`../decisions/net-driver-resolution.md`, `../decisions/reference-as-data-type.md`).
 
-- [ ] R54 -- Move the emitted host-boundary out of the C++ backend. Today the backend renders the
-      program entry point as one raw C++ string blob covering both the invariant host boundary (argv
-      parsing, plusargs collection, engine construction, `BindDesign`, shutdown) and the
-      design-derived tops construction. Every new host-boundary concept -- a seed CLI flag, a VCD
-      sink path, a simulation deadline, verbosity, signal handling -- grows that blob rather than
-      landing as real, type-checked runtime code. Target: the runtime provides a single
-      host-boundary entry that takes `argc` / `argv` and a design-supplied tops constructor; the
-      backend emits only the tops constructor (which is what MIR actually knows) plus a one-line
-      hand-off. New host-boundary concepts are then added by editing runtime C++, not by growing the
-      emitter's string surface. This is a host-execution-model concern, not a semantic-IR one, so it
-      stays outside MIR. **Blocker**: none.
+- [x] R54 -- Runtime `RunDesignHost` consolidates every invariant host-boundary concern (argv
+      parsing, plusarg collection, engine construction, `BindDesign`, exception mapping). The
+      emitted host is a design-supplied `$root` builder plus a one-line `main` hand-off, so new
+      host-boundary concepts (seed CLI flags, a VCD sink path, a simulation deadline, verbosity,
+      signal handling) grow runtime C++, not the emitter's string surface. The builder body itself
+      remains the C++ backend's allocation form (composed by the emitter from the root class name
+      and hierarchy-segment type rather than rendered from a single MIR/LIR root-construct
+      artifact); unifying it with the JIT's allocation shape waits for instance-representation
+      unification.
 
 ## Out of Scope
 

--- a/include/lyra/runtime/simulation_entry.hpp
+++ b/include/lyra/runtime/simulation_entry.hpp
@@ -1,8 +1,37 @@
 #pragma once
 
+#include <memory>
+
 namespace lyra::runtime {
 
 class Engine;
+class Scope;
+class RuntimeServices;
+
+// A design-derived callable that allocates the design's `$root` scope. The
+// emitted host names one such function and passes its address; the runtime
+// invokes it after building the Engine but before binding. The builder owns
+// the design-specific construction call (the root class, its constructor
+// signature, the `$root` display name); nothing else about the host boundary
+// leaks into emitted code.
+using RootBuilder = std::unique_ptr<Scope> (*)(RuntimeServices&);
+
+// The host program's design-simulation entry. Collects the LRM 21.6
+// command-line plusarg tokens off `argv`, constructs the Engine seeded
+// with those tokens, invokes `builder` to allocate the design's `$root`
+// (whose generated constructor elaborates the design), binds the built
+// tree, and drives the scheduler to completion. Returns the simulation's
+// exit code, mapping any escaping C++ exception to EXIT_FAILURE the same
+// way `RunSimulation` does. Never throws.
+//
+// This is the entry the emitted `main` calls. Consolidating every
+// host-boundary concern here -- argv parsing, engine construction, bind,
+// scheduler drive, exception mapping -- keeps the emitter's string
+// surface a one-line hand-off, so future host concerns (e.g. seed CLI
+// flags, a VCD sink path, a simulation deadline, verbosity, signal
+// handling) are added by editing runtime C++ rather than growing the
+// emitter.
+auto RunDesignHost(int argc, char** argv, RootBuilder builder) -> int;
 
 // Boundary between a host program and the simulation Engine. Drives a
 // bound Engine to completion and converts any escaping C++ exception
@@ -12,9 +41,10 @@ class Engine;
 // Engine::Run is the scheduler proper -- its body describes the LRM
 // region order and may throw on invariant violation or allocation
 // failure. This function is the host-process boundary that catches
-// such exceptions and maps them to an exit code. Emitted main.cpp
-// calls this rather than Engine::Run directly; any other host program
-// that embeds the runtime should do the same.
+// such exceptions and maps them to an exit code. A host program that
+// wants to construct its own Engine and drive its own root allocation
+// (an embedding API, a differential test) calls this directly instead
+// of RunDesignHost.
 auto RunSimulation(Engine& engine) -> int;
 
 }  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -449,49 +449,44 @@ auto RenderScopeHeaderFile(
 }
 
 auto RenderHostMain(const mir::CompilationUnit& root) -> std::string {
-  std::string out;
-  out += "#include <memory>\n";
-  out += "#include <string>\n";
-  out += "#include <string_view>\n";
-  out += "#include <utility>\n";
-  out += "#include <vector>\n";
-  out += "\n";
-  out += "#include \"lyra/runtime/engine.hpp\"\n";
-  out += "#include \"lyra/runtime/scope.hpp\"\n";
-  out += "#include \"lyra/runtime/simulation_entry.hpp\"\n";
   const auto& root_class = root.GetClass(root.root);
   const std::string root_cpp_name = ToCppName(root_class.name);
-  out += std::format("#include \"{}.hpp\"\n", root_cpp_name);
-  out += "\n";
-  // The host constructs the design-root unit and hands it to the engine. The
-  // root's constructor elaborates the design -- it builds the top-level units
-  // as its owned children -- so this harness invokes generated behavior rather
-  // than composing the object tree itself. The engine then walks the built
-  // tree. The segment carries the root's `$root` display name with no
-  // per-dimension indices; its type literal comes from the canonical
-  // RenderTypeAsCpp mapping, so this file does not repeat a type name MIR owns.
-  // LRM 21.6: `+`-prefixed argv entries are plusargs; the runtime stores them
-  // with the `+` stripped so a match compares against the user-supplied prefix
-  // directly.
-  out += "auto main(int argc, char** argv) -> int {\n";
-  out += "  std::vector<std::string> plusargs;\n";
-  out += "  for (int i = 1; i < argc; ++i) {\n";
-  out += "    const std::string_view arg{argv[i]};\n";
-  out += "    if (arg.starts_with(\"+\")) {\n";
-  out += "      plusargs.emplace_back(arg.substr(1));\n";
-  out += "    }\n";
-  out += "  }\n";
-  out += "  auto options = lyra::runtime::DefaultEngineOptions();\n";
-  out += "  options.plusargs = std::move(plusargs);\n";
-  out += "  lyra::runtime::Engine engine{std::move(options)};\n";
   const std::string segment_cpp =
       RenderTypeAsCpp(root, root_class, root.builtins.hierarchy_segment);
+
+  // Every invariant host-boundary concern -- argv parsing, engine
+  // construction, bind, scheduler drive, exception mapping -- lives in
+  // `RunDesignHost`. The emitter contributes only the C++ call that
+  // allocates `$root`: the concrete root class, its constructor arguments
+  // (parent, hierarchy segment, services). That call is composed here from
+  // MIR-known parts (the root class name, the hierarchy-segment type)
+  // rather than rendered from a single MIR/LIR root-construct artifact --
+  // allocation is realized per backend (a JIT backend allocates a generic
+  // runtime object; the C++ backend allocates its concrete class), so this
+  // shim carries the C++ form. `main` is a one-line hand-off; a new
+  // host-boundary concept is added to `RunDesignHost` in runtime C++,
+  // never to this shim.
+  std::string out;
+  out += "#include <memory>\n";
+  out += "\n";
+  out += "#include \"lyra/runtime/scope.hpp\"\n";
+  out += "#include \"lyra/runtime/simulation_entry.hpp\"\n";
+  out += std::format("#include \"{}.hpp\"\n", root_cpp_name);
+  out += "\n";
+  out += "namespace {\n";
+  out += "\n";
+  out += "auto BuildRoot(lyra::runtime::RuntimeServices& services)\n";
+  out += "    -> std::unique_ptr<lyra::runtime::Scope> {\n";
   out += std::format(
-      "  auto root = std::make_unique<{0}>(nullptr, {1}{{\"{2}\", {{}}}}, "
-      "engine.Services());\n",
+      "  return std::make_unique<{0}>(nullptr, {1}{{\"{2}\", {{}}}}, "
+      "services);\n",
       root_cpp_name, segment_cpp, root_class.name);
-  out += "  engine.BindDesign(std::move(root));\n";
-  out += "  return lyra::runtime::RunSimulation(engine);\n";
+  out += "}\n";
+  out += "\n";
+  out += "}  // namespace\n";
+  out += "\n";
+  out += "auto main(int argc, char** argv) -> int {\n";
+  out += "  return lyra::runtime::RunDesignHost(argc, argv, &BuildRoot);\n";
   out += "}\n";
   return out;
 }

--- a/src/lyra/runtime/simulation_entry.cpp
+++ b/src/lyra/runtime/simulation_entry.cpp
@@ -1,14 +1,39 @@
 #include "lyra/runtime/simulation_entry.hpp"
 
+#include <cstddef>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <new>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/engine.hpp"
 
 namespace lyra::runtime {
+
+auto RunDesignHost(int argc, char** argv, RootBuilder builder) -> int {
+  // LRM 21.6: `+`-prefixed argv entries are plusargs; strip the `+` so a
+  // stored token compares directly against a user-supplied prefix.
+  const std::span<char*> args{argv, static_cast<std::size_t>(argc)};
+  std::vector<std::string> plusargs;
+  for (std::size_t i = 1; i < args.size(); ++i) {
+    const std::string_view view{args[i]};
+    if (view.starts_with("+")) {
+      plusargs.emplace_back(view.substr(1));
+    }
+  }
+  auto options = DefaultEngineOptions();
+  options.plusargs = std::move(plusargs);
+  Engine engine{std::move(options)};
+  auto root = builder(engine.Services());
+  engine.BindDesign(std::move(root));
+  return RunSimulation(engine);
+}
 
 auto RunSimulation(Engine& engine) -> int {
   try {


### PR DESCRIPTION
## Summary

Introduces `lyra::runtime::RunDesignHost(argc, argv, builder)` as the single entry the emitted `main` calls, and shrinks the emitted host to a design-derived `$root` allocation shim plus a one-line hand-off. Every invariant host-boundary concern — argv parsing, plusarg collection, engine construction, `BindDesign`, exception mapping — now lives in real, type-checked runtime code rather than a raw C++ string blob composed by the emitter.

## Design

The prior emitted `main.cpp` interleaved five host-boundary steps in one hand-written string blob. The DPI PR extracted `RunSimulation` as the exception-safe scheduler wrapper; this change lifts the remaining invariant steps into `RunDesignHost`, layered on top of `RunSimulation`. The emitter contributes only what MIR reflects about the design: the concrete root class, its constructor arguments (parent, hierarchy segment, services). Future host concerns — seed CLI flags, a VCD sink path, a simulation deadline, verbosity, signal handling — grow `RunDesignHost` in runtime C++ instead of the emitter's string surface.

The three runtime entries now stratify cleanly. `Engine::Run` is the scheduler proper. `RunSimulation(engine)` maps escaping exceptions to an exit code. `RunDesignHost(argc, argv, builder)` is the full host shell an emitted `main` calls; a host program that constructs its own engine (an embedding API, a differential test) uses `RunSimulation` directly.

The `$root` allocation shim itself remains the C++ backend's form. That call is composed by the emitter from MIR-known parts (root class name, hierarchy-segment type) rather than rendered from a single MIR/LIR root-construct artifact, because allocation is realized per backend — a JIT backend allocates a generic runtime object with a `UnitDefinition` reference; the C++ backend allocates its concrete class. Unifying the shim body with the JIT's allocation shape waits for instance-representation unification and is out of scope here. The change consolidates every invariant concern; the residual per-backend piece is honestly labeled in both the code comment and the refactor entry (R54).

## Testing

`bazel test //...` (4/4 green). Existing `cpp_run` cases exercise the full new hand-off path; `tests/cases/cpp/plusargs_match` covers argv-side plusarg collection end to end.