### PR TITLE
Support DPI-C scalar imports on the C++ backend

### DIFF
--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -38,6 +38,13 @@ shape, per-backend foreign-call materialization, and per-backend foreign-symbol 
 completes as one deliverable: scalar import works end to end on both the C++ and the LLVM / JIT
 backend. Every later item leaves the MIR shape backend-agnostic and lands on both backends.
 
+The C++ backend half of D1 is done: a scalar import (2-state integral, `real`, and `string`,
+`input`-only functions) declares, marshals across the boundary, calls the foreign symbol, and
+marshals the result back; a user C source is linked in through a repeatable `--dpi-link` option, and
+mixed-language tests assert the round trip. The remaining D1 work is the LLVM / JIT backend, which
+does not yet resolve an external foreign symbol; the MIR is already backend-agnostic, so that half
+is additive.
+
 ## Sub-Steps
 
 The `D*` IDs are stable references. They do not impose a total order; real dependencies are stated

--- a/include/lyra/backend/cpp/render_type.hpp
+++ b/include/lyra/backend/cpp/render_type.hpp
@@ -1,12 +1,23 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/support/dpi_abi.hpp"
 
 namespace lyra::backend::cpp {
+
+// The C ABI type spelling an SV value crosses the DPI-C boundary as
+// (LRM 35.5.6): the single carrier-to-C++ mapping both the carrier type render
+// and the emitted `extern "C"` foreign declaration read. The 2-state integral
+// carriers are signed to match SV `byte` / `shortint` / `int` / `longint`; a
+// 1-bit `bit` crosses as `unsigned char`, `real` as `double`, a string as a C
+// string, and a `void` return has no carrier value.
+[[nodiscard]] auto DpiCarrierCppType(support::DpiAbiClass abi)
+    -> std::string_view;
 
 // Renders a MIR type as the corresponding C++ type expression. `owner_class`
 // is the class that lexically declares the field whose type is being rendered;

--- a/include/lyra/driver/cpp_build.hpp
+++ b/include/lyra/driver/cpp_build.hpp
@@ -24,17 +24,21 @@ auto AssembleProject(
 // (the same recipe `build.sh` carries). Returns the produced executable's path;
 // a non-zero compiler exit surfaces its stderr as a diagnostic.
 auto BuildProject(
-    const std::filesystem::path& dir, const pch::Options& pch_opts)
+    const std::filesystem::path& dir, const pch::Options& pch_opts,
+    std::span<const std::string> dpi_link_sources)
     -> diag::Result<std::filesystem::path>;
 
 // its exit code. `root` is the design-root unit the program constructs.
 // `child_args` are forwarded verbatim as argv to the built program (LRM 21.6
-// plusargs land here). This is the ephemeral path behind `run`: it never
-// materializes a portable project.
+// plusargs land here). `dpi_link_sources` are native sources (`.c` / `.cpp`)
+// providing DPI-C foreign symbols, compiled and linked into the program
+// (LRM 35). This is the ephemeral path behind `run`: it never materializes a
+// portable project.
 auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
     const mir::CompilationUnit& root, const std::filesystem::path& work_dir,
     bool format, const pch::Options& pch_opts,
-    std::span<const std::string> child_args) -> diag::Result<int>;
+    std::span<const std::string> child_args,
+    std::span<const std::string> dpi_link_sources) -> diag::Result<int>;
 
 }  // namespace lyra::driver

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -13,6 +13,8 @@
 #include "lyra/mir/field.hpp"
 #include "lyra/mir/method.hpp"
 #include "lyra/mir/param.hpp"
+#include "lyra/mir/static_callable.hpp"
+#include "lyra/mir/static_callable_id.hpp"
 #include "lyra/mir/static_constant_id.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/struct_id.hpp"
