### PR TITLE
Elaborate hierarchical designs on the execution backend

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -138,6 +138,11 @@ the detail lives in the entry itself.
   design-level free function. Engine / bind / run stay host runner policy and never enter MIR; both
   backends' host shells collapse to creating the engine, calling the root construct, then bind /
   run.
+- [member-slot-storage](member-slot-storage.md) -- a member is a logical place (a base plus a
+  projection chain, named by load / store); a unit definition declares a member schema and a generic
+  instance owns one runtime-managed slot per member. The C++ backend realizes a member as a native
+  field, the execution backend as a runtime-owned slot; physical in-frame layout is a later
+  optimization, the member-storage counterpart of the opaque-handle value baseline.
 
 ### Compile-time model and specialization
 

--- a/docs/decisions/member-slot-storage.md
+++ b/docs/decisions/member-slot-storage.md
@@ -1,0 +1,98 @@
+# Member storage as runtime-owned typed slots
+
+Date: 2026-07-09 Status: accepted
+
+## Context
+
+A design unit's construct writes into its own members. A scalar submodule instance is attached to
+the runtime tree (`AddOwnedChild`) and, additionally, its borrowed typed handle is stored in a
+companion member of the parent -- the layout-visible head a cross-unit reference projects
+(`self -> companion -> ...`). This store is part of every construct that instantiates a scalar
+submodule, including the synthesized `$root` unit constructing the top-level units.
+
+The C++ backend realizes a member as a native C++ field on its instance subclass; the store is an
+ordinary field assignment the C++ compiler lays out. The execution backend has no such subclass. It
+allocates a generic instance, and until now that instance carried no member storage, so it could not
+run any construct that writes a member -- which is every hierarchical construct, `$root` included.
+
+This is a member-storage question, distinct from the value-realization one
+([jit-value-realization](jit-value-realization.md)) already settled: that decision owns how a
+_value_ (a `PackedArray`, a `String`) crosses the boundary and who owns its transient lifetime.
+Member storage is where an instance's own _places_ live. The two are independent axes.
+
+## Decision
+
+A member is a logical place. A place is a base value plus a projection chain of member / index /
+dereference / ... steps, named by logical identity, and a load or store names a place. A member step
+carries a class-local member identity, never a physical offset. A unit definition declares a member
+schema; a generic instance owns one runtime-managed slot per member, which is how the execution
+backend realizes a member place. This is the member-storage counterpart of the opaque-handle value
+realization: the runtime owns the storage, the generated code addresses it through the ABI, and no
+physical layout is derived.
+
+- **A member is a logical place, realized per backend.** The C++ backend realizes it as a native
+  field; the execution backend realizes it as a runtime-owned slot. Both are the same logical member
+  place -- a base and a member projection reached by load / store; only the realization differs.
+  This matches the LIR contract that a place names storage by logical identity and its physical
+  layout is derived below LIR.
+
+- **The definition carries the member schema; the instance carries the storage.** The
+  per-specialization definition declares how many slots an instance has (a definition-level fact); a
+  generic instance allocates that many runtime-owned slots (an instance-level fact). A backend that
+  lays members out natively leaves the slot count zero and never allocates runtime slots.
+
+- **Physical in-frame layout is a later optimization.** Deriving native field offsets -- so member
+  bytes live in the instance's own storage and value members fold into machine operations -- is the
+  `CodegenLayout` maturity path, not a correctness prerequisite. The runtime-owned slot model is the
+  baseline, exactly as opaque handles are the baseline for values.
+
+### The first realized subset is the typed route slot
+
+The only member the baseline realizes is the borrowed-scope-pointer companion -- the typed head of a
+cross-unit route. A value member (`int i`) needs a physical representation and is part of the later
+layout work; it is not a slot in this baseline. The subset is chosen by what construct-and-own needs
+and what is realizable without physical layout, not by a unit or member being special.
+
+## Rejected alternatives
+
+- **Demand-driven companions (allocate a companion only when a cross-unit reference projects through
+  it).** Whether a companion is needed is known to the _referrer_, which is a different unit than
+  the parent that allocates the member. Deciding member allocation from another unit's body breaks
+  per-unit independent lowering. Even restricted to `$root` -- whose companions are provably dead,
+  since nothing references a top through the root's typed handle -- it special-cases the top level,
+  which the elaboration model deliberately does not do. A dead companion on `$root` is a separate,
+  legitimate later optimization, not the basis for avoiding member storage.
+
+- **Move the typed route head into runtime-owned by-name storage instead of a member.** This would
+  re-express the cross-unit route as a runtime lookup rather than a typed layout-visible slot,
+  changing the hierarchical-routing model. That model is retained here; the route head stays a typed
+  member.
+
+- **Derive physical member layout now.** Making native in-frame layout a precondition turns a
+  performance-and-maturity capability into a correctness gate, exactly the framing rejected for
+  values. The slot model is already correct and uniform.
+
+## Consequences
+
+- The unit definition gains a member-slot count; a generic instance owns that many opaque slots that
+  a member place resolves to. The C++ backend's native fields are unaffected and it leaves the slot
+  count zero.
+- LIR gains a class member schema and the place vocabulary -- a place is a base plus a projection
+  chain, named by load / store -- with a member step carrying a class-local member identity. A LIR
+  verifier checks that a place's base is projectable, its member steps exist, and its load / store
+  types line up. The execution backend realizes a member place as runtime slot access, the C++
+  backend from its own fields.
+- The execution backend can run any construct that writes a member, so it elaborates hierarchical
+  designs and the `$root` unit through the same construct path the C++ backend uses.
+- Physical layout and native value members remain future work; reaching them does not change this
+  baseline.
+
+## Cross-references
+
+- `docs/decisions/jit-value-realization.md` (the independent value-realization axis: opaque handles
+  as the baseline, physical layout later)
+- `docs/decisions/generated-behavior-boundary.md` (the unit definition; allocation stays a backend
+  concern until member storage is unified)
+- `docs/decisions/root-unit-elaboration.md` (the `$root` construct whose companion store this
+  storage realizes)
+- `docs/architecture/lir.md` (a member is a logical place; physical layout is derived below LIR)

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -25,10 +25,13 @@ deleted.
 - [ ] Execution backend -- MIR / LIR lowered to LLVM IR, consumed as either an AOT binary or a JIT
       image. JIT and AOT are link-time choices over one backend, not separate surfaces. Contracts in
       `../architecture/backend_contract.md` and `../architecture/runtime_distribution.md`. Design
-      elaboration (constructing the top-level units) runs on the C++ backend as the synthesized
-      design-root unit's construct (`../decisions/root-unit-elaboration.md`); the execution backend
-      does not yet lower cross-unit construction, so it constructs each top directly, does not run
-      the design-root's elaboration, and does not run a design whose tops instantiate submodules.
+      elaboration runs on both backends as the synthesized design-root unit's construct
+      (`../decisions/root-unit-elaboration.md`): the execution backend lowers cross-unit
+      construction and realizes members as runtime-owned slots
+      (`../decisions/member-slot-storage.md`), so it elaborates a hierarchy of modules through the
+      design-root, matching the C++ backend. Still open on the execution backend: selecting among
+      multiple specializations of one parameterized module at construction, and native layout for
+      value members (the baseline keeps opaque slots).
 - [ ] Per-unit artifact emission -- one artifact per unit specialization, assembled by linking,
       replacing the transitional single-`main.cpp` aggregation. Contract in
       `../architecture/emission_model.md` (inv 1).

--- a/include/lyra/backend/llvm/codegen_function.hpp
+++ b/include/lyra/backend/llvm/codegen_function.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <utility>
 
 #include <llvm/IR/IRBuilder.h>
 
