### PR TITLE
State a condition's predicate reduction in MIR

### DIFF
--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -31,7 +31,8 @@ status.
 Each file contains:
 
 - A short header stating the feature's scope and its defined "done" state.
-- The checkbox list of sub-steps, with completed items checked off as their PRs land.
+- The checkbox list of sub-steps, with an item flipped to `[x]` in the same change that lands its
+  code -- the working tree before commit included, never a follow-up change.
 - Any blockers, open design questions, or cross-references to architecture contracts the work must
   satisfy.
 

--- a/docs/progress/activation.md
+++ b/docs/progress/activation.md
@@ -2,8 +2,7 @@
 
 Tracks where the runtime's execution code differs from the golden activation model in
 `../architecture/activation.md`. Each entry names the current shape, the contract shape it must
-reach, and what (if anything) blocks it. Entries get checked off as their PRs land; when the last
-lands, this file is deleted.
+reach, and what (if anything) blocks it.
 
 The runtime already realizes the load-bearing core of the contract: an activation is a coroutine
 frame; the scheduler holds a payload-neutral activation token and never sees the completion type; a

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -14,9 +14,7 @@ in four parts:
   dissolved each so they are not reintroduced.
 
 An item is checked only when its behavior is reproduced on the current architecture, or, for an
-infrastructure surface, built. Items are written at the semantic level: completing one is flipping
-`[ ]` to `[x]`, not rewriting it into an account of what landed. When every item lands, this file is
-deleted.
+infrastructure surface, built.
 
 ## Infrastructure
 

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -4,7 +4,7 @@ Tracks multi-level module structure and hierarchical paths: a module instantiati
 the per-instance object tree this builds, the connections across that tree (ports), and references
 that name signals in another instance (hierarchical references). Covers the archive items under
 `archived/tests/sv_features/hierarchy/` (`instantiation`, `ports`, `refs`) and the instantiation
-side of `archived/tests/sv_features/generate/`. When the last item lands, this file is deleted.
+side of `archived/tests/sv_features/generate/`.
 
 The stage IDs (A1, B1, ...) are stable references. Stage letters **do** imply dependency order: a
 later stage may not begin until the stages it depends on are settled. Within a stage the items are

--- a/docs/progress/nets.md
+++ b/docs/progress/nets.md
@@ -9,7 +9,7 @@ tracks the delta between the code and that model.
 Done when the in-scope net types carry correct driver-resolution semantics end to end --
 declaration, single- and multi-driver resolution, the wired and tri-state net types, drive strength,
 pull/supply, and charge storage -- and net-typed port connections behave as those nets across the
-object graph. When the last item lands, the file is deleted.
+object graph.
 
 ## Contracts
 

--- a/docs/progress/query-functions.md
+++ b/docs/progress/query-functions.md
@@ -7,7 +7,7 @@ report properties of a data type or of an array's shape, not a computation over 
 
 Done when the whole 20.6 / 20.7 family lowers and runs for every data type: the fixed-size forms as
 elaboration-time constants, and the dynamically sized forms as runtime queries of the array's
-current state. When the last item lands, this file is deleted.
+current state.
 
 ## Semantic model
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -17,8 +17,6 @@ next touched, not when some future event is deemed to "trigger" it. The only hon
 an entry open are a named unlanded prerequisite (it is blocked), or a cut large and cross-cutting
 enough to warrant its own focused review.
 
-Entries get checked off as their PRs land. When the last entry lands, the file is deleted.
-
 ## Sub-Steps
 
 - [x] R1 -- The canonical builtin TypeIds (`int`, `bit[0]`, `string`, `void`, `realtime`, and the
@@ -835,7 +833,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       exists, so the record is built for a real reader rather than to hide duplicate prototypes.
       **Blocker**: none.
 
-- [ ] R56 -- A condition is a value; reducing it to a control predicate is an explicit conversion,
+- [x] R57 -- A condition is a value; reducing it to a control predicate is an explicit conversion,
       not a backend's contextual one. MIR already owns the primitive: `BoolCastExpr` reduces any
       operand to a host bool, and a real or chandle `!` lowers through it. But `IfStmt`,
       `WhileStmt`, the loop forms, and `ConditionalExpr` all carry a raw SV-typed condition, and the

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -16,11 +16,4 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string;
 // so this render is purely mechanical -- it does not inject any wrapper.
 auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr) -> std::string;
 