@@ -101,6 +103,12 @@ struct Class {
   // the constructor forwards its address to the runtime base through
   // `base_init`.
   base::Arena<StaticConstantDecl, StaticConstantId> static_constants;
+  // The class-level static callables this class owns -- receiver-less callables
+  // in its associated namespace, the callable peer of the static constants. A
+  // DPI-C import (LRM 35.4) lives here as an external-symbol callable; nothing
+  // in the instance method arena is one. Empty for a class that declares no
+  // static callable.
+  base::Arena<StaticCallableDecl, StaticCallableId> static_callables;
   // The base-constructor arguments beyond the forwarded prefix params, as
   // ordinary MIR expressions the backend translates in order (their expression
   // tree lives in `constructor.body.exprs`). A runtime tree node passes the

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -15,6 +15,7 @@
 #include "lyra/mir/local_ref.hpp"
 #include "lyra/mir/method_id.hpp"
 #include "lyra/mir/param.hpp"
+#include "lyra/mir/static_callable_id.hpp"
 #include "lyra/mir/static_constant_id.hpp"
 #include "lyra/mir/struct_construct.hpp"
 #include "lyra/mir/unary_op.hpp"
@@ -125,12 +126,15 @@ struct TypeQualifier {
 
 using ScopeQualifier = std::variant<TypeQualifier>;
 
-// The target of a `Direct` call -- the symbol identity. Two identity
-// spaces today: built-in runtime entries (closed-namespace `BuiltinFn`)
-// and user-declared class methods (per-class `MethodId` arena). The two
-// collapse into one `CallableId` once external callables (DPI) and SV
-// class statics share one callable-declaration shape.
-using DirectTarget = std::variant<MethodId, support::BuiltinFn>;
+// The target of a `Direct` call -- the symbol identity. Three identity
+// spaces: built-in runtime entries (closed-namespace `BuiltinFn`),
+// user-declared class methods (per-class `MethodId` arena), and class-level
+// static callables (per-class `StaticCallableId` arena -- a DPI-C import's
+// external symbol, a receiver-less associated callable). These collapse into
+// one `CallableId` once the method and static-callable declarations share one
+// callable-declaration shape.
+using DirectTarget =
+    std::variant<MethodId, support::BuiltinFn, StaticCallableId>;
 
 // A direct call to a named symbol. The single shape for every direct
 // invocation -- user method, built-in instance method, type-qualified

--- a/include/lyra/mir/static_callable.hpp
+++ b/include/lyra/mir/static_callable.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "lyra/mir/type_id.hpp"
+#include "lyra/support/dpi_abi.hpp"
+
+namespace lyra::mir {
+
+// One parameter of an external callable's ABI projection (LRM 35.5.6): the SV
+// type the boundary marshals from, paired with the C ABI carrier category it
+// crosses as. Both are fixed once at HIR-to-MIR and read by a backend's
+// marshaling, never re-derived from the type.
+struct ForeignParam {
+  TypeId sv_type;
+  support::DpiAbiClass abi;
+};
+
+// The external implementation form of a callable: a foreign linkage name plus
+// the pure property, with no SV body. A DPI-C import is realized as one
+// (LRM 35.4). `is_pure` marks an import the LRM lets the simulator treat as
+// side-effect-free (LRM 35.5.4). The source language and calling convention are
+// implicitly C, the only foreign linkage today; a second linkage adds them
+// here.
+struct ExternalSymbol {
+  std::string foreign_name;
+  bool is_pure;
+};
+
+// A class-level receiver-less associated callable, the callable peer of a
+// static constant. It is called by name with no `self`, so it is a
+// type-associated function, not an instance method, and lives in the class's
+// static-callable namespace rather than the instance method arena. Its
+// implementation form is an external foreign symbol today -- a DPI-C import; a
+// bodied static (an SV class static method) is the second form the same home
+// admits when that feature lands, at which point the implementation form
+// becomes a variant.
+//
+// The signature is the ABI projection: each parameter's SV type and carrier
+// class, and the return SV type and carrier class. The SV semantic signature
+// stays on the frontend where type checking ran; MIR carries only what
+// marshaling and linkage need.
+struct StaticCallableDecl {
+  std::string name;
+  std::vector<ForeignParam> params;
+  TypeId ret_sv_type;
+  support::DpiAbiClass ret_abi;
+  ExternalSymbol external;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/static_callable_id.hpp
+++ b/include/lyra/mir/static_callable_id.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::mir {
+
+// Identity of a class-level static callable -- a named, receiver-less callable
+// the class owns in its associated namespace. Scoped to the class that declares
+// it, the callable peer of a static-constant identity.
+struct StaticCallableId {
+  std::uint32_t value;
+
+  auto operator<=>(const StaticCallableId&) const
+      -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -10,6 +10,7 @@
 #include "lyra/mir/closure_id.hpp"
 #include "lyra/mir/struct_id.hpp"
 #include "lyra/mir/type_id.hpp"
+#include "lyra/support/dpi_abi.hpp"
 
 namespace lyra::mir {
 
@@ -29,6 +30,7 @@ enum class TypeKind {
   kShortReal,
   kRealTime,
   kChandle,
+  kDpiCarrier,
   kVoid,
   kObject,
   kExternalUnitObject,
@@ -237,6 +239,23 @@ struct RealTimeType {
 struct ChandleType {
   auto operator==(const ChandleType&) const -> bool = default;
 };
+
+// A foreign-ABI carrier: the plain C ABI type an SV value is marshaled to or
+// from when it crosses the DPI-C boundary (LRM 35.5.6). One value per carrier
+// category; a backend maps the category to a concrete C ABI type (kInt ->
+// int32_t, kReal -> double, kString -> const char*, ...).
+//
+// Invariant -- this is an ABI temporary, never a value-model type. It occurs
+// only within a single foreign-call lowering window: as the result type of a
+// marshal-to-carrier expression, and as the operand and result type of a
+// foreign call. It is never an SV variable's type, never stored to storage,
+// never produced by a user expression, and never escapes that window.
+struct DpiCarrierType {
+  support::DpiAbiClass abi;
+
+  auto operator==(const DpiCarrierType&) const -> bool = default;
+};
+
 struct VoidType {
   auto operator==(const VoidType&) const -> bool = default;
 };
@@ -533,10 +552,10 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, WildcardIndexType, StringType, StringViewType,
     MachineIntType, EventType, RealType, ShortRealType, RealTimeType,
-    ChandleType, VoidType, ObjectType, ExternalUnitObjectType, ScopeType,
-    InstanceType, GenScopeType, ProceduralStorageScopeType, ServicesType,
-    FilesType, DiagnosticType, RuntimeLibraryType, CoroutineType, RefType,
-    PointerType, ManagedRefType, VectorType, TupleType, UnionType,
+    ChandleType, DpiCarrierType, VoidType, ObjectType, ExternalUnitObjectType,
+    ScopeType, InstanceType, GenScopeType, ProceduralStorageScopeType,
+    ServicesType, FilesType, DiagnosticType, RuntimeLibraryType, CoroutineType,
+    RefType, PointerType, ManagedRefType, VectorType, TupleType, UnionType,
     ObservableType, ResolvedType, DriverType, StructType, ClosureType>;
 
 struct Type {

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -276,6 +276,12 @@ enum class BuiltinFn : std::uint16_t {
   // from packed bits (LRM 6.16) or from a byte unpacked array (LRM 21.3.4.3).
   kToInt64,
   kRound,
+  // Native-host value accessors used by DPI-C marshaling (LRM 35.5.6):
+  // `kRealValue` reads a `Real` / `ShortReal` out as its host floating value;
+  // `kStringCStr` borrows a `String` as a NUL-terminated C string valid for the
+  // owning string's lifetime. Instance methods on the receiver (`args[0]`).
+  kRealValue,
+  kStringCStr,
   kFromInt,
   kConvertFrom,
   kFromPackedArray,

--- a/include/lyra/support/dpi_abi.hpp
+++ b/include/lyra/support/dpi_abi.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 namespace lyra::support {
 
@@ -23,5 +24,31 @@ enum class DpiAbiClass : std::uint8_t {
   kReal,
   kString,
 };
+
+// The SV keyword an ABI category corresponds to. The shared human-readable
+// spelling every HIR and MIR dump names the category by, so the two dumps
+// agree without each restating the mapping.
+[[nodiscard]] constexpr auto DpiAbiClassName(DpiAbiClass abi)
+    -> std::string_view {
+  switch (abi) {
+    case DpiAbiClass::kVoid:
+      return "void";
+    case DpiAbiClass::kBit:
+      return "bit";
+    case DpiAbiClass::kByte:
+      return "byte";
+    case DpiAbiClass::kShortInt:
+      return "shortint";
+    case DpiAbiClass::kInt:
+      return "int";
+    case DpiAbiClass::kLongInt:
+      return "longint";
+    case DpiAbiClass::kReal:
+      return "real";
+    case DpiAbiClass::kString:
+      return "string";
+  }
+  return "unknown";
+}
 
 }  // namespace lyra::support

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -246,6 +246,14 @@ class String {
     return impl_;
   }
 
+  // Borrows the string as a NUL-terminated C string. The pointer is owned by
+  // this `String` and stays valid until the string is mutated or destroyed;
+  // it is the carrier a DPI-C `const char*` argument crosses the boundary as
+  // (LRM 35.5.6). A caller that needs the string to outlive this object copies.
+  [[nodiscard]] auto CStr() const -> const char* {
+    return impl_.c_str();
+  }
+
  private:
   // Hand-rolled to avoid std::from_chars's pointer-pair API; accumulates one
   // digit at a time. Underscores are skipped per the LRM atoi family rules.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -326,6 +326,33 @@ auto RenderScopeAsClass(
   return out;
 }
 
+// The `extern "C"` declarations for every DPI-C import the unit calls: each
+// import's foreign symbol as a C-linkage prototype over its ABI carrier types
+// (LRM 35.4 / 35.5.6). Emitted before the classes that call them so a foreign
+// call resolves against a declared signature; the definitions come from the
+// user's linked C. Empty when the unit declares no import.
+auto RenderForeignImportDeclarations(const mir::CompilationUnit& unit)
+    -> std::string {
+  std::string out;
+  for (std::size_t i = 0; i < unit.classes.size(); ++i) {
+    const mir::ClassId id{static_cast<std::uint32_t>(i)};
+    if (!unit.classes.IsDefined(id)) continue;
+    for (const auto& callable : unit.GetClass(id).static_callables) {
+      std::string params;
+      for (std::size_t p = 0; p < callable.params.size(); ++p) {
+        if (p != 0) params += ", ";
+        params += std::string{DpiCarrierCppType(callable.params[p].abi)};
+      }
+      out +=
+          std::format(
+              R"(extern "C" {} {}({});)", DpiCarrierCppType(callable.ret_abi),
+              callable.external.foreign_name, params) +
+          "\n";
+    }
+  }
+  return out;
+}
+
 auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
     -> std::vector<std::string> {
   std::vector<std::string> names;
@@ -385,6 +412,11 @@ auto RenderScopeHeaderFile(
     out += std::format("#include \"{}.hpp\"\n", ToCppName(name));
   }
   out += "\n";
+  if (const std::string foreign_decls = RenderForeignImportDeclarations(unit);
+      !foreign_decls.empty()) {
+    out += foreign_decls;
+    out += "\n";
+  }
   bool any_enum = false;
   for (std::size_t i = 0; i < unit.types.size(); ++i) {
     const mir::TypeId type_id{static_cast<std::uint32_t>(i)};

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -252,6 +252,10 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "ToInt64";
     case support::BuiltinFn::kRound:
       return "Round";
+    case support::BuiltinFn::kRealValue:
+      return "Value";
+    case support::BuiltinFn::kStringCStr:
+      return "CStr";
     case support::BuiltinFn::kFromInt:
       return "FromInt";
     case support::BuiltinFn::kConvertFrom:
@@ -439,6 +443,16 @@ auto RenderDirectBuiltinCall(
       .leading_arg_count = 1};
 }
 
+// Renders a `Direct` callee whose target is a class-level static callable.
+// Today that is a DPI-C import: a global `extern "C"` symbol reached by its
+// foreign linkage name, with no receiver and no qualifier, so the callee text
+// is the bare foreign name and no leading argument is absorbed into it.
+auto RenderDirectStaticCallableCall(
+    const ScopeView& view, mir::StaticCallableId id) -> CalleeRender {
+  const auto& callable = view.Class().static_callables.Get(id);
+  return {.expr = callable.external.foreign_name, .leading_arg_count = 0};
+}
+
 auto RenderCalleePart(
     const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
     -> CalleeRender {
@@ -454,6 +468,9 @@ auto RenderCalleePart(
                     [&](const support::BuiltinFn& id) {
                       return RenderDirectBuiltinCall(
                           view, call, id, d.qualification);
+                    },
+                    [&](const mir::StaticCallableId& s) {
+                      return RenderDirectStaticCallableCall(view, s);
                     },
                 },
                 d.target);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -11,8 +11,31 @@
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/support/dpi_abi.hpp"
 
 namespace lyra::backend::cpp {
+
+auto DpiCarrierCppType(support::DpiAbiClass abi) -> std::string_view {
+  switch (abi) {
+    case support::DpiAbiClass::kBit:
+      return "unsigned char";
+    case support::DpiAbiClass::kByte:
+      return "std::int8_t";
+    case support::DpiAbiClass::kShortInt:
+      return "std::int16_t";
+    case support::DpiAbiClass::kInt:
+      return "std::int32_t";
+    case support::DpiAbiClass::kLongInt:
+      return "std::int64_t";
+    case support::DpiAbiClass::kReal:
+      return "double";
+    case support::DpiAbiClass::kString:
+      return "const char*";
+    case support::DpiAbiClass::kVoid:
+      return "void";
+  }
+  throw InternalError("DpiCarrierCppType: unknown DpiAbiClass");
+}
 
 auto RenderPackedType(const mir::PackedArrayType& pa) -> std::string {
   const char* signed_lit =
@@ -77,6 +100,9 @@ auto RenderTypeAsCpp(
                 throw InternalError(
                     "RenderTypeAsCpp: unsupported MachineIntType width");
             }
+          },
+          [](const mir::DpiCarrierType& d) -> std::string {
+            return std::string{DpiCarrierCppType(d.abi)};
           },
           [](const mir::EventType&) -> std::string {
             return std::string{"lyra::runtime::NamedEvent"};
@@ -252,8 +278,8 @@ auto RenderTypeAsCpp(
           },
           [](const auto&) -> std::string {
             throw InternalError(
-                "RenderTypeAsCpp: MIR type not yet supported in C++ render "
-                "cut");
+                "RenderTypeAsCpp: MIR type not yet supported in the C++ "
+                "backend");
           },
       },
       unit.types.Get(type_id).data);

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -65,6 +65,10 @@ struct ParsedArgs {
   // from the trailing bucket at parse time. `run` forwards them verbatim to
   // the built program's argv; other subcommands never consult them.
   std::vector<std::string> plusargs;
+  // LRM 35 DPI-C link inputs: native source files (`.c` / `.cpp`) providing the
+  // foreign symbols an `import "DPI-C"` calls. Compiled and linked into the
+  // built program alongside the emitted C++.
+  std::vector<std::string> dpi_link_sources;
 };
 
 void AddCompilationFlags(argparse::ArgumentParser& cmd) {
@@ -106,6 +110,9 @@ void AddCompilationFlags(argparse::ArgumentParser& cmd) {
       .help("reformat the emitted C++ with clang-format (skipped if absent)")
       .default_value(false)
       .implicit_value(true);
+  cmd.add_argument("--dpi-link")
+      .help("native source (.c/.cpp) providing DPI-C foreign symbols to link")
+      .append();
   cmd.add_argument("files").help("SystemVerilog source files").remaining();
 }
 
@@ -118,6 +125,9 @@ void BindCompilationFlags(
   if (auto incs =
           cmd.present<std::vector<std::string>>("--include-directory")) {
     out.input.incdirs = std::move(*incs);
+  }
+  if (auto dpi = cmd.present<std::vector<std::string>>("--dpi-link")) {
+    out.dpi_link_sources = std::move(*dpi);
   }
   if (auto defs = cmd.present<std::vector<std::string>>("--define-macro")) {
     out.input.defines = std::move(*defs);
@@ -491,7 +501,8 @@ auto main(int argc, char** argv) -> int {
           report(std::move(assembled.error()), mgr);
           return 1;
         }
-        auto built = lyra::driver::BuildProject(dir, pch_opts);
+        auto built =
+            lyra::driver::BuildProject(dir, pch_opts, args.dpi_link_sources);
         if (!built) {
           report(std::move(built.error()), mgr);
           return 1;
@@ -544,7 +555,7 @@ auto main(int argc, char** argv) -> int {
             const auto& root = *result.artifacts.root_unit;
             auto exit_code = lyra::driver::RunInPlace(
                 *runtime, units, root, *tmp_or, args.format, pch_opts,
-                args.plusargs);
+                args.plusargs, args.dpi_link_sources);
             if (!exit_code) {
               report(std::move(exit_code.error()), mgr);
               return 1;

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -169,15 +169,64 @@ auto EmitAndWriteSources(
   return {};
 }
 
+// Prepares one DPI-C link input for the final link (LRM 35). A `.c` source is
+// compiled to an object in its own step so its symbols keep C linkage -- the
+// emitted `extern "C"` declaration expects that, and the C++ driver would
+// otherwise mangle a `.c` compiled in the C++ invocation. A `.cpp` joins the
+// C++ link directly (the user gives it C linkage with `extern "C"`). Returns
+// the path to add to the link line.
+auto PrepareDpiLinkInput(
+    const std::filesystem::path& cxx, const std::string& src,
+    const std::filesystem::path& work_dir) -> diag::Result<std::string> {
+  const std::filesystem::path src_path{src};
+  const std::string ext = src_path.extension().string();
+  if (ext == ".cpp" || ext == ".cc" || ext == ".cxx") {
+    return src;
+  }
+  if (ext != ".c") {
+    return diag::Fail(
+        diag::DiagCode::kHostBuildFailed,
+        std::format(
+            "unsupported DPI-C link input '{}': only .c and .cpp are supported",
+            src));
+  }
+  const std::filesystem::path obj =
+      work_dir / (src_path.stem().string() + ".dpi.o");
+  const std::vector<std::string> compile_args = {"-x", "c",  "-c",
+                                                 src,  "-o", obj.string()};
+  auto compiled = support::RunProcessCaptured(cxx, compile_args);
+  if (!compiled) {
+    return IoError(std::move(compiled.error()));
+  }
+  if (compiled->exit_code != 0) {
+    return diag::Fail(
+        diag::DiagCode::kHostBuildFailed,
+        std::format(
+            "compiling DPI-C source '{}' failed:\n{}", src,
+            compiled->stderr_text));
+  }
+  return obj.string();
+}
+
 auto CompileProgram(
     const std::filesystem::path& main_cpp,
     const std::filesystem::path& include_root, const std::filesystem::path& lib,
-    const std::filesystem::path& program, const pch::Options& pch_opts)
-    -> diag::Result<void> {
+    const std::filesystem::path& program, const pch::Options& pch_opts,
+    std::span<const std::string> dpi_link_sources) -> diag::Result<void> {
   auto cxx_or = support::ResolveCxxCompiler();
   if (!cxx_or) {
     return IoError(std::move(cxx_or.error()));
   }
+  std::vector<std::string> link_inputs;
+  link_inputs.reserve(dpi_link_sources.size());
+  for (const std::string& src : dpi_link_sources) {
+    auto prepared = PrepareDpiLinkInput(*cxx_or, src, program.parent_path());
+    if (!prepared) {
+      return std::unexpected(std::move(prepared.error()));
+    }
+    link_inputs.push_back(*std::move(prepared));
+  }
+
   std::vector<std::string> args = {
       std::string(kCxxStandardFlag), "-I", include_root.string()};
   if (auto cached = pch::EnsureCached(*cxx_or, include_root, pch_opts)) {
@@ -185,6 +234,9 @@ auto CompileProgram(
     args.push_back(cached->string());
   }
   args.push_back(main_cpp.string());
+  for (const std::string& in : link_inputs) {
+    args.push_back(in);
+  }
   args.push_back(lib.string());
   args.emplace_back("-o");
   args.push_back(program.string());
@@ -236,12 +288,14 @@ auto AssembleProject(
 }
 
 auto BuildProject(
-    const std::filesystem::path& dir, const pch::Options& pch_opts)
+    const std::filesystem::path& dir, const pch::Options& pch_opts,
+    std::span<const std::string> dpi_link_sources)
     -> diag::Result<std::filesystem::path> {
   const auto program = dir / kProgramName;
   if (auto r = CompileProgram(
           dir / kMainSource, dir / kRuntimeIncludeDir,
-          dir / kRuntimeLibDir / kRuntimeLibFile, program, pch_opts);
+          dir / kRuntimeLibDir / kRuntimeLibFile, program, pch_opts,
+          dpi_link_sources);
       !r) {
     return std::unexpected(std::move(r.error()));
   }
@@ -252,14 +306,15 @@ auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
     const mir::CompilationUnit& root, const std::filesystem::path& work_dir,
     bool format, const pch::Options& pch_opts,
-    std::span<const std::string> child_args) -> diag::Result<int> {
+    std::span<const std::string> child_args,
+    std::span<const std::string> dpi_link_sources) -> diag::Result<int> {
   if (auto r = EmitAndWriteSources(units, root, work_dir, format); !r) {
     return std::unexpected(std::move(r.error()));
   }
   const auto program = work_dir / kProgramName;
   if (auto r = CompileProgram(
           work_dir / kMainSource, runtime.include_root, runtime.lib, program,
-          pch_opts);
+          pch_opts, dpi_link_sources);
       !r) {
     return std::unexpected(std::move(r.error()));
   }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -976,40 +976,18 @@ class HirDumper {
   void DumpForeignImport(std::size_t index, const ForeignImportDecl& fi) {
     Line(
         std::format(
-            "ForeignImport[{}] function \"{}\" c_name=\"{}\"{} ret={}", index,
+            R"(ForeignImport[{}] function "{}" c_name="{}"{} ret={})", index,
             fi.name, fi.foreign_name, fi.is_pure ? " pure" : "",
-            FormatDpiAbiClass(fi.ret_abi)));
+            support::DpiAbiClassName(fi.ret_abi)));
     Indent();
     for (std::size_t i = 0; i < fi.params.size(); ++i) {
       Line(
           std::format(
-              "Param[{}] {} : Type[{}]", i, FormatDpiAbiClass(fi.params[i].abi),
+              "Param[{}] {} : Type[{}]", i,
+              support::DpiAbiClassName(fi.params[i].abi),
               fi.params[i].sv_type.value));
     }
     Dedent();
-  }
-
-  [[nodiscard]] static auto FormatDpiAbiClass(support::DpiAbiClass abi)
-      -> std::string_view {
-    switch (abi) {
-      case support::DpiAbiClass::kVoid:
-        return "void";
-      case support::DpiAbiClass::kBit:
-        return "bit";
-      case support::DpiAbiClass::kByte:
-        return "byte";
-      case support::DpiAbiClass::kShortInt:
-        return "shortint";
-      case support::DpiAbiClass::kInt:
-        return "int";
-      case support::DpiAbiClass::kLongInt:
-        return "longint";
-      case support::DpiAbiClass::kReal:
-        return "real";
-      case support::DpiAbiClass::kString:
-        return "string";
-    }
-    throw InternalError("FormatDpiAbiClass: unknown support::DpiAbiClass");
   }
 
   [[nodiscard]] static auto FormatParamDirection(ParamDirection dir)

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -576,6 +576,158 @@ auto LowerMethodCall(
       .type = result_type};
 }
 
+// SV value -> foreign ABI carrier (marshal-in, LRM 35.5.6). An integral value
+// yields its host int64, narrowed to the carrier's C width by a host cast; a
+// real yields its native floating value; a string borrows a NUL-terminated C
+// string that stays valid for the call. Reuses the ordinary value accessors;
+// the boundary conversion is a plain expression, not a DPI-specific primitive.
+auto MarshalArgToCarrier(
+    mir::CompilationUnit& unit, mir::Block& block, mir::ExprId sv_id,
+    support::DpiAbiClass abi) -> mir::ExprId {
+  const mir::TypeId carrier =
+      unit.types.Intern(mir::TypeData{mir::DpiCarrierType{.abi = abi}});
+  switch (abi) {
+    case support::DpiAbiClass::kBit:
+    case support::DpiAbiClass::kByte:
+    case support::DpiAbiClass::kShortInt:
+    case support::DpiAbiClass::kInt:
+    case support::DpiAbiClass::kLongInt: {
+      const mir::ExprId host_int = block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee =
+                          mir::Direct{.target = support::BuiltinFn::kToInt64},
+                      .arguments = {sv_id}},
+              .type = unit.builtins.int32});
+      return block.exprs.Add(
+          mir::Expr{
+              .data = mir::CastExpr{.operand = host_int}, .type = carrier});
+    }
+    case support::DpiAbiClass::kReal:
+      return block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee =
+                          mir::Direct{.target = support::BuiltinFn::kRealValue},
+                      .arguments = {sv_id}},
+              .type = carrier});
+    case support::DpiAbiClass::kString:
+      return block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee =
+                          mir::Direct{
+                              .target = support::BuiltinFn::kStringCStr},
+                      .arguments = {sv_id}},
+              .type = carrier});
+    case support::DpiAbiClass::kVoid:
+      throw InternalError(
+          "MarshalArgToCarrier: void is not an argument carrier");
+  }
+  throw InternalError("MarshalArgToCarrier: unknown DpiAbiClass");
+}
+
+// Foreign ABI carrier -> SV value (marshal-out) into the declared return type's
+// canonical shape. An integral carrier is landed into the return type's
+// representation by the packed factory (the prototype carries that shape, so
+// width / signedness / state domain follow the declared type); a real / string
+// carrier constructs the SV value directly.
+auto MarshalResultFromCarrier(
+    ModuleLowerer& module, WalkFrame frame, mir::ExprId call_id,
+    support::DpiAbiClass abi, mir::TypeId result_type) -> mir::Expr {
+  mir::Block& block = *frame.current_block;
+  switch (abi) {
+    case support::DpiAbiClass::kBit:
+    case support::DpiAbiClass::kByte:
+    case support::DpiAbiClass::kShortInt:
+    case support::DpiAbiClass::kInt:
+    case support::DpiAbiClass::kLongInt: {
+      const mir::ExprId prototype =
+          block.exprs.Add(BuildDefaultValueExpr(module, frame, result_type));
+      return mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::Direct{
+                          .target = support::BuiltinFn::kFromInt,
+                          .qualification =
+                              mir::TypeQualifier{.type = result_type}},
+                  .arguments = {call_id, prototype}},
+          .type = result_type};
+    }
+    case support::DpiAbiClass::kReal:
+    case support::DpiAbiClass::kString:
+      return mir::Expr{
+          .data =
+              mir::CallExpr{.callee = mir::Construct{}, .arguments = {call_id}},
+          .type = result_type};
+    case support::DpiAbiClass::kVoid:
+      throw InternalError("MarshalResultFromCarrier: void has no marshal-out");
+  }
+  throw InternalError("MarshalResultFromCarrier: unknown DpiAbiClass");
+}
+
+// LRM 35.4 import call: an ordinary call to the external static callable,
+// wrapped in boundary marshaling. Each actual is marshaled to its ABI carrier,
+// the foreign symbol is called over the carriers, and a non-void result is
+// marshaled back to the declared SV return type. The ABI classes are read from
+// the callable's own declaration, resolved once at its declaration lowering.
+template <ExprLowerer Lowerer>
+auto LowerForeignImportCall(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    const hir::ForeignImportRef& ref, diag::SourceSpan span,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  if (ref.hops.value != 0) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedDpi,
+        "a call to a DPI-C import declared in an enclosing scope is not yet "
+        "supported");
+  }
+  auto& module = lowerer.Module();
+  auto& unit = module.Unit();
+  auto& block = *frame.current_block;
+  const auto& hir_exprs = lowerer.HirExprs();
+  const mir::StaticCallableId callable{ref.id.value};
+  const mir::StaticCallableDecl& decl =
+      frame.current_class->static_callables.Get(callable);
+
+  std::vector<mir::ExprId> carrier_args;
+  carrier_args.reserve(c.arguments.size());
+  for (std::size_t i = 0; i < c.arguments.size(); ++i) {
+    if (!c.arguments[i].has_value()) {
+      throw InternalError("DPI-C import call argument unexpectedly elided");
+    }
+    auto sv_or = lowerer.LowerExpr(hir_exprs.Get(*c.arguments[i]), frame);
+    if (!sv_or) return std::unexpected(std::move(sv_or.error()));
+    const mir::ExprId sv_id = block.exprs.Add(*std::move(sv_or));
+    carrier_args.push_back(
+        MarshalArgToCarrier(unit, block, sv_id, decl.params[i].abi));
+  }
+
+  // A void import has no carrier result and needs no marshal-out; a valued one
+  // returns its ABI carrier, which is then marshaled back to the SV type.
+  const bool is_void = decl.ret_abi == support::DpiAbiClass::kVoid;
+  const mir::TypeId call_type =
+      is_void ? unit.builtins.void_type
+              : unit.types.Intern(
+                    mir::TypeData{mir::DpiCarrierType{.abi = decl.ret_abi}});
+  mir::Expr foreign_call{
+      .data =
+          mir::CallExpr{
+              .callee = mir::Direct{.target = callable},
+              .arguments = std::move(carrier_args)},
+      .type = call_type};
+  if (is_void) {
+    return foreign_call;
+  }
+  const mir::ExprId call_id = block.exprs.Add(std::move(foreign_call));
+  return MarshalResultFromCarrier(
+      module, frame, call_id, decl.ret_abi, result_type);
+}
+
 }  // namespace
 
 template <ExprLowerer Lowerer>
