### PR TITLE
Support the chandle data type

### DIFF
--- a/docs/decisions/dpi-foreign-boundary.md
+++ b/docs/decisions/dpi-foreign-boundary.md
@@ -188,11 +188,9 @@ usage inflate the scope.
 
 - Both backends consume the same MIR for a foreign call and a marshal conversion; only the
   type-mapping of the ABI carrier and the realization of the foreign-linkage symbol differ.
-- Foreign-symbol linkage must be built per backend: the C++ backend gains a user-link-input seam in
-  its build recipe; the LLVM/JIT backend gains external-symbol resolution in its execution session.
-  Neither exists today.
-- A `chandle` argument needs a runtime representation and a type-mapping entry, which do not exist
-  yet; it is required before `chandle` crosses the boundary.
+- Foreign-symbol linkage is a per-backend concern: the C++ backend resolves it through a
+  user-link-input seam in its build recipe; the LLVM/JIT backend resolves it through external-symbol
+  resolution in its execution session.
 - The export-context install composes into the one shared run entry, so it serves both backends from
   a single place.
 

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -235,8 +235,9 @@ the lookup key and imposes an ordering.
       frontend rejects a wildcard-indexed array used in `foreach` or with a manipulation method that
       returns an index (LRM 7.8.1 / 7.12.1), so those illegal forms never reach lowering. A
       packed-struct key (LRM 7.8.5) is an integral index, keyed and ordered by its bit-pattern
-      value. The class index (LRM 7.8.3) stays blocked on class support and is deferred to that
-      workstream.
+      value. A chandle key (LRM 6.14) identifies an entry by pointer identity; the LRM leaves the
+      relative ordering of two entries to the implementation. The class index (LRM 7.8.3) stays
+      blocked on class support and is deferred to that workstream.
 
 ## Cross-references
 

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -73,8 +73,7 @@ Granular tracking lives in `integral.md` and `datatypes.md`.
 
 - [x] datatypes/default_init -- LRM Table 6-7 default initialization across families and nesting.
 - [x] datatypes/enum
-- [ ] datatypes/general -- parameters and typedef done; chandle remains and rides on the DPI
-      boundary (its only non-null value source), so it is built with `dpi/*`.
+- [x] datatypes/general -- parameters, typedef, and chandle.
 - [x] datatypes/integral -- `integral.md`.
 - [x] datatypes/packed -- `packed.md`.
 - [x] datatypes/real
@@ -117,7 +116,7 @@ Tracked in `functions.md` (the full LRM 13 subroutine surface).
 - [x] functions/string_return -- F7.
 - [x] functions/container_params -- F7, F8.
 - [x] functions/container_outparams -- F4, F8.