@@ -37,12 +38,24 @@ class CodeGenFunction {
   auto LowerAggregate(const lir::AggregateInstr& agg, lir::TypeId result_type)
       -> llvm::Value*;
   auto LowerOperand(const lir::Operand& operand) -> llvm::Value*;
+
+  // Resolves a place to the base instance and the member slot index its
+  // projection selects, the index already a runtime-ABI constant. Realizes a
+  // single member step so far; a deeper projection chain is realized when its
+  // steps land.
+  auto ResolveMemberSlot(const lir::Place& place)
+      -> std::pair<llvm::Value*, llvm::Value*>;
   auto LowerIntConst(const lir::IntConst& constant) -> llvm::Value*;
   auto LowerStrConst(const lir::StrConst& constant) -> llvm::Value*;
   void LowerTerminator(const lir::Terminator& terminator);
 
   auto BuiltinCallee(support::BuiltinFn fn) -> llvm::FunctionCallee;
   auto ConstructCallee(lir::TypeId result) -> llvm::FunctionCallee;
+
+  // The leading argument a construct call needs beyond its lowered operands: an
+  // external-unit construct is prefixed with the child's definition reference;
+  // every other construct needs none.
+  auto ConstructDefinitionArg(lir::TypeId result) -> llvm::Value*;
 
   CodeGenModule* module_;
   const lir::Function* fn_;

--- a/include/lyra/backend/llvm/codegen_module.hpp
+++ b/include/lyra/backend/llvm/codegen_module.hpp
@@ -14,8 +14,10 @@
 #include "lyra/backend/llvm/emit.hpp"
 #include "lyra/backend/llvm/runtime_abi.hpp"
 #include "lyra/lir/class_id.hpp"
+#include "lyra/lir/type_id.hpp"
 
 namespace llvm {
+class Constant;
 class Function;
 }  // namespace llvm
 
@@ -57,6 +59,13 @@ class CodeGenModule {
   // class and the method's index -- never a reconstructed symbol name.
   auto MethodFunction(lir::ClassId class_id, std::uint32_t index)
       -> llvm::Function*;
+
+  // The definition-reference projection of an external-unit object type: the
+  // address of that unit's runtime definition, as an external symbol the host
+  // resolves. The sibling of `MethodFunction` -- both project a LIR identity to
+  // its artifact. A construct that builds a child of the unit passes this
+  // opaque reference to the runtime; the generated code never inspects it.
+  auto UnitDefinitionRef(lir::TypeId object_type) -> llvm::Constant*;
 
  private:
   void DeclareCallable(

--- a/include/lyra/backend/llvm/emit.hpp
+++ b/include/lyra/backend/llvm/emit.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 namespace llvm {
 class LLVMContext;
@@ -51,5 +52,11 @@ class EmittedModule {
 // value is an opaque handle the runtime builds from a step entry and its
 // environment.
 auto EmitModule(const lir::CompilationUnit& unit) -> EmittedModule;
+
+// The linkage symbol under which a unit publishes its runtime definition. A
+// unit's construct references a child unit's definition by this name; the host
+// resolves it to the built definition object. One source of truth so the
+// producing reference and the resolving host never drift.
+auto UnitDefinitionSymbolName(std::string_view unit_name) -> std::string;
 
 }  // namespace lyra::backend::llvm_backend

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -37,6 +37,25 @@ class RuntimeAbi {
   auto MakePrintLiteralItem() -> llvm::FunctionCallee;
   auto PackedConst() -> llvm::FunctionCallee;
 
+  // Builds a scope's structural identity from its parent-side label and its
+  // per-dimension indices; the runtime owns the resulting segment handle.
+  auto MakeSegment() -> llvm::FunctionCallee;
+
+  // Allocates a generic instance of the unit named by `definition`, runs its
+  // construct entry to build its subtree, and returns the owning handle. The
+  // definition is an opaque cross-unit reference the generated code never
+  // inspects.
+  auto MakeUnit() -> llvm::FunctionCallee;
+
+  // Attaches a freshly built child to its parent's containment edge, returning
+  // the child as a borrowed scope handle.
+  auto AddOwnedChild() -> llvm::FunctionCallee;
+
+  // Reads / writes a member slot of an instance by slot index. A member is a
+  // logical place; the runtime owns the slot storage.
+  auto LoadField() -> llvm::FunctionCallee;
+  auto StoreField() -> llvm::FunctionCallee;
+
  private:
   auto Get(
       const char* name, llvm::Type* result, llvm::ArrayRef<llvm::Type*> params)

--- a/include/lyra/compiler/compile.hpp
+++ b/include/lyra/compiler/compile.hpp
@@ -38,15 +38,21 @@ struct CompileArtifacts {
   // owned children. It is a compiler output distinct from the source units, so
   // the host constructs it directly rather than searching the source set.
   std::optional<mir::CompilationUnit> root_unit;
-  // Each LIR unit borrows the same-index MIR unit above for types and metadata,
-  // so `lir_units` must not outlive `mir_units`. A vector move keeps the MIR
-  // elements at their addresses, so the borrow survives moving these artifacts.
+  // The executable body of each source unit, co-indexed with `mir_units`. Each
+  // LIR unit is self-contained -- it owns its own type graph and holds no
+  // reference back to the MIR it was lowered from.
   std::optional<std::vector<lir::CompilationUnit>> lir_units;
   // The definition metadata of each compiled unit, co-indexed with `lir_units`:
   // a compiled unit is its executable body plus these immutable source-level
   // facts, held apart because LIR carries no source-language concept. A host
   // builds the runtime definition from the two together.
   std::optional<std::vector<ElaboratedUnitMetadata>> unit_metadata;
+  // The design-root unit lowered to its executable body plus metadata, present
+  // exactly when `lir_units` is. The execution backend loads it alongside the
+  // source units and runs its construct to elaborate the design, the same path
+  // the C++ backend takes through the root's constructor.
+  std::optional<lir::CompilationUnit> root_lir_unit;
+  std::optional<ElaboratedUnitMetadata> root_metadata;
   // A subset of the compiled units: a unit reached only through instantiation
   // is compiled but is not a top.
   std::vector<std::string> top_unit_names;

--- a/include/lyra/jit/executor.hpp
+++ b/include/lyra/jit/executor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <span>
+
 namespace lyra::lir {
 struct CompilationUnit;
 }  // namespace lyra::lir
@@ -10,14 +12,18 @@ struct ElaboratedUnitMetadata;
 
 namespace lyra::jit {
 
-// Emits one compilation unit's executable body to an LLVM module, JIT-compiles
-// it in this process, constructs the design against the runtime -- filling the
-// unit definition's constant metadata from `metadata`, the source-level facts
-// LIR does not carry -- and runs the simulation to completion, returning its
-// exit code. The JIT owning the generated code outlives the design, so the
+// JIT-compiles every unit of a design in this process and runs it to
+// completion, returning the simulation's exit code. Each unit's executable body
+// becomes one module; its definition metadata (`metadata`, co-indexed with
+// `units`) fills the constant facts LIR does not carry. The design-root unit's
+// construct elaborates the design by building the top-level units as its owned
+// children -- the same path the C++ backend takes through the root's
+// constructor. The JIT owning the generated code outlives the design, so the
 // runtime's pointers into generated code stay valid for the whole run.
 auto Execute(
-    const lir::CompilationUnit& unit,
-    const compiler::ElaboratedUnitMetadata& metadata) -> int;
+    std::span<const lir::CompilationUnit> units,
+    std::span<const compiler::ElaboratedUnitMetadata> metadata,
+    const lir::CompilationUnit& root_unit,
+    const compiler::ElaboratedUnitMetadata& root_metadata) -> int;
 
 }  // namespace lyra::jit

--- a/include/lyra/lir/compilation_unit.hpp
+++ b/include/lyra/lir/compilation_unit.hpp
@@ -24,12 +24,22 @@ struct RuntimeLibraryBase {
 
 using Base = std::variant<RuntimeLibraryBase>;
 
-// One compiled class: its name, the base it extends, its construction logic,
-// and its callable bodies. Mirrors `mir::Class` with every body lowered to a
-// CFG.
+// A typed member of a class instance -- the storage a member place reaches by a
+// member projection. Its position in this list is its class-local member
+// identity. The C++ backend realizes a member as a native field; a generic
+// runtime instance realizes it as runtime-owned storage.
+struct Member {
+  std::string name;
+  TypeId type;
+};
+
+// One compiled class: its name, the base it extends, its member slots, its
+// construction logic, and its callable bodies. Mirrors `mir::Class` with every
+// body lowered to a CFG.
 struct Class {
   std::string name;
   std::optional<Base> base;
+  std::vector<Member> members;
   Function constructor;
   std::vector<Function> methods;
 };

--- a/include/lyra/lir/function.hpp
+++ b/include/lyra/lir/function.hpp
@@ -100,7 +100,51 @@ struct AggregateInstr {
   std::vector<Operand> elements;
 };
 
-using InstrData = std::variant<CallInstr, AggregateInstr>;
+// A class-local logical member identity: the member's stable declaration-order
+// slot in its class's member list, carried over from the MIR field it lowers
+// from. It is meaningful only together with the base's class/object type --
+// `member 0` of one class is unrelated to `member 0` of another. Never a
+// physical index or byte offset.
+struct MemberId {
+  std::uint32_t value;
+
+  auto operator<=>(const MemberId&) const -> std::strong_ordering = default;
+};
+
+// One step of a place's projection chain: it selects a member of the object the
+// projection has reached so far. The place vocabulary is member, index,
+// dereference, slice, and downcast; only member is realized so far, each
+// further step joining this variant as its feature lands.
+struct MemberProjection {
+  MemberId member;
+};
+
+using Projection = std::variant<MemberProjection>;
+
+// Storage named by logical identity: a base value plus a projection chain of
+// member / index / dereference / ... steps. A place is what a load, store, or
+// address-of names; the physical address it resolves to is derived below LIR,
+// never encoded here. An empty chain names the base itself.
+struct Place {
+  Operand base;
+  std::vector<Projection> chain;
+};
+
+// Reads the value held at `place`. The result's type is the place's type -- the
+// type the projection chain arrives at.
+struct LoadInstr {
+  Place place;
+};
+
+// Writes `value` into `place`. The store yields no value; its instruction
+// result is an unused void.
+struct StoreInstr {
+  Place place;
+  Operand value;
+};
+
+using InstrData =
+    std::variant<CallInstr, AggregateInstr, LoadInstr, StoreInstr>;
 
 // One instruction: it defines `result` (whose type lives on the function's
 // value arena) from `data`.

--- a/include/lyra/lir/verify.hpp
+++ b/include/lyra/lir/verify.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace lyra::lir {
+
+struct CompilationUnit;
+
+// Checks the LIR place model within a unit and throws InternalError on a
+// malformed place: a Load / Store whose base is not projectable to an object,
+// whose member projection is out of range, or whose value / result types do not
+// line up. A narrow first slice -- it verifies places, not the CFG, call ABI,
+// or every instruction; further checks join it as the vocabulary grows. A
+// failure is a compiler-bug invariant, not a user diagnostic.
+void Verify(const CompilationUnit& unit);
+
+}  // namespace lyra::lir

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -33,6 +33,7 @@ class FunctionLowerer {
  private:
   auto LowerStmtInto(const mir::Stmt& stmt) -> diag::Result<void>;
   auto LowerExpr(mir::ExprId id) -> diag::Result<lir::Operand>;
+  auto LowerPlace(mir::ExprId id) -> diag::Result<lir::Place>;
   auto Emit(lir::TypeId type, lir::InstrData data) -> lir::Operand;
 
   UnitLowerer* unit_;

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -27,4 +27,25 @@ void lyra_rt_write(void* files, void* descriptor, void* text);
 auto lyra_rt_make_coroutine(void (*entry)(void*), void* env) -> void*;
 void lyra_rt_register_initial(void* self, void* coroutine);
 void lyra_rt_register_final(void* self, void* coroutine);
+
+// Builds a scope's structural identity from its base label and per-dimension
+// indices (a span of 32-bit index values, empty for a scalar). The segment is
+// a transient runtime value owned by the current call scope.
+auto lyra_rt_make_segment(void* label, LyraSpan indices) -> void*;
+
+// Allocates a generic instance of `definition`, runs its construct entry to
+// build its subtree, and returns the owning handle to the caller (which hands
+// it to `lyra_rt_add_owned_child`). `definition` is an opaque cross-unit
+// reference the generated code never inspects.
+auto lyra_rt_make_unit(
+    const void* definition, void* parent, void* segment, void* services)
+    -> void*;
+
+// Attaches a freshly built child to its parent, transferring ownership into the
+// runtime tree; returns the child as a borrowed scope handle.
+auto lyra_rt_add_owned_child(void* parent, void* child) -> void*;
+
+// Reads / writes a generic instance's member slot by index.
+auto lyra_rt_load_field(void* self, std::uint32_t index) -> void*;
+void lyra_rt_store_field(void* self, std::uint32_t index, void* value);
 }

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -244,6 +244,29 @@ class Instance : public Scope {
   const UnitDefinition* definition_;
 };
 
+// A design-unit instance whose member storage the runtime owns, rather than a
+// backend's native object layout. A generic instance holds one opaque slot per
+// member the definition declares; a member place resolves to one of these slots
+// by index. This is the runtime-owned counterpart of the C++ backend's native
+// member fields: a member is a logical place, and this is its realization when
+// the backend does not lay one out physically.
+class GeneratedInstance : public Instance {
+ public:
+  GeneratedInstance(
+      Scope* parent, HierarchySegment segment, RuntimeServices& services,
+      const UnitDefinition* definition)
+      : Instance(parent, std::move(segment), services, definition),
+        slots_(definition->member_slot_count, nullptr) {
+  }
+
+  [[nodiscard]] auto Slot(std::uint32_t index) -> void*& {
+    return slots_.at(index);
+  }
+
+ private:
+  std::vector<void*> slots_;
+};
+
 // A module-local generate naming scope (`if` / `for` / `case` generate block):
 // an intra-unit owned child that crosses no compilation-unit boundary. It
 // carries its own scope program and no unit metadata.

--- a/include/lyra/runtime/scope_program.hpp
+++ b/include/lyra/runtime/scope_program.hpp
@@ -74,12 +74,16 @@ struct ScopeProgram {
 
 // The immutable per-specialization definition of a design unit: the root
 // scope's program (held by value, so a unit's whole generated behavior is one
-// constant) and the structural-construction entry. Construction is
-// bootstrap-called (a JIT design) or realized by the backend's own constructor
-// (the C++ backend), distinct from the per-phase lifecycle dispatch.
+// constant), the structural-construction entry, and the count of member slots
+// an instance carries. Construction is bootstrap-called (a JIT design) or
+// realized by the backend's own constructor (the C++ backend), distinct from
+// the per-phase lifecycle dispatch. The slot count sizes the runtime-owned
+// storage of a generic instance; a backend that lays members out natively (the
+// C++ backend, whose subclass holds real fields) leaves it zero.
 struct UnitDefinition {
   ScopeProgram root;
   ScopeEntry construct = &ScopeNoOp;
+  std::uint32_t member_slot_count = 0;
 
   constexpr UnitDefinition() = default;
   constexpr UnitDefinition(ScopeProgram root, ScopeEntry construct)

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -26,13 +26,31 @@ auto CodeGenFunction::LowerInstr(const lir::Instr& instr) -> llvm::Value* {
           },
           [&](const lir::AggregateInstr& agg) -> llvm::Value* {
             return LowerAggregate(agg, result_type);
+          },
+          [&](const lir::LoadInstr& load) -> llvm::Value* {
+            const auto [base, member] = ResolveMemberSlot(load.place);
+            return builder_.CreateCall(
+                module_->Runtime().LoadField(), {base, member});
+          },
+          [&](const lir::StoreInstr& store) -> llvm::Value* {
+            const auto [base, member] = ResolveMemberSlot(store.place);
+            return builder_.CreateCall(
+                module_->Runtime().StoreField(),
+                {base, member, LowerOperand(store.value)});
           }},
       instr.data);
 }
 
 auto CodeGenFunction::LowerCall(const lir::CallInstr& call) -> llvm::Value* {
   std::vector<llvm::Value*> args;
-  args.reserve(call.args.size());
+  // A construct that builds a child unit leads with the child's definition
+  // reference, which the result type names rather than the operand list.
+  if (const auto* construct = std::get_if<lir::ConstructTarget>(&call.target)) {
+    if (llvm::Value* definition = ConstructDefinitionArg(construct->result)) {
+      args.push_back(definition);
+    }
+  }
+  args.reserve(args.size() + call.args.size());
   for (const lir::Operand& arg : call.args) {
     args.push_back(LowerOperand(arg));
   }
@@ -104,6 +122,27 @@ auto CodeGenFunction::LowerOperand(const lir::Operand& operand)
       operand);
 }
 
+// The JIT realizes a member place as a runtime-owned slot on the base instance,
+// addressed by the member index. Only a single member step is produced so far;
+// a deeper projection chain (index, dereference) is realized when its steps
+// land.
+auto CodeGenFunction::ResolveMemberSlot(const lir::Place& place)
+    -> std::pair<llvm::Value*, llvm::Value*> {
+  if (place.chain.size() != 1) {
+    throw InternalError(
+        "llvm codegen: only a single-step member place is yet lowerable");
+  }
+  const auto* member = std::get_if<lir::MemberProjection>(&place.chain.front());
+  if (member == nullptr) {
+    throw InternalError(
+        "llvm codegen: only a member projection is yet lowerable");
+  }
+  return {
+      LowerOperand(place.base),
+      llvm::ConstantInt::get(
+          llvm::Type::getInt32Ty(module_->Context()), member->member.value)};
+}
+
 // A machine integer is a native LLVM constant. A packed value has no native
 // constant form in the opaque value model -- it is a runtime object -- so its
 // constant is materialized by a runtime constructor rather than emitted inline.
@@ -160,6 +199,8 @@ auto CodeGenFunction::BuiltinCallee(support::BuiltinFn fn)
       return module_->Runtime().RegisterInitial();
     case support::BuiltinFn::kRegisterFinal:
       return module_->Runtime().RegisterFinal();
+    case support::BuiltinFn::kAddOwnedChild:
+      return module_->Runtime().AddOwnedChild();
     default:
       throw InternalError(
           "llvm codegen: builtin is not yet lowerable to the runtime ABI");
@@ -180,14 +221,42 @@ auto CodeGenFunction::ConstructCallee(lir::TypeId result)
             if (r.kind == lir::RuntimeLibraryKind::kPrintLiteralItem) {
               return module_->Runtime().MakePrintLiteralItem();
             }
+            if (r.kind == lir::RuntimeLibraryKind::kHierarchySegment) {
+              return module_->Runtime().MakeSegment();
+            }
             throw InternalError(
                 "llvm codegen: runtime-library construct is not yet lowerable");
+          },
+          [&](const lir::PointerType& p) -> llvm::FunctionCallee {
+            if (std::holds_alternative<lir::ExternalUnitObjectType>(
+                    module_->Unit().types.Get(p.pointee).data)) {
+              return module_->Runtime().MakeUnit();
+            }
+            throw InternalError(
+                "llvm codegen: pointer construct is not yet lowerable");
           },
           [&](const auto&) -> llvm::FunctionCallee {
             throw InternalError(
                 "llvm codegen: construct result type is not yet lowerable");
           }},
       module_->Unit().types.Get(result).data);
+}
+
+auto CodeGenFunction::ConstructDefinitionArg(lir::TypeId result)
+    -> llvm::Value* {
+  // Only a construct of a pointer to an external unit leads with a definition;
+  // its reference comes from the type-keyed projection, so this call knows the
+  // symbol is needed without knowing how it is named.
+  const auto* pointer =
+      std::get_if<lir::PointerType>(&module_->Unit().types.Get(result).data);
+  if (pointer == nullptr) {
+    return nullptr;
+  }
+  if (!std::holds_alternative<lir::ExternalUnitObjectType>(
+          module_->Unit().types.Get(pointer->pointee).data)) {
+    return nullptr;
+  }
+  return module_->UnitDefinitionRef(pointer->pointee);
 }
 
 }  // namespace lyra::backend::llvm_backend