@@ -611,10 +763,9 @@ auto LowerHirCallExpr(
           [&](const hir::BuiltinMethodRef& b) -> diag::Result<mir::Expr> {
             return LowerBuiltinMethodCall(lowerer, frame, c, b, result_type);
           },
-          [&](const hir::ForeignImportRef&) -> diag::Result<mir::Expr> {
-            return diag::Fail(
-                span, diag::DiagCode::kUnsupportedDpi,
-                "a call to a DPI-C import is not yet supported");
+          [&](const hir::ForeignImportRef& imp) -> diag::Result<mir::Expr> {
+            return LowerForeignImportCall(
+                lowerer, frame, c, imp, span, result_type);
           },
       },
       c.callee);

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -1467,6 +1467,30 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   mir_class.contained = shape.contained;
   mir_class.type_aliases = shape.type_aliases;
 
+  // A DPI-C import declares no body, so it never enters the subroutine body
+  // machinery below. Its ABI projection and foreign name were resolved once at
+  // AST-to-HIR; here they translate straight into the class's static-callable
+  // namespace, the external-symbol callable the import call lowers against.
+  for (std::size_t i = 0; i < hir_scope.foreign_imports.size(); ++i) {
+    const hir::ForeignImportDecl& imp = hir_scope.foreign_imports.Get(
+        hir::ForeignImportId{static_cast<std::uint32_t>(i)});
+    std::vector<mir::ForeignParam> params;
+    params.reserve(imp.params.size());
+    for (const hir::DpiParamAbi& p : imp.params) {
+      params.push_back(
+          mir::ForeignParam{
+              .sv_type = module.TranslateType(p.sv_type), .abi = p.abi});
+    }
+    mir_class.static_callables.Add(
+        mir::StaticCallableDecl{
+            .name = imp.name,
+            .params = std::move(params),
+            .ret_sv_type = module.TranslateType(imp.ret_sv_type),
+            .ret_abi = imp.ret_abi,
+            .external = mir::ExternalSymbol{
+                .foreign_name = imp.foreign_name, .is_pure = imp.is_pure}});
+  }
+
   const mir::TypeId void_type = module.Unit().builtins.void_type;
   const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
   ScopeChainNode outer_scope_link{};

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -60,6 +60,14 @@ auto LowerCallTarget(
                     [](const support::BuiltinFn& fn)
                         -> diag::Result<lir::CallTarget> {
                       return lir::CallTarget{lir::BuiltinTarget{.fn = fn}};
+                    },
+                    [](const mir::StaticCallableId&)
+                        -> diag::Result<lir::CallTarget> {
+                      return diag::Fail(
+                          diag::DiagCode::kUnsupportedExpressionForm,
+                          "mir_to_lir: a DPI-C import call is not yet "
+                          "lowerable "
+                          "to LIR");
                     }},
                 d.target);
           },

