### PR TITLE
Name the owner in a static-callable target

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -807,20 +807,33 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       artifact); unifying it with the JIT's allocation shape waits for instance-representation
       unification.
 
-- [ ] R55 -- An external callable belongs to the compilation unit, not to a class. A DPI-C import is
-      an external callable (`../decisions/unified-callable-model.md`): a foreign-symbol declaration
-      -- signature, linkage name, language, calling convention -- with no body and no receiver. Its
-      identity at link time is the linkage name, a global. Today it is stored per class and named by
-      a class-relative id, so a call resolves the declaration only in the caller's own class, and a
-      call to an import declared in an enclosing scope is rejected as unsupported. That rejection is
-      an artifact of the storage model, not a language limitation: with no body and no receiver
-      there is nothing to reach at run time, so the declaring scope's depth is a compile-time lookup
-      distance, never a runtime reach -- unlike an internal subroutine, whose enclosing-scope hop is
-      a real receiver climb. Target: external callables live on the compilation unit, named by a
-      unit-level id; the enclosing-scope hop count disappears from the reference; each foreign
-      symbol is declared once per emitted unit rather than once per declaring class. Cover it with a
-      positive case (an import declared at module scope, called from a nested block), never by
-      pinning the current rejection. **Blocker**: none.
+- [x] R55 -- A receiver-less associated callable names its own owner. An instance method's call
+      target recovers its declaring class from its receiver; a type-associated callable -- a DPI-C
+      import today, an SV class static method later -- has no receiver, so a bare slot id left the
+      owner implicit, meaning the caller's own class. A call to a callable declared in an enclosing
+      scope therefore had to be rejected rather than resolved against the wrong namespace. The call
+      target now names the owning class and the slot, so an import declared at module scope is
+      callable from a generate block. The declaring scope's depth is a compile-time lookup distance,
+      resolved once during lowering and absent from the target; nothing is reached at run time,
+      because the callable has no body and no receiver. Declarations stay in the declaring type's
+      associated namespace (`../decisions/dpi-foreign-boundary.md`,
+      `../architecture/object_model.md` invariants 7 and 8); only the target identity gained what it
+      was missing, and that identity survives the later collapse of the method and static-callable
+      identity spaces into one callable identity (R8).
+
+- [ ] R56 -- A foreign symbol has no single record. An external callable's symbol -- its linkage
+      name and purity -- is copied into every declaring type's associated namespace, so one
+      link-time global can hold several declarations in one compilation unit and emit one
+      `extern "C"` prototype per declaration. The frontend guarantees the copies agree (two imports
+      of one C identifier with mismatching signatures are rejected), so the emitted code is correct
+      today; this is redundancy, not a defect. It is not fixed by deduplicating in the render: a
+      render entry is a mechanical function of one node and makes no decisions, so a redundancy the
+      render must hide is a redundancy in MIR (`../architecture/backend_contract.md`). Target shape:
+      the unit holds one record per foreign symbol, keyed by its linkage name, that the
+      type-associated declarations reference -- the single source of truth a generated ABI header
+      and the JIT's external-symbol resolution both read. Deferred until one of those consumers
+      exists, so the record is built for a real reader rather than to hide duplicate prototypes.
+      **Blocker**: none.
 
 - [ ] R56 -- A condition is a value; reducing it to a control predicate is an explicit conversion,
       not a backend's contextual one. MIR already owns the primitive: `BoolCastExpr` reduces any

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -8,6 +8,7 @@
 
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/cast.hpp"
+#include "lyra/mir/class_id.hpp"
 #include "lyra/mir/closure.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/inc_dec_op.hpp"