--- a/src/lyra/backend/llvm/codegen_module.cpp
+++ b/src/lyra/backend/llvm/codegen_module.cpp
@@ -3,8 +3,10 @@
 #include <format>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
+#include <llvm/IR/Constant.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Type.h>
@@ -15,6 +17,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/lir/compilation_unit.hpp"
 #include "lyra/lir/function.hpp"
+#include "lyra/lir/type.hpp"
 
 namespace lyra::backend::llvm_backend {
 
@@ -82,6 +85,23 @@ void CodeGenModule::DeclareCallable(
 auto CodeGenModule::MethodFunction(lir::ClassId class_id, std::uint32_t index)
     -> llvm::Function* {
   return methods_.at(std::pair{class_id.value, index});
+}
+
+auto CodeGenModule::UnitDefinitionRef(lir::TypeId object_type)
+    -> llvm::Constant* {
+  const auto* external = std::get_if<lir::ExternalUnitObjectType>(
+      &unit_->types.Get(object_type).data);
+  if (external == nullptr) {
+    throw InternalError(
+        "llvm codegen: a unit definition reference requires an external-unit "
+        "type");
+  }
+  // The definition is opaque to generated code, which only forwards its
+  // address; an i8 placeholder gives the external symbol a type without
+  // encoding the runtime struct's layout.
+  return module_->getOrInsertGlobal(
+      UnitDefinitionSymbolName(external->unit_name),
+      llvm::Type::getInt8Ty(*context_));
 }
 
 }  // namespace lyra::backend::llvm_backend

--- a/src/lyra/backend/llvm/emit_llvm.cpp
+++ b/src/lyra/backend/llvm/emit_llvm.cpp
@@ -1,5 +1,7 @@
+#include <format>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <llvm/IR/LLVMContext.h>
@@ -35,6 +37,10 @@ auto EmittedModule::Release() && -> Owned {
 
 auto EmitModule(const lir::CompilationUnit& unit) -> EmittedModule {
   return CodeGenModule(unit).Run();
+}
+
+auto UnitDefinitionSymbolName(std::string_view unit_name) -> std::string {
+  return std::format("{}.definition", unit_name);
 }
 
 }  // namespace lyra::backend::llvm_backend

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -79,4 +79,32 @@ auto RuntimeAbi::PackedConst() -> llvm::FunctionCallee {
        llvm::Type::getInt1Ty(*ctx_), llvm::Type::getInt1Ty(*ctx_)});
 }
 