--- a/src/lyra/lowering/mir_to_lir/translate_type.cpp
+++ b/src/lyra/lowering/mir_to_lir/translate_type.cpp
@@ -287,6 +287,9 @@ auto UnitLowerer::TranslateTypeData(const mir::Type& ty) -> lir::TypeData {
           },
           [&](const mir::ClosureType&) -> lir::TypeData {
             return RecordUnsupportedType("a closure");
+          },
+          [&](const mir::DpiCarrierType&) -> lir::TypeData {
+            return RecordUnsupportedType("a DPI-C ABI carrier");
           }},
       ty.data);
 }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -26,6 +26,7 @@
 #include "lyra/mir/type.hpp"
 #include "lyra/mir/unary_op.hpp"
 #include "lyra/support/builtin_fn.hpp"
+#include "lyra/support/dpi_abi.hpp"
 #include "lyra/value/format.hpp"
 
 namespace lyra::mir {
@@ -222,6 +223,10 @@ class MirDumper {
             [](const ShortRealType&) -> std::string { return "ShortRealType"; },
             [](const RealTimeType&) -> std::string { return "RealTimeType"; },
             [](const ChandleType&) -> std::string { return "ChandleType"; },
+            [](const DpiCarrierType& d) -> std::string {
+              return std::format(
+                  "DpiCarrier({})", support::DpiAbiClassName(d.abi));
+            },
             [](const VoidType&) -> std::string { return "VoidType"; },
             [](const ObjectType& o) -> std::string {
               return std::format("Object(#{})", o.class_id.value);
@@ -476,6 +481,13 @@ class MirDumper {
             },
             [](const support::BuiltinFn& id) -> std::string {
               return std::format("builtin=\"{}\"", support::BuiltinFnName(id));
+            },
+            [this](const StaticCallableId& s) -> std::string {
+              const auto& owner = ResolveScopeAtHops(0);
+              const auto& callable = owner.static_callables.Get(s);
+              return std::format(
+                  R"(static_callable={} "{}" c_name="{}")", s.value,
+                  callable.name, callable.external.foreign_name);
             },
         },
         target);
@@ -776,6 +788,18 @@ class MirDumper {
     }
     Dedent();
 
+    if (!s.static_callables.empty()) {
+      Line("StaticCallables:");
+      Indent();
+      for (std::size_t i = 0; i < s.static_callables.size(); ++i) {
+        DumpStaticCallable(
+            s.static_callables.Get(
+                StaticCallableId{static_cast<std::uint32_t>(i)}),
+            i);
+      }
+      Dedent();
+    }
+
     Line("Constructor:");
     Indent();
     DumpCallableBody(s.constructor);
@@ -794,6 +818,23 @@ class MirDumper {
           std::format(
               "[{}] \"{}\"{} : {}", i, v.name, as, FormatVarType(v.type)));
     }