-- [ ] functions/chandle -- F9; rides on the chandle data type (`datatypes/general`).
+- [x] functions/chandle -- F9.
 
 ### generate
 

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -9,19 +9,12 @@ unpacked arrays here; the variable-size aggregate family in `aggregate.md`), `da
 
 ## Actionable
 
-Enum, real, string, fixed-size unpacked arrays, the integral-family declaration initializers, and
-parameter references in expressions are complete. The variable-size aggregate family (dynamic array,
-queue, associative array) is complete; see `aggregate.md`. Unpacked struct and union are complete.
-Default initialization (LRM Table 6-7) and value representation, including a wide value carrying X/Z
-across the 64-bit word boundary, are complete. Chandle is the only remaining datatype, and its
-representation is built with the DPI boundary it serves.
-
-| Item | Status                                                                         |
-| ---- | ------------------------------------------------------------------------------ |
-| -    | Variable-size aggregates (array / queue / assoc) -- `aggregate.md` (complete). |
-| -    | Unpacked struct / union -- complete.                                           |
-| -    | `datatypes/default_init`, `datatypes/representation` -- complete.              |
-| -    | Chandle -- rides on the DPI workstream (its only non-null value source).       |
+All items closed; the datatype surface in scope is complete. Enum, real, string, fixed-size unpacked
+arrays, the integral-family declaration initializers, and parameter references in expressions are
+complete. The variable-size aggregate family (dynamic array, queue, associative array) is complete;
+see `aggregate.md`. Unpacked struct and union are complete. Default initialization (LRM Table 6-7)
+and value representation, including a wide value carrying X/Z across the 64-bit word boundary, are
+complete. Chandle is complete.
 
 ## Enum
 
@@ -126,3 +119,29 @@ frontend inserts an implicit conversion when a literal participates in an expres
 - LRM 6.16 (String data type), Table 6-9 (String operators), 6.16.1 -- 6.16.15 (String methods),
   Table 6-7 (Default initial values).
 - Archive items: `datatypes/string/{string_concat}`.
+
+## Chandle
+
+LRM 6.14: `chandle` stores a pointer passed through the DPI. It always initializes to `null`, and
+its only legal uses are equality (`==` / `!=`) and case equality (`===` / `!==`) against another
+chandle or `null`, a boolean test that is 0 when null and 1 otherwise, assignment from another
+chandle or `null`, membership in an associative array, a class, or a subroutine's arguments and
+return value. It is illegal as a port, in a sensitivity list or event expression, in a continuous
+assignment, in an untagged union, and in a packed type, so a chandle never participates in event
+propagation and a structural chandle is not observable storage.
+
+- [x] CH1 -- Declaration and `null` default, assignment from `null` and from another chandle, the
+      equality and case-equality families against a chandle and against `null`, the boolean test
+      (including `!`), passing to and returning from a subroutine with the identity preserved, use
+      as an unpacked-struct field, as an associative-array element, and as an associative-array key
+      (whose relative entry ordering LRM 6.14 leaves to the implementation). A non-null chandle
+      originates only at the DPI boundary, where it crosses as an opaque pointer in either direction
+      (`dpi.md`).
+- [x] CH2 -- A chandle reaching a format argument, alone or nested in an aggregate, is an LRM 6.14
+      violation the frontend does not filter, so lowering diagnoses it. No simulation prints a host
+      pointer.
+
+### Cross-references
+
+- LRM 6.14 (Chandle data type), Table 11-1 (Operators and data types), Table 6-7 (Default initial
+  values), 7.8 (Associative arrays), 35.5.6 (DPI type mapping).

--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -41,15 +41,21 @@ backend. Every later item leaves the MIR shape backend-agnostic and lands on bot
 The C++ backend half of D1 is done: a scalar import (2-state integral, `real`, and `string`,
 `input`-only functions) declares, marshals across the boundary, calls the foreign symbol, and
 marshals the result back; a user C source is linked in through a repeatable `--dpi-link` option, and
-mixed-language tests assert the round trip. The remaining D1 work is the LLVM / JIT backend, which
-does not yet resolve an external foreign symbol; the MIR is already backend-agnostic, so that half
-is additive.
+mixed-language tests assert the round trip.
+
+The remaining D1 work is the LLVM / JIT backend, and it is not additive. That backend still cannot
+lower a minimal procedural body -- a plain write to a module variable does not reach LIR -- so a
+foreign call has no body to sit inside, and resolving an external symbol on its own would buy
+nothing. The MIR is already backend-agnostic and the MIR-to-LIR lowering names the foreign-call gap
+explicitly, so the DPI-specific work is small; it unblocks with the general execution-backend
+buildout (`architecture-reset.md`), not before. Re-check that backend's procedural coverage before
+planning this item.
 
 The C++ backend also carries the general D2 argument surface: `output` and `inout` scalar arguments
-(2-state integral, `real`, `string`) cross by pointer with a copy back into the actual, functions
-returning a value alongside `output` / `inout` arguments work in expression position, and non-pure
-imports and packed 2-state values up to one machine word are accepted. The sole remaining D2 gap is
-`chandle`, which needs a runtime representation of its own before it can cross the boundary.
+(2-state integral, `real`, `string`, `chandle`) cross by pointer with a copy back into the actual,
+functions returning a value alongside `output` / `inout` arguments work in expression position, and
+non-pure imports and packed 2-state values up to one machine word are accepted. `chandle` crosses as
+an opaque pointer in either direction and round-trips its identity.
 
 ## Sub-Steps
 
@@ -65,9 +71,9 @@ inline.
       backend, resolved through the execution session on the LLVM / JIT backend), asserted by a
       mixed-language test.
 - [ ] D2 -- General import (LRM 35.5.5, 35.5.6). `output` and `inout` arguments, non-pure imports,
-      and packed 2-state values up to a single machine word are supported on the C++ backend, with
-      the copy-out directions crossing by pointer to a boundary temporary. `chandle` is the
-      remaining gap: it needs a runtime representation before it can cross the boundary.
+      `chandle`, and packed 2-state values up to a single machine word are supported on the C++
+      backend, with the copy-out directions crossing by pointer to a boundary temporary. The
+      remaining work is the LLVM / JIT backend, which shares the same MIR.
 - [ ] D3 -- 4-state and wide marshaling: 4-state scalars and vectors across the boundary (the DPI
       canonical 4-state layout versus Lyra's internal representation) and packed vectors wider than
       one machine word (LRM 35.5.6).
@@ -127,11 +133,9 @@ and the out-of-scope boundary. Work proceeds against that record.
 
 Prerequisites surfaced during design:
 
-- `chandle` has no runtime representation or type-mapping entry today; it must gain one before D2
-  (where a `chandle` argument first crosses the boundary).
-- Foreign-symbol linkage does not exist on either backend: the C++ backend needs a user-link-input
-  seam in its build recipe, and the LLVM / JIT backend needs external-symbol resolution in its
-  execution session; both are part of D1.
+- Foreign-symbol linkage: the C++ backend needed a user-link-input seam in its build recipe, and the
+  LLVM / JIT backend needs external-symbol resolution in its execution session; both are part of D1.
+  Only the LLVM / JIT half remains.
 
 ## Cross-references
 

--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -18,9 +18,8 @@ and [Out of Scope](#out-of-scope).
 
 ## Actionable
 
-F1 is the entry point: the value-returning function call and return path. Most other items build on
-it -- the dependencies are stated inline. Tasks that suspend (T2) wait on the timing machinery owned
-by `processes.md`.
+All sub-steps are closed; the subroutine surface in scope is complete. What remains is the one
+[Blocked](#blocked) item, which waits on module hierarchy.
 
 ## Sub-Steps
 
@@ -97,8 +96,9 @@ everything and the inline "rides on" notes record the real dependencies.
       reassigns inside the body copies the resulting container back, and a returned container is
       independent of the body's local. The outdated-reference rules of LRM 13.5.2 are a `ref`-formal
       concern, not a by-value one, and are tracked with F10.
-- [ ] F9 -- `chandle` arguments and return values (LRM 6.14). Identity round-trip and `null`
-      handling through the subroutine boundary.
+- [x] F9 -- `chandle` arguments and return values (LRM 6.14). Identity round-trip and `null`
+      handling through the subroutine boundary. A chandle is an ordinary value at the boundary, so
+      it needed no call-path work of its own beyond the data type (`datatypes.md`).
 
 ### Tasks
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -822,6 +822,25 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       positive case (an import declared at module scope, called from a nested block), never by
       pinning the current rejection. **Blocker**: none.
 
+- [ ] R56 -- A condition is a value; reducing it to a control predicate is an explicit conversion,
+      not a backend's contextual one. MIR already owns the primitive: `BoolCastExpr` reduces any
+      operand to a host bool, and a real or chandle `!` lowers through it. But `IfStmt`,
+      `WhileStmt`, the loop forms, and `ConditionalExpr` all carry a raw SV-typed condition, and the
+      C++ backend recovers the predicate by handing that value to C++'s contextual conversion -- a
+      passthrough render that works only because every value type happens to expose
+      `explicit operator bool`. The semantic fact "this value is read as a predicate here" is
+      therefore stated nowhere in MIR; each backend rediscovers it from the operand's type at the
+      branch site, which is exactly the re-derivation `mir.md` invariant 10 forbids, and an LLVM
+      backend must synthesize a different test per type (`icmp ne ptr null` for a chandle, a runtime
+      call for a `PackedArray`) with no MIR node telling it to. The asymmetry is visible today: `!h`
+      on a chandle carries an explicit `BoolCastExpr` while `if (h)` does not, for no reason other
+      than that `!`'s result must be re-shaped to a 1-bit integral. Target: every condition context
+      carries its condition already reduced through `BoolCastExpr` at HIR-to-MIR, and the backend's
+      condition-rendering passthrough disappears -- render emits the cast like any other node. No
+      new node kind is needed; the cut is to make the existing primitive mandatory where a predicate
+      is consumed, and to settle each value type's predicate semantics against LRM Table 11-1 while
+      doing so. **Blocker**: none.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/runtime/prelude.hpp
+++ b/include/lyra/runtime/prelude.hpp
@@ -43,6 +43,7 @@
 #include "lyra/runtime/var.hpp"                // IWYU pragma: keep
 #include "lyra/value/array_case_equal.hpp"     // IWYU pragma: keep
 #include "lyra/value/associative_array.hpp"    // IWYU pragma: keep
+#include "lyra/value/chandle.hpp"              // IWYU pragma: keep
 #include "lyra/value/dynamic_array.hpp"        // IWYU pragma: keep
 #include "lyra/value/enum.hpp"                 // IWYU pragma: keep
 #include "lyra/value/format.hpp"               // IWYU pragma: keep

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -279,9 +279,11 @@ enum class BuiltinFn : std::uint16_t {
   // Native-host value accessors used by DPI-C marshaling (LRM 35.5.6):
   // `kRealValue` reads a `Real` / `ShortReal` out as its host floating value;
   // `kStringCStr` borrows a `String` as a NUL-terminated C string valid for the
-  // owning string's lifetime. Instance methods on the receiver (`args[0]`).
+  // owning string's lifetime; `kChandlePtr` reads a `Chandle` out as the opaque
+  // pointer it carries. Instance methods on the receiver (`args[0]`).
   kRealValue,
   kStringCStr,
+  kChandlePtr,
   kFromInt,
   kConvertFrom,
   kFromPackedArray,

--- a/include/lyra/support/dpi_abi.hpp
+++ b/include/lyra/support/dpi_abi.hpp
@@ -12,7 +12,7 @@ namespace lyra::support {
 // available; every layer below reads the category.
 //
 // The set covers 2-state integral scalars up to one machine word, real, string,
-// and void; four-state, wide packed, chandle, and open-array carriers are not
+// chandle, and void; four-state, wide packed, and open-array carriers are not
 // yet represented.
 enum class DpiAbiClass : std::uint8_t {
   kVoid,
@@ -23,6 +23,7 @@ enum class DpiAbiClass : std::uint8_t {
   kLongInt,
   kReal,
   kString,
+  kChandle,
 };
 
 // The direction of a DPI-C formal argument (LRM 35.5.1.2). `ref` is illegal in
@@ -78,6 +79,8 @@ enum class DpiDirection : std::uint8_t {
       return "real";
     case DpiAbiClass::kString:
       return "string";
+    case DpiAbiClass::kChandle:
+      return "chandle";
   }
   return "unknown";
 }

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <iterator>
 #include <map>
 #include <optional>
@@ -12,6 +13,7 @@
 
 #include "lyra/value/array_case_equal.hpp"
 #include "lyra/value/array_manipulation.hpp"
+#include "lyra/value/chandle.hpp"
 #include "lyra/value/concepts.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/oob_shield.hpp"
@@ -108,6 +110,24 @@ struct AssocKeyTraits<PackedArray> {
 template <>
 struct AssocKeyTraits<WildcardKey> {
   using Less = WildcardKeyLess;
+};
+
+// LRM 6.14: a chandle may key an associative array, and the relative ordering
+// of two entries is explicitly allowed to vary between runs. The order is
+// therefore a host storage choice, not an SV operator -- `<` is not defined on
+// a chandle
+// -- and `std::less` supplies the total order `std::map` needs over unrelated
+// pointers.
+struct ChandleKeyLess {
+  [[nodiscard]] auto operator()(const Chandle& a, const Chandle& b) const
+      -> bool {
+    return std::less<>{}(a.Ptr(), b.Ptr());
+  }
+};
+
+template <>
+struct AssocKeyTraits<Chandle> {
+  using Less = ChandleKeyLess;
 };
 
 // A wildcard key formats as its underlying integral value (LRM 21.2.1.6 prints

--- a/include/lyra/value/chandle.hpp
+++ b/include/lyra/value/chandle.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstddef>
+
+#include "lyra/value/concepts.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+// Runtime representation of the SystemVerilog `chandle` (LRM 6.14): storage for
+// a pointer passed across the DPI-C boundary, at least wide enough to hold a
+// host pointer. The value is opaque to SystemVerilog, which may only compare
+// two chandles, compare one against `null`, and test one for a boolean value.
+//
+// A chandle is a value type rather than a bare host pointer because it appears
+// as an associative-array element, a class member, and a struct field, and
+// every such element must satisfy `LyraValue`. Its operator surface therefore
+// follows LRM Table 11-1's "Any data type" row: equality yields a 1-bit
+// `PackedArray`, as it does for every other value type. LRM 6.14 gives `===` /
+// `!==` the same semantics as `==` / `!=`, so `CaseEqualComparable` holds and
+// `CaseEqual` shares pointer identity with `IsBitIdentical`. Relational
+// operators are not defined on a chandle, so `Ordered` does not.
+//
+// There is deliberately no `Formatter<Chandle>`: LRM 6.14 permits a chandle
+// only in the equality family and a boolean test, so a chandle never reaches a
+// format argument -- HIR-to-MIR rejects that program.
+class Chandle {
+ public:
+  Chandle() = default;
+
+  // `null` is the only literal a chandle admits, and it arrives as the host
+  // `nullptr` that a null literal renders to. The conversion is implicit so a
+  // comparison against `null` and a store of `null` each bind without a cast.
+  // The parameter is a type tag carrying no value, so it stays unnamed.
+  // NOLINTNEXTLINE(google-explicit-constructor,readability-named-parameter)
+  Chandle(std::nullptr_t) {
+  }
+
+  explicit Chandle(void* p) : p_(p) {
+  }
+
+  // The foreign-side view of the handle, read when it crosses the DPI-C
+  // boundary as its `void*` carrier.
+  [[nodiscard]] auto Ptr() const -> void* {
+    return p_;
+  }
+
+  // LRM 11.4.5 `==` / `!=` (Any data type), compared as pointer identity.
+  [[nodiscard]] auto operator==(const Chandle& o) const -> PackedArray {
+    return PackedArray::Bit(p_ == o.p_);
+  }
+  [[nodiscard]] auto operator!=(const Chandle& o) const -> PackedArray {
+    return PackedArray::Bit(p_ != o.p_);
+  }
+
+  // LRM 6.14: `===` / `!==` on a chandle carry the same semantics as `==` /
+  // `!=`. Coincides with `IsBitIdentical` because a chandle's value is its bit
+  // pattern.
+  [[nodiscard]] auto CaseEqual(const Chandle& o) const -> PackedArray {
+    return PackedArray::Bit(p_ == o.p_);
+  }
+
+  // LRM 9.4.2 update event predicate (engine change-detection hook).
+  [[nodiscard]] auto IsBitIdentical(const Chandle& o) const -> bool {
+    return p_ == o.p_;
+  }
+
+  // A chandle holds a pointer and has no X/Z plane.
+  [[nodiscard]] static auto HasUnknown() -> bool {
+    return false;
+  }
+
+  // LRM 6.14: a chandle is always initialized to `null`. Satisfies the
+  // container OOB-shield contract so a chandle can be an associative-array
+  // element.
+  auto ResetToDefault() -> void {
+    p_ = nullptr;
+  }
+
+  // LRM 6.14: a chandle tested for a boolean value is 0 when null, 1 otherwise.
+  explicit operator bool() const {
+    return p_ != nullptr;
+  }
+
+ private:
+  void* p_ = nullptr;
+};
+
+static_assert(LyraValue<Chandle>);
+static_assert(CaseEqualComparable<Chandle>);
+static_assert(!Ordered<Chandle>);
+static_assert(!WildcardComparable<Chandle>);
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -256,6 +256,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Value";
     case support::BuiltinFn::kStringCStr:
       return "CStr";
+    case support::BuiltinFn::kChandlePtr:
+      return "Ptr";
     case support::BuiltinFn::kFromInt:
       return "FromInt";
     case support::BuiltinFn::kConvertFrom:

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -31,6 +31,8 @@ auto DpiCarrierCppType(support::DpiAbiClass abi) -> std::string_view {
       return "double";
     case support::DpiAbiClass::kString:
       return "const char*";
+    case support::DpiAbiClass::kChandle:
+      return "void*";
     case support::DpiAbiClass::kVoid:
       return "void";
   }
@@ -103,6 +105,9 @@ auto RenderTypeAsCpp(
           },
           [](const mir::DpiCarrierType& d) -> std::string {
             return std::string{DpiCarrierCppType(d.abi)};
+          },
+          [](const mir::ChandleType&) -> std::string {
+            return std::string{"lyra::value::Chandle"};
           },
           [](const mir::EventType&) -> std::string {
             return std::string{"lyra::runtime::NamedEvent"};

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -58,13 +58,15 @@ auto ParamDirectionOf(const slang::ast::FormalArgumentSymbol& formal)
 
 // Classifies an SV type into its DPI-C carrier category (LRM 35.5.6). This is
 // the one place slang types are inspected for DPI. The supported set is 2-state
-// integral scalars up to one machine word, `real`, `string`, and `void`;
-// anything else is a located Unsupported so the gap is a clean diagnostic.
+// integral scalars up to one machine word, `real`, `string`, `chandle`, and
+// `void`; anything else is a located Unsupported so the gap is a clean
+// diagnostic.
 auto ClassifyDpiAbi(const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<support::DpiAbiClass> {
   const auto& t = type.getCanonicalType();
   if (t.isVoid()) return support::DpiAbiClass::kVoid;
   if (t.isString()) return support::DpiAbiClass::kString;
+  if (t.isCHandle()) return support::DpiAbiClass::kChandle;
   if (t.isFloating()) {
     if (t.as<slang::ast::FloatingType>().floatKind ==
         slang::ast::FloatingType::Real) {
@@ -89,11 +91,6 @@ auto ClassifyDpiAbi(const slang::ast::Type& type, diag::SourceSpan span)
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedDpi,
         "wide packed DPI-C value is not yet supported");
-  }
-  if (t.isCHandle()) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedDpi,
-        "chandle DPI-C argument is not yet supported");
   }
   return diag::Fail(
       span, diag::DiagCode::kUnsupportedDpi, "DPI-C type is not yet supported");

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -408,14 +408,16 @@ auto TranslateTypeData(
             .key_type = module.Unit().builtins.wildcard_index,
         }};
       }
-      // A declared index covers string (LRM 7.8.2) and integral, which includes
-      // a packed struct / enum (LRM 7.8.4 / 7.8.5). A class index (LRM 7.8.3)
-      // and a real index are rejected.
-      if (!(aa.indexType->isIntegral() || aa.indexType->isString())) {
+      // A declared index covers string (LRM 7.8.2), integral, which includes a
+      // packed struct / enum (LRM 7.8.4 / 7.8.5), and chandle, whose entries
+      // may order arbitrarily (LRM 6.14). A class index (LRM 7.8.3) and a real
+      // index are rejected.
+      if (!(aa.indexType->isIntegral() || aa.indexType->isString() ||
+            aa.indexType->isCHandle())) {
         return diag::Fail(
             decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,
-            "associative arrays are only supported with a string, integral, or "
-            "wildcard index type");
+            "associative arrays are only supported with a string, integral, "
+            "chandle, or wildcard index type");
       }
       auto key_id_or = module.InternType(*aa.indexType, decl_span);
       if (!key_id_or) {

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -302,6 +302,10 @@ auto BuildDefaultValueExpr(
           [&](const mir::ManagedRefType&) -> mir::Expr {
             return mir::Expr{.data = mir::NullLiteral{}, .type = type};
           },
+          // LRM 6.14: a chandle is always initialized to null.
+          [&](const mir::ChandleType&) -> mir::Expr {
+            return mir::Expr{.data = mir::NullLiteral{}, .type = type};
+          },
           [&](const mir::VectorType&) -> mir::Expr {
             return mir::Expr{
                 .data =

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -628,6 +628,16 @@ auto MarshalSvToCarrier(
                               .target = support::BuiltinFn::kStringCStr},
                       .arguments = {sv_id}},
               .type = carrier});
+    case support::DpiAbiClass::kChandle:
+      return block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee =
+                          mir::Direct{
+                              .target = support::BuiltinFn::kChandlePtr},
+                      .arguments = {sv_id}},
+              .type = carrier});
     case support::DpiAbiClass::kVoid:
       throw InternalError(
           "MarshalArgToCarrier: void is not an argument carrier");
@@ -638,9 +648,9 @@ auto MarshalSvToCarrier(
 // Foreign ABI carrier -> SV value into a declared SV type's canonical shape. An
 // integral carrier is landed into the type's representation by the packed
 // factory (the prototype carries that shape, so width / signedness / state
-// domain follow the declared type); a real / string carrier constructs the SV
-// value directly. Feeds both a function's marshaled return and the copy-back of
-// an output / inout argument into its actual.
+// domain follow the declared type); a real / string / chandle carrier
+// constructs the SV value directly. Feeds both a function's marshaled return
+// and the copy-back of an output / inout argument into its actual.
 auto MarshalCarrierToSv(
     ModuleLowerer& module, WalkFrame frame, mir::ExprId call_id,
     support::DpiAbiClass abi, mir::TypeId result_type) -> mir::Expr {
@@ -666,6 +676,7 @@ auto MarshalCarrierToSv(
     }
     case support::DpiAbiClass::kReal:
     case support::DpiAbiClass::kString:
+    case support::DpiAbiClass::kChandle:
       return mir::Expr{
           .data =
               mir::CallExpr{.callee = mir::Construct{}, .arguments = {call_id}},

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -296,10 +296,13 @@ auto BuildMirUnaryExpr(
     return MakeBuiltinFnCall(*builtin, {operand_id}, result_type);
   }
 
-  // LRM 11.3.1 real `!`: route through `bool(...)` and wrap the host-bool
-  // result in `FromBool` so the surface type stays the 1-bit integral the
-  // SV semantic prescribes.
-  if (op == mir::UnaryOp::kLogicalNot && IsRealFamilyType(operand_ty)) {
+  // LRM 11.3.1 real `!` and LRM 6.14 chandle `!`: route through `bool(...)` and
+  // wrap the host-bool result in `FromBool` so the surface type stays the 1-bit
+  // integral the SV semantic prescribes. A chandle's boolean value is 0 when it
+  // is null and 1 otherwise.
+  if (op == mir::UnaryOp::kLogicalNot &&
+      (IsRealFamilyType(operand_ty) ||
+       operand_ty.Kind() == mir::TypeKind::kChandle)) {
     const mir::ExprId operand_bool =
         block.exprs.Add(MakeBoolCast(operand_id, unit.builtins.bit1));
     const mir::ExprId not_id = block.exprs.Add(
@@ -327,13 +330,14 @@ auto BuildMirBinaryExpr(
   const bool string_lhs = lhs_ty.Kind() == mir::TypeKind::kString;
   const bool string_rhs = rhs_ty.Kind() == mir::TypeKind::kString;
 
-  // LRM 8.4: handle equality compares object identity and yields a 1-bit
-  // value. A handle's `==` / `!=` produces a host bool, reshaped to the SV
-  // 1-bit integral by `FromBool` so the result carries the value type a 1-bit
-  // signal assignment expects.
+  // LRM 8.4: class-handle equality compares object identity and yields a 1-bit
+  // value. A class handle's `==` / `!=` produces a host bool, reshaped to the
+  // SV 1-bit integral by `FromBool` so the result carries the value type a
+  // 1-bit signal assignment expects. A chandle is not in this family: it is a
+  // value type whose `==` already yields the 1-bit integral directly, like a
+  // string or a real, so it renders as a plain binary operator.
   const auto is_handle = [](const mir::Type& ty) {
-    return ty.Kind() == mir::TypeKind::kManagedRef ||
-           ty.Kind() == mir::TypeKind::kChandle;
+    return ty.Kind() == mir::TypeKind::kManagedRef;
   };
   if ((is_handle(lhs_ty) || is_handle(rhs_ty)) &&
       (op == mir::BinaryOp::kEquality || op == mir::BinaryOp::kInequality)) {

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <expected>
 #include <optional>
@@ -31,6 +32,44 @@
 namespace lyra::lowering::hir_to_mir {
 
 namespace {
+
+// LRM 6.14 permits a chandle only in the equality family and a boolean test, so
+// a chandle -- alone or nested inside an aggregate whose `%p` would print it --
+// is never a legal format operand. slang does not filter the form, so lowering
+// does, exactly as it does for a `real` case-equality (LRM Table 11-1). The
+// runtime consequently carries no chandle formatter, and no simulation prints a
+// host pointer.
+auto TypeContainsChandle(const mir::CompilationUnit& unit, mir::TypeId type)
+    -> bool {
+  return std::visit(
+      Overloaded{
+          [](const mir::ChandleType&) { return true; },
+          [&](const mir::UnpackedArrayType& t) {
+            return TypeContainsChandle(unit, t.element_type);
+          },
+          [&](const mir::DynamicArrayType& t) {
+            return TypeContainsChandle(unit, t.element_type);
+          },
+          [&](const mir::QueueType& t) {
+            return TypeContainsChandle(unit, t.element_type);
+          },
+          [&](const mir::AssociativeArrayType& t) {
+            return TypeContainsChandle(unit, t.key_type) ||
+                   TypeContainsChandle(unit, t.element_type);
+          },
+          [&](const mir::TupleType& t) {
+            return std::ranges::any_of(t.elements, [&](mir::TypeId e) {
+              return TypeContainsChandle(unit, e);
+            });
+          },
+          [&](const mir::UnionType& t) {
+            return std::ranges::any_of(t.elements, [&](mir::TypeId e) {
+              return TypeContainsChandle(unit, e);
+            });
+          },
+          [](const auto&) { return false; }},
+      unit.types.Get(type).data);
+}
 
 auto ToValueFormatKind(support::FormatDirectiveKind k) -> value::FormatKind {
   switch (k) {
@@ -75,9 +114,17 @@ auto BuildPrintValueItem(
     mir::FormatSpec spec) -> diag::Result<mir::RuntimePrintItem> {
   const auto& hir_proc = process.HirBody();
   auto& block = *frame.current_block;
-  auto lowered_or = process.LowerExpr(hir_proc.exprs.Get(hir_arg), frame);
+  const hir::Expr& hir_expr = hir_proc.exprs.Get(hir_arg);
+  auto lowered_or = process.LowerExpr(hir_expr, frame);
   if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
   mir::Expr lowered = *std::move(lowered_or);
+
+  if (TypeContainsChandle(process.Module().Unit(), lowered.type)) {
+    return diag::Fail(
+        hir_expr.span, diag::DiagCode::kUnsupportedExpressionForm,
+        "a chandle is not a legal format argument (LRM 6.14 permits a chandle "
+        "only in an equality comparison and a boolean test)");
+  }
 
   // %s formats by operand type (LRM 21.2.1.7): a String and a packed value
   // each format directly, without building a string value. Only an unpacked

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -370,6 +370,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "real_value";
     case BuiltinFn::kStringCStr:
       return "string_cstr";
+    case BuiltinFn::kChandlePtr:
+      return "chandle_ptr";
     case BuiltinFn::kFromInt:
       return "from_int";
     case BuiltinFn::kConvertFrom:

--- a/tests/cases/cpp/chandle/case.yaml
+++ b/tests/cases/cpp/chandle/case.yaml
@@ -1,0 +1,25 @@
+id: cpp.chandle
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      default null
+      bang null
+      non null
+      truthy
+      read=7
+      case eq
+      case ne null
+      assoc holds
+      keyed=3
+      struct holds x=9
+      assigned null
+      out read=5
+      inout read=6

--- a/tests/cases/cpp/chandle/dpi.c
+++ b/tests/cases/cpp/chandle/dpi.c
@@ -1,0 +1,35 @@
+#include <stdlib.h>
+
+typedef struct {
+  int v;
+} Obj;
+
+void* make_obj(int seed) {
+  Obj* o = malloc(sizeof(Obj));
+  o->v = seed;
+  return o;
+}
+
+int read_obj(void* h) {
+  return ((Obj*)h)->v;
+}
+
+void alloc_obj(void** h, int seed) {
+  Obj* o = malloc(sizeof(Obj));
+  o->v = seed;
+  *h = o;
+}
+
+// Reads the incoming handle and writes a different one back, so the copy-in and
+// the copy-back halves of an inout chandle are both exercised.
+void bump_obj(void** h) {
+  Obj* old = (Obj*)*h;
+  Obj* fresh = malloc(sizeof(Obj));
+  fresh->v = old->v + 1;
+  free(old);
+  *h = fresh;
+}
+
+void free_obj(void* h) {
+  free(h);
+}

--- a/tests/cases/cpp/chandle/main.sv
+++ b/tests/cases/cpp/chandle/main.sv
@@ -1,0 +1,56 @@
+module Top;
+  import "DPI-C" function chandle make_obj(input int seed);
+  import "DPI-C" function int read_obj(input chandle h);
+  import "DPI-C" function void alloc_obj(output chandle h, input int seed);
+  import "DPI-C" function void bump_obj(inout chandle h);
+  import "DPI-C" function void free_obj(input chandle h);
+
+  typedef struct {
+    chandle h;
+    int x;
+  } Boxed;
+
+  chandle h;
+  chandle g;
+  chandle m[string];
+  int cnt[chandle];
+  Boxed b;
+
+  function automatic chandle identity(chandle x);
+    return x;
+  endfunction
+
+  initial begin
+    if (h == null) $display("default null");
+    if (!h) $display("bang null");
+
+    h = make_obj(7);
+    if (h != null) $display("non null");
+    if (h) $display("truthy");
+    $display("read=%0d", read_obj(h));
+
+    g = identity(h);
+    if (g === h) $display("case eq");
+    if (g !== null) $display("case ne null");
+
+    m["a"] = h;
+    if (m["a"] === h) $display("assoc holds");
+
+    cnt[h] = 3;
+    $display("keyed=%0d", cnt[h]);
+
+    b.h = h;
+    b.x = 9;
+    if (b.h === h) $display("struct holds x=%0d", b.x);
+
+    free_obj(h);
+    h = null;
+    if (h == null) $display("assigned null");
+
+    alloc_obj(g, 5);
+    $display("out read=%0d", read_obj(g));
+    bump_obj(g);
+    $display("inout read=%0d", read_obj(g));
+    free_obj(g);
+  end
+endmodule

--- a/tests/cases/errors/chandle_display/case.yaml
+++ b/tests/cases/errors/chandle_display/case.yaml
@@ -1,4 +1,4 @@
-id: errors.dpi_import_chandle
+id: errors.chandle_display
 tags: [errors, diag]
 input:
   command: [emit, cpp]
@@ -10,9 +10,9 @@ expect:
   exit: 1
   stderr:
     contains:
-      - "main.sv:2:"
+      - "main.sv:3:"
       - "unsupported:"
-      - "chandle DPI-C argument is not yet supported"
+      - "chandle"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/chandle_display/main.sv
+++ b/tests/cases/errors/chandle_display/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  chandle h;
+  initial $display("%p", h);
+endmodule

--- a/tests/cases/errors/chandle_display_in_aggregate/case.yaml
+++ b/tests/cases/errors/chandle_display_in_aggregate/case.yaml
@@ -1,0 +1,18 @@
+id: errors.chandle_display_in_aggregate
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "main.sv:3:"
+      - "unsupported:"
+      - "chandle"
+    not_contains:
+      - "internal error"
+      - "\x1b["

--- a/tests/cases/errors/chandle_display_in_aggregate/main.sv
+++ b/tests/cases/errors/chandle_display_in_aggregate/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  chandle m[string];
+  initial $display("%p", m);
+endmodule

--- a/tests/cases/errors/dpi_import_chandle/main.sv
+++ b/tests/cases/errors/dpi_import_chandle/main.sv
@@ -1,3 +1,0 @@
-module Top;
-  import "DPI-C" function void f(input chandle h);
-endmodule


### PR DESCRIPTION
## Summary

Implements SystemVerilog's `chandle` (LRM 6.14) end to end on the C++ backend. The load-bearing decision is that a chandle is a Lyra **value type**, not a bare `void*` in the backend's type mapping. The falsifier is one line of legal SV: `chandle arr[string];`. An associative-array member is wrapped in `ObservableType`, so it renders as `Var<AssociativeArray<String, ?>>`; `Var<T>` gates on the `LyraValue` concept, whose `operator==` must return `PackedArray` and whose `IsBitIdentical` / `HasUnknown` recurse into the element. A raw pointer fails that contract as a template error inside emitted code. So `lyra::value::Chandle` wraps a `void*` and satisfies `LyraValue` and `CaseEqualComparable`, but neither `Ordered` (LRM Table 11-1 defines no relational operator on a chandle) nor `WildcardComparable`; all four are statically asserted.

Once that is settled, every SV operator on a chandle lands on a path that already exists, so this change is a net removal of special cases. It closes `dpi.md` D2, `datatypes.md` (chandle was the last remaining datatype), `functions.md` F9 (its last remaining sub-step), and the corresponding `architecture-reset.md` roll-ups.

## Design

MIR needed no new node kind. `ChandleType` already existed in all three IR layers and `NullLiteral` already existed for class handles.

| SV form | MIR shape | Change |
| --- | --- | --- |
| `chandle h;` | default is `NullLiteral` | one new arm |
| `h = null` | `NullLiteral` typed `ChandleType` | none |
| `h == g`, `h != null` | plain `BinaryExpr` | **removes** a special case |
| `h === g`, `h !== null` | `kCaseEqual` builtin call | none |
| `!h` | `FromBool(LogicalNot(BoolCastExpr(h)))` | one new arm |
| `if (h)`, `h ? a : b` | condition expression, unchanged | none |

The removed special case was a latent bug: `BuildMirBinaryExpr` lumped `kChandle` with `kManagedRef` and wrapped `==` in `FromBool`, which is correct only for a raw pointer whose `==` yields a host `bool`. With `Chandle::operator==` returning `PackedArray`, `FromBool(PackedArray)` would not compile. Chandle now takes the same plain-operator path as `String` and `Real`. Case equality cost nothing at all: `===` already routes through the `kCaseEqual` builtin for every type, so modelling `CaseEqualComparable` was sufficient.

A scalar `chandle` member is **not** observable storage: `MaybeWrapObservable` is an allowlist that already excluded it, matching `decisions/value-type-concepts.md` and LRM 6.14, which forbids a chandle in a sensitivity list, an event expression, and a continuous assignment. Containers holding chandles are wrapped as usual.

At the DPI boundary, `DpiAbiClass::kChandle` carries `void*`, and the marshal pair mirrors `kString` exactly: out through an instance accessor builtin (`Ptr()`, the sibling of `CStr()`), in through `Construct` (the sibling of `String(const char*)`). Output and inout needed no new plumbing -- the writeback path from #1031 yields a `void*` boundary temp and the emit-side "append `*`" rule produces a `void**` formal. Lifetime is simpler than `string`: `Ptr()` returns by value, so there is no borrow that must outlive the call.

Two things the LRM forced that were not in the original plan. `$display("%p", h)` is accepted by slang but forbidden by LRM 6.14, which permits a chandle only in the equality family and a boolean test; lowering now rejects it, recursively through aggregates, following the precedent `value-type-concepts.md` records for `real ===`. The runtime therefore ships no `Formatter<Chandle>` and no simulation can print a host pointer -- and without the recursion, `$display("%p", m)` on a `chandle m[string]` would surface as a C++ template error inside generated code rather than a diagnostic. Separately, `int cnt[chandle];` was rejected by a wrong gate on associative index types; LRM 6.14 explicitly permits a chandle key and leaves the relative ordering of entries to the implementation, so `AssocKeyTraits<Chandle>` orders by `std::less` over the raw pointer -- a host storage choice, not an SV relational operator.

## Testing

One grouped `cpp_run` case, `cpp/chandle`, covers the null default, `==` / `!=` / `===` / `!==` against a chandle and against `null`, the boolean test including `!`, subroutine pass and return with identity preserved, an unpacked-struct field, an associative-array element and an associative-array key, plus the DPI `input` / `output` / `inout` / return directions for the chandle carrier. They are grouped rather than split because a chandle's only non-null source in the entire language is the DPI boundary, so the datatype case must link a C object regardless; splitting the directions across the existing DPI cases would duplicate that object while leaving this case still linking one. There is no overlap with `dpi_import_input` / `dpi_import_output_inout`, which prove the two lowering paths for int / real / string, whereas this proves the marshal code for a fourth carrier.

Two `errors` cases cover the format rejection, scalar and nested-in-aggregate. They cannot share a file because emit stops at the first diagnostic, and each costs about 9 ms since no C++ is compiled. `errors/dpi_import_chandle` is deleted; it pinned the rejection this change removes.

## Notes

`docs/progress/dpi.md` previously claimed the JIT half of D1 "is additive". It is not: that backend cannot yet lower a minimal procedural body -- a plain write to a module variable does not reach LIR -- so a foreign call has no body to sit inside. Corrected in place.

The `if (h)` / `!h` asymmetry is real and is recorded as `refactor.md` R56. `!h` carries an explicit `BoolCastExpr` only because its result must be re-shaped to a 1-bit integral, while `if (h)` hands a raw SV-typed condition to the backend's passthrough render and relies on C++'s contextual conversion. That is a property of the existing condition-truthiness model, not of chandle, and the fix needs no new node kind -- `BoolCastExpr` already is the primitive; the cut is to make it mandatory wherever a predicate is consumed. Deliberately not smuggled into this PR.