### PR TITLE
State construction as a protocol on the class

### DIFF
--- a/docs/decisions/parameter-code-shape-over-approximation.md
+++ b/docs/decisions/parameter-code-shape-over-approximation.md
@@ -26,15 +26,16 @@ knows it is intended.
 
 ## Findings that shaped the design
 
-### F1. The constructor-input vehicle already exists, used narrowly
+### F1. No MIR-level constructor-input vehicle exists today
 
 The architecture's target shape -- a value that flows into the constructor rather than being baked
--- is already implemented and running: `mir::Class.params` plus the `ParamRef` expression. Today it
-carries exactly one thing: the `generate for` loop variable, threaded as a structural parameter into
-each generate-arm scope so the arm body reads the genvar as a runtime value. The generate loop bound
-is an expression evaluated in the constructor (`hir::LoopGenerate` holds it as an `ExprId`), so
-`generate for` / `generate if` already lower to constructor-time logic. The vehicle is proven;
-module parameters simply do not ride it yet -- they are constant-folded.
+-- is not present in MIR. `generate for` folds the loop variable per arm and constructs each arm's
+own concrete scalar child directly, so the arm body reads the genvar as a compile-time constant. The
+generate loop bound is still an expression evaluated in the constructor (`hir::LoopGenerate` holds
+it as an `ExprId`), but no structural parameter is threaded onto the arm scope for later runtime
+read. The infrastructure to thread a constructor-input value (a scope-level runtime parameter the
+constructor body reads as a runtime value) has not been built yet, so no existing vehicle stands
+ready for module parameters to reuse when the classification lands.
 
 ### F2. Over-approximating the specialization key is sound, not a hack
 
@@ -101,7 +102,9 @@ Two constraints bind going forward, so that deferring the optimization does not 
 ## Consequences
 
 - No classification tool and no module-parameter-as-constructor-input threading are built now. The
-  existing genvar vehicle (`mir::Class.params` / `ParamRef`) is the seam the future work extends.
+  future work builds the constructor-input vehicle from scratch: a scope-level runtime parameter
+  that the constructor body reads as a runtime value, with `generate for` and module parameters
+  wired onto it together.
 - When compile-time sharing across parameter values becomes a turnaround-budget problem, the
   deferred work is: classify parameters per `specialization_model.md` invariants 2-4; thread the
   constructor-input axis as runtime parameters by extending the genvar vehicle to module parameters;

--- a/docs/decisions/variable-initialization.md
+++ b/docs/decisions/variable-initialization.md
@@ -27,9 +27,9 @@ Before this decision, MIR carried the variable initializer two ways:
 
 The C++ backend plucked path (1) into an inline class-body NSDMI (`Var<int> a{1};`) and rendered
 path (2) inside a static `init(Self* self)` helper. A `RenderContext::in_class_member_init_` flag
-switched receiver-access rendering between NSDMI position and function-body position, because
-`MemberAccessExpr(self, X)` and `ParamRef(p)` had to spell as the bare field name in NSDMI scope but
-`self->X` in the body.
+switched receiver-access rendering between NSDMI position and function-body position, because a
+member access (a class field, a structural param read) had to spell as the bare field name in NSDMI
+scope but as `self->X` in the body.
 
 The two-channel shape forced every backend to read state from two places. It also locked the render
 to a C++-specific syntactic mode dependency that a LIR / LLVM-IR backend would have no analogue for.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -676,26 +676,19 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       so the former linear search per access -- the one remaining place the backend re-derived
       information the lowering already had -- is gone.
 
-- [ ] R51 -- Close R45's last asymmetry: a class constructor should be a `mir::MethodDecl` resolved
-      through `Construct` like any other callable, not a separate `CallableCode` field on the side.
-      R45 unified the call side onto `Direct / Indirect / Construct`, so a child construction at a
-      parent's body already emits a generic `Construct(self, segment, services, structural...)`
-      callee whose args are plain MIR primitives. The receiver side -- the constructor declaration
-      -- is now a `Class::constructor` `CallableCode` carrying its own signature
-      (`locals[0] = self`), but it is still a separate field rather than a `MethodDecl` resolved
-      through `Construct` like any other callable; the C++ ctor entry args
-      (`parent / segment / services / structural...`) are not in MIR at all. The interim shape lands
-      the prefix args as `Class::ctor_prefix_params` so the render can iterate without restating any
-      type literal, and the render forwards each prefix arg to the base by pure name pass-through
-      (no `std::move`) -- which causes one `HierarchySegment` copy per scope construction. The
-      principled close: make the constructor a `MethodDecl` carrying its full signature, let the
-      call site's `Construct` callee resolve to it like any other callable, and let the C++ render
-      share the generic method renderer with one C++-specific mem-init mapping. Moving args into the
-      base init list then becomes an explicit MIR primitive (a `Move(expr)` wrapper or equivalent
-      data-flow encoding) rather than a render-time type-kind heuristic, so the copy can be elided
-      without the render learning what `HierarchySegment` / `Scope*` / `RuntimeServices&` mean.
-      **Likely interacts with**: R8 (callable-model unification) and R47 (SV class object model),
-      since both touch what "a class with a body" looks like at MIR.
+- [x] R51 -- Class construction is stated as a protocol on the class rather than side fields on the
+      class or render conventions in the backend. `Class::constructor` is a `ConstructorDecl`
+      pairing (a) the ctor's callable code, stored as an ordinary `MethodDecl` in `Class::methods`,
+      with (b) explicit base and per-field initialization ordered before the body runs. The C++
+      render composes the mem-init list from those stated facts alone; the interim
+      `Class::ctor_prefix_params` / `Class::params` / `Class::base_init` side fields are removed,
+      the prefix params flow through the ctor's own signature, and `ParamRef` (dead vocabulary tied
+      to the removed `Class::params`) is gone. Value transfer to the base call is an explicit
+      `MoveExpr` MIR primitive that the C++ backend translates mechanically to `std::move(...)`; an
+      alias-style handle (services / files / diagnostic) is exempt via `Type::IsAliasHandle` rather
+      than a render-side pattern match, so the render learns no runtime type name. The previous
+      `HierarchySegment` copy per scope construction is elided as a consequence; the LLVM path
+      treats `MoveExpr` as pass-through and defers transfer to LIR liveness.
 
 - [ ] R52 -- Collapse the closure environment and the activation frame onto MIR's value/reference
       spine. The design round this entry once held is resolved: the contract is

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -12,6 +12,7 @@
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/field.hpp"
 #include "lyra/mir/method.hpp"