+  }
+
+  void DumpStaticCallable(const StaticCallableDecl& c, std::size_t index) {
+    Line(
+        std::format(
+            R"(StaticCallable[{}] "{}" external c_name="{}"{} ret={} : {})",
+            index, c.name, c.external.foreign_name,
+            c.external.is_pure ? " pure" : "",
+            support::DpiAbiClassName(c.ret_abi), FormatVarType(c.ret_sv_type)));
+    Indent();
+    for (std::size_t i = 0; i < c.params.size(); ++i) {
+      Line(
+          std::format(
+              "Param[{}] {} : {}", i, support::DpiAbiClassName(c.params[i].abi),
+              FormatVarType(c.params[i].sv_type)));
+    }
+    Dedent();
   }
 
   void DumpStruct(StructId id, const StructDecl& decl) {

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -72,6 +72,7 @@ auto Type::Kind() const -> TypeKind {
           [](const ShortRealType&) { return TypeKind::kShortReal; },
           [](const RealTimeType&) { return TypeKind::kRealTime; },
           [](const ChandleType&) { return TypeKind::kChandle; },
+          [](const DpiCarrierType&) { return TypeKind::kDpiCarrier; },
           [](const VoidType&) { return TypeKind::kVoid; },
           [](const ObjectType&) { return TypeKind::kObject; },
           [](const ExternalUnitObjectType&) {

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -79,6 +79,8 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
         } else if constexpr (std::is_same_v<T, MachineIntType>) {
           HashField(seed, t.bit_width);
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.signedness)));
+        } else if constexpr (std::is_same_v<T, DpiCarrierType>) {
+          HashCombine(seed, std::hash<int>{}(static_cast<int>(t.abi)));
         } else if constexpr (std::is_same_v<T, RuntimeLibraryType>) {
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.kind)));
         } else if constexpr (std::is_same_v<T, CoroutineType>) {

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -366,6 +366,10 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "to_int64";
     case BuiltinFn::kRound:
       return "round";
+    case BuiltinFn::kRealValue:
+      return "real_value";
+    case BuiltinFn::kStringCStr:
+      return "string_cstr";
     case BuiltinFn::kFromInt:
       return "from_int";
     case BuiltinFn::kConvertFrom:

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -65,6 +65,8 @@ cc_test(
         [
             "cases/**/*.yaml",
             "cases/**/*.sv",
+            "cases/**/*.c",
+            "cases/**/*.cpp",
         ],
         allow_empty = True,
     ),

--- a/tests/cases/cpp/dpi_import_int/case.yaml
+++ b/tests/cases/cpp/dpi_import_int/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.dpi_import_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      add_one=42
+      mul=42

--- a/tests/cases/cpp/dpi_import_int/dpi.c
+++ b/tests/cases/cpp/dpi_import_int/dpi.c
@@ -1,0 +1,7 @@
+int add_one(int x) {
+  return x + 1;
+}
+
+int mul(int a, int b) {
+  return a * b;
+}

--- a/tests/cases/cpp/dpi_import_int/main.sv
+++ b/tests/cases/cpp/dpi_import_int/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  import "DPI-C" function int add_one(input int x);
+  import "DPI-C" function int mul(input int a, input int b);
+  int r;
+  initial begin
+    r = add_one(41);
+    $display("add_one=%0d", r);
+    r = mul(6, 7);
+    $display("mul=%0d", r);
+  end
+endmodule

--- a/tests/cases/cpp/dpi_import_real/case.yaml
+++ b/tests/cases/cpp/dpi_import_real/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.dpi_import_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      scale=6.0
+      negate=-2.5

--- a/tests/cases/cpp/dpi_import_real/dpi.c
+++ b/tests/cases/cpp/dpi_import_real/dpi.c
@@ -1,0 +1,7 @@
+double scale(double r, int k) {
+  return r * k;
+}
+
+double negate(double r) {
+  return -r;
+}

--- a/tests/cases/cpp/dpi_import_real/main.sv
+++ b/tests/cases/cpp/dpi_import_real/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  import "DPI-C" function real scale(input real r, input int k);
+  import "DPI-C" function real negate(input real r);
+  real a;
+  initial begin
+    a = scale(1.5, 4);
+    $display("scale=%0.1f", a);
+    a = negate(2.5);
+    $display("negate=%0.1f", a);
+  end
+endmodule

--- a/tests/cases/cpp/dpi_import_string/case.yaml
+++ b/tests/cases/cpp/dpi_import_string/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.dpi_import_string
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      var=11
+      lit=2

--- a/tests/cases/cpp/dpi_import_string/dpi.c
+++ b/tests/cases/cpp/dpi_import_string/dpi.c
@@ -1,0 +1,5 @@
+#include <string.h>
+
+int slen(const char* s) {
+  return (int)strlen(s);
+}

--- a/tests/cases/cpp/dpi_import_string/main.sv
+++ b/tests/cases/cpp/dpi_import_string/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  import "DPI-C" function int slen(input string s);
+  string s;
+  int n;
+  initial begin
+    s = "hello world";
+    n = slen(s);
+    $display("var=%0d", n);
+    n = slen("hi");
+    $display("lit=%0d", n);
+  end
+endmodule

--- a/tests/framework/runner.cpp
+++ b/tests/framework/runner.cpp
@@ -170,6 +170,19 @@ auto ParseCase(
       c.input.extra_args.push_back(a.as<std::string>());
     }
   }