+auto RuntimeAbi::MakeSegment() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_make_segment", types_->Ptr(), {types_->Ptr(), types_->Span()});
+}
+
+auto RuntimeAbi::MakeUnit() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_make_unit", types_->Ptr(),
+      {types_->Ptr(), types_->Ptr(), types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::AddOwnedChild() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_add_owned_child", types_->Ptr(), {types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::LoadField() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_load_field", types_->Ptr(),
+      {types_->Ptr(), llvm::Type::getInt32Ty(*ctx_)});
+}
+
+auto RuntimeAbi::StoreField() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_store_field", types_->Void(),
+      {types_->Ptr(), llvm::Type::getInt32Ty(*ctx_), types_->Ptr()});
+}
+
 }  // namespace lyra::backend::llvm_backend

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -9,6 +9,7 @@
 #include "lyra/frontend/load.hpp"
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/lir/verify.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
@@ -128,6 +129,7 @@ auto Compile(
       return result;
     }
     lir_units.push_back(*std::move(lir_or));
+    lir::Verify(lir_units.back());
     unit_metadata.push_back(BuildUnitMetadata(mir_units.back()));
   }
 
@@ -135,10 +137,11 @@ auto Compile(
   // so it references them by the same cross-unit-by-name link every submodule
   // instantiation uses. It is a distinct compiler output, not one of the source
   // units, so it is held apart rather than mixed into `mir_units`. Its
-  // constructor elaborates the design through cross-unit construction, which
-  // MIR-to-LIR does not yet lower, so it is not carried to LIR; the execution
-  // backend constructs each top unit directly.
+  // constructor elaborates the design through the same owned-child construction
+  // any parent uses, lowered like any other unit.
   std::optional<mir::CompilationUnit> root_unit;
+  std::optional<lir::CompilationUnit> root_lir_unit;
+  std::optional<ElaboratedUnitMetadata> root_metadata;
   if (want_mir) {
     const hir::ModuleUnit root_hir =
         BuildRootHirUnit(result.artifacts.top_unit_names);
@@ -150,6 +153,16 @@ auto Compile(
       return result;
     }
     root_unit = *std::move(root_mir);
+    if (want_lir) {
+      auto root_lir = lowering::mir_to_lir::LowerUnit(*root_unit);
+      if (!root_lir) {
+        sink.Report(std::move(root_lir.error()));
+        return result;
+      }
+      root_lir_unit = *std::move(root_lir);
+      lir::Verify(*root_lir_unit);
+      root_metadata = BuildUnitMetadata(*root_unit);
+    }
   }
 
   result.artifacts.hir_units = std::move(hir_units);
@@ -160,6 +173,8 @@ auto Compile(
   if (want_lir) {
     result.artifacts.lir_units = std::move(lir_units);
     result.artifacts.unit_metadata = std::move(unit_metadata);
+    result.artifacts.root_lir_unit = std::move(root_lir_unit);
+    result.artifacts.root_metadata = std::move(root_metadata);
   }
 
   return result;

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <argparse/argparse.hpp>
 #include <cstdio>
 #include <exception>
@@ -463,12 +462,17 @@ auto main(int argc, char** argv) -> int {
         for (const auto& unit : *result.artifacts.lir_units) {
           fmt::print("{}", lyra::lir::DumpLir(unit));
         }
+        fmt::print("{}", lyra::lir::DumpLir(*result.artifacts.root_lir_unit));
         return 0;
       case CommandKind::kDumpLlvm:
         for (const auto& unit : *result.artifacts.lir_units) {
           fmt::print(
               "{}", lyra::backend::llvm_backend::EmitModule(unit).Print());
         }
+        fmt::print(
+            "{}", lyra::backend::llvm_backend::EmitModule(
+                      *result.artifacts.root_lir_unit)
+                      .Print());
         return 0;
       case CommandKind::kEmitCpp: {
         auto runtime = resolve_runtime();
@@ -513,23 +517,13 @@ auto main(int argc, char** argv) -> int {
       case CommandKind::kRun:
         switch (args.backend) {
           case Backend::kJit: {
-            const auto& lir_units = *result.artifacts.lir_units;
-            const auto& unit_metadata = *result.artifacts.unit_metadata;
-            const auto& top_names = result.artifacts.top_unit_names;
-            // The JIT constructs each top unit directly (it does not yet lower
-            // the synthesized design-root unit's cross-unit construction), so
-            // it runs only the top-level units, skipping `$root` and
-            // submodules.
-            int exit_code = 0;
-            for (std::size_t i = 0; i < lir_units.size(); ++i) {
-              const auto& name =
-                  lir_units[i].classes.Get(lir_units[i].root).name;
-              if (std::ranges::find(top_names, name) == top_names.end()) {
-                continue;
-              }
-              exit_code = lyra::jit::Execute(lir_units[i], unit_metadata[i]);
-            }
-            return exit_code;
+            // The design-root unit's construct elaborates the whole design,
+            // building the top-level units as its owned children, so the JIT
+            // runs the design once from that one entry rather than per top.
+            return lyra::jit::Execute(
+                *result.artifacts.lir_units, *result.artifacts.unit_metadata,
+                *result.artifacts.root_lir_unit,
+                *result.artifacts.root_metadata);
           }
           case Backend::kAot:
           case Backend::kLli:

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
@@ -24,6 +25,7 @@
 #include "lyra/runtime/hierarchy_segment.hpp"
 #include "lyra/runtime/jit_execution.hpp"
 #include "lyra/runtime/scope.hpp"
+#include "lyra/runtime/scope_program.hpp"
 #include "lyra/runtime/simulation_entry.hpp"
 
 namespace lyra::jit {
@@ -71,94 +73,147 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_make_coroutine", &lyra_rt_make_coroutine);
   add("lyra_rt_register_initial", &lyra_rt_register_initial);
   add("lyra_rt_register_final", &lyra_rt_register_final);
+  add("lyra_rt_make_segment", &lyra_rt_make_segment);
+  add("lyra_rt_make_unit", &lyra_rt_make_unit);
+  add("lyra_rt_add_owned_child", &lyra_rt_add_owned_child);
+  add("lyra_rt_load_field", &lyra_rt_load_field);
+  add("lyra_rt_store_field", &lyra_rt_store_field);
   Check(
       jit.getMainJITDylib().define(
           llvm::orc::absoluteSymbols(std::move(symbols))),
       "define runtime abi");
 }
 
-}  // namespace
-
-auto Execute(
-    const lir::CompilationUnit& unit,
-    const compiler::ElaboratedUnitMetadata& metadata) -> int {
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
-
-  auto jit = Unwrap(llvm::orc::LLJITBuilder().create(), "create jit");
-  DefineRuntimeAbi(*jit);
-
-  auto owned = backend::llvm_backend::EmitModule(unit).Release();
-  Check(
-      jit->addIRModule(
-          llvm::orc::ThreadSafeModule(
-              std::move(owned.module), std::move(owned.context))),
-      "add module");
-
+// Fills a unit's runtime definition from its JIT-compiled entries and its
+// source-level metadata. The lifecycle entries are ABI-compatible native
+// functions over the generic scope receiver; an entry the scope has no work for
+// is absent and keeps the runtime no-op default. Looking a symbol up here
+// materializes its module, which resolves that module's cross-unit definition
+// references -- every definition symbol is injected before any is filled, so
+// those references find their address regardless of fill order.
+void FillDefinition(
+    llvm::orc::LLJIT& jit, const lir::CompilationUnit& unit,
+    const compiler::ElaboratedUnitMetadata& metadata,
+    runtime::UnitDefinition& definition) {
   const lir::Class& root_class = unit.classes.Get(unit.root);
   auto lookup =
       [&](std::string_view entry) -> std::optional<llvm::orc::ExecutorAddr> {
-    auto symbol = jit->lookup(root_class.name + "." + std::string(entry));
+    auto symbol = jit.lookup(root_class.name + "." + std::string(entry));
     if (!symbol) {
       llvm::consumeError(symbol.takeError());
       return std::nullopt;
     }
     return *symbol;
   };
-
-  // The linked module supplies each lifecycle entry as an ABI-compatible native
-  // function over the generic scope receiver (`void(Scope*)`); an entry the
-  // scope has no work for is absent and keeps the runtime no-op default. The
-  // constant metadata comes from the unit's definition metadata, not from the
-  // executable body -- LIR carries no time precision or def name. The program,
-  // definition, and the metadata whose name the def-name borrows all outlive
-  // the simulation, which runs to completion below before this frame returns.
-  runtime::ScopeProgram program;
-  program.metadata.def_name = runtime::AbiStringRef(
+  definition.root.metadata.def_name = runtime::AbiStringRef(
       metadata.def_name.data(),
       static_cast<std::uint32_t>(metadata.def_name.size()));
-  program.metadata.time_precision_power = metadata.time_precision_power;
+  definition.root.metadata.time_precision_power = metadata.time_precision_power;
   if (auto entry = lookup("ResolveState")) {
-    program.resolve_state = entry->toPtr<runtime::ScopeEntry>();
+    definition.root.resolve_state = entry->toPtr<runtime::ScopeEntry>();
   }
   if (auto entry = lookup("InitializeState")) {
-    program.initialize_state = entry->toPtr<runtime::ScopeEntry>();
+    definition.root.initialize_state = entry->toPtr<runtime::ScopeEntry>();
   }
   if (auto entry = lookup("CreateProcesses")) {
-    program.create_processes = entry->toPtr<runtime::ScopeEntry>();
+    definition.root.create_processes = entry->toPtr<runtime::ScopeEntry>();
   }
-
-  runtime::UnitDefinition definition;
-  definition.root = program;
   if (auto entry = lookup("constructor")) {
     definition.construct = entry->toPtr<runtime::ScopeEntry>();
+  }
+  definition.member_slot_count =
+      static_cast<std::uint32_t>(root_class.members.size());
+}
+
+// One design unit loaded into the JIT: its executable body, its source-level
+// metadata, and the runtime definition built from the two, which owns a stable
+// address the runtime and peer units reference.
+struct LoadedUnit {
+  const lir::CompilationUnit* unit;
+  const compiler::ElaboratedUnitMetadata* metadata;
+  std::unique_ptr<runtime::UnitDefinition> definition;
+};
+
+}  // namespace
+
+auto Execute(
+    std::span<const lir::CompilationUnit> units,
+    std::span<const compiler::ElaboratedUnitMetadata> metadata,
+    const lir::CompilationUnit& root_unit,
+    const compiler::ElaboratedUnitMetadata& root_metadata) -> int {
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+
+  auto jit = Unwrap(llvm::orc::LLJITBuilder().create(), "create jit");
+  DefineRuntimeAbi(*jit);
+
+  // Every unit -- the source units and the design-root -- becomes one module in
+  // the shared JIT, so a unit's construct reaches another unit's entries and
+  // definition by symbol. Each unit's definition owns a stable address for the
+  // whole run; the runtime holds pointers into it. The root is loaded and
+  // driven like any other unit, distinguished only as the bootstrap entry
+  // below.
+  std::vector<LoadedUnit> loaded;
+  loaded.reserve(units.size() + 1);
+  for (std::size_t i = 0; i < units.size(); ++i) {
+    loaded.push_back(
+        LoadedUnit{
+            .unit = &units[i],
+            .metadata = &metadata[i],
+            .definition = std::make_unique<runtime::UnitDefinition>()});
+  }
+  loaded.push_back(
+      LoadedUnit{
+          .unit = &root_unit,
+          .metadata = &root_metadata,
+          .definition = std::make_unique<runtime::UnitDefinition>()});
+
+  for (const LoadedUnit& entry : loaded) {
+    auto owned = backend::llvm_backend::EmitModule(*entry.unit).Release();
+    Check(
+        jit->addIRModule(
+            llvm::orc::ThreadSafeModule(
+                std::move(owned.module), std::move(owned.context))),
+        "add module");
+  }
+
+  // A unit publishes its definition as an injected data symbol its peers'
+  // construct entries reference. Each definition is filled from the unit's
+  // JIT-compiled entries after every definition's address is injected, so a
+  // cross-unit reference resolves regardless of the order the units are filled.
+  llvm::orc::SymbolMap definition_symbols;
+  for (const LoadedUnit& entry : loaded) {
+    const std::string symbol = backend::llvm_backend::UnitDefinitionSymbolName(
+        entry.unit->classes.Get(entry.unit->root).name);
+    definition_symbols[jit->getExecutionSession().intern(symbol)] =
+        llvm::orc::ExecutorSymbolDef(
+            llvm::orc::ExecutorAddr::fromPtr(entry.definition.get()),
+            llvm::JITSymbolFlags::Exported);
+  }
+  Check(
+      jit->getMainJITDylib().define(
+          llvm::orc::absoluteSymbols(std::move(definition_symbols))),
+      "define unit definitions");
+
+  for (const LoadedUnit& entry : loaded) {
+    FillDefinition(*jit, *entry.unit, *entry.metadata, *entry.definition);
   }
 
   runtime::Engine engine;
 
-  // The design-root unit's constructor elaborates the design by building the
-  // top-level units through the cross-unit construct ABI, which this backend
-  // does not yet lower. The JIT therefore constructs the top unit directly and
-  // adopts it under a no-op `$root`; the engine then walks the built tree
-  // exactly as for any backend.
-  static constexpr runtime::ScopeProgram kRootProgram{};
-  auto root = std::make_unique<runtime::Scope>(
+  // The design-root unit's construct elaborates the design: it builds the
+  // top-level units through the cross-unit construct ABI, which recurses into
+  // their subtrees. The bootstrap allocates the root instance and runs that
+  // construct in a generated-call scope, exactly as the runtime enters any
+  // construct entry; the engine then walks the built tree.
+  const runtime::UnitDefinition& root_definition = *loaded.back().definition;
+  auto root = std::make_unique<runtime::GeneratedInstance>(
       nullptr, runtime::HierarchySegment{"$root", {}}, engine.Services(),
-      &kRootProgram);
-  auto top = std::make_unique<runtime::Instance>(
-      root.get(), runtime::HierarchySegment{root_class.name, {}},
-      engine.Services(), &definition);
-
-  // Construction runs generated code that allocates opaque value temporaries in
-  // the ambient arena, so the bootstrap driver wraps the construct call in a
-  // generated-call scope. The lifecycle phases in BindDesign each establish
-  // their own scope at the runtime's per-call boundary; each process body does
-  // the same when the simulation resumes it.
+      &root_definition);
   {
     runtime::GeneratedCallScope construct_scope;
-    definition.construct(top.get());
+    root_definition.construct(root.get());
   }
-  root->AddOwnedChild(std::move(top));
   engine.BindDesign(std::move(root));
   return runtime::RunSimulation(engine);
 }

--- a/src/lyra/lir/dump.cpp
+++ b/src/lyra/lir/dump.cpp
@@ -39,6 +39,12 @@ class LirDumper {
     if (cls.base.has_value()) {
       Line(std::format("Base: {}", FormatBase(*cls.base)));
     }
+    for (std::size_t i = 0; i < cls.members.size(); ++i) {
+      Line(
+          std::format(
+              "member[{}] \"{}\" : {}", i, cls.members[i].name,
+              FormatType(cls.members[i].type)));
+    }
     DumpFunction(cls.constructor);
     for (const Function& method : cls.methods) {
       DumpFunction(method);
@@ -86,6 +92,14 @@ class LirDumper {
             },
             [&](const AggregateInstr& agg) -> std::string {
               return std::format("aggregate({})", FormatOperands(agg.elements));
+            },
+            [&](const LoadInstr& load) -> std::string {
+              return std::format("load {}", FormatPlace(load.place));
+            },
+            [&](const StoreInstr& store) -> std::string {
+              return std::format(
+                  "store {} = {}", FormatPlace(store.place),
+                  FormatOperand(store.value));
             }},
         data);
   }
@@ -144,6 +158,18 @@ class LirDumper {
         out += ", ";
       }
       out += FormatOperand(ops[i]);
+    }
+    return out;
+  }
+
+  [[nodiscard]] static auto FormatPlace(const Place& place) -> std::string {
+    std::string out = FormatOperand(place.base);
+    for (const Projection& step : place.chain) {
+      std::visit(
+          Overloaded{[&](const MemberProjection& m) {
+            out += std::format(".member({})", m.member.value);
+          }},
+          step);
     }
     return out;
   }

--- a/src/lyra/lir/verify.cpp
+++ b/src/lyra/lir/verify.cpp
@@ -1,0 +1,153 @@
+#include "lyra/lir/verify.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <variant>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
+#include "lyra/lir/class_id.hpp"
+#include "lyra/lir/compilation_unit.hpp"
+#include "lyra/lir/function.hpp"
+#include "lyra/lir/type.hpp"
+#include "lyra/lir/type_id.hpp"
+
+namespace lyra::lir {
+
+namespace {
+
+// The class an object-or-pointer-to-object type names, peeling the borrowed
+// pointer a receiver arrives through. A type that is neither an object nor a
+// pointer to one is not projectable by a member step.
+auto AsClassId(const CompilationUnit& unit, TypeId type)
+    -> std::optional<ClassId> {
+  return std::visit(
+      Overloaded{
+          [](const ObjectType& o) -> std::optional<ClassId> {
+            return o.class_id;
+          },
+          [&](const PointerType& p) -> std::optional<ClassId> {
+            return AsClassId(unit, p.pointee);
+          },
+          [](const auto&) -> std::optional<ClassId> { return std::nullopt; }},
+      unit.types.Get(type).data);
+}
+
+// A reference-like type crosses as one opaque handle: distinct reference types
+// (a borrowed scope pointer, a borrowed unit pointer) share a representation,
+// so a store between them is a reinterpretation the MIR pointer cast already
+// justified, not a type error.
+auto IsReference(const CompilationUnit& unit, TypeId type) -> bool {
+  return std::visit(
+      Overloaded{
+          [](const PointerType&) { return true; },
+          [](const RefType&) { return true; },
+          [](const ManagedRefType&) { return true; },
+          [](const auto&) { return false; }},
+      unit.types.Get(type).data);
+}
+
+auto IsVoid(const CompilationUnit& unit, TypeId type) -> bool {
+  return std::holds_alternative<VoidType>(unit.types.Get(type).data);
+}
+
+auto OperandType(const Function& fn, const Operand& op)
+    -> std::optional<TypeId> {
+  return std::visit(
+      Overloaded{
+          [&](const Use& u) -> std::optional<TypeId> {
+            return fn.values.Get(u.value).type;
+          },
+          [](const IntConst& c) -> std::optional<TypeId> { return c.type; },
+          [](const StrConst& c) -> std::optional<TypeId> { return c.type; },
+          [](const FuncRef&) -> std::optional<TypeId> { return std::nullopt; }},
+      op);
+}
+
+// The type a place's projection chain arrives at: the base's storage type,
+// projected one step at a time. Each member step resolves the base to a class
+// and selects the member's declared type.
+auto PlaceType(
+    const CompilationUnit& unit, const Function& fn, const Place& place)
+    -> TypeId {
+  const std::optional<TypeId> base = OperandType(fn, place.base);
+  if (!base) {
+    throw InternalError("lir verify: place base has no storage type");
+  }
+  TypeId current = *base;
+  for (const Projection& step : place.chain) {
+    std::visit(
+        Overloaded{[&](const MemberProjection& m) {
+          const std::optional<ClassId> class_id = AsClassId(unit, current);
+          if (!class_id) {
+            throw InternalError(
+                "lir verify: member projection on a non-object base");
+          }
+          const Class& cls = unit.classes.Get(*class_id);
+          if (m.member.value >= cls.members.size()) {
+            throw InternalError(
+                std::format(
+                    "lir verify: member index {} out of range on class '{}'",
+                    m.member.value, cls.name));
+          }
+          current = cls.members[m.member.value].type;
+        }},
+        step);
+  }
+  return current;
+}
+
+void VerifyFunction(const CompilationUnit& unit, const Function& fn) {
+  for (const BasicBlock& block : fn.blocks) {
+    for (const Instr& instr : block.instrs) {
+      const TypeId result_type = fn.values.Get(instr.result).type;
+      std::visit(
+          Overloaded{
+              [&](const LoadInstr& load) {
+                const TypeId place_type = PlaceType(unit, fn, load.place);
+                if (result_type != place_type) {
+                  throw InternalError(
+                      "lir verify: load result type does not match its place "
+                      "type");
+                }
+              },
+              [&](const StoreInstr& store) {
+                const TypeId place_type = PlaceType(unit, fn, store.place);
+                const std::optional<TypeId> value_type =
+                    OperandType(fn, store.value);
+                if (!value_type) {
+                  throw InternalError("lir verify: store value has no type");
+                }
+                const bool compatible = *value_type == place_type ||
+                                        (IsReference(unit, *value_type) &&
+                                         IsReference(unit, place_type));
+                if (!compatible) {
+                  throw InternalError(
+                      "lir verify: store value type is not compatible with its "
+                      "place type");
+                }
+                if (!IsVoid(unit, result_type)) {
+                  throw InternalError("lir verify: store must yield void");
+                }
+              },
+              [](const CallInstr&) {}, [](const AggregateInstr&) {}},
+          instr.data);
+    }
+  }
+}
+
+}  // namespace
+
+void Verify(const CompilationUnit& unit) {
+  for (std::size_t i = 0; i < unit.classes.size(); ++i) {
+    const Class& cls = unit.classes.Get(ClassId{static_cast<std::uint32_t>(i)});
+    VerifyFunction(unit, cls.constructor);
+    for (const Function& method : cls.methods) {
+      VerifyFunction(unit, method);
+    }
+  }
+}
+
+}  // namespace lyra::lir

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -265,12 +265,59 @@ auto FunctionLowerer::LowerExpr(mir::ExprId id) -> diag::Result<lir::Operand> {
             // the cast lowers to its operand unchanged.
             return LowerExpr(c.operand);
           },
+          [&](const mir::FieldAccessExpr&) -> diag::Result<lir::Operand> {
+            auto place = LowerPlace(id);
+            if (!place) {
+              return std::unexpected(std::move(place.error()));
+            }
+            return Emit(
+                unit_->TranslateType(type),
+                lir::LoadInstr{.place = *std::move(place)});
+          },
+          [&](const mir::AssignExpr& assign) -> diag::Result<lir::Operand> {
+            if (assign.compound_op.has_value()) {
+              return diag::Fail(
+                  diag::DiagCode::kUnsupportedExpressionForm,
+                  "mir_to_lir: a compound assignment is not yet lowerable to "
+                  "LIR");
+            }
+            auto place = LowerPlace(assign.target);
+            if (!place) {
+              return std::unexpected(std::move(place.error()));
+            }
+            auto value = LowerExpr(assign.value);
+            if (!value) {
+              return std::unexpected(std::move(value.error()));
+            }
+            Emit(
+                unit_->TranslateType(unit_->Mir().builtins.void_type),
+                lir::StoreInstr{.place = *std::move(place), .value = *value});
+            return *std::move(value);
+          },
           [](const auto&) -> diag::Result<lir::Operand> {
             return diag::Fail(
                 diag::DiagCode::kUnsupportedExpressionForm,
                 "mir_to_lir: MIR expression form is not yet lowerable to LIR");
           }},
       expr.data);
+}
+
+auto FunctionLowerer::LowerPlace(mir::ExprId id) -> diag::Result<lir::Place> {
+  const mir::Expr& expr = code_->body.exprs.Get(id);
+  const auto* field = std::get_if<mir::FieldAccessExpr>(&expr.data);
+  if (field == nullptr) {
+    return diag::Fail(
+        diag::DiagCode::kUnsupportedExpressionForm,
+        "mir_to_lir: only a member access is yet lowerable to a place");
+  }
+  auto base = LowerExpr(field->receiver);
+  if (!base) {
+    return std::unexpected(std::move(base.error()));
+  }
+  return lir::Place{
+      .base = *std::move(base),
+      .chain = {lir::Projection{
+          lir::MemberProjection{.member = lir::MemberId{field->field.value}}}}};
 }
 
 auto FunctionLowerer::Emit(lir::TypeId type, lir::InstrData data)