+#include "lyra/mir/method_id.hpp"
 #include "lyra/mir/param.hpp"
 #include "lyra/mir/static_callable.hpp"
 #include "lyra/mir/static_callable_id.hpp"
@@ -36,17 +37,39 @@ struct StaticConstantDecl {
   ExprId value;
 };
 
+// A constructor's invocation of its base's constructor. Every arg evaluates in
+// the enclosing constructor's local scope. The callee identity is implicit --
+// it is the base declared on the class this ConstructorDecl belongs to; there
+// is exactly one base and exactly one constructor per class, so restating the
+// callee here would duplicate structure the class already fixes. Absent when
+// the class extends nothing.
+struct BaseInit {
+  std::vector<ExprId> args;
+};
+
+// The class's construction protocol -- distinct from the callable code that
+// runs the constructor body. The body is an ordinary callable stored beside
+// the other class methods, reached by the `method` index; construction facts
+// the body does not itself express -- how the base is initialized and how a
+// field gets its pre-body initializer -- live here. A consumer that emits
+// construction reads `base_init` and `member_inits` in declaration order,
+// then descends into the method body.
+struct ConstructorDecl {
+  MethodId method;
+  std::optional<BaseInit> base_init;
+  std::vector<FieldInit> member_inits;
+};
+
 // The structural portion of a class declaration: the fields a peer needs to
 // read about a class while its own body is being lowered. Each field has the
 // same semantics as the same-named field on `Class`; the executable parts