+  if (in["link_sources"]) {
+    for (const auto& s : in["link_sources"]) {
+      const auto rel = s.as<std::string>();
+      const auto abs = case_dir / rel;
+      if (!std::filesystem::exists(abs)) {
+        throw std::runtime_error(
+            std::format(
+                "{}: referenced link source '{}' does not exist at '{}'",
+                yaml_path.string(), rel, abs.string()));
+      }
+      c.input.link_sources.push_back(rel);
+    }
+  }
 
   const auto& ex = root["expect"];
   if (ex && ex.IsMap()) {
@@ -487,6 +500,10 @@ auto RunCppCase(const std::filesystem::path& lyra_exe, const TestCase& c)
   }
   for (const auto& a : c.input.extra_args) {
     argv.push_back(a);
+  }
+  for (const auto& s : c.input.link_sources) {
+    argv.emplace_back("--dpi-link");
+    argv.push_back((c.case_dir / s).string());
   }
   for (const auto& f : resolved_input_files) {
     argv.push_back(f.string());

--- a/tests/framework/runner.hpp
+++ b/tests/framework/runner.hpp
@@ -20,6 +20,9 @@ struct CaseInput {
   std::optional<std::string> top;
   std::vector<std::string> files;
   std::vector<std::string> extra_args;
+  // Native sources (.c / .cpp) providing DPI-C foreign symbols, passed to the
+  // run via `--dpi-link` and linked into the built program (LRM 35).
+  std::vector<std::string> link_sources;
 };
 
 struct ExpectedVariable {


### PR DESCRIPTION
## Summary

A SystemVerilog `import "DPI-C"` scalar function now works end to end on the C++ backend. An imported subroutine lowers to a bodyless external callable; a call to it marshals each `input` actual to its C ABI carrier, calls the foreign symbol, and marshals the result back into the declared return type. The supported surface is 2-state integral scalars, `real`, and `string`, `input`-only functions (LRM 35.4, 35.5.1). A user-provided C source is compiled and linked into the built program through a repeatable `--dpi-link` option, and mixed-language tests assert the round trip.

## Design

The MIR stays backend-agnostic. A DPI import is a receiver-less associated callable stored in a class's static-callable namespace (`StaticCallableDecl`), reached as an ordinary `Direct` call through a new `StaticCallableId` target arm. The boundary carrier is a `DpiCarrierType` -- an ABI-temporary plumbing type that only ever occurs inside a single foreign-call lowering window, never as an SV variable or storage type. Marshaling reuses the ordinary value conversions (`ToInt64` / `FromInt`, the `Real` and `String` constructors, and native `Value` / `c_str` accessors) rather than a DPI-specific runtime primitive family; the integral carrier narrows to its exact C width with an explicit host cast, and a valued result lands into the declared return type's canonical shape. A single `DpiAbiClass -> C++ carrier` table drives both the carrier render and the emitted `extern "C"` declaration. The LLVM / JIT backend half (external foreign-symbol resolution) is future work; the IR already supports it, and `mir_to_lir` gates the external target and carrier with clean diagnostics.

## Testing

`bazel test //...` is green. Three `cpp_run` cases (`dpi_import_int` / `dpi_import_real` / `dpi_import_string`) compile and link a C source and assert the marshaled round trip against `$display`; the string case borrows through a `string` variable to exercise the C-string lifetime. The declaration-time negative diagnostics (`output` / `inout`, `context`, task, 4-state) remain.