### PR TITLE
Add process lineage and wait fork

### DIFF
--- a/docs/architecture/activation.md
+++ b/docs/architecture/activation.md
@@ -35,6 +35,9 @@ the awaiter consumes, not of the scheduler.
   through the activation, never through the scheduler.
 - The three activation relations: **ownership** (who releases it), **continuation** (who consumes
   the outcome and resumes on completion), and **cancellation domain** (who is cancelled together).
+- The **process lineage**: the parent-child tree of processes (LRM 9.5), which realizes ownership
+  and cancellation membership for a spawned process. A lineage node outlives the execution it named,
+  for as long as any descendant is live.
 - The **registration set**: every external reference to a parked activation (a region queue slot, a
   delay slot, an event waiter entry, a value-change subscription, a join aggregator entry) as a
   revocable registration owned by the activation.
@@ -70,10 +73,12 @@ the awaiter consumes, not of the scheduler.
 3. **Ownership, continuation, and cancellation membership are three distinct relations.** Ownership
    decides who releases the activation; continuation decides who consumes its outcome and resumes on
    completion; cancellation membership decides who is cancelled when a domain is disabled. A direct
-   task enable makes the enabler all three; a fork branch separates them -- owned and cancelled by
-   the fork domain, its outcome aggregated by a join state, with no single resuming continuation.
-   _Consequence: these relations are not one pointer; a model that collapses them cannot express
-   fork or selective cancellation._
+   task enable makes the enabler all three; a fork branch separates them -- attached to the spawning
+   process's lineage, which determines storage ownership and cancellation membership, while its
+   outcome is aggregated by the join state of the fork statement that spawned it, with no single
+   resuming continuation. _Consequence: these relations are not one pointer; a model that collapses
+   them cannot express fork or selective cancellation. The lineage edge realizes two of them; the
+   join state realizes the third._
 
 4. **Every external reference to a parked activation is a revocable registration, and a frame is
    destroyed only after no scheduler structure can name its token.** When an activation suspends,
@@ -92,10 +97,10 @@ the awaiter consumes, not of the scheduler.
    is not an activation.** A process is owned by its scope, has process identity, completes `Void`,
    and is observed by the engine (no continuation). A task activation inherits the enabler's process
    identity, completes with a typed payload, and resumes the enabler. A fork branch has its own
-   process identity, is owned by the fork domain, completes `Void`, and reports to a join state. A
-   deferred effect is a closure submitted to a region, not an activation. _Consequence: each kind
-   reuses the activation core but binds its own ownership / continuation / completion; deferred work
-   never enters the activation/completion model._
+   process identity, is owned by the spawning process's lineage, completes `Void`, and reports to a
+   join state. A deferred effect is a closure submitted to a region, not an activation.
+   _Consequence: each kind reuses the activation core but binds its own ownership / continuation /
+   completion; deferred work never enters the activation/completion model._
 
 ## Boundary to Adjacent Layers
 
@@ -144,9 +149,22 @@ the awaiter consumes, not of the scheduler.
   nor settle an outcome a consumer awaits (invariant 6).
 
 - **A fork branch modeled as a task the parent awaits.** A branch has its own process identity, is
-  owned and cancelled by the fork domain, and reports to a join state under a join-mode condition;
+  owned by the spawning process's lineage, and reports to a join state under a join-mode condition;
   `join_none` has no parent wait at all. Reusing task-enable ownership for a branch conflates the
   two (invariant 3, invariant 6).
+
+- **A cancellation domain scoped to the fork statement rather than to the process.** `disable fork`
+  terminates every descendant of the calling process, spawned by any fork that process ever
+  executed, and `wait fork` observes the immediate children accumulated across all of them (LRM
+  9.6.1, 9.6.3). A per-fork-statement domain cannot answer either question. The join state is
+  per-fork-statement because the join condition is; the lineage is per-process because cancellation
+  and child observation are.
+
+- **A lineage node whose lifetime is its activation's execution.** `disable fork` reaches "the
+  descendants of subprocesses that have already terminated" (LRM 9.6.3), so a terminated process
+  stays reachable from its parent while any descendant is still live. Releasing the node with the
+  frame loses that reach; retaining the frame to keep the node pins the activation storage the frame
+  solely owns. Node lifetime and execution lifetime are distinct.
 
 ## Notes / Examples
 
@@ -164,12 +182,16 @@ A fork splits them:
 
 ```text
 fork branch  ->  branch activation, completion slot `Void`, own process identity
-  ownership            = the fork domain
+  ownership            = the spawning process's lineage (it releases the branch)
   continuation         = none (the branch resumes no one)
-  cancellation domain  = the fork domain
+  cancellation domain  = the spawning process (an ancestor's `disable fork` reaches it)
 join state  <-  each branch reports terminated / faulted / cancelled
   join / join_any / join_none decide when the forking process resumes
 ```
+
+Ownership and cancellation membership ride the same lineage edge here; continuation rides the join
+state. That the first two coincide for a branch is not a collapse of the relations -- what invariant
+3 forbids is one edge that also carries the consumer.
 
 The C++ backend realizes an activation as a coroutine frame. Its activation token is the coroutine
 promise's non-templated base (the scheduler holds a pointer to it); its completion slot is the typed

--- a/docs/progress/activation.md
+++ b/docs/progress/activation.md
@@ -6,9 +6,11 @@ reach, and what (if anything) blocks it.
 
 The runtime already realizes the load-bearing core of the contract: an activation is a coroutine
 frame; the scheduler holds a payload-neutral activation token and never sees the completion type; a
-suspending callable's result type is `Coroutine<T>` and a typed await consumes its value; a fork
-branch is owned by the fork domain and reports to a join state. The gaps below are where the current
-shape is still wrong or incomplete relative to the contract.
+suspending callable's result type is `Coroutine<T>` and a typed await consumes its value; a spawned
+process is attached to its spawner's lineage, which is both the ownership and the
+cancellation-domain relation and outlives the execution it named while any descendant is live; and
+its outcome is aggregated by a join state. The gaps below are where the current shape is still wrong
+or incomplete relative to the contract.
 
 ## Items
 