-// (`constructor_block`, `methods`) are not represented here.
+// (`constructor`, `methods`) are not represented here.
 struct ClassShape {
   std::string name;
   std::optional<ClassRef> base;
   TypeId self_pointer_type;
   TimeResolution time_resolution;
   base::Arena<ParamDecl, ParamId> ctor_prefix_params;
-  base::Arena<ParamDecl, ParamId> params;
   base::Arena<FieldDecl, FieldId> fields;
   std::vector<ClassId> contained;
   std::vector<TypeAliasDecl> type_aliases;
@@ -66,25 +89,11 @@ struct Class {
   // class exposes the precision so the engine can take the design-global
   // minimum (LRM 3.14.3) and so delays scale to it.
   TimeResolution time_resolution;
-  // The C++ ctor params that forward to the runtime base ctor -- the
-  // `(parent, segment, services)` trio for a Scope-derived class, the
-  // empty list for a baseless plain object. The lowering populates them
-  // by reading the runtime SDK contract for the chosen base; the render
-  // walks the list to emit the prefix signature and the base init list
-  // generically. Decoupling type names from the render layer: the only
-  // place that knows "Scope* / HierarchySegment / RuntimeServices&" mean
-  // those C++ tokens is the MIR-level RenderTypeAsCpp dispatch.
-  base::Arena<ParamDecl, ParamId> ctor_prefix_params;
-  // Structural ctor params that also install a same-named member field
-  // (a genvar binding, an upward-class param). Each renders as a ctor
-  // param after the prefix list and as a `field(param)` mem-init entry.
-  base::Arena<ParamDecl, ParamId> params;
   base::Arena<FieldDecl, FieldId> fields;
-  // Construction logic, run when the object is allocated. A callable like any
-  // other: `params[0]` is the receiver `self`, body locals live in its `locals`
-  // arena. The backend's C++ constructor is the allocation shell that kicks
-  // this off; an empty body needs no kickoff.
-  CallableCode constructor;
+  // The class's construction protocol. The callable code that runs the ctor
+  // body is stored beside the other methods; base and per-field
+  // initialization not expressible in that body live on the protocol itself.
+  ConstructorDecl constructor;
   // The classes this one structurally owns -- the children it builds and, for a
   // backend that nests, emits inside itself. Each names a registry identity, in
   // construction order. Ownership of the declarations is the unit's registry;
@@ -100,8 +109,8 @@ struct Class {
   base::Arena<MethodDecl, MethodId> methods;
   // The class-level static constants this class owns, emitted as static
   // members. A runtime scope's generated-behavior record is one such constant;
-  // the constructor forwards its address to the runtime base through
-  // `base_init`.
+  // the constructor forwards its address to the runtime base through the
+  // construction protocol.
   base::Arena<StaticConstantDecl, StaticConstantId> static_constants;
   // The class-level static callables this class owns -- receiver-less callables
   // in its associated namespace, the callable peer of the static constants. A
@@ -109,17 +118,22 @@ struct Class {
   // in the instance method arena is one. Empty for a class that declares no
   // static callable.
   base::Arena<StaticCallableDecl, StaticCallableId> static_callables;
-  // The base-constructor arguments beyond the forwarded prefix params, as
-  // ordinary MIR expressions the backend translates in order (their expression
-  // tree lives in `constructor.body.exprs`). A runtime tree node passes the
-  // address of its generated-behavior constant here; a plain object passes
-  // none.
-  std::vector<ExprId> base_init;
   std::vector<TypeAliasDecl> type_aliases;
 
   void AddTypeAlias(TypeAliasDecl decl) {
     type_aliases.push_back(std::move(decl));
   }
 };
+
+// The ctor's callable code. A convenience for consumers that read the ctor
+// as an opaque callable rather than dereferencing the construction
+// protocol's method index by hand.
+//
+// Read-only: the arena backing the method is append-only, and the ctor is
+// finalized before insertion, so any post-add mutation would violate value
+// immutability.
+inline auto GetConstructorCode(const Class& c) -> const CallableCode& {
+  return c.methods.Get(c.constructor.method).code;
+}
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -14,7 +14,6 @@
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/local_ref.hpp"
 #include "lyra/mir/method_id.hpp"
-#include "lyra/mir/param.hpp"
 #include "lyra/mir/static_callable_id.hpp"
 #include "lyra/mir/static_constant_id.hpp"
 #include "lyra/mir/struct_construct.hpp"
@@ -200,6 +199,22 @@ struct AddressOfExpr {
   ExprId operand;
 };
 
+// A consuming (transfer) read of the operand: the operand's contents flow
+// into the enclosing expression as the last use of that operand's storage,
+// and no subsequent read of the same storage is valid. `Expr::type` is the
+// operand's type -- move does not change what value the expression yields,
+// only how ownership crosses the boundary. Lowering emits this at last-use
+// sites where the backend must transfer rather than copy (a ctor param
+// forwarded to the base construction); an ordinary read stays a plain
+// expression.
+//
+// Operand must be a type whose value can be transferred. Alias-style handle
+// types carry no ownership to move, so lowering never wraps them here -- a
+// move primitive over an alias is a semantic type error.
+struct MoveExpr {
+  ExprId operand;
+};
+
 // Reinterprets a borrowed pointer as a pointer to a different pointee type.
 // `operand` is a pointer-typed expression; `Expr::type` is the destination
 // `PointerType`. Used when a runtime entry returns a type-erased pointer
@@ -342,9 +357,9 @@ struct StaticConstantRef {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
-    HostIntLiteral, ParamRef, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
+    HostIntLiteral, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
     ConditionalExpr, AssignExpr, IncDecExpr, CallExpr, DerefExpr, AddressOfExpr,
-    PointerCastExpr, CastExpr, FieldAccessExpr, StructConstructExpr,
+    MoveExpr, PointerCastExpr, CastExpr, FieldAccessExpr, StructConstructExpr,
     ClosureExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr, TupleExpr,
     AwaitExpr, TupleGetExpr, UnionExpr, UnionGetExpr, UnionGetRefExpr,
     FunctionRef, StaticConstantRef>;

--- a/include/lyra/mir/param.hpp
+++ b/include/lyra/mir/param.hpp
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <string>
 
-#include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
@@ -18,17 +17,6 @@ struct ParamId {
 struct ParamDecl {
   std::string name;
   TypeId type;
-};
-
-// A read of a constructor-bound structural param (a generate `genvar` per LRM
-// 27.4), addressed like a field: `receiver` is the scope object that owns the
-// param -- `self` for a same-scope read, an enclosing-scope object reached by
-// climbing the object tree for a cross-scope read -- and `param` names the
-// field on that object. The climb is baked into `receiver`, parallel to
-// `FieldAccessExpr`, so the read needs no enclosing-hop count of its own.
-struct ParamRef {
-  ExprId receiver = {};
-  ParamId param = {};
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -574,6 +574,12 @@ struct Type {
   // distinguish should match on the variant directly.
   [[nodiscard]] auto IsIntegralPacked() const -> bool;
   [[nodiscard]] auto AsIntegralPacked() const -> const PackedArrayType&;
+  // True for a stable runtime facade the backend realizes as a live reference
+  // rather than a movable value -- the runtime services handle, the file
+  // table handle, the diagnostic dispatcher handle. Lowering sites that
+  // decide whether an operand may be transferred consult this: an alias
+  // handle carries no ownership to move.
+  [[nodiscard]] auto IsAliasHandle() const -> bool;
 };
 
 class CompilationUnit;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -20,7 +20,6 @@
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/field.hpp"
-#include "lyra/mir/param.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::backend::cpp {
@@ -53,18 +52,6 @@ auto RenderFieldList(
     out += RenderField(view, field, indent);
   }
   return out;
-}
-
-auto RenderParamField(
-    const mir::CompilationUnit& unit, const mir::Class& owner_class,
-    const mir::ParamDecl& param, std::size_t indent) -> std::string {
-  return std::format(
-      "{}const {} {};\n", Indent(indent),
-      RenderTypeAsCpp(unit, owner_class, param.type), param.name);
-}
-
-auto CtorParamName(std::size_t index) -> std::string {
-  return std::format("param{}", index);
 }
 
 auto RenderMethodParam(
@@ -107,9 +94,8 @@ auto RenderMethod(
   return out;
 }
 
-// Joins string parts with ", " for emission of ctor sig args, base init
-// forwards, and member-init list entries. Local to RenderConstructor; the
-// rest of the file does not yet need a shared helper.
+// Joins string parts with ", " for emission of ctor sig args, base-init
+// forwards, and member-init list entries.
 auto JoinCommaSeparated(const std::vector<std::string>& parts) -> std::string {
   std::string out;
   for (const auto& part : parts) {
@@ -122,55 +108,50 @@ auto JoinCommaSeparated(const std::vector<std::string>& parts) -> std::string {
 }
 
 auto RenderConstructor(
-    const ScopeView& scope_view, const mir::Class& s,
-    const std::string& base_class, std::size_t indent) -> std::string {
-  // The render iterates every ctor entry in MIR-stated order without
-  // switching on what each type means: ctor_prefix_params forward to the
-  // base by name, structural params bind to same-named fields.
-  // Each type goes through the single RenderTypeAsCpp dispatch, so the
-  // C++ form of every type lives in exactly one place. Base forwarding is
-  // plain pass-through (no std::move) -- C++ may copy a HierarchySegment
-  // once at construction, which the iteration-time budget can absorb.
-  //
-  // The base's trailing arguments (a tree node forwards the address of its
-  // generated-behavior constant) arrive as ordinary MIR expressions in
-  // `base_init`, translated in order after the prefix params.
+    const ScopeView& scope_view, const mir::Class& s, std::size_t indent)
+    -> std::string {
+  // The C++ ctor is composed from the class's construction protocol: the
+  // ctor's own callable carries the signature (with `self` at position 0
+  // per MIR contract -- omitted here because C++ makes `this` implicit); the
+  // base-init phase carries the args to forward to the base ctor; each
+  // member-init maps a field to its initializing expression. The body is the
+  // ctor callable's own body, threaded through a static `init(self)` helper
+  // so a body-local `self` reference resolves the same way it does in every
+  // other method render.
   const auto& unit = scope_view.Unit();
+  const auto& ctor_code = mir::GetConstructorCode(s);
   const auto render_typed_name = [&](mir::TypeId type, std::string_view name) {
     return std::format("{} {}", RenderTypeAsCpp(unit, s, type), name);
   };
 
   std::vector<std::string> sig_args;
-  std::vector<std::string> base_forwards;
-  std::vector<std::string> field_inits;
-  sig_args.reserve(s.ctor_prefix_params.size() + s.params.size());
-  base_forwards.reserve(s.ctor_prefix_params.size() + s.base_init.size());
-  field_inits.reserve(s.params.size());
-
-  for (std::size_t i = 0; i < s.ctor_prefix_params.size(); ++i) {
-    const auto& p =
-        s.ctor_prefix_params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
+  sig_args.reserve(ctor_code.params.size());
+  // Skip params[0] (self, MIR contract); the C++ ctor's receiver is `this`.
+  for (std::size_t i = 1; i < ctor_code.params.size(); ++i) {
+    const auto& p = ctor_code.locals.Get(ctor_code.params[i]);
     sig_args.push_back(render_typed_name(p.type, p.name));
-    base_forwards.push_back(p.name);
-  }
-  for (const mir::ExprId arg : s.base_init) {
-    base_forwards.push_back(RenderExpr(scope_view, scope_view.Expr(arg)));
-  }
-  for (std::size_t i = 0; i < s.params.size(); ++i) {
-    const auto& p = s.params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
-    const auto param_name = CtorParamName(i);
-    sig_args.push_back(render_typed_name(p.type, param_name));
-    field_inits.push_back(std::format("{}({})", p.name, param_name));
   }
 
   std::vector<std::string> init_parts;
-  init_parts.reserve(1 + field_inits.size());
-  if (!s.ctor_prefix_params.empty()) {
+  if (s.constructor.base_init.has_value()) {
+    const std::string base_class = RenderTypeAsCpp(
+        unit, s, mir::ResolveBaseContract(unit, *s.base).renderable);
+    std::vector<std::string> base_args_rendered;
+    base_args_rendered.reserve(s.constructor.base_init->args.size());
+    for (const mir::ExprId arg : s.constructor.base_init->args) {
+      base_args_rendered.push_back(
+          RenderExpr(scope_view, scope_view.Expr(arg)));
+    }
     init_parts.push_back(
-        std::format("{}({})", base_class, JoinCommaSeparated(base_forwards)));
+        std::format(
+            "{}({})", base_class, JoinCommaSeparated(base_args_rendered)));
   }
-  for (auto& f : field_inits) {
-    init_parts.push_back(std::move(f));
+  for (const mir::FieldInit& mi : s.constructor.member_inits) {
+    const auto& f = s.fields.Get(mi.target);
+    init_parts.push_back(
+        std::format(
+            "{}({})", f.name,
+            RenderExpr(scope_view, scope_view.Expr(mi.value))));
   }
 
   const std::string cpp_name = ToCppName(s.name);
@@ -181,15 +162,10 @@ auto RenderConstructor(
                 "{}({}) : {}", cpp_name, JoinCommaSeparated(sig_args),
                 JoinCommaSeparated(init_parts));
 
-  // The C++ constructor is the one shape that is not an ordinary method:
-  // it has no result type and runs a member-init list before its body, so
-  // it is not a lifecycle entry -- construction precedes elaboration. It is an
-  // allocation shell that forwards to the base and the field members, then
-  // kicks off the body -- a static worker over `self`, the same shape
-  // every method uses. An empty body needs no kickoff.
-  if (s.constructor.body.root_stmts.empty()) {
-    return std::format("{}{} {{}}\n", Indent(indent), sig);
-  }
+  // The C++ ctor is an allocation shell that forwards to the base and the
+  // field members, then hands off to a static `init(self)` -- the same
+  // static-over-self shape every method render uses, so a body-local self
+  // reference resolves as `self` here just like in any other body.
   return std::format(
       "{0}{1} {{ init(this); }}\n"
       "{0}static auto init({2}* self) -> void {{\n"
@@ -231,7 +207,7 @@ auto RenderStaticConstant(
     const ScopeView& parent_view, const mir::Class& s,
     const mir::StaticConstantDecl& c, std::size_t indent) -> std::string {
   const ScopeView view =
-      parent_view.WithClass(s, s.constructor).WithBlock(c.body);
+      parent_view.WithClass(s, mir::GetConstructorCode(s)).WithBlock(c.body);
   return std::format(
       "\n{0}static constexpr {1} {2} = {3};\n", Indent(indent),
       RenderTypeAsCpp(parent_view.Unit(), s, c.type), c.name,
@@ -246,8 +222,8 @@ auto RenderScopeAsClass(
   // class (one hop above the child).
   const ScopeView this_anchor =
       (parent_struct_view == nullptr)
-          ? ScopeView::ForRoot(unit, s, s.constructor)
-          : parent_struct_view->WithClass(s, s.constructor);
+          ? ScopeView::ForRoot(unit, s, mir::GetConstructorCode(s))
+          : parent_struct_view->WithClass(s, mir::GetConstructorCode(s));
 
   const std::optional<mir::BaseContract> base =
       s.base.has_value()
@@ -277,26 +253,11 @@ auto RenderScopeAsClass(
     out += "\n";
   }
 
-  // A tree node forwards to its runtime base; a plain object (a class) has no
-  // base but still runs its constructor body to initialize its members. Either
-  // way the constructor is emitted when there is a base to forward to or a body
-  // to run; a baseless object with an empty body keeps the implicit default.
-  if (base.has_value()) {
-    out += RenderConstructor(
-        this_anchor, s, RenderTypeAsCpp(unit, s, base->renderable), indent + 1);
-  } else if (!s.constructor.body.root_stmts.empty()) {
-    out += RenderConstructor(this_anchor, s, "", indent + 1);
-  }
+  out += RenderConstructor(this_anchor, s, indent + 1);
 
   // Members follow the constructor and methods. They are public so cross-unit
   // references can reach them directly.
-  if (!s.params.empty() || !s.fields.empty()) {
-    out += "\n";
-  }
-  for (const auto& p : s.params) {
-    out += RenderParamField(unit, s, p, indent + 1);
-  }
-  if (!s.params.empty() && !s.fields.empty()) {
+  if (!s.fields.empty()) {
     out += "\n";
   }
   out += RenderFieldList(this_anchor, s.fields, indent + 1);
@@ -304,9 +265,14 @@ auto RenderScopeAsClass(
   // Each method declares its access -- a class instance method is the object's
   // public callable surface, a scope's processes and lifecycle hooks are
   // internal -- and the access specifier follows that stated visibility,
-  // coalescing a run of methods that share one.
+  // coalescing a run of methods that share one. The ctor lives in the same
+  // method storage but is emitted separately with C++ mem-init-list syntax,
+  // so it is skipped here.
   std::optional<mir::MethodVisibility> open_section;
-  for (const auto& sub : s.methods) {
+  for (std::size_t i = 0; i < s.methods.size(); ++i) {
+    const mir::MethodId mid{static_cast<std::uint32_t>(i)};
+    if (mid == s.constructor.method) continue;
+    const auto& sub = s.methods.Get(mid);
     if (open_section != sub.visibility) {
       open_section = sub.visibility;
       out += std::format(

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -167,16 +167,6 @@ auto RenderRealLiteralExpr(
       "lyra::value::{}{{{}}}", is_short ? "ShortReal" : "Real", body);
 }
 
-auto RenderParamExpr(const ScopeView& view, const mir::ParamRef& r)
-    -> std::string {
-  const mir::Expr& receiver = view.Expr(r.receiver);
-  const auto& ptr =
-      std::get<mir::PointerType>(view.Unit().types.Get(receiver.type).data);
-  const std::string& name =
-      view.ClassByObjectType(ptr.pointee).params.Get(r.param).name;
-  return std::format("{}->{}", RenderExpr(view, receiver), name);
-}
-
 auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
     -> std::string {
   // Every callable body is a static function over the explicit receiver `self`
@@ -839,9 +829,6 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
           [](const mir::HostIntLiteral& h) -> std::string {
             return std::format("{}LL", h.value);
           },
-          [&](const mir::ParamRef& r) -> std::string {
-            return RenderParamExpr(view, r);
-          },
           [&](const mir::LocalRef& l) -> std::string {
             return LookupLocalName(view, l);
           },
@@ -874,6 +861,10 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
           },
           [&](const mir::AddressOfExpr& a) -> std::string {
             return RenderAddressOfExpr(view, a);
+          },
+          [&](const mir::MoveExpr& m) -> std::string {
+            return std::format(
+                "std::move({})", RenderExpr(view, view.Expr(m.operand)));
           },
           [&](const mir::PointerCastExpr& c) -> std::string {
             return RenderPointerCastExpr(view, c, expr.type);

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -41,8 +41,6 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
       .base = std::nullopt,
       .self_pointer_type = self_pointer_type,
       .time_resolution = {},
-      .ctor_prefix_params = {},
-      .params = {},
       .fields = {},
       .constructor = {},
       .contained = {},
@@ -50,9 +48,12 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
       .methods = {},
       .static_constants = {},
       .static_callables = {},
-      .base_init = {},
       .type_aliases = {}};
 
+  // The constructor's callable code is built in a local first, then handed
+  // to the class's method storage last so its id sits after every
+  // declaration-ordered SV method -- each SV method keeps its natural
+  // declaration index.
   mir::CallableCode ctor_code;
   CallableBindings ctor_bindings(module.Unit(), ctor_code);
   const mir::LocalId self_id = ctor_bindings.Declare(
@@ -145,7 +146,14 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
 
   ctor_code.params = {self_id};
   ctor_code.result_type = module.Unit().builtins.void_type;
-  mir_class.constructor = std::move(ctor_code);
+  const mir::MethodId ctor_method_id = mir_class.methods.Add(
+      mir::MethodDecl{
+          .name = "<ctor>",
+          .code = std::move(ctor_code),
+          .overrides = std::nullopt,
+          .visibility = mir::MethodVisibility::kInternal});
+  mir_class.constructor = mir::ConstructorDecl{
+      .method = ctor_method_id, .base_init = std::nullopt, .member_inits = {}};
 
   return mir_class;
 }

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -799,30 +799,12 @@ auto InstallPortConnections(
 }
 
 void ValidateOwnedChildConstruction(
-    ModuleLowerer& module, const mir::Class& owner_class,
-    const mir::Block& block, mir::ClassId child_scope_id,
-    std::span<const mir::ExprId> ctor_args) {
+    const mir::Class& owner_class, mir::ClassId child_scope_id) {
   if (std::ranges::find(owner_class.contained, child_scope_id) ==
       owner_class.contained.end()) {
     throw InternalError(
         "owned-child construction: child scope is not a direct child of the "
         "enclosing class");
-  }
-  const auto& child_scope_shape = module.GetClassShape(child_scope_id);
-  if (ctor_args.size() != child_scope_shape.params.size()) {
-    throw InternalError(
-        "owned-child construction: args count does not match child class "
-        "param count");
-  }
-  for (std::size_t i = 0; i < ctor_args.size(); ++i) {
-    const auto& arg = block.exprs.Get(ctor_args[i]);
-    const auto& param = child_scope_shape.params.Get(
-        mir::ParamId{static_cast<std::uint32_t>(i)});
-    if (arg.type != param.type) {
-      throw InternalError(
-          "owned-child construction: arg type does not match structural "
-          "param type");
-    }
   }
 }
 
@@ -840,12 +822,11 @@ void ValidateOwnedChildConstruction(
 void AppendOwnedChildConstruction(
     ModuleLowerer& module, const WalkFrame& arm_frame,
     const std::string& runtime_label, mir::ClassId child_scope_id,
-    std::vector<mir::ExprId> ctor_args, std::optional<mir::ExprId> array_index,
+    std::optional<mir::ExprId> array_index,
     std::optional<mir::FieldId> companion_field) {
   mir::Block& arm_block = *arm_frame.current_block;
   const mir::Class& owner_class = *arm_frame.current_class;
-  ValidateOwnedChildConstruction(
-      module, owner_class, arm_block, child_scope_id, ctor_args);
+  ValidateOwnedChildConstruction(owner_class, child_scope_id);
 
   const auto& builtins = module.Unit().builtins;
   const mir::TypeId self_ptr_type = owner_class.self_pointer_type;
@@ -888,14 +869,11 @@ void AppendOwnedChildConstruction(
           .type = builtins.hierarchy_segment});
 
   std::vector<mir::ExprId> ctor_call_args;
-  ctor_call_args.reserve(3 + ctor_args.size());
+  ctor_call_args.reserve(3);
   ctor_call_args.push_back(self_read());
   ctor_call_args.push_back(segment_id);
   ctor_call_args.push_back(
       arm_block.exprs.Add(BuildServicesCallExpr(module, arm_frame)));
-  for (const mir::ExprId arg : ctor_args) {
-    ctor_call_args.push_back(arg);
-  }
   const mir::ExprId ctor_call_id = arm_block.exprs.Add(
       mir::Expr{
           .data =
@@ -958,8 +936,8 @@ auto LowerResolvedGenerate(
       index_id = body.exprs.Add(mir::MakeInt32Literal(int32_type, *item.index));
     }
     AppendOwnedChildConstruction(
-        lowerer.Module(), body_frame, binding.label, binding.scope_id, {},
-        index_id, binding.companion);
+        lowerer.Module(), body_frame, binding.label, binding.scope_id, index_id,
+        binding.companion);
   }
   const mir::BlockId body_id = block.child_scopes.Add(std::move(body));
   return mir::Stmt{
@@ -1337,13 +1315,13 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
 // -- a UnitDefinition adding the construct entry. A class that is not a runtime
 // tree node gets none.
 auto InstallGeneratedDefinition(
-    mir::CompilationUnit& unit, mir::Class& cls,
+    mir::CompilationUnit& unit, mir::Class& cls, mir::CallableCode& ctor_code,
     std::optional<mir::MethodId> resolve_body,
     std::optional<mir::MethodId> init_body,
-    std::optional<mir::MethodId> create_body) -> void {
+    std::optional<mir::MethodId> create_body) -> std::vector<mir::ExprId> {
   const mir::BaseContract contract = mir::ResolveBaseContract(unit, *cls.base);
   if (!contract.is_runtime_tree_node) {
-    return;
+    return {};
   }
   const bool is_unit =
       contract.representation == mir::ScopeRepresentationKind::kUnitInstance;
@@ -1444,7 +1422,7 @@ auto InstallGeneratedDefinition(
   const mir::StaticConstantId def_id = cls.static_constants.Add(std::move(def));
 
   // The constructor hands the base the address of the constant just installed.
-  auto& cex = cls.constructor.body.exprs;
+  auto& cex = ctor_code.body.exprs;
   const mir::ExprId ref = cex.Add(
       mir::Expr{
           .data = mir::StaticConstantRef{.constant = def_id},
@@ -1454,7 +1432,49 @@ auto InstallGeneratedDefinition(
           .data = mir::AddressOfExpr{.operand = ref},
           .type = unit.types.PointerTo(
               const_type, mir::PointerOwnership::kBorrowed)});
-  cls.base_init = {addr};
+  return {addr};
+}
+
+// Composes the base-init arg list (each prefix forwarded as a consuming use,
+// followed by trailing args), moves the ctor callable into the class's
+// method storage, and points the construction protocol at it. `ctor_code`
+// must be finalized (params and result_type set) but not yet inserted into
+// the arena.
+void FinalizeConstructor(
+    mir::CompilationUnit& unit, mir::Class& cls, mir::CallableCode ctor_code,
+    const std::vector<mir::LocalId>& prefix_local_ids,
+    const std::vector<mir::ExprId>& base_trailing_args) {
+  std::optional<mir::BaseInit> base_init_opt;
+  if (cls.base.has_value()) {
+    std::vector<mir::ExprId> base_args;
+    base_args.reserve(prefix_local_ids.size() + base_trailing_args.size());
+    for (const mir::LocalId id : prefix_local_ids) {
+      const mir::TypeId ty = ctor_code.locals.Get(id).type;
+      const mir::ExprId local_ref = ctor_code.body.exprs.Add(
+          mir::Expr{.data = mir::LocalRef{.var = id}, .type = ty});
+      if (unit.types.Get(ty).IsAliasHandle()) {
+        base_args.push_back(local_ref);
+      } else {
+        base_args.push_back(ctor_code.body.exprs.Add(
+            mir::Expr{
+                .data = mir::MoveExpr{.operand = local_ref}, .type = ty}));
+      }
+    }
+    for (const mir::ExprId e : base_trailing_args) {
+      base_args.push_back(e);
+    }
+    base_init_opt = mir::BaseInit{.args = std::move(base_args)};
+  }
+  const mir::MethodId ctor_method_id = cls.methods.Add(
+      mir::MethodDecl{
+          .name = "<ctor>",
+          .code = std::move(ctor_code),
+          .overrides = std::nullopt,
+          .visibility = mir::MethodVisibility::kInternal});
+  cls.constructor = mir::ConstructorDecl{
+      .method = ctor_method_id,
+      .base_init = std::move(base_init_opt),
+      .member_inits = {}};
 }
 
 auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
@@ -1469,8 +1489,6 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   mir_class.base = shape.base;
   mir_class.self_pointer_type = shape.self_pointer_type;
   mir_class.time_resolution = shape.time_resolution;
-  mir_class.ctor_prefix_params = shape.ctor_prefix_params;
-  mir_class.params = shape.params;
   mir_class.fields = shape.fields;
   mir_class.contained = shape.contained;
   mir_class.type_aliases = shape.type_aliases;
@@ -1516,6 +1534,17 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   mir::CallableCode ctor_code;
   CallableBindings ctor_bindings(module.Unit(), ctor_code);
   const mir::LocalId self_id = seed_self(ctor_bindings);
+  // Each prefix param the base contract demands lands as an ordinary local
+  // after `self`, so a base call reads it as a plain LocalRef and the ctor
+  // signature exposes it as a regular parameter.
+  std::vector<mir::LocalId> ctor_prefix_local_ids;
+  ctor_prefix_local_ids.reserve(shape.ctor_prefix_params.size());
+  for (std::size_t i = 0; i < shape.ctor_prefix_params.size(); ++i) {
+    const auto& p = shape.ctor_prefix_params.Get(
+        mir::ParamId{static_cast<std::uint32_t>(i)});
+    ctor_prefix_local_ids.push_back(ctor_bindings.DeclareAnonymous(
+        mir::LocalDecl{.name = p.name, .type = p.type}));
+  }
   mir::Block& ctor_block = ctor_code.body;
   const WalkFrame ctor_frame =
       parent_frame.WithClass(&mir_class, outer_scope_link)
@@ -1708,8 +1737,6 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     sub_class.base = sub_shape.base;
     sub_class.self_pointer_type = sub_shape.self_pointer_type;
     sub_class.time_resolution = sub_shape.time_resolution;
-    sub_class.ctor_prefix_params = sub_shape.ctor_prefix_params;
-    sub_class.params = sub_shape.params;
     sub_class.fields = sub_shape.fields;
     sub_class.contained = sub_shape.contained;
     sub_class.type_aliases = sub_shape.type_aliases;
@@ -1719,6 +1746,14 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     const mir::LocalId sub_self_id = sub_ctor_bindings.Declare(
         BindingOriginId::Receiver(),
         mir::LocalDecl{.name = "self", .type = sub_shape.self_pointer_type});
+    std::vector<mir::LocalId> sub_ctor_prefix_local_ids;
+    sub_ctor_prefix_local_ids.reserve(sub_shape.ctor_prefix_params.size());
+    for (std::size_t j = 0; j < sub_shape.ctor_prefix_params.size(); ++j) {
+      const auto& p = sub_shape.ctor_prefix_params.Get(
+          mir::ParamId{static_cast<std::uint32_t>(j)});
+      sub_ctor_prefix_local_ids.push_back(sub_ctor_bindings.DeclareAnonymous(
+          mir::LocalDecl{.name = p.name, .type = p.type}));
+    }
     mir::Block& sub_ctor_block = sub_ctor_code.body;
     ScopeChainNode sub_scope_link{};
     const WalkFrame sub_ctor_frame =
@@ -1732,7 +1767,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           std::get_if<hir::ProceduralScopeId>(&child_entry.runtime_parent);
       if (parent_scope == nullptr || parent_scope->value != i) continue;
       AppendOwnedChildConstruction(
-          module, sub_ctor_frame, child_entry.label, child_entry.class_id, {},
+          module, sub_ctor_frame, child_entry.label, child_entry.class_id,
           std::nullopt, child_entry.companion_field);
     }
     // Register each static on this procedural-storage scope as a by-name
@@ -1774,11 +1809,23 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
               .type = void_type});
       sub_ctor_block.AppendStmt(mir::ExprStmt{.expr = call});
     }
-    sub_ctor_code.params = {sub_self_id};
+    sub_ctor_code.params.clear();
+    sub_ctor_code.params.reserve(1 + sub_ctor_prefix_local_ids.size());
+    sub_ctor_code.params.push_back(sub_self_id);
+    for (const mir::LocalId id : sub_ctor_prefix_local_ids) {
+      sub_ctor_code.params.push_back(id);
+    }
     sub_ctor_code.result_type = void_type;
-    sub_class.constructor = std::move(sub_ctor_code);
-    InstallGeneratedDefinition(
-        module.Unit(), sub_class, std::nullopt, std::nullopt, std::nullopt);
+    // Ctor code stays local so subsequent lowering can still append exprs
+    // into its body; once complete, it is moved into the class's method
+    // storage and referenced by the construction protocol.
+    const std::vector<mir::ExprId> sub_base_trailing_args =
+        InstallGeneratedDefinition(
+            module.Unit(), sub_class, sub_ctor_code, std::nullopt, std::nullopt,
+            std::nullopt);
+    FinalizeConstructor(
+        module.Unit(), sub_class, std::move(sub_ctor_code),
+        sub_ctor_prefix_local_ids, sub_base_trailing_args);
     module.Unit().DefineClass(entry.class_id, std::move(sub_class));
   }
 
@@ -1792,7 +1839,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     if (!entry.materialized) continue;
     if (!std::holds_alternative<EnclosingClass>(entry.runtime_parent)) continue;
     AppendOwnedChildConstruction(
-        module, ctor_frame, entry.label, entry.class_id, {}, std::nullopt,
+        module, ctor_frame, entry.label, entry.class_id, std::nullopt,
         entry.companion_field);
   }
 
@@ -1887,9 +1934,16 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
       lowerer, ctor_frame, resolve_frame, init_frame, activate_frame);
   if (!port_conn_r) return std::unexpected(std::move(port_conn_r.error()));
 
-  ctor_code.params = {self_id};
+  ctor_code.params.clear();
+  ctor_code.params.reserve(1 + ctor_prefix_local_ids.size());
+  ctor_code.params.push_back(self_id);
+  for (const mir::LocalId id : ctor_prefix_local_ids) {
+    ctor_code.params.push_back(id);
+  }
   ctor_code.result_type = void_type;
-  mir_class.constructor = std::move(ctor_code);
+  // Ctor code stays local so subsequent lowering can still append exprs into
+  // its body; once complete, it is moved into the class's method storage and
+  // referenced by the construction protocol.
 
   auto& unit = module.Unit();
 
@@ -1921,8 +1975,13 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   const std::optional<mir::MethodId> create_body = add_body(
       activate_block, activate_code, activate_self_id, "CreateProcesses");
 
-  InstallGeneratedDefinition(
-      unit, mir_class, resolve_body, init_body, create_body);
+  const std::vector<mir::ExprId> base_trailing_args =
+      InstallGeneratedDefinition(
+          unit, mir_class, ctor_code, resolve_body, init_body, create_body);
+
+  FinalizeConstructor(
+      unit, mir_class, std::move(ctor_code), ctor_prefix_local_ids,
+      base_trailing_args);
 
   unit.DefineClass(class_id_, std::move(mir_class));
   return {};

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -294,6 +294,12 @@ auto FunctionLowerer::LowerExpr(mir::ExprId id) -> diag::Result<lir::Operand> {
                 lir::StoreInstr{.place = *std::move(place), .value = *value});
             return *std::move(value);
           },
+          [&](const mir::MoveExpr& m) -> diag::Result<lir::Operand> {
+            // Move-vs-copy is derived from SSA liveness at this layer; the
+            // marker unwraps to its operand and the downstream backend
+            // decides the transfer.
+            return LowerExpr(m.operand);
+          },
           [](const auto&) -> diag::Result<lir::Operand> {
             return diag::Fail(
                 diag::DiagCode::kUnsupportedExpressionForm,

--- a/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
@@ -60,15 +60,18 @@ auto UnitLowerer::LowerClass(lir::ClassId class_id, const mir::Class& cls)
   }
 
   auto constructor =
-      FunctionLowerer(*this, cls.constructor, "constructor", class_id).Run();
+      FunctionLowerer(
+          *this, mir::GetConstructorCode(cls), "constructor", class_id)
+          .Run();
   if (!constructor) {
     return std::unexpected(std::move(constructor.error()));
   }
   out.constructor = *std::move(constructor);
 
   for (std::size_t i = 0; i < cls.methods.size(); ++i) {
-    const mir::MethodDecl& method =
-        cls.methods.Get(mir::MethodId{static_cast<std::uint32_t>(i)});
+    const mir::MethodId mid{static_cast<std::uint32_t>(i)};
+    if (mid == cls.constructor.method) continue;
+    const mir::MethodDecl& method = cls.methods.Get(mid);
     auto fn = FunctionLowerer(*this, method.code, method.name, class_id).Run();
     if (!fn) {
       return std::unexpected(std::move(fn.error()));

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -579,17 +579,15 @@ class MirDumper {
               return std::format(
                   "AddressOfExpr operand=Expr[{}]", a.operand.value);
             },
+            [](const MoveExpr& m) -> std::string {
+              return std::format("MoveExpr operand=Expr[{}]", m.operand.value);
+            },
             [](const PointerCastExpr& c) -> std::string {
               return std::format(
                   "PointerCastExpr operand=Expr[{}]", c.operand.value);
             },
             [](const CastExpr& c) -> std::string {
               return std::format("CastExpr operand=Expr[{}]", c.operand.value);
-            },
-            [](const ParamRef& r) -> std::string {
-              return std::format(
-                  "ParamRef receiver=Expr[{}] param=Param[{}]",
-                  r.receiver.value, r.param.value);
             },
             [this](const LocalRef& r) -> std::string {
               const auto& var = code_->locals.Get(r.var);
@@ -766,16 +764,6 @@ class MirDumper {
     }
     Dedent();
 
-    if (!s.params.empty()) {
-      Line("Params:");
-      Indent();
-      for (std::size_t i = 0; i < s.params.size(); ++i) {
-        const auto& p = s.params.Get(ParamId{static_cast<std::uint32_t>(i)});
-        Line(std::format("[{}] \"{}\" : {}", i, p.name, FormatVarType(p.type)));
-      }
-      Dedent();
-    }
-
     Line("Fields:");
     Indent();
     DumpFieldList(s.fields);
@@ -784,7 +772,9 @@ class MirDumper {
     Line("Methods:");
     Indent();
     for (std::size_t i = 0; i < s.methods.size(); ++i) {
-      DumpMethod(s.methods.Get(MethodId{static_cast<std::uint32_t>(i)}), i);
+      const MethodId mid{static_cast<std::uint32_t>(i)};
+      if (mid == s.constructor.method) continue;
+      DumpMethod(s.methods.Get(mid), i);
     }
     Dedent();
 
@@ -802,7 +792,34 @@ class MirDumper {
 
     Line("Constructor:");
     Indent();
-    DumpCallableBody(s.constructor);
+    Line(std::format("Method: #{}", s.constructor.method.value));
+    if (s.constructor.base_init.has_value()) {
+      Line("BaseInit:");
+      Indent();
+      for (std::size_t i = 0; i < s.constructor.base_init->args.size(); ++i) {
+        Line(
+            std::format(
+                "[{}] arg=Expr[{}]", i,
+                s.constructor.base_init->args[i].value));
+      }
+      Dedent();
+    }
+    if (!s.constructor.member_inits.empty()) {
+      Line("MemberInits:");
+      Indent();
+      for (std::size_t i = 0; i < s.constructor.member_inits.size(); ++i) {
+        const auto& mi = s.constructor.member_inits[i];
+        Line(
+            std::format(
+                "[{}] field=Field[{}] value=Expr[{}]", i, mi.target.value,
+                mi.value.value));
+      }
+      Dedent();
+    }
+    Line("Body:");
+    Indent();
+    DumpCallableBody(GetConstructorCode(s));
+    Dedent();
     Dedent();
 
     Dedent();

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -143,6 +143,12 @@ auto Type::AsIntegralPacked() const -> const PackedArrayType& {
       "PackedArrayType or EnumType)");
 }
 
+auto Type::IsAliasHandle() const -> bool {
+  return std::holds_alternative<ServicesType>(data) ||
+         std::holds_alternative<FilesType>(data) ||
+         std::holds_alternative<DiagnosticType>(data);
+}
+
 namespace {
 
 auto AsUniquePointee(const CompilationUnit& unit, TypeId type)


### PR DESCRIPTION
## Summary

Class construction becomes a protocol on the class rather than side fields on `Class` or render conventions in the backend. `Class::constructor` is a `ConstructorDecl` pairing (a) the ctor's callable code, stored as an ordinary `MethodDecl` in `Class::methods`, with (b) explicit base and per-field initialization ordered before the body runs. The C++ render composes the mem-init list from those stated facts alone; the interim `Class::ctor_prefix_params` / `Class::params` / `Class::base_init` side fields are removed, and the prefix params flow through the ctor's own signature.

## Design

Value transfer to the base call is stated explicitly as a `MoveExpr` MIR primitive. The C++ backend translates it mechanically to `std::move(...)`, so the previous `HierarchySegment` copy per scope construction is elided without the renderer learning what `RuntimeServices` / `HierarchySegment` / `Scope*` mean. An alias-style handle (services / files / diagnostic) is exempt from the move wrap via `Type::IsAliasHandle` rather than a render-side pattern match. The LLVM path treats `MoveExpr` as pass-through and defers transfer to LIR liveness.

The previously dead `ParamRef` MIR expression is removed too -- it existed only for a `Class::params` vehicle that had no producer. Two decision docs that referenced that dead vocabulary (`parameter-code-shape-over-approximation.md` F1 and `variable-initialization.md`) are updated to reflect the current state.

## Testing

Verified against the full `//...` suite; playground `_root` / `Test` / `gen0_gen` mem-init lists show `std::move(parent), std::move(segment), services` as expected.