--- a/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
@@ -52,6 +52,13 @@ auto UnitLowerer::LowerClass(lir::ClassId class_id, const mir::Class& cls)
     out.base = LowerBase(*cls.base);
   }
 
+  for (std::size_t i = 0; i < cls.fields.size(); ++i) {
+    const mir::FieldDecl& field =
+        cls.fields.Get(mir::FieldId{static_cast<std::uint32_t>(i)});
+    out.members.push_back(
+        lir::Member{.name = field.name, .type = TranslateType(field.type)});
+  }
+
   auto constructor =
       FunctionLowerer(*this, cls.constructor, "constructor", class_id).Run();
   if (!constructor) {

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -1,14 +1,19 @@
 #include "lyra/runtime/jit_execution.hpp"
 
+#include <cstdint>
+#include <memory>
 #include <span>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/file_table.hpp"
 #include "lyra/runtime/generated_call_scope.hpp"
+#include "lyra/runtime/hierarchy_segment.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/scope.hpp"
+#include "lyra/runtime/scope_program.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/string.hpp"
@@ -39,8 +44,11 @@ auto RunGeneratedProcess(GeneratedEntry entry, void* env) -> Coroutine<void> {
 using lyra::runtime::Coroutine;
 using lyra::runtime::FileTable;
 using lyra::runtime::GeneratedCallScope;
+using lyra::runtime::GeneratedInstance;
+using lyra::runtime::HierarchySegment;
 using lyra::runtime::RuntimeServices;
 using lyra::runtime::Scope;
+using lyra::runtime::UnitDefinition;
 using lyra::value::Format;
 using lyra::value::PackedArray;
 using lyra::value::PrintItem;
@@ -115,5 +123,44 @@ void lyra_rt_register_initial(void* self, void* coroutine) {
 void lyra_rt_register_final(void* self, void* coroutine) {
   static_cast<Scope*>(self)->AbiRegisterFinal(
       std::move(*static_cast<Coroutine<void>*>(coroutine)));
+}
+
+auto lyra_rt_make_segment(void* label, LyraSpan indices) -> void* {
+  const std::span<const std::int32_t> values(
+      static_cast<const std::int32_t*>(indices.data), indices.count);
+  std::vector<PackedArray> resolved;
+  resolved.reserve(values.size());
+  for (const std::int32_t index : values) {
+    resolved.push_back(PackedArray::FromInt(index, 32, false, false));
+  }
+  return GeneratedCallScope::Current().Arena().New<HierarchySegment>(
+      std::string(static_cast<const char*>(label)), resolved);
+}
+
+auto lyra_rt_make_unit(
+    const void* definition, void* parent, void* segment, void* services)
+    -> void* {
+  const auto* def = static_cast<const UnitDefinition*>(definition);
+  auto instance = std::make_unique<GeneratedInstance>(
+      static_cast<Scope*>(parent), *static_cast<HierarchySegment*>(segment),
+      *static_cast<RuntimeServices*>(services), def);
+  {
+    GeneratedCallScope scope;
+    def->construct(instance.get());
+  }
+  return instance.release();
+}
+
+auto lyra_rt_add_owned_child(void* parent, void* child) -> void* {
+  return static_cast<Scope*>(parent)->AddOwnedChild(
+      std::unique_ptr<Scope>(static_cast<Scope*>(child)));
+}
+
+auto lyra_rt_load_field(void* self, std::uint32_t index) -> void* {
+  return static_cast<GeneratedInstance*>(self)->Slot(index);
+}
+
+void lyra_rt_store_field(void* self, std::uint32_t index, void* value) {
+  static_cast<GeneratedInstance*>(self)->Slot(index) = value;
 }
 }

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -1,4 +1,3 @@
-#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -34,6 +33,20 @@ auto WriteTrivialSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+// A two-level hierarchy: the top instantiates a submodule, and each level runs
+// an initial block. Elaborating it exercises the design-root unit constructing
+// the top and the top constructing its submodule as owned children.
+auto WriteHierarchicalSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Leaf;\n"
+      << "  initial $display(\"leaf ran\");\n"
+      << "endmodule\n"
+      << "module Test;\n"
+      << "  Leaf a();\n"
+      << "  initial $display(\"top ran\");\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -50,6 +63,31 @@ TEST(LyraRun, ExecutesSourceEndToEnd) {
       << run.stdout_text << run.stderr_text;
   EXPECT_EQ(run.exit_code, 0) << run.stderr_text;
   EXPECT_NE(run.stdout_text.find("ran 42"), std::string::npos)
+      << "stdout: " << run.stdout_text;
+}
+
+// The JIT backend elaborates the design through the synthesized design-root
+// unit's construct: it builds the top as an owned child, and the top builds its
+// submodule, so both levels' initial blocks run. This is the execution-backend
+// counterpart of the C++ backend's constructor-driven elaboration.
+TEST(LyraRun, JitElaboratesHierarchyThroughDesignRoot) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteHierarchicalSource(src);
+
+  const std::vector<std::string> args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto run = RunChildProcess(lyra, args, 120s);
+  ASSERT_EQ(run.termination, TerminationKind::kExitedNormally)
+      << run.stdout_text << run.stderr_text;
+  EXPECT_EQ(run.exit_code, 0) << run.stderr_text;
+  EXPECT_NE(run.stdout_text.find("top ran"), std::string::npos)
+      << "stdout: " << run.stdout_text;
+  EXPECT_NE(run.stdout_text.find("leaf ran"), std::string::npos)
       << "stdout: " << run.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

The execution backend (JIT) now elaborates a design the same way the C++ backend does: it runs the synthesized `$root` unit's generated construct, which builds the top-level modules as its owned children, and each of those builds its own submodules. This makes hierarchical designs runnable on the execution backend for the first time, and removes the old bypass that constructed each top directly under a no-op `$root`. Both backends now drive the design through the one `$root` construct path.

Reaching that required members to have storage on the execution backend, because a construct that instantiates a scalar submodule stores the child's borrowed typed handle into a companion member of the parent -- `$root` included. The generic runtime instance previously had no member storage, so this lands the first permanent slice of member layout: a member is a logical place, realized as a runtime-owned slot on the execution backend and as a native field on the C++ backend.

## Design

The member model is the LIR place vocabulary from `lir.md`, not a compact stopgap: a place is a base value plus a projection chain of member / index / dereference / ... steps, and a load or store names a place. Only the member step is realized so far; the rest of the vocabulary joins as its features land. A member step carries a class-local logical member identity (the stable declaration-order slot carried over from the MIR field), never a physical offset -- the physical realization is derived below LIR. A new narrow `lir::Verify` checks the place model: a place's base is projectable, its member steps exist on the base's class, and its load / store types line up; a violation is a compiler-bug invariant.

Cross-unit construction reuses the existing owned-child primitive: `$root` and every hierarchical unit lower to LIR, and a construct of another unit resolves that unit's definition through a type-keyed projection (`UnitDefinitionRef`), the LLVM sibling of the C++ backend's type-name projection of the same `ExternalUnitObjectType`. The JIT loads every unit as its own module, injects each definition's address as a linked symbol before filling any, and bootstraps the design by running `$root`'s construct.

### What did not change

The opaque-handle runtime ABI is unchanged in shape: a member place still resolves to a runtime-owned `void*` slot the generated code reaches through the ABI. Physical in-frame layout and native value members remain future work; reaching them reuses the same place instructions. Two decision docs record the model: `member-slot-storage.md` and the existing `root-unit-elaboration.md`.

## Testing

`bazel test //...` is green. A new end-to-end case runs a two-level hierarchy through `run --backend jit` and asserts both levels' initial blocks execute, differentially matching the C++ backend.