@@ -25,24 +27,30 @@ shape is still wrong or incomplete relative to the contract.
       a parked activation -- a region queue slot, a delay slot, an event waiter entry, a
       value-change subscription, a join aggregator entry -- is a revocable registration the
       activation owns, and a frame is destroyed only after the registration set is empty. Current
-      shape: value-change subscriptions are tracked and revocable, but region-queue membership and
-      event-waiter entries hold references the activation cannot itself revoke. Target: one
-      revocable registration set covering every registration kind, with destruction gated on it.
-      Until then, no new registration kind may be added that an activation cannot revoke. Partly
-      gated on cancellation (below), but the general registration-set contract should land first.
+      shape: value-change subscriptions and the completion-aggregator waiter (the parked parent of a
+      `join` / `join_any`, and the parked process of a `wait fork`) are revocable registrations that
+      detach safely from either end; but a delay slot, region-queue membership, and event-waiter
+      entries still hold references the activation cannot itself revoke. Target: one revocable
+      registration set covering every registration kind, with destruction gated on it. Until then,
+      no new registration kind may be added that an activation cannot revoke. Partly gated on
+      cancellation (below), but the general registration-set contract should land first.
 
 - [ ] **Cancellation is absent.** Contract: the terminal outcome includes `Cancelled`; a
       cancellation domain -- a relation distinct from ownership and continuation -- decides which
       activations are cancelled together; disabling settles `Cancelled`, revokes every registration,
-      cancels the owned descendants, then releases the frame. Current shape: there is no
-      cancellation path, no `Cancelled` outcome, and no cancellation-domain relation. Target: the
-      full cancellation model behind `disable` / `disable fork` (LRM 9.6.x). Blocked on the
-      `disable` language feature; the activation lifetime must not foreclose it (it does not --
-      frame ownership already cascades, and the registration-set and outcome-unification items above
-      are the remaining prerequisites).
+      cancels the owned descendants, then releases the frame. Current shape: the cancellation-domain
+      relation now exists -- the process lineage, over which a `disable fork` would walk, with a
+      terminated process retained while any descendant is live -- and a body's terminal execution
+      state is outcome-neutral, ready to carry `Cancelled`; but there is no cancellation path and no
+      `Cancelled` outcome yet. Target: the full cancellation model behind `disable` / `disable fork`
+      (LRM 9.6.x). Blocked on the `disable` language feature; the activation lifetime must not
+      foreclose it (it does not -- frame ownership already cascades, and the registration-set and
+      outcome-unification items above are the remaining prerequisites).
 
 - [ ] **Runtime vocabulary trails the model.** The execution code names the activation and its core
       in coroutine-implementation terms; the contract's vocabulary is activation / completion slot /
-      cancellation domain / join state, with the coroutine mechanics as one realization. Rename to
-      the model's vocabulary where it clarifies the boundary between execution control and
-      completion. Low priority; unblocked.
+      cancellation domain / join state, with the coroutine mechanics as one realization. The
+      execution-state axis is now named for the model -- a process's states are execution states,
+      and its end state is outcome-neutral termination rather than "completed" -- but the
+      completion-slot and join-state vocabulary still trails. Rename the rest where it clarifies the
+      boundary between execution control and completion. Low priority; unblocked.

--- a/docs/progress/fork-join.md
+++ b/docs/progress/fork-join.md
@@ -106,8 +106,10 @@ long, follows from where the storage lives and how long the enclosing activation
 
 ### Process control over spawned threads
 
-- [ ] FJ6 -- `wait fork` blocks the current process until all of its immediate child processes (not
-      their descendants) have terminated (LRM 9.6.1).
+- [x] FJ6 -- `wait fork` blocks the current process until all of its immediate child processes (not
+      their descendants) have terminated (LRM 9.6.1). Because a task runs in its caller's thread
+      (LRM 9.5), a `wait fork` inside a task waits on children the enclosing process spawned before
+      the task was called, and a process with no live child resumes without suspending.
 - [ ] FJ7 -- `disable fork` terminates all descendant processes of the calling process, including
       descendants of subprocesses that have already terminated (LRM 9.6.3).
 

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -86,8 +86,9 @@ machinery owned by other workstreams; see [Blocked](#blocked).
       `wait_order(...)`, event aliasing / nullness / comparison are out of scope.
 - [x] P11 -- `wait (cond) body` level-sensitive control (LRM 9.4.3). Sensitivity is precomputed by
       slang's flow analysis on `cond` as a standalone expression. The "skip suspend if cond is
-      already true" semantic falls out of the lowering. `wait fork;` (LRM 9.6.1) and
-      `wait_order(...)` (LRM 15.6) are out of scope.
+      already true" semantic falls out of the lowering. `wait fork;` (LRM 9.6.1) is a distinct
+      process-control construct tracked in `fork-join.md`; `wait_order(...)` (LRM 15.6) is out of
+      scope.
 
 ### Concurrency
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -265,10 +265,16 @@ struct WaitStmt {
   std::vector<SensitivityEntry> sensitivity_list;
 };
 
+// LRM 9.6.1 `wait fork`: block the enclosing process until all of its immediate
+// child subprocesses have terminated. Carries no operand -- the child set is
+// the executing process's, resolved at runtime.
+struct WaitForkStmt {};
+
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, ForkStmt, IfStmt, CaseStmt,
     CaseInsideStmt, ForStmt, WhileStmt, RepeatStmt, DoWhileStmt, ForeverStmt,
-    BreakStmt, ContinueStmt, ReturnStmt, TimedStmt, EventTriggerStmt, WaitStmt>;
+    BreakStmt, ContinueStmt, ReturnStmt, TimedStmt, EventTriggerStmt, WaitStmt,
+    WaitForkStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/lowering/hir_to_mir/statement/fork_join.hpp
+++ b/include/lyra/lowering/hir_to_mir/statement/fork_join.hpp
@@ -21,4 +21,8 @@ auto LowerForkStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::ForkStmt& f) -> diag::Result<mir::Stmt>;
 