-// Renders `expr` for use in a C++ boolean context (`if`, `while`, `do`, `for`
-// condition, ternary cond, `&&` / `||` / `!`). When the expression's MIR type
-// is a packed array, `PackedArray`'s `explicit operator bool` fires on the
-// contextual conversion; no explicit wrapping is needed.
-auto RenderConditionAsBool(const ScopeView& view, const mir::Expr& expr)
-    -> std::string;
-
 }  // namespace lyra::backend::cpp

--- a/include/lyra/lowering/hir_to_mir/case_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/case_cascade.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -92,8 +93,8 @@ auto BuildCaseCascade(
     WalkFrame frame, mir::Block wrapper_block,
     std::optional<std::string> outer_label, std::size_t item_count,
     std::vector<mir::Block> body_scopes,
-    std::optional<mir::Block> default_scope, PredicateBuilder&& build_predicate)
-    -> diag::Result<mir::Stmt> {
+    std::optional<mir::Block> default_scope, mir::TypeId bit1_type,
+    PredicateBuilder&& build_predicate) -> diag::Result<mir::Stmt> {
   std::optional<mir::Block> tail = std::move(default_scope);
 
   for (std::size_t i = item_count; i-- > 1;) {
@@ -114,7 +115,7 @@ auto BuildCaseCascade(
 
     level_block.AppendStmt(
         mir::IfStmt{
-            .condition = *pred_or,
+            .condition = ReduceToCondition(level_block, *pred_or, bit1_type),
             .then_scope = body_scope_id,
             .else_scope = else_scope_id});
 
@@ -138,7 +139,7 @@ auto BuildCaseCascade(
 
     wrapper_block.AppendStmt(
         mir::IfStmt{
-            .condition = *pred0_or,
+            .condition = ReduceToCondition(wrapper_block, *pred0_or, bit1_type),
             .then_scope = body0_id,
             .else_scope = else0_id});
   } else if (tail.has_value()) {

--- a/include/lyra/lowering/hir_to_mir/condition.hpp
+++ b/include/lyra/lowering/hir_to_mir/condition.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::mir {
+struct Block;
+}  // namespace lyra::mir
+
+namespace lyra::lowering::hir_to_mir {
+
+// Reduces a lowered expression consumed as a condition to a stated boolean
+// predicate, appending a `BoolCastExpr` over it to `block` and returning its
+// id. Every condition context (if / while / for / do-while / ternary) stores
+// the reduced predicate, so a backend emits the host-bool reduction
+// mechanically from the node and never re-derives it from the operand's value
+// type (LRM 12.4: the condition is true when the expression is nonzero, and
+// false when it is zero, x, or z). `bit1_type` is the 1-bit type the cast
+// carries by convention; the bool-ness rides on the node kind, not the type.
+auto ReduceToCondition(
+    mir::Block& block, mir::ExprId cond, mir::TypeId bit1_type) -> mir::ExprId;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -64,13 +64,16 @@ struct UnaryExpr {
   ExprId operand;
 };
 
-// Reduces an operand to a host `bool`. Used to bring real / string operands
-// onto the host-bool plane before a C++ native logical operator (`&&`, `||`,
-// `!`), and as the inner argument of `BuiltinFn::kFromBool` when the result
-// must re-shape to a 1-bit packed value. `Expr::type` is conventionally
-// `builtins.bit1` (the result is observable only after `FromBool` re-shapes
-// it; the operand of a `BoolCastExpr` is whatever the host's `bool(...)`
-// conversion accepts).
+// Reduces an operand to a host `bool` -- the predicate-reduction primitive. It
+// stands wherever a value is consumed as a boolean: a condition context (an
+// if / while / for / do-while / ternary, LRM 12.4, true when the operand is
+// nonzero and false when it is zero, x, or z), an operand of a native logical
+// operator (`&&` / `||` / `!`), and the inner argument of a re-shape back to a
+// 1-bit packed value. The node kind, not the operand's type, is what tells a
+// backend to emit the reduction, so a condition never leaves the boolean
+// decision to a contextual conversion at the branch site. `Expr::type` carries
+// the 1-bit type by convention; the operand is any value the host's `bool(...)`
+// conversion accepts.
 struct BoolCastExpr {
   ExprId operand;
 };

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -281,10 +281,9 @@ auto RenderBinaryExpr(const ScopeView& view, const mir::BinaryExpr& b)
       RenderExpr(view, view.Expr(b.rhs)));
 }
 
-// Brings an operand onto the host-bool plane so a native C++ logical
-// operator (`&&` / `||` / `!`) can take it. The wrap is observable only as
-// the operand of `kFromBool` -- the value-shape re-projection back to the
-// SV 1-bit integral lives there.
+// Emits the host-bool reduction the node states, so a condition and a native
+// C++ logical operand read a value as a boolean the same way, without leaving
+// the boolean decision to a contextual conversion at the use site.
 auto RenderBoolCastExpr(const ScopeView& view, const mir::BoolCastExpr& b)
     -> std::string {
   return std::format("bool({})", RenderExpr(view, view.Expr(b.operand)));
@@ -293,7 +292,7 @@ auto RenderBoolCastExpr(const ScopeView& view, const mir::BoolCastExpr& b)
 auto RenderConditionalExpr(const ScopeView& view, const mir::ConditionalExpr& c)
     -> std::string {
   return std::format(
-      "({} ? {} : {})", RenderConditionAsBool(view, view.Expr(c.condition)),
+      "({} ? {} : {})", RenderExpr(view, view.Expr(c.condition)),
       RenderExpr(view, view.Expr(c.then_value)),
       RenderExpr(view, view.Expr(c.else_value)));
 }
@@ -937,13 +936,6 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
           },
       },
       expr.data);
-}
-
-auto RenderConditionAsBool(const ScopeView& view, const mir::Expr& expr)
-    -> std::string {
-  // PackedArray's `explicit operator bool` fires in any boolean context (if /
-  // while / for / ternary cond / `&&` / `||` / `!`), so no wrapping needed.
-  return RenderExpr(view, expr);
 }
 
 }  // namespace lyra::backend::cpp

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -90,7 +90,7 @@ auto RenderIfStmt(
   const auto& then_scope = view.Block().child_scopes.Get(s.then_scope);
   std::string result;
   result += std::format(
-      "{}if ({}) {{\n", Indent(indent), RenderConditionAsBool(view, cond_expr));
+      "{}if ({}) {{\n", Indent(indent), RenderExpr(view, cond_expr));
   result += RenderNestedBlock(view, then_scope, indent + 1);
   result += std::format("{}}}", Indent(indent));
   if (s.else_scope.has_value()) {
@@ -121,7 +121,7 @@ auto RenderForStmt(
   std::string cond;
   if (s.condition.has_value()) {
     const auto& cond_expr = view.Block().exprs.Get(*s.condition);
-    cond = RenderConditionAsBool(view, cond_expr);
+    cond = RenderExpr(view, cond_expr);
   }
   std::string step;
   for (std::size_t i = 0; i < s.step.size(); ++i) {
@@ -147,8 +147,7 @@ auto RenderWhileStmt(
   const auto& cond_expr = view.Block().exprs.Get(s.condition);
   const auto& block = view.Block().child_scopes.Get(s.scope);
   std::string result = std::format(
-      "{}while ({}) {{\n", Indent(indent),
-      RenderConditionAsBool(view, cond_expr));
+      "{}while ({}) {{\n", Indent(indent), RenderExpr(view, cond_expr));
   result += RenderNestedBlock(view, block, indent + 1);
   result += std::format("{}}}\n", Indent(indent));
   return result;
@@ -162,8 +161,7 @@ auto RenderDoWhileStmt(
   std::string result = std::format("{}do {{\n", Indent(indent));
   result += RenderNestedBlock(view, block, indent + 1);
   result += std::format(
-      "{}}} while ({});\n", Indent(indent),
-      RenderConditionAsBool(view, cond_expr));
+      "{}}} while ({});\n", Indent(indent), RenderExpr(view, cond_expr));
   return result;
 }
 

--- a/src/lyra/lowering/hir_to_mir/condition.cpp
+++ b/src/lyra/lowering/hir_to_mir/condition.cpp
@@ -1,0 +1,14 @@
+#include "lyra/lowering/hir_to_mir/condition.hpp"
+
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto ReduceToCondition(
+    mir::Block& block, mir::ExprId cond, mir::TypeId bit1_type) -> mir::ExprId {
+  return block.exprs.Add(
+      mir::Expr{.data = mir::BoolCastExpr{.operand = cond}, .type = bit1_type});
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -15,6 +15,7 @@
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
@@ -194,6 +195,7 @@ auto BuildUniqueCheckClosure(
   mir::Block& body = closure.Body();
 
   const mir::TypeId int32_type = module.Unit().builtins.int32;
+  const mir::TypeId bit1_type = module.Unit().builtins.bit1;
   const BodyBindingRef self_ref =
       closure.Bindings().EnsureCarrier(BindingOriginId::Receiver());
 
@@ -222,7 +224,7 @@ auto BuildUniqueCheckClosure(
         mir::Expr{
             .data =
                 mir::ConditionalExpr{
-                    .condition = bit_read,
+                    .condition = ReduceToCondition(body, bit_read, bit1_type),
                     .then_value = one_lit,
                     .else_value = zero_lit},
             .type = int32_type});
@@ -270,7 +272,7 @@ auto BuildUniqueCheckClosure(
 
   body.AppendStmt(
       mir::IfStmt{
-          .condition = predicate_id,
+          .condition = ReduceToCondition(body, predicate_id, bit1_type),
           .then_scope = diag_scope_id,
           .else_scope = std::nullopt});
 
@@ -287,6 +289,7 @@ auto BuildDeferredCheckCascade(
     -> mir::Stmt {
   const mir::TypeId void_type = module.Unit().builtins.void_type;
   const mir::TypeId int32_type = module.Unit().builtins.int32;
+  const mir::TypeId bit1_type = module.Unit().builtins.bit1;
 
   // SnapshotPredicate / BuildDefaultValueExpr append to wrapper, so route
   // through a wrapper-local frame; the cascade levels each derive their own
@@ -344,7 +347,7 @@ auto BuildDeferredCheckCascade(
 
     level_block.AppendStmt(
         mir::IfStmt{
-            .condition = cond_read,
+            .condition = ReduceToCondition(level_block, cond_read, bit1_type),
             .then_scope = body_scope_id,
             .else_scope = else_scope_id});
     tail = std::move(level_block);
@@ -363,7 +366,7 @@ auto BuildDeferredCheckCascade(
 
     wrapper.AppendStmt(
         mir::IfStmt{
-            .condition = cond_read0,
+            .condition = ReduceToCondition(wrapper, cond_read0, bit1_type),
             .then_scope = body0_id,
             .else_scope = else0_id});
   }

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -13,6 +13,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
@@ -455,7 +456,9 @@ auto LowerHirConditionalExpr(
   auto& block = *frame.current_block;
   auto cond_or = lowerer.LowerExpr(lowerer.HirExprs().Get(c.condition), frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
+  const mir::ExprId cond_id = ReduceToCondition(
+      block, block.exprs.Add(*std::move(cond_or)),
+      lowerer.Module().Unit().builtins.bit1);
   auto then_or = lowerer.LowerExpr(lowerer.HirExprs().Get(c.then_value), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const mir::ExprId then_id = block.exprs.Add(*std::move(then_or));

--- a/src/lyra/lowering/hir_to_mir/expression/system/plusargs.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/plusargs.cpp
@@ -9,6 +9,7 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
@@ -132,7 +133,9 @@ auto LowerValuePlusargs(
   const mir::ExprId assign_id = then_body.exprs.Add(assign_expr);
   then_body.AppendStmt(mir::ExprStmt{.expr = assign_id});
 
-  body.AppendIfThen(cond_id, std::move(then_body));
+  body.AppendIfThen(
+      ReduceToCondition(body, cond_id, unit.builtins.bit1),
+      std::move(then_body));
 
   const mir::ExprId final_hit =
       body.exprs.Add(mir::MakeLocalRefExpr(hit_var, int32_t_id));

--- a/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
@@ -13,6 +13,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
@@ -133,7 +134,8 @@ auto LowerStrobeCall(
     guard.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
     body.AppendStmt(
         mir::IfStmt{
-            .condition = is_cancelled,
+            .condition =
+                ReduceToCondition(body, is_cancelled, unit.builtins.bit1),
             .then_scope = body.child_scopes.Add(std::move(guard)),
             .else_scope = std::nullopt});
   }

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -15,6 +15,7 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
@@ -99,7 +100,8 @@ auto EmitIsUnknownGuard(
           module.Unit().builtins.integer, static_cast<std::int64_t>(-1)));
   then_body.AppendStmt(mir::ReturnStmt{.value = minus_one});
 
-  body.AppendIfThen(guard_id, std::move(then_body));
+  body.AppendIfThen(
+      ReduceToCondition(body, guard_id, bit_t), std::move(then_body));
 }
 
 auto ValidateTargetType(
@@ -314,7 +316,9 @@ auto LowerScanSystemSubroutineCall(
     const mir::ExprId assign_id = then_body.exprs.Add(assign_expr);
     then_body.AppendStmt(mir::ExprStmt{.expr = assign_id});
 
-    body.AppendIfThen(cond_id, std::move(then_body));
+    body.AppendIfThen(
+        ReduceToCondition(body, cond_id, unit.builtins.bit1),
+        std::move(then_body));
   }
 
   const mir::ExprId count_id =

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -13,6 +13,7 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/deferred_check_cascade.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
@@ -38,7 +39,9 @@ auto LowerIfStmt(
   if (!cond_expr_or) {
     return std::unexpected(std::move(cond_expr_or.error()));
   }
-  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_expr_or));
+  const mir::ExprId cond_id = ReduceToCondition(
+      block, block.exprs.Add(*std::move(cond_expr_or)),
+      process.Module().Unit().builtins.bit1);
 
   auto then_or = LowerStmtIntoChildScope(process, frame, i.then_stmt);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
@@ -189,7 +192,8 @@ auto LowerCaseStmt(
 
   return BuildCaseCascade(
       frame, std::move(wrapper), std::move(label), c.items.size(),
-      std::move(body_scopes), std::move(default_scope), build_predicate);
+      std::move(body_scopes), std::move(default_scope), bit_type,
+      build_predicate);
 }
 
 auto LowerCaseInsideStmt(
@@ -291,7 +295,8 @@ auto LowerCaseInsideStmt(
 
   return BuildCaseCascade(
       frame, std::move(wrapper), std::move(label), c.items.size(),
-      std::move(body_scopes), std::move(default_scope), build_item_predicate);
+      std::move(body_scopes), std::move(default_scope), bit_type,
+      build_item_predicate);
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/loops.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/loops.cpp
@@ -12,6 +12,7 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/statement/blocks.hpp"
@@ -80,7 +81,9 @@ auto LowerForStmt(
     if (!cond_or) {
       return std::unexpected(std::move(cond_or.error()));
     }
-    cond_id = block.exprs.Add(*std::move(cond_or));
+    cond_id = ReduceToCondition(
+        block, block.exprs.Add(*std::move(cond_or)),
+        process.Module().Unit().builtins.bit1);
   }
 
   std::vector<mir::ExprId> step_ids;
@@ -123,7 +126,9 @@ auto LowerWhileStmt(
   if (!cond_or) {
     return std::unexpected(std::move(cond_or.error()));
   }
-  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
+  const mir::ExprId cond_id = ReduceToCondition(
+      block, block.exprs.Add(*std::move(cond_or)),
+      process.Module().Unit().builtins.bit1);
 
   auto body_or = LowerStmtIntoChildScope(process, frame, w.body);
   if (!body_or) {
@@ -152,7 +157,9 @@ auto LowerDoWhileStmt(
   if (!cond_or) {
     return std::unexpected(std::move(cond_or.error()));
   }
-  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
+  const mir::ExprId cond_id = ReduceToCondition(
+      block, block.exprs.Add(*std::move(cond_or)),
+      process.Module().Unit().builtins.bit1);
 
   const mir::BlockId body_scope_id =
       frame.current_block->child_scopes.Add(std::move(*body_or));
@@ -199,7 +206,7 @@ auto LowerRepeatStmt(
       wrapper.exprs.Add(mir::MakeLocalRefExpr(idx_var, int_type));
   const mir::ExprId count_ref_cond =
       wrapper.exprs.Add(mir::MakeLocalRefExpr(count_var, int_type));
-  const mir::ExprId cond_id = wrapper.exprs.Add(
+  const mir::ExprId less_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::BinaryExpr{
@@ -207,6 +214,7 @@ auto LowerRepeatStmt(
                   .lhs = idx_ref_cond,
                   .rhs = count_ref_cond},
           .type = bit_type});
+  const mir::ExprId cond_id = ReduceToCondition(wrapper, less_id, bit_type);
 
   const mir::ExprId idx_ref_step =
       wrapper.exprs.Add(mir::MakeLocalRefExpr(idx_var, int_type));

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -16,6 +16,7 @@
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
@@ -314,7 +315,10 @@ auto LowerWaitStmt(
       wrapper.child_scopes.Add(std::move(inner_block));
 
   wrapper.AppendStmt(
-      mir::WhileStmt{.condition = not_cond_id, .scope = inner_scope_id});
+      mir::WhileStmt{
+          .condition = ReduceToCondition(
+              wrapper, not_cond_id, process.Module().Unit().builtins.bit1),
+          .scope = inner_scope_id});
 
   const hir::Stmt& body_hir = hir_proc.stmts.Get(w.body);
   auto body_or = process.LowerStmt(body_hir, wrapper_frame);


### PR DESCRIPTION
## Summary

A condition -- the test of an `if`, `while`, `for`, `do-while`, or ternary -- is a value, and reducing it to a control predicate is an explicit conversion, not something a backend recovers from the operand's type at the branch site. Previously every condition carried a raw SV-typed value and the C++ backend recovered the predicate by handing that value to C++'s contextual `bool` conversion, which worked only because every value type happens to expose an `explicit operator bool`. The semantic fact "this value is read as a predicate here" was stated nowhere in MIR -- exactly the re-derivation `mir.md` invariant 10 forbids -- and left a visible asymmetry: a chandle `!h` carried an explicit `BoolCastExpr` while `if (h)` did not. Now every condition context carries its condition already reduced through `BoolCastExpr` at HIR-to-MIR, and the backend's condition-rendering passthrough is gone: render emits the reduction like any other node. Behavior on the C++ backend is unchanged (`bool(x)` is the same reduction the contextual conversion performed); the win is that the predicate reduction is stated in MIR, so an LLVM backend reads one node instead of synthesizing a per-type test with nothing telling it to, and each value type's predicate semantics hold against LRM Table 11-1 (nonzero true; zero, x, or z false). This completes R57.

This PR also makes the progress-doc check-off convention single-source. The rule -- an item is flipped to `[x]` in the same change that lands its code, the working tree before commit included, never a follow-up change -- now lives only in the progress `README`, and the per-file copies that had drifted (in `refactor`, `activation`, `nets`, `query-functions`, `hierarchy`, and `architecture-reset`) are removed, each file keeping only its own feature-specific content.

## Testing

`bazel test //...` passes. The condition change is behavior-neutral on the C++ backend, proven by the existing condition tests -- `if` / `while` / `for` / `case` / ternary across every value type, including a chandle in an `if` condition.