@@ -125,15 +126,30 @@ struct TypeQualifier {
 
 using ScopeQualifier = std::variant<TypeQualifier>;
 
+// Identity of a class-level static callable at a call site: the class whose
+// associated namespace declares it, and the slot within that class. A
+// receiver-less callable has no receiver to name its owner, so the owner is
+// part of the symbol identity rather than recovered from an operand -- which
+// is what lets a call reach an associated callable of an enclosing class
+// (a DPI-C import declared in the module, called from a generate block) and,
+// later, a static method of another class.
+struct StaticCallableTarget {
+  ClassId owner;
+  StaticCallableId slot;
+
+  auto operator==(const StaticCallableTarget&) const -> bool = default;
+};
+
 // The target of a `Direct` call -- the symbol identity. Three identity
 // spaces: built-in runtime entries (closed-namespace `BuiltinFn`),
-// user-declared class methods (per-class `MethodId` arena), and class-level
-// static callables (per-class `StaticCallableId` arena -- a DPI-C import's
-// external symbol, a receiver-less associated callable). These collapse into
-// one `CallableId` once the method and static-callable declarations share one
-// callable-declaration shape.
+// user-declared class methods (per-class `MethodId` arena, whose owner the
+// receiver names), and class-level static callables (`StaticCallableTarget`,
+// which names its own owner -- a DPI-C import's external symbol, a
+// receiver-less associated callable). These collapse into one `CallableId`
+// once the method and static-callable declarations share one
+// callable-declaration shape; the owner survives that collapse.
 using DirectTarget =
-    std::variant<MethodId, support::BuiltinFn, StaticCallableId>;
+    std::variant<MethodId, support::BuiltinFn, StaticCallableTarget>;
 
 // A direct call to a named symbol. The single shape for every direct
 // invocation -- user method, built-in instance method, type-qualified

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -446,12 +446,17 @@ auto RenderDirectBuiltinCall(
 }
 
 // Renders a `Direct` callee whose target is a class-level static callable.
-// Today that is a DPI-C import: a global `extern "C"` symbol reached by its
-// foreign linkage name, with no receiver and no qualifier, so the callee text
-// is the bare foreign name and no leading argument is absorbed into it.
+// The target names the class whose associated namespace declares it, which need
+// not be the class being rendered -- an import declared in the module is called
+// from a generate block's class. Today that callable is a DPI-C import: a
+// global `extern "C"` symbol reached by its foreign linkage name, with no
+// receiver and no qualifier, so the callee text is the bare foreign name and no
+// leading argument is absorbed into it.
 auto RenderDirectStaticCallableCall(
-    const ScopeView& view, mir::StaticCallableId id) -> CalleeRender {
-  const auto& callable = view.Class().static_callables.Get(id);
+    const ScopeView& view, const mir::StaticCallableTarget& target)
+    -> CalleeRender {
+  const auto& callable =
+      view.Unit().GetClass(target.owner).static_callables.Get(target.slot);
   return {.expr = callable.external.foreign_name, .leading_arg_count = 0};
 }
 
@@ -471,7 +476,7 @@ auto RenderCalleePart(
                       return RenderDirectBuiltinCall(
                           view, call, id, d.qualification);
                     },
-                    [&](const mir::StaticCallableId& s) {
+                    [&](const mir::StaticCallableTarget& s) {
                       return RenderDirectStaticCallableCall(view, s);
                     },
                 },

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -694,7 +694,7 @@ auto MarshalCarrierToSv(
 template <ExprLowerer Lowerer>
 auto LowerForeignImportInputsOnly(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const mir::StaticCallableDecl& decl, mir::StaticCallableId callable,
+    const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto& module = lowerer.Module();
   auto& unit = module.Unit();
@@ -722,7 +722,7 @@ auto LowerForeignImportInputsOnly(
   mir::Expr foreign_call{
       .data =
           mir::CallExpr{
-              .callee = mir::Direct{.target = callable},
+              .callee = mir::Direct{.target = target},
               .arguments = std::move(carrier_args)},
       .type = call_type};
   if (is_void) {
@@ -742,7 +742,7 @@ auto LowerForeignImportInputsOnly(
 template <ExprLowerer Lowerer>
 auto LowerForeignImportWithWriteback(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const mir::StaticCallableDecl& decl, mir::StaticCallableId callable,
+    const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto& module = lowerer.Module();
   auto& unit = module.Unit();
@@ -822,7 +822,7 @@ auto LowerForeignImportWithWriteback(
   mir::Expr foreign_call{
       .data =
           mir::CallExpr{
-              .callee = mir::Direct{.target = callable},
+              .callee = mir::Direct{.target = target},
               .arguments = std::move(call_args)},
       .type = call_type};
 
@@ -869,6 +869,20 @@ auto LowerForeignImportWithWriteback(
       unit, *frame.current_block, closure.Build(result_id));
 }
 
+// The compilation-unit identity of the class `hops` enclosing levels up. A
+// receiver-less callable names its owner in the call target, so that owner must
+// be a unit-stable class identity rather than a position in the lowering walk;
+// a class carries its own identity in its self-pointer type, so recover it from
+// there.
+auto EnclosingClassIdAtHops(
+    const WalkFrame& frame, const mir::CompilationUnit& unit,
+    mir::EnclosingHops hops) -> mir::ClassId {
+  const mir::TypeId self_ptr =
+      frame.EnclosingClassAtHops(hops).self_pointer_type;
+  const auto& ptr = std::get<mir::PointerType>(unit.types.Get(self_ptr).data);
+  return std::get<mir::ObjectType>(unit.types.Get(ptr.pointee).data).class_id;
+}
+
 // LRM 35.4 import call: an ordinary call to the external static callable,
 // wrapped in boundary marshaling. The ABI classes and directions are read from
 // the callable's own declaration, resolved once at its declaration lowering. An
@@ -877,17 +891,20 @@ auto LowerForeignImportWithWriteback(
 template <ExprLowerer Lowerer>
 auto LowerForeignImportCall(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const hir::ForeignImportRef& ref, diag::SourceSpan span,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  if (ref.hops.value != 0) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedDpi,
-        "a call to a DPI-C import declared in an enclosing scope is not yet "
-        "supported");
-  }
-  const mir::StaticCallableId callable{ref.id.value};
+    const hir::ForeignImportRef& ref, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  // An import is a receiver-less associated callable of the scope that declares
+  // it. `hops` is how far out that scope sits from the caller -- a declaration
+  // lookup distance, resolved here and then gone; the callable has no body and
+  // no receiver, so nothing is reached at run time and the call names its owner
+  // directly.
+  const mir::CompilationUnit& unit = lowerer.Module().Unit();
+  const mir::EnclosingHops hops{.value = ref.hops.value};
+  const mir::StaticCallableTarget target{
+      .owner = EnclosingClassIdAtHops(frame, unit, hops),
+      .slot = mir::StaticCallableId{ref.id.value}};
   const mir::StaticCallableDecl& decl =
-      frame.current_class->static_callables.Get(callable);
+      frame.EnclosingClassAtHops(hops).static_callables.Get(target.slot);
 
   const bool has_writeback =
       std::ranges::any_of(decl.params, [](const mir::ForeignParam& p) {
@@ -895,10 +912,10 @@ auto LowerForeignImportCall(
       });
   if (has_writeback) {
     return LowerForeignImportWithWriteback(
-        lowerer, frame, c, decl, callable, result_type);
+        lowerer, frame, c, decl, target, result_type);
   }
   return LowerForeignImportInputsOnly(
-      lowerer, frame, c, decl, callable, result_type);
+      lowerer, frame, c, decl, target, result_type);
 }
 
 }  // namespace
@@ -937,8 +954,7 @@ auto LowerHirCallExpr(
             return LowerBuiltinMethodCall(lowerer, frame, c, b, result_type);
           },
           [&](const hir::ForeignImportRef& imp) -> diag::Result<mir::Expr> {
-            return LowerForeignImportCall(
-                lowerer, frame, c, imp, span, result_type);
+            return LowerForeignImportCall(lowerer, frame, c, imp, result_type);
           },
       },
       c.callee);

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -61,7 +61,7 @@ auto LowerCallTarget(
                         -> diag::Result<lir::CallTarget> {
                       return lir::CallTarget{lir::BuiltinTarget{.fn = fn}};
                     },
-                    [](const mir::StaticCallableId&)
+                    [](const mir::StaticCallableTarget&)
                         -> diag::Result<lir::CallTarget> {
                       return diag::Fail(
                           diag::DiagCode::kUnsupportedExpressionForm,

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -482,12 +482,13 @@ class MirDumper {
             [](const support::BuiltinFn& id) -> std::string {
               return std::format("builtin=\"{}\"", support::BuiltinFnName(id));
             },
-            [this](const StaticCallableId& s) -> std::string {
-              const auto& owner = ResolveScopeAtHops(0);
-              const auto& callable = owner.static_callables.Get(s);
+            [this](const StaticCallableTarget& s) -> std::string {
+              const auto& callable =
+                  unit_->GetClass(s.owner).static_callables.Get(s.slot);
               return std::format(
-                  R"(static_callable={} "{}" c_name="{}")", s.value,
-                  callable.name, callable.external.foreign_name);
+                  R"(static_callable=Class[{}].{} "{}" c_name="{}")",
+                  s.owner.value, s.slot.value, callable.name,
+                  callable.external.foreign_name);
             },
         },
         target);

--- a/tests/cases/cpp/dpi_import_input/case.yaml
+++ b/tests/cases/cpp/dpi_import_input/case.yaml
@@ -16,3 +16,5 @@ expect:
       negate=-2.5
       var=11
       lit=2
+      nested=8
+      deeper=15

--- a/tests/cases/cpp/dpi_import_input/main.sv
+++ b/tests/cases/cpp/dpi_import_input/main.sv
@@ -23,4 +23,25 @@ module Top;
     n = slen("hi");
     $display("lit=%0d", n);
   end
+
+  // The imports are declared here, at module scope. A call from inside a
+  // generate block reaches a receiver-less associated callable of an enclosing
+  // class, so the call target must name that class rather than the caller's --
+  // a different path from a call in the declaring scope (LRM 35.4).
+  if (1) begin : g
+    int gn;
+    initial begin
+      #1;
+      gn = add_one(7);
+      $display("nested=%0d", gn);
+    end
+    if (1) begin : h
+      int hn;
+      initial begin
+        #2;
+        hn = mul(3, 5);
+        $display("deeper=%0d", hn);
+      end
+    end
+  end
 endmodule


### PR DESCRIPTION
## Summary

A call to a DPI-C import declared in an enclosing scope was rejected with an "unsupported" diagnostic, so an import declared at module scope could not be called from any generate block -- an ordinary SystemVerilog shape. The rejection was not a language limitation; it was a gap in the call-target identity. A DPI import is a receiver-less associated callable (`decisions/dpi-foreign-boundary.md`), and its `Direct` call target carried only a class-relative slot id with the owning class left implicit as the caller's own class. An instance method recovers its owner from its receiver; a receiver-less callable has no receiver to recover it from, so a call in a different class resolved against the wrong namespace, and the guard existed to stop that.

## Design

The static-callable arm of `DirectTarget` now carries its owner: `StaticCallableTarget{ ClassId owner, StaticCallableId slot }`. HIR already recorded the enclosing-scope hop distance to the declaring scope; HIR-to-MIR resolves that distance to a compilation-unit-stable `ClassId` (recovered from the enclosing class's own self-pointer type) and drops it from the target. Nothing is reached at run time -- the callable has no body and no receiver -- so the hop count is a compile-time declaration-lookup distance only, resolved once during lowering and gone. The declaration stays in the declaring type's associated namespace (`architecture/object_model.md` invariants 7 and 8); only the target identity gained the owner it was missing. The same completed identity is what a future SystemVerilog class static method call needs, and it survives the later collapse of the method and static-callable identity spaces into one callable identity (R8).

This change deliberately does not deduplicate the `extern "C"` prototype a repeated import of one symbol emits. That duplication is redundancy, not a defect: the frontend rejects two imports of one C identifier with mismatching signatures, so the prototypes are always token-identical and the emitted C++ is legal. Hiding it in the render would violate the mechanical-render contract, and the correct fix -- one unit-level record per foreign symbol -- wants a real reader (a generated ABI header, JIT symbol resolution) before it is built. It is tracked as R56.

## Testing

`bazel test //...` is green. The `dpi_import_input` case now declares its imports at module scope and calls them from a generate block and a nested generate block, asserting the round trip end to end (emit, compile, link the C object, run).