+auto LowerWaitForkStmt(
+    ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label)
+    -> diag::Result<mir::Stmt>;
+
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/runtime/coroutine.hpp
+++ b/include/lyra/runtime/coroutine.hpp
@@ -14,6 +14,7 @@ namespace lyra::runtime {
 
 class Observable;
 class RuntimeProcess;
+class WakeRegistration;
 
 // Non-templated scheduling state shared by every coroutine frame -- a process
 // body, a task body, a fork branch -- regardless of the value the frame
@@ -30,6 +31,17 @@ struct PromiseBase {
   std::vector<Observable*> pending_value_change_subscriptions;
   std::function<void()> on_complete;
   std::coroutine_handle<> self;
+  // The wake source this frame is currently parked on, if any. Held so the
+  // frame unlinks itself when destroyed, keeping the source from waking freed
+  // storage.
+  WakeRegistration* parked_registration = nullptr;
+
+  PromiseBase() = default;
+  PromiseBase(const PromiseBase&) = delete;
+  auto operator=(const PromiseBase&) -> PromiseBase& = delete;
+  PromiseBase(PromiseBase&&) = delete;
+  auto operator=(PromiseBase&&) -> PromiseBase& = delete;
+  ~PromiseBase();
 
   // A promise protocol hook is an instance customization point by contract, so
   // it stays a member even when an implementation reads no promise state; the

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -13,9 +13,9 @@
 #include "lyra/base/time.hpp"
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/diagnostic.hpp"
+#include "lyra/runtime/execution_context.hpp"
 #include "lyra/runtime/file_table.hpp"
 #include "lyra/runtime/plusargs.hpp"
-#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/stream_dispatcher.hpp"
@@ -104,13 +104,17 @@ class Engine {
   //                        code per LRM 20.10).
   // Now                 -- query current simulation time.
   // Spawn               -- adopt a coroutine created mid-simulation as a
-  //                        runnable process and schedule it (used by fork-join
-  //                        branches); construct-neutral by design.
+  //                        process of the executing process's lineage and
+  //                        schedule it (used by fork-join branches);
+  //                        construct-neutral by design.
   void ScheduleNextDelta(CoroutineHandle handle);
   void ScheduleInactive(CoroutineHandle handle);
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
   void RequestFinish(int level, bool fatal = false);
   void Spawn(Coroutine<void> coroutine);
+  // The process whose body is executing right now (LRM 9.5): what a fork spawn
+  // parents its branch to, and what `wait fork` observes.
+  [[nodiscard]] auto CurrentProcess() -> RuntimeProcess&;
   [[nodiscard]] auto Now() const -> SimTime {
     return now_;
   }
@@ -146,6 +150,10 @@ class Engine {
   // it.
   void ResolveGlobalTimePrecision();
   void RegisterProcesses();
+  // Runs a suspended frame's owning process against the engine's execution
+  // context. Resuming demands that context, so a body always executes with its
+  // own process identity published.
+  auto ResumeProcess(CoroutineHandle handle) -> bool;
   void RunProcess(CoroutineHandle handle);
   void DrainRunnableQueue(std::deque<CoroutineHandle>& queue);
 
@@ -180,10 +188,7 @@ class Engine {
   PlusArgsSource plusargs_;
   RuntimeServices services_{stream_, diagnostic_, files_, plusargs_, *this};
   std::unique_ptr<Scope> root_;
-  // Processes created during simulation (fork-join branches), owned for their
-  // dynamic lifetime. Each is dropped in RunProcess when it completes; static
-  // processes live on their scope instead.
-  std::vector<std::unique_ptr<RuntimeProcess>> spawned_;
+  ExecutionContext execution_context_;
   SchedulerQueues queues_;
   SimTime now_ = 0;
   std::int8_t global_precision_power_ = kDefaultTimePrecisionPower;

--- a/include/lyra/runtime/execution_context.hpp
+++ b/include/lyra/runtime/execution_context.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <utility>
+
+namespace lyra::runtime {
+
+class RuntimeProcess;
+
+// The process whose body is executing right now. A fork spawn and the LRM 9.6
+// process-control statements act on the calling process, and they cannot always
+// reach it through a coroutine handle: `fork ... join_none` is legal inside a
+// function (LRM 13.4.4), whose body is not a coroutine and can await nothing,
+// yet LRM 9.6.1 makes the branches it spawns children of the enclosing process.
+// The executing process is ambient runtime state, like the current simulation
+// time.
+class ExecutionContext {
+ public:
+  [[nodiscard]] auto CurrentProcess() const -> RuntimeProcess&;
+
+ private:
+  friend class ExecutionContextGuard;
+
+  RuntimeProcess* current_ = nullptr;
+};
+
+// Publishes `process` as the executing process for the extent of the scope.
+// Restoring the previous process on exit, rather than clearing, makes the host
+// call stack the context stack, so a resume that unwinds or that re-enters
+// generated code leaves no stale identity behind.
+class ExecutionContextGuard {
+ public:
+  ExecutionContextGuard(ExecutionContext& context, RuntimeProcess& process)
+      : context_(&context),
+        previous_(std::exchange(context.current_, &process)) {
+  }
+
+  ExecutionContextGuard(const ExecutionContextGuard&) = delete;
+  auto operator=(const ExecutionContextGuard&)
+      -> ExecutionContextGuard& = delete;
+  ExecutionContextGuard(ExecutionContextGuard&&) = delete;
+  auto operator=(ExecutionContextGuard&&) -> ExecutionContextGuard& = delete;
+
+  ~ExecutionContextGuard() {
+    context_->current_ = previous_;
+  }
+
+ private:
+  ExecutionContext* context_;
+  RuntimeProcess* previous_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/fork.hpp
+++ b/include/lyra/runtime/fork.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <coroutine>
 #include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
+#include "lyra/runtime/wake_registration.hpp"
 
 namespace lyra::runtime {
 
@@ -32,8 +35,7 @@ class ForkGroup {
   }
 
   void ParkParent(CoroutineHandle parent) {
-    parent_ = parent;
-    parent_parked_ = true;
+    parent_registration_.Arm(parent);
   }
 
   // Called from a branch's completion. Decrements the outstanding count and
@@ -42,17 +44,17 @@ class ForkGroup {
     if (completions_needed_ > 0) {
       completions_needed_ -= 1;
     }
-    if (parent_parked_ && completions_needed_ == 0) {
-      parent_parked_ = false;
-      services_->ScheduleNextDelta(parent_);
+    if (completions_needed_ == 0) {
+      if (CoroutineHandle parent = parent_registration_.TakeForWake()) {
+        services_->ScheduleNextDelta(parent);
+      }
     }
   }
 
  private:
   RuntimeServices* services_;
   std::int64_t completions_needed_;
-  CoroutineHandle parent_{};
-  bool parent_parked_ = false;
+  WakeRegistration parent_registration_;
 };
 
 // What the parent `co_await`s after the branches are spawned. The wait reports
@@ -130,6 +132,36 @@ auto ForkWaitFirst(RuntimeServices& services, Branches... branches)
 template <class... Branches>
 void SpawnAll(RuntimeServices& services, Branches... branches) {
   (services.Spawn(std::move(branches)), ...);
+}
+
+// LRM 9.6.1 `wait fork`: block the executing process until every immediate
+// child it spawned has terminated. The condition is read from the executing
+// process; the frame parked on it is the one that ran `wait fork` (the task
+// frame when `wait fork` sits in a task), so it is armed through the suspending
+// handle rather than the process's own body.
+class WaitForkAwaitable {
+ public:
+  explicit WaitForkAwaitable(RuntimeServices& services) : services_(&services) {
+  }
+
+  [[nodiscard]] auto await_ready() const -> bool {
+    return services_->CurrentProcess().HasNoLiveChild();
+  }
+
+  template <class P>
+  void await_suspend(std::coroutine_handle<P> waiter) const {
+    services_->CurrentProcess().ArmWaitFork(&waiter.promise());
+  }
+
+  void await_resume() const noexcept {
+  }
+
+ private:
+  RuntimeServices* services_;
+};
+
+inline auto WaitFork(RuntimeServices& services) -> WaitForkAwaitable {
+  return WaitForkAwaitable{services};
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/process_kind.hpp
+++ b/include/lyra/runtime/process_kind.hpp
@@ -5,8 +5,9 @@ namespace lyra::runtime {
 enum class ProcessKind {
   kInitial,
   kFinal,
-  // A process brought into being during simulation (a fork-join branch), owned
-  // by the engine's dynamic pool rather than registered at startup.
+  // A process brought into being during simulation (a fork-join branch),
+  // adopted into the lineage of the process that spawned it rather than
+  // registered on a scope at startup.
   kSpawned,
 };
 

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -1,19 +1,37 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/wake_registration.hpp"
 
 namespace lyra::runtime {
 
-enum class ProcessState : std::uint8_t {
+class ExecutionContext;
+
+enum class ProcessExecutionState : std::uint8_t {
   kCreated,
   kRunning,
   kWaiting,
-  kCompleted,
+  kTerminated,
 };
 
+// A node of the dynamic process lineage (LRM 9.5) and, while its body runs, the
+// owner of the coroutine frame executing it. The two lifetimes are distinct:
+// the frame is released the moment the body terminates, whereas the node
+// survives for as long as any descendant is still alive. LRM 9.6.3 demands the
+// separation -- `disable fork` terminates the descendants of subprocesses that
+// have already terminated, so a terminated process stays reachable from its
+// parent. The child list consequently holds terminated nodes alongside running
+// ones.
+//
+// A process's children are those it spawned itself, whether directly or from a
+// task or function it called (LRM 9.6.1): a subroutine call runs in the
+// caller's thread and creates no process of its own. The list therefore
+// accumulates across every fork the process executes.
 class RuntimeProcess {
  public:
   RuntimeProcess(ProcessKind kind, Coroutine<void> coroutine);
@@ -21,33 +39,77 @@ class RuntimeProcess {
   RuntimeProcess(const RuntimeProcess&) = delete;
   auto operator=(const RuntimeProcess&) -> RuntimeProcess& = delete;
   // Non-movable: the coroutine promise stores a back-pointer to this
-  // RuntimeProcess, so its address must be stable for the lifetime of the
-  // coroutine. Owners (RuntimeScope) hold processes via unique_ptr.
+  // RuntimeProcess, and so does every child node, so its address must stay
+  // stable for as long as either can name it. Owners hold processes via
+  // unique_ptr.
   RuntimeProcess(RuntimeProcess&&) noexcept = delete;
   auto operator=(RuntimeProcess&&) noexcept -> RuntimeProcess& = delete;
   ~RuntimeProcess() = default;
 
   [[nodiscard]] auto Kind() const -> ProcessKind;
+
   // Resumes `handle` -- the specific coroutine frame that suspended (the
   // innermost one when a task enabled by this process is suspended). Symmetric
   // transfer carries control back up the enable chain. Returns true if the
   // whole process ran to completion (judged on the top-level coroutine), false
   // if it suspended again on some awaitable. Captured `handle` may be destroyed
   // by the time this returns, so completion and exceptions are read off the
-  // top-level coroutine, not `handle`.
-  auto ResumeWith(CoroutineHandle handle) -> bool;
+  // top-level coroutine, not `handle`. Completing releases the frame; the node
+  // outlives it.
+  //
+  // Taking the context is what makes this the only way a body can run: the
+  // resumed body reaches its own process identity through the context, and a
+  // caller cannot resume without supplying one.
+  auto ResumeWith(ExecutionContext& context, CoroutineHandle handle) -> bool;
 
   // The top-level coroutine frame. Awaitables register the innermost handle for
   // wakeup; this is what the engine schedules to start the process and what
-  // completion is judged against.
-  [[nodiscard]] auto TopHandle() const -> CoroutineHandle {
-    return coroutine_.Token();
-  }
+  // completion is judged against. Null once the body has terminated.
+  [[nodiscard]] auto TopHandle() const -> CoroutineHandle;
+
+  // Takes `child` into this process's lineage. A fork's parallel statement is a
+  // thread of the process that executed the fork (LRM 9.5), which is the
+  // process running when the branch is spawned, not the frame that spawned it.
+  void AdoptChild(std::unique_ptr<RuntimeProcess> child);
+
+  [[nodiscard]] auto Parent() const -> RuntimeProcess*;
+
+  // Parks `waiter` on this process's `wait fork` condition (LRM 9.6.1). The
+  // waiter is the frame that executed `wait fork` -- in a task it is the task
+  // frame, not this process's own body -- so process identity and the parked
+  // activation are deliberately distinct.
+  void ArmWaitFork(CoroutineHandle waiter);
+
+  // True when no immediate child is still executing: the whole live set has
+  // reached a terminal state, or there were none. Terminated children retained
+  // for their own live descendants (LRM 9.6.3) do not count as live. This is
+  // the `wait fork` condition.
+  [[nodiscard]] auto HasNoLiveChild() const -> bool;
+
+  // If a frame is parked here on `wait fork` and the condition now holds,
+  // unlink and return that frame for scheduling; null otherwise.
+  [[nodiscard]] auto TakeWaitForkWaiterIfSatisfied() -> CoroutineHandle;
+
+  // Releases `process`, whose body has just terminated, along with every
+  // ancestor the release leaves with no lineage to retain, walking upward from
+  // the leaf. Deliberately not a call on the released node: the release
+  // destroys it. A process with no parent is owned by its scope and is never
+  // released here.
+  static void ReleaseTerminatedLineage(RuntimeProcess& process);
 
  private:
+  // The sole writer of the terminal state, so a body can never be marked
+  // terminated while it still owns the frame it ran in.
+  void SettleTerminated();
+  [[nodiscard]] auto IsReleasable() const -> bool;
+  void EraseChild(RuntimeProcess& child);
+
   ProcessKind kind_;
   Coroutine<void> coroutine_;
-  ProcessState state_ = ProcessState::kCreated;
+  ProcessExecutionState execution_state_ = ProcessExecutionState::kCreated;
+  RuntimeProcess* parent_ = nullptr;
+  std::vector<std::unique_ptr<RuntimeProcess>> children_;
+  WakeRegistration wait_fork_registration_;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -19,6 +19,7 @@ class FileTable;
 class PlusArgsSource;
 class Engine;
 class Observable;
+class RuntimeProcess;
 
 class RuntimeServices {
  public:
@@ -90,6 +91,9 @@ class RuntimeServices {
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
   void RequestFinish(int level, bool fatal = false);
   void Spawn(Coroutine<void> coroutine);
+  // The process whose body is executing right now (LRM 9.5); the observation
+  // target `wait fork` reads and a fork spawn parents its branch to.
+  [[nodiscard]] auto CurrentProcess() -> RuntimeProcess&;
   [[nodiscard]] auto Now() const -> SimTime;
 
   // The design-global time precision (LRM 3.14.3) the delay awaitable scales a

--- a/include/lyra/runtime/wake_registration.hpp
+++ b/include/lyra/runtime/wake_registration.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+namespace lyra::runtime {
+
+struct PromiseBase;
+
+// A revocable, one-shot link between a wake source -- a fork's join state, a
+// process's `wait fork` condition -- and the single frame parked on it. At most
+// one frame parks per source: a fork has one forking process, and a `wait fork`
+// condition has the one process that executed it.
+//
+// Either end may be torn down first. Arming links the two; a wake or a revoke
+// unlinks both, so whichever happens first wins and the other becomes a no-op.
+// A parked frame is therefore never resumed into freed storage, and a source
+// never wakes a frame that has been destroyed. LRM 9.6 process control destroys
+// an activation while it is parked, which is what makes the revoke direction
+// reachable.
+class WakeRegistration {
+ public:
+  WakeRegistration() = default;
+  WakeRegistration(const WakeRegistration&) = delete;
+  auto operator=(const WakeRegistration&) -> WakeRegistration& = delete;
+  // Non-movable: the parked frame holds a pointer back to this link.
+  WakeRegistration(WakeRegistration&&) = delete;
+  auto operator=(WakeRegistration&&) -> WakeRegistration& = delete;
+  ~WakeRegistration();
+
+  void Arm(PromiseBase* waiter);
+
+  // The source's wake condition is met: unlink the parked frame and hand it
+  // back for scheduling, or null if none is parked or it already detached.
+  [[nodiscard]] auto TakeForWake() -> PromiseBase*;
+
+  // `waiter`'s frame is being torn down or cancelled: drop it so a later wake
+  // is a no-op.
+  void RevokeWaiter(PromiseBase* waiter);
+
+ private:
+  PromiseBase* waiter_ = nullptr;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -255,6 +255,11 @@ enum class BuiltinFn : std::uint16_t {
   kForkWaitAll,
   kForkWaitFirst,
   kSpawnAll,
+  // LRM 9.6.1 `wait fork`: suspends the executing process until every immediate
+  // child it spawned has terminated. Takes only the services handle; the child
+  // set is the executing process's, read at runtime. The call's result is
+  // `void` and the caller awaits it, the same await shape as `join`.
+  kWaitFork,
   // Lifecycle activation registration (LRM 9.2): binds a process body's
   // coroutine to the scope's startup (`kRegisterInitial`) or shutdown
   // (`kRegisterFinal`) lifecycle. Distinct callees, not one tagged call --

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -248,6 +248,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "ForkWaitFirst";
     case support::BuiltinFn::kSpawnAll:
       return "SpawnAll";
+    case support::BuiltinFn::kWaitFork:
+      return "WaitFork";
     case support::BuiltinFn::kToInt64:
       return "ToInt64";
     case support::BuiltinFn::kRound:
@@ -358,6 +360,7 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
     case support::BuiltinFn::kForkWaitAll:
     case support::BuiltinFn::kForkWaitFirst:
     case support::BuiltinFn::kSpawnAll:
+    case support::BuiltinFn::kWaitFork:
     case support::BuiltinFn::kTestPlusargs:
     case support::BuiltinFn::kValuePlusargs:
       return "lyra::runtime";

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -1475,6 +1475,9 @@ class HirDumper {
               Dedent();
               Dedent();
             },
+            [&](const WaitForkStmt&) {
+              Line(std::format("Stmt[{}] WaitForkStmt", id.value));
+            },
         },
         s.data);
   }

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -122,6 +122,10 @@ auto LowerStatement(
       return LowerWaitStmt(
           proc, frame, stmt.as<slang::ast::WaitStatement>(), span);
 
+    case slang::ast::StatementKind::WaitFork:
+      return hir::Stmt{
+          .label = std::nullopt, .data = hir::WaitForkStmt{}, .span = span};
+
     case slang::ast::StatementKind::Timed:
       return LowerTimedStmt(
           proc, frame, stmt.as<slang::ast::TimedStatement>(), span);

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -90,6 +90,9 @@ auto ProcessLowerer::LowerStmt(const hir::Stmt& stmt, WalkFrame frame)
           [&](const hir::WaitStmt& w) {
             return LowerWaitStmt(*this, frame, stmt.label, w);
           },
+          [&](const hir::WaitForkStmt&) {
+            return LowerWaitForkStmt(*this, frame, stmt.label);
+          },
       },
       stmt.data);
 }

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -132,4 +132,32 @@ auto LowerForkStmt(
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
 
+// LRM 9.6.1 `wait fork`: suspend the executing process until its immediate
+// children have terminated. It lowers to a single awaited runtime call taking
+// only the services handle; the child set is resolved at runtime from the
+// executing process, so MIR carries no operand. The awaited call's result type
+// is `void`, the same await shape as `join`.
+auto LowerWaitForkStmt(
+    ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label)
+    -> diag::Result<mir::Stmt> {
+  mir::Block& block = *frame.current_block;
+  const auto& builtins = process.Module().Unit().builtins;
+  const mir::ExprId services_id =
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+  const mir::ExprId call_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::Direct{.target = support::BuiltinFn::kWaitFork},
+                  .arguments = {services_id}},
+          .type = builtins.void_type});
+  const mir::ExprId await_id = block.exprs.Add(
+      mir::Expr{
+          .data = mir::AwaitExpr{.awaitable = call_id},
+          .type = builtins.void_type});
+  return mir::Stmt{
+      .label = std::move(label), .data = mir::ExprStmt{.expr = await_id}};
+}
+
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -224,7 +224,7 @@ void Engine::ExecutePostponedRegion() {
 void Engine::ExecuteFinalProcesses() {
   phase_ = SchedulerPhase::kPostponed;
   for (CoroutineHandle handle : queues_.finals) {
-    const bool completed = handle->Process().ResumeWith(handle);
+    const bool completed = ResumeProcess(handle);
     if (completed) {
       continue;
     }
@@ -290,6 +290,14 @@ auto Engine::IsRunnablePhase() const -> bool {
          phase_ == SchedulerPhase::kReactive;
 }
 
+auto Engine::ResumeProcess(CoroutineHandle handle) -> bool {
+  // Capture the owning process before resuming, since `handle` may be an
+  // enabled task's frame that is destroyed as control returns up the enable
+  // chain.
+  RuntimeProcess& process = handle->Process();
+  return process.ResumeWith(execution_context_, handle);
+}
+
 void Engine::RunProcess(CoroutineHandle handle) {
   // Sole gate for post-$finish user code; finals bypass via their own path.
   if (finished_) {
@@ -300,20 +308,22 @@ void Engine::RunProcess(CoroutineHandle handle) {
         "Engine::RunProcess: process resumed outside runnable phase");
   }
   // No wait dispatch: each awaitable has already arranged its own wakeup path
-  // during await_suspend. Capture the owning process before resuming, since
-  // `handle` may be an enabled task's frame that is destroyed as control
-  // returns up the enable chain.
+  // during await_suspend.
   RuntimeProcess& process = handle->Process();
-  const bool completed = process.ResumeWith(handle);
-  // A spawned process (a fork-join branch) is owned by the engine for its
-  // dynamic lifetime; drop it the moment it finishes -- executor-standard
-  // drop-on-completion, co-located with the resume that completed it. Static
-  // processes are owned by their scope and outlive the simulation.
-  if (completed && process.Kind() == ProcessKind::kSpawned) {
-    std::erase_if(spawned_, [&](const std::unique_ptr<RuntimeProcess>& p) {
-      return p.get() == &process;
-    });
+  if (!ResumeProcess(handle)) {
+    return;
   }
+  // A terminating process is the last live child its parent was waiting on iff
+  // the parent's `wait fork` condition now holds (LRM 9.6.1); wake the parked
+  // waiter before releasing, while the just-terminated node is still linked.
+  if (RuntimeProcess* parent = process.Parent(); parent != nullptr) {
+    if (CoroutineHandle waiter = parent->TakeWaitForkWaiterIfSatisfied()) {
+      ScheduleNextDelta(waiter);
+    }
+  }
+  // Releasing destroys `process` and every ancestor the release leaves with no
+  // lineage to retain, so no statement may follow it here.
+  RuntimeProcess::ReleaseTerminatedLineage(process);
 }
 
 void Engine::RequestFinish(
@@ -359,11 +369,15 @@ void Engine::ScheduleAtTime(SimTime when, CoroutineHandle handle) {
 }
 
 void Engine::Spawn(Coroutine<void> coroutine) {
-  auto process = std::make_unique<RuntimeProcess>(
+  auto child = std::make_unique<RuntimeProcess>(
       ProcessKind::kSpawned, std::move(coroutine));
-  const CoroutineHandle handle = process->TopHandle();
-  spawned_.push_back(std::move(process));
+  const CoroutineHandle handle = child->TopHandle();
+  execution_context_.CurrentProcess().AdoptChild(std::move(child));
   ScheduleActive(handle);
+}
+
+auto Engine::CurrentProcess() -> RuntimeProcess& {
+  return execution_context_.CurrentProcess();
 }
 
 auto Engine::CheckedAdd(SimTime base, SimDuration delta) -> SimTime {

--- a/src/lyra/runtime/execution_context.cpp
+++ b/src/lyra/runtime/execution_context.cpp
@@ -1,0 +1,15 @@
+#include "lyra/runtime/execution_context.hpp"
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/runtime_process.hpp"
+
+namespace lyra::runtime {
+
+auto ExecutionContext::CurrentProcess() const -> RuntimeProcess& {
+  if (current_ == nullptr) {
+    throw InternalError("ExecutionContext: no process is executing");
+  }
+  return *current_;
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_process.cpp
+++ b/src/lyra/runtime/runtime_process.cpp
@@ -1,9 +1,13 @@
 #include "lyra/runtime/runtime_process.hpp"
 
+#include <cstddef>
+#include <memory>
 #include <utility>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/execution_context.hpp"
 #include "lyra/runtime/process_kind.hpp"
 
 namespace lyra::runtime {
@@ -19,25 +23,99 @@ auto RuntimeProcess::Kind() const -> ProcessKind {
   return kind_;
 }
 
-auto RuntimeProcess::ResumeWith(CoroutineHandle handle) -> bool {
-  if (state_ == ProcessState::kCompleted) {
-    throw InternalError(
-        "RuntimeProcess::ResumeWith: cannot resume completed process");
+auto RuntimeProcess::TopHandle() const -> CoroutineHandle {
+  return coroutine_.Token();
+}
+
+auto RuntimeProcess::Parent() const -> RuntimeProcess* {
+  return parent_;
+}
+
+void RuntimeProcess::ArmWaitFork(CoroutineHandle waiter) {
+  wait_fork_registration_.Arm(waiter);
+}
+
+auto RuntimeProcess::HasNoLiveChild() const -> bool {
+  for (const auto& child : children_) {
+    if (child->execution_state_ != ProcessExecutionState::kTerminated) {
+      return false;
+    }
   }
-  if (state_ == ProcessState::kRunning) {
+  return true;
+}
+
+auto RuntimeProcess::TakeWaitForkWaiterIfSatisfied() -> CoroutineHandle {
+  if (!HasNoLiveChild()) {
+    return nullptr;
+  }
+  return wait_fork_registration_.TakeForWake();
+}
+
+auto RuntimeProcess::IsReleasable() const -> bool {
+  return execution_state_ == ProcessExecutionState::kTerminated &&
+         children_.empty();
+}
+
+void RuntimeProcess::AdoptChild(std::unique_ptr<RuntimeProcess> child) {
+  child->parent_ = this;
+  children_.push_back(std::move(child));
+}
+
+void RuntimeProcess::EraseChild(RuntimeProcess& child) {
+  const std::size_t erased = std::erase_if(
+      children_, [&](const std::unique_ptr<RuntimeProcess>& node) {
+        return node.get() == &child;
+      });
+  if (erased != 1) {
+    throw InternalError("RuntimeProcess::EraseChild: child is not ours");
+  }
+}
+
+void RuntimeProcess::ReleaseTerminatedLineage(RuntimeProcess& process) {
+  RuntimeProcess* node = &process;
+  while (node->parent_ != nullptr && node->IsReleasable()) {
+    RuntimeProcess* parent = node->parent_;
+    parent->EraseChild(*node);
+    node = parent;
+  }
+}
+
+void RuntimeProcess::SettleTerminated() {
+  execution_state_ = ProcessExecutionState::kTerminated;
+  // The frame is parked at its final suspend point and holds the only copies of
+  // this activation's automatic storage, so it is released with the terminal
+  // state rather than pinned for as long as the node lives. A branch this body
+  // spawned may still be running, which is why the node itself stays (LRM
+  // 9.6.3).
+  coroutine_ = Coroutine<void>{};
+}
+
+auto RuntimeProcess::ResumeWith(
+    ExecutionContext& context, CoroutineHandle handle) -> bool {
+  if (execution_state_ == ProcessExecutionState::kTerminated) {
+    throw InternalError(
+        "RuntimeProcess::ResumeWith: cannot resume terminated process");
+  }
+  if (execution_state_ == ProcessExecutionState::kRunning) {
     throw InternalError("RuntimeProcess::ResumeWith: reentrant resume");
   }
-  state_ = ProcessState::kRunning;
-  handle->self.resume();
+  execution_state_ = ProcessExecutionState::kRunning;
+  {
+    const ExecutionContextGuard guard(context, *this);
+    handle->self.resume();
+  }
   // A task's exception propagates up the enable chain to the top-level promise,
   // so it is read there regardless of which frame threw.
   if (auto exc = std::exchange(
           coroutine_.Handle().promise().pending_exception, nullptr)) {
     std::rethrow_exception(exc);
   }
-  const bool completed = coroutine_.Done();
-  state_ = completed ? ProcessState::kCompleted : ProcessState::kWaiting;
-  return completed;
+  if (!coroutine_.Done()) {
+    execution_state_ = ProcessExecutionState::kWaiting;
+    return false;
+  }
+  SettleTerminated();
+  return true;
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -68,6 +68,13 @@ void RuntimeServices::Spawn(Coroutine<void> coroutine) {
   engine_->Spawn(std::move(coroutine));
 }
 
+auto RuntimeServices::CurrentProcess() -> RuntimeProcess& {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::CurrentProcess: no Engine bound");
+  }
+  return engine_->CurrentProcess();
+}
+
 auto RuntimeServices::Now() const -> SimTime {
   if (engine_ == nullptr) {
     throw InternalError("RuntimeServices::Now: no Engine bound");

--- a/src/lyra/runtime/wake_registration.cpp
+++ b/src/lyra/runtime/wake_registration.cpp
@@ -1,0 +1,41 @@
+#include "lyra/runtime/wake_registration.hpp"
+
+#include "lyra/runtime/coroutine.hpp"
+
+namespace lyra::runtime {
+
+WakeRegistration::~WakeRegistration() {
+  if (waiter_ != nullptr) {
+    waiter_->parked_registration = nullptr;
+  }
+}
+
+void WakeRegistration::Arm(PromiseBase* waiter) {
+  waiter_ = waiter;
+  waiter->parked_registration = this;
+}
+
+auto WakeRegistration::TakeForWake() -> PromiseBase* {
+  PromiseBase* waiter = waiter_;
+  if (waiter != nullptr) {
+    waiter->parked_registration = nullptr;
+    waiter_ = nullptr;
+  }
+  return waiter;
+}
+
+void WakeRegistration::RevokeWaiter(PromiseBase* waiter) {
+  if (waiter_ != waiter) {
+    return;
+  }
+  waiter_ = nullptr;
+  waiter->parked_registration = nullptr;
+}
+
+PromiseBase::~PromiseBase() {
+  if (parked_registration != nullptr) {
+    parked_registration->RevokeWaiter(this);
+  }
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -316,6 +316,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "fork_wait_first";
     case BuiltinFn::kSpawnAll:
       return "spawn_all";
+    case BuiltinFn::kWaitFork:
+      return "wait_fork";
     case BuiltinFn::kRegisterInitial:
       return "register_initial";
     case BuiltinFn::kRegisterFinal:

--- a/tests/cases/cpp/fork_join_none_in_final/case.yaml
+++ b/tests/cases/cpp/fork_join_none_in_final/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.fork_join_none_in_final
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [5] initial done
+      final enter
+      final exit

--- a/tests/cases/cpp/fork_join_none_in_final/main.sv
+++ b/tests/cases/cpp/fork_join_none_in_final/main.sv
@@ -1,0 +1,19 @@
+`timescale 1ns / 1ns
+module Test;
+  // LRM 9.2.3: a `final` procedure admits exactly the statements a function
+  // admits, so `join_none` is the one legal fork here (LRM 13.4.4), and it
+  // spawns a branch of the final procedure's own process (LRM 9.5). No
+  // remaining scheduled event executes once the final procedures have run, so
+  // that branch never starts.
+  initial begin
+    #5 $display("[%0d] initial done", $time);
+  end
+
+  final begin
+    $display("final enter");
+    fork
+      $display("final branch");
+    join_none
+    $display("final exit");
+  end
+endmodule

--- a/tests/cases/cpp/fork_wait_fork/case.yaml
+++ b/tests/cases/cpp/fork_wait_fork/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.fork_wait_fork
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [10] child1
+      [20] child2
+      [30] child3
+      [30] after wait fork
+      [30] initial after do_test
+      [50] grandchild

--- a/tests/cases/cpp/fork_wait_fork/main.sv
+++ b/tests/cases/cpp/fork_wait_fork/main.sv
@@ -1,0 +1,31 @@
+`timescale 1ns / 1ns
+module Test;
+  // LRM 9.6.1 `wait fork`: block until every immediate child subprocess has
+  // terminated, excluding their descendants. `wait fork` runs inside a task,
+  // which executes in the enclosing process's thread (LRM 9.5), so it waits on
+  // children spawned by the `initial` block before the task was ever called
+  // (child1, child2) as well as those the task spawns (child3). The nested
+  // `join_none` makes `grandchild` a descendant, not an immediate child, so it
+  // is not waited on -- its parent branch terminates the moment it has spawned
+  // it, yet its lineage is retained until the grandchild finishes (LRM 9.6.3).
+  task automatic do_test();
+    fork
+      #30 $display("[%0d] child3", $time);
+      fork
+        #50 $display("[%0d] grandchild", $time);
+      join_none
+    join_none
+    wait fork;
+    $display("[%0d] after wait fork", $time);
+  endtask
+
+  initial begin
+    fork
+      #10 $display("[%0d] child1", $time);
+      #20 $display("[%0d] child2", $time);
+    join_none
+    do_test();
+    $display("[%0d] initial after do_test", $time);
+    #100;
+  end
+endmodule

--- a/tests/cases/cpp/fork_wait_fork_no_park/case.yaml
+++ b/tests/cases/cpp/fork_wait_fork_no_park/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.fork_wait_fork_no_park
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [0] no children
+      [5] child
+      [10] child already finished

--- a/tests/cases/cpp/fork_wait_fork_no_park/main.sv
+++ b/tests/cases/cpp/fork_wait_fork_no_park/main.sv
@@ -1,0 +1,18 @@
+`timescale 1ns / 1ns
+module Test;
+  // The `wait fork` cases that resolve without suspending (LRM 9.6.1): a process
+  // with no live child returns at once. The first `wait fork` runs before any
+  // fork, so there is nothing to wait on; the second runs after the spawned
+  // child has already finished. Two `wait fork` statements in one process are
+  // independent -- each observes the child set as it stands when reached.
+  initial begin
+    wait fork;
+    $display("[%0d] no children", $time);
+    fork
+      #5 $display("[%0d] child", $time);
+    join_none
+    #10;
+    wait fork;
+    $display("[%0d] child already finished", $time);
+  end
+endmodule


### PR DESCRIPTION
## Summary

The runtime gains a dynamic process lineage: each spawned fork branch is adopted into a parent-child tree owned by the process that spawned it, replacing the flat pool that recorded no relationship. A terminated process node is retained while any descendant is still live, so the descendants of a subprocess that has already finished stay reachable -- the structure `disable fork` will later walk, and the reason node lifetime is kept distinct from the coroutine frame it ran. Building on the tree, this adds `wait fork` (LRM 9.6.1): a process blocks until every immediate child it spawned has terminated, excluding their descendants.

The executing process is now published as ambient runtime state through a single resume entry, so a fork spawn and a `wait fork` reach the current process the same way a delay reaches the current time -- necessary because `fork ... join_none` is legal inside a function, whose body cannot await and so has no coroutine handle to recover identity from.

## Design

A parked activation and its wake source now link through a revocable, one-shot registration that detaches safely from either end, so neither wakes nor revokes into freed storage. The `join` / `join_any` parent-park is routed through it, retiring a previously un-revocable handle; `wait fork` reuses the same registration as a second holder. This is the minimal revocable-registration substrate the cancellation model (`disable fork`) will extend.

The process's terminal execution state is named for the model -- outcome-neutral termination rather than "completed" -- so a later `Cancelled` outcome sits on a separate axis from execution control.

## Testing

`wait fork` behavior is covered by SV cases compared against Verilator: the LRM 9.6.1 canonical shape (a `wait fork` in a task waiting on children the enclosing process spawned before the call, with grandchildren excluded), the immediate-return paths (no children, a child already finished, multiple `wait fork`), and `fork ... join_none` inside a `final`. Full `bazel test //...` is green.