### PR TITLE
Lower expressions and control flow to the execution backend

### DIFF
--- a/docs/architecture/lir.md
+++ b/docs/architecture/lir.md
@@ -83,11 +83,15 @@ identity is the suspect, not the analysis.
 1. LIR is a CFG-shaped IR. Every callable body is a graph of basic blocks with explicit successors.
    _Machine-execution consequence: control flow is the graph the codegen consumes; structured
    constructs do not survive at this layer._
-2. Each LIR value is either a place or a transient value, and which one is explicit. A value is a
-   place -- named storage -- exactly when it needs one: its address is taken, or it names storage
-   written through more than once. A value computed once and consumed is a transient value with a
-   pure dataflow origin. _Machine-execution consequence: the codegen knows for every value whether
-   it lives in memory or in a register-class temporary; no value's storage class must be inferred._
+2. Each LIR value is either a place or a transient value, and which one is explicit. Which one a
+   local is follows a canonical lowering rule, not the source language's notion of a variable: a
+   local is a place -- named storage -- exactly when the canonical lowering needs an address for it
+   (its address is taken, it is assigned after its initialization, or it holds a control-flow join).
+   A value computed once and consumed is a transient value with a pure dataflow origin. The rule
+   fixes the storage topology; it does not minimize it -- recovering a register where the address is
+   never truly needed is a separate derivation below LIR. _Machine-execution consequence: the
+   codegen knows for every value whether it lives in memory or in a register-class temporary; no
+   value's storage class must be inferred._
 3. LIR fixes logical storage topology, not physical layout. A place names storage by logical
    identity -- a base local and a projection chain of member, index, and dereference steps -- never
    as a byte offset, an address, or pointer arithmetic. The physical realization of that topology is
@@ -189,6 +193,19 @@ lowering introduces. A source-level variable with static lifetime is not a funct
 member of the enclosing class, reached through `self` as a place. The bulk of a program's state is
 member storage reached through receivers, not locals on a frame.
 
+LIR is not an SSA form. A local is either a transient -- computed once, consumed, with a pure
+dataflow origin -- or a place, which is storage on the frame. Which one a local is follows a
+canonical lowering rule, not the source language's notion of a variable: a local is a place exactly
+when the canonical lowering needs an address for it -- its address is taken, it is assigned after
+its initialization, or it holds a control-flow join. Everything else is a transient. So there is no
+phi and none is needed: a value produced on more than one path is a place each path writes, a
+conditional expression writes its result into a place from each arm, and a loop-carried variable is
+a place the body updates. A parameter arrives as a transient (the incoming argument) and becomes a
+place only when the body assigns it or takes its address, in which case the entry block copies the
+argument into that place. Recovering a register where the address is never truly needed is a
+target-side derivation, not a property LIR must establish: LIR states the storage topology, it does
+not minimize it.
+
 A closure lowers to a code reference plus an environment value; invocation is an indirect call
 passing the environment and the call arguments. `self` is the first argument, supplied like any
 other; LIR has no implicit receiver. A direct call to a statically known callable passes the
@@ -202,6 +219,15 @@ member by its logical identity, not by an offset. An observable signal arrives a
 runtime-library call -- the cell's get / set / mutate, because HIR-to-MIR expressed the access that
 way -- and lowers as a call, the same as any other. Whether a plain-value member's place becomes a
 load or a store, and at what address, is the physical layer's question, not LIR's.
+
+A member access always yields a place. What the use site does with that place -- read the value it
+holds, write a value into it, or name where it lives -- is the use site's decision, never a property
+of the access. Some storage has no first-class value in LIR at all: a storage cell, a scope, an
+object-tree node. Such a type is address-only, and every operation over it consumes its address, so
+loading or storing a place of that type is a lowering defect. Address-only is a fact about the
+storage object, not about how values are represented: a packed value reached through an opaque
+handle is an ordinary first-class value, and a place holding one is loaded and stored like any
+other. The cell that holds it is what may only be addressed.
 
 LIR carries the fact that a packed value is two-state or four-state; it does not carry how a
 four-state value is stored. The canonical encoding of a four-state value -- value bits plus a state

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -139,10 +139,11 @@ the detail lives in the entry itself.
   backends' host shells collapse to creating the engine, calling the root construct, then bind /
   run.
 - [member-slot-storage](member-slot-storage.md) -- a member is a logical place (a base plus a
-  projection chain, named by load / store); a unit definition declares a member schema and a generic
-  instance owns one runtime-managed slot per member. The C++ backend realizes a member as a native
-  field, the execution backend as a runtime-owned slot; physical in-frame layout is a later
-  optimization, the member-storage counterpart of the opaque-handle value baseline.
+  projection chain, named by load, store, and address-of); a unit definition declares a member
+  storage schema and a generic instance owns one storage object per member. The C++ backend realizes
+  a member as a native field, the execution backend as runtime-owned storage; a cell is only ever
+  addressed, never read as a value. Physical in-frame layout is a later optimization, the
+  member-storage counterpart of the opaque-handle value baseline.
 
 ### Compile-time model and specialization
 

--- a/docs/decisions/member-slot-storage.md
+++ b/docs/decisions/member-slot-storage.md
@@ -1,4 +1,4 @@
-# Member storage as runtime-owned typed slots
+# Member storage as runtime-owned typed storage
 
 Date: 2026-07-09 Status: accepted
 
@@ -22,36 +22,36 @@ Member storage is where an instance's own _places_ live. The two are independent
 
 ## Decision
 
-A member is a logical place. A place is a base value plus a projection chain of member / index /
-dereference / ... steps, named by logical identity, and a load or store names a place. A member step
-carries a class-local member identity, never a physical offset. A unit definition declares a member
-schema; a generic instance owns one runtime-managed slot per member, which is how the execution
-backend realizes a member place. This is the member-storage counterpart of the opaque-handle value
-realization: the runtime owns the storage, the generated code addresses it through the ABI, and no
-physical layout is derived.
+A member is a logical place. A place is a base plus a projection chain of dereference / member /
+index / ... steps, named by logical identity; a load, a store, and an address-of each name a place.
+A member step carries a class-local member identity, never a physical offset. A unit definition
+declares a member storage schema; a generic instance owns one storage object per member, and a
+member place resolves to that object's address. This is the member-storage counterpart of the
+opaque-handle value realization: the runtime owns the storage, the generated code addresses it
+through the ABI, and no physical layout is derived.
 
 - **A member is a logical place, realized per backend.** The C++ backend realizes it as a native
-  field; the execution backend realizes it as a runtime-owned slot. Both are the same logical member
-  place -- a base and a member projection reached by load / store; only the realization differs.
-  This matches the LIR contract that a place names storage by logical identity and its physical
-  layout is derived below LIR.
+  field; the execution backend realizes it as a runtime-owned storage object. Both are the same
+  logical member place -- a base and a member projection -- and only the realization differs. This
+  matches the LIR contract that a place names storage by logical identity and its physical layout is
+  derived below LIR.
 
-- **The definition carries the member schema; the instance carries the storage.** The
-  per-specialization definition declares how many slots an instance has (a definition-level fact); a
-  generic instance allocates that many runtime-owned slots (an instance-level fact). A backend that
-  lays members out natively leaves the slot count zero and never allocates runtime slots.
+- **The definition describes the storage schema; the instance owns the storage.** The
+  per-specialization definition carries, per member, what storage that member needs: a box holding a
+  borrowed handle, or an observable cell of a given value domain. A generic instance realizes one
+  storage object per descriptor. A backend that lays members out natively leaves the schema empty
+  and owns nothing.
+
+- **What a member place means follows its storage kind.** A member whose storage holds a value is
+  read and written through the place. A member whose storage _is_ a cell has no value to read out of
+  it: the place is only ever addressed, and the library calls that operate on the cell take that
+  address. LIR states which of the two a member is, through its type, and rejects a load or a store
+  of the latter.
 
 - **Physical in-frame layout is a later optimization.** Deriving native field offsets -- so member
   bytes live in the instance's own storage and value members fold into machine operations -- is the
-  `CodegenLayout` maturity path, not a correctness prerequisite. The runtime-owned slot model is the
-  baseline, exactly as opaque handles are the baseline for values.
-
-### The first realized subset is the typed route slot
-
-The only member the baseline realizes is the borrowed-scope-pointer companion -- the typed head of a
-cross-unit route. A value member (`int i`) needs a physical representation and is part of the later
-layout work; it is not a slot in this baseline. The subset is chosen by what construct-and-own needs
-and what is realizable without physical layout, not by a unit or member being special.
+  `CodegenLayout` maturity path, not a correctness prerequisite. The runtime-owned storage model is
+  the baseline, exactly as opaque handles are the baseline for values.
 
 ## Rejected alternatives
 
@@ -74,17 +74,20 @@ and what is realizable without physical layout, not by a unit or member being sp
 
 ## Consequences
 
-- The unit definition gains a member-slot count; a generic instance owns that many opaque slots that
-  a member place resolves to. The C++ backend's native fields are unaffected and it leaves the slot
-  count zero.
+- The unit definition gains a member storage schema; a generic instance owns one storage object per
+  descriptor, and a member place resolves to that object's address. The C++ backend's native fields
+  are unaffected and it leaves the schema empty.
 - LIR gains a class member schema and the place vocabulary -- a place is a base plus a projection
-  chain, named by load / store -- with a member step carrying a class-local member identity. A LIR
-  verifier checks that a place's base is projectable, its member steps exist, and its load / store
-  types line up. The execution backend realizes a member place as runtime slot access, the C++
-  backend from its own fields.
+  chain, named by load, store, and address-of -- with a member step carrying a class-local member
+  identity and a dereference step as the only way to cross a reference. A LIR verifier checks that a
+  place's projections type-check, that an address-of yields a reference to its place's type, and
+  that no cell is loaded or stored as if it held a value. The execution backend realizes a member
+  place as a runtime storage address, the C++ backend from its own fields.
 - The execution backend can run any construct that writes a member, so it elaborates hierarchical
-  designs and the `$root` unit through the same construct path the C++ backend uses.
-- Physical layout and native value members remain future work; reaching them does not change this
+  designs and the `$root` unit through the same construct path the C++ backend uses, and it runs
+  procedural code over member variables.
+- Physical layout remains future work: an observable cell is a runtime object addressed through the
+  ABI rather than bytes in the instance's own storage. Reaching native layout does not change this
   baseline.
 
 ## Cross-references

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -25,11 +25,14 @@ infrastructure surface, built.
       `../architecture/backend_contract.md` and `../architecture/runtime_distribution.md`. Design
       elaboration runs on both backends as the synthesized design-root unit's construct
       (`../decisions/root-unit-elaboration.md`): the execution backend lowers cross-unit
-      construction and realizes members as runtime-owned slots
+      construction and realizes members as runtime-owned storage
       (`../decisions/member-slot-storage.md`), so it elaborates a hierarchy of modules through the
-      design-root, matching the C++ backend. Still open on the execution backend: selecting among
-      multiple specializations of one parameterized module at construction, and native layout for
-      value members (the baseline keeps opaque slots).
+      design-root, matching the C++ backend. It also runs procedural code over the integral and
+      string value domains -- variables, expressions, structured control flow, and value-carrying
+      formatted output -- with control flow lowered to a control-flow graph. Still open on the
+      execution backend: the remaining value domains (reals, enumerations, aggregates, containers),
+      time control and process suspension, subroutine reference arguments, closures, DPI-C imports,
+      and native layout for value members (the baseline keeps runtime-owned cells).
 - [ ] Per-unit artifact emission -- one artifact per unit specialization, assembled by linking,
       replacing the transitional single-`main.cpp` aggregation. Contract in
       `../architecture/emission_model.md` (inv 1).

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -852,6 +852,20 @@ enough to warrant its own focused review.
       is consumed, and to settle each value type's predicate semantics against LRM Table 11-1 while
       doing so. **Blocker**: none.
 
+- [ ] R58 -- A design unit's definition reference has two realizations. Semantic modeling already
+      states it once: a unit's definition is a class-level constant, and the constructor hands the
+      base its address, so a unit installs its own definition. The C++ backend renders exactly that.
+      The execution backend does not read it: it drops the constructor's base initialization, and
+      the code generator instead re-derives a definition symbol from the child's type at every
+      construction site, so a child unit's definition is supplied by its caller rather than by the
+      unit itself. The two backends therefore disagree on who owns a definition reference, and the
+      same concept is realized once in semantic modeling and once, independently, in the code
+      generator. **Target shape**: one realization -- the unit installs its own definition, both
+      backends render that, and cross-unit construction names a unit rather than its definition.
+      **Blocker**: none identified, but it moves the definition out of the construction ABI, which
+      touches how a unit definition is published and filled; it warrants its own review rather than
+      riding along with a value-domain or storage cut.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/backend/llvm/codegen_function.hpp
+++ b/include/lyra/backend/llvm/codegen_function.hpp
@@ -2,15 +2,16 @@
 
 #include <cstdint>
 #include <unordered_map>
-#include <utility>
+#include <vector>
 
 #include <llvm/IR/IRBuilder.h>
 
+#include "lyra/backend/llvm/runtime_abi.hpp"
 #include "lyra/lir/function.hpp"
 #include "lyra/lir/type_id.hpp"
-#include "lyra/support/builtin_fn.hpp"
 
 namespace llvm {
+class BasicBlock;
 class Function;
 class FunctionCallee;
 class Value;
@@ -33,35 +34,52 @@ class CodeGenFunction {
 
  private:
   auto LowerInstr(const lir::Instr& instr) -> llvm::Value*;
-  auto LowerCall(const lir::CallInstr& call) -> llvm::Value*;
-  auto ResolveCallee(const lir::CallTarget& target) -> llvm::FunctionCallee;
+  auto LowerCall(const lir::CallInstr& call, lir::TypeId result_type)
+      -> llvm::Value*;
+  auto ResolveCallee(const lir::CallInstr& call, lir::TypeId result_type)
+      -> llvm::FunctionCallee;
   auto LowerAggregate(const lir::AggregateInstr& agg, lir::TypeId result_type)
       -> llvm::Value*;
+  auto LowerBinary(const lir::BinaryInstr& binary) -> llvm::Value*;
+  auto LowerUnary(const lir::UnaryInstr& unary) -> llvm::Value*;
+  auto LowerBoolCast(const lir::BoolCastInstr& cast) -> llvm::Value*;
   auto LowerOperand(const lir::Operand& operand) -> llvm::Value*;
 
-  // Resolves a place to the base instance and the member slot index its
-  // projection selects, the index already a runtime-ABI constant. Realizes a
-  // single member step so far; a deeper projection chain is realized when its
-  // steps land.
-  auto ResolveMemberSlot(const lir::Place& place)
-      -> std::pair<llvm::Value*, llvm::Value*>;
+  // The address a place names. The base contributes the storage the chain
+  // starts from -- a place local's own frame slot, or the referent of a
+  // reference value
+  // -- and each further step walks one projection.
+  auto ResolvePlaceAddress(const lir::Place& place) -> llvm::Value*;
   auto LowerIntConst(const lir::IntConst& constant) -> llvm::Value*;
   auto LowerStrConst(const lir::StrConst& constant) -> llvm::Value*;
   void LowerTerminator(const lir::Terminator& terminator);
 
-  auto BuiltinCallee(support::BuiltinFn fn) -> llvm::FunctionCallee;
-  auto ConstructCallee(lir::TypeId result) -> llvm::FunctionCallee;
+  auto BuiltinCallee(
+      const lir::BuiltinTarget& target, const lir::CallInstr& call,
+      lir::TypeId result_type) -> llvm::FunctionCallee;
+  auto ValueBuiltinCallee(
+      const lir::BuiltinTarget& target, const lir::CallInstr& call,
+      lir::TypeId result_type) -> llvm::FunctionCallee;
+  auto ConstructCallee(const lir::CallInstr& call) -> llvm::FunctionCallee;
 
   // The leading argument a construct call needs beyond its lowered operands: an
   // external-unit construct is prefixed with the child's definition reference;
   // every other construct needs none.
   auto ConstructDefinitionArg(lir::TypeId result) -> llvm::Value*;
 
+  // The type of an operand, and the value domain a library entry is chosen by.
+  [[nodiscard]] auto OperandType(const lir::Operand& operand) const
+      -> lir::TypeId;
+  [[nodiscard]] auto DomainOf(lir::TypeId type) const -> ValueDomain;
+  // The domain of the cell an operand addresses, for a cell operation.
+  [[nodiscard]] auto CellDomain(const lir::Operand& cell) const -> ValueDomain;
+
   CodeGenModule* module_;
   const lir::Function* fn_;
   llvm::Function* value_;
   llvm::IRBuilder<> builder_;
   std::unordered_map<std::uint32_t, llvm::Value*> values_;
+  std::vector<llvm::BasicBlock*> blocks_;
 };
 
 }  // namespace lyra::backend::llvm_backend

--- a/include/lyra/backend/llvm/codegen_module.hpp
+++ b/include/lyra/backend/llvm/codegen_module.hpp
@@ -62,9 +62,8 @@ class CodeGenModule {
 
   // The definition-reference projection of an external-unit object type: the
   // address of that unit's runtime definition, as an external symbol the host
-  // resolves. The sibling of `MethodFunction` -- both project a LIR identity to
-  // its artifact. A construct that builds a child of the unit passes this
-  // opaque reference to the runtime; the generated code never inspects it.
+  // resolves. A construct that builds a child of the unit passes this opaque
+  // reference to the runtime; the generated code never inspects it.
   auto UnitDefinitionRef(lir::TypeId object_type) -> llvm::Constant*;
 
  private:

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -1,11 +1,42 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <string_view>
+
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Module.h>
+
+#include "lyra/lir/operator.hpp"
+#include "lyra/lir/type_id.hpp"
+#include "lyra/support/builtin_fn.hpp"
+
+namespace lyra::lir {
+struct CompilationUnit;
+}  // namespace lyra::lir
 
 namespace lyra::backend::llvm_backend {
 
 class CodeGenTypes;
+
+// The runtime value type a library entry operates on, and that a storage cell
+// is realized as. Chosen from the LIR type at the site that needs it, never
+// carried as a tag the runtime inspects: the generated module names the entry
+// it means.
+//
+// This enumerates runtime realizations, not source types. Several source types
+// share one domain -- an enumeration and an integral both become a packed value
+// -- and a source type with no runtime realization has no domain at all. It
+// grows only when the runtime library gains a value type, never to mirror the
+// source language's type kinds.
+enum class ValueDomain : std::uint8_t { kPacked, kString };
+
+auto ValueDomainName(ValueDomain domain) -> std::string_view;
+
+// The domain a LIR type is realized in. The one place a LIR type is classified,
+// so the entry a call names and the storage a cell owns cannot disagree.
+auto ValueDomainOf(const lir::CompilationUnit& unit, lir::TypeId type)
+    -> ValueDomain;
 
 // The runtime ABI the generated module calls: each runtime entry point declared
 // once with its canonical signature. The ABI is execution-strategy-neutral --
@@ -51,15 +82,54 @@ class RuntimeAbi {
   // the child as a borrowed scope handle.
   auto AddOwnedChild() -> llvm::FunctionCallee;
 
-  // Reads / writes a member slot of an instance by slot index. A member is a
-  // logical place; the runtime owns the slot storage.
-  auto LoadField() -> llvm::FunctionCallee;
-  auto StoreField() -> llvm::FunctionCallee;
+  // The address of an instance's member storage, by class-local member index.
+  // A member is a logical place; the runtime owns the storage it resolves to.
+  auto MemberAddress() -> llvm::FunctionCallee;
+
+  // Operations on an observable storage cell, reached through its address.
+  // `Initialize` installs the cell's declared representation once; `Set`
+  // threads services so a change wakes the cell's subscribers.
+  auto CellGet(ValueDomain domain) -> llvm::FunctionCallee;
+  auto CellInitialize(ValueDomain domain) -> llvm::FunctionCallee;
+  auto CellSet(ValueDomain domain) -> llvm::FunctionCallee;
+
+  // Publishes a member cell under its source-level name so the scope can be
+  // navigated by name.
+  auto RegisterSignal() -> llvm::FunctionCallee;
+
+  // The library realization of an operator over a value domain. The entry's
+  // name is the domain and the operator's own spelling, so a new operator or a
+  // new domain cannot silently resolve to the wrong entry.
+  auto Binary(ValueDomain domain, lir::BinaryOp op) -> llvm::FunctionCallee;
+  auto Unary(ValueDomain domain, lir::UnaryOp op) -> llvm::FunctionCallee;
+
+  // The library realization of a value builtin -- an operation the source
+  // language spells as a call rather than an operator (a shift, a reduction, a
+  // conversion). Named the same way an operator is, from the domain and the
+  // builtin's own spelling. Its signature is the call site's own: the value
+  // model gives each runtime value one representation, so the operand and
+  // result types at the call are the entry's parameter and result types.
+  auto ValueBuiltin(
+      ValueDomain domain, lyra::support::BuiltinFn fn, llvm::Type* result,
+      llvm::ArrayRef<llvm::Type*> params) -> llvm::FunctionCallee;
+
+  // Reduces a value to the machine boolean a conditional branch tests.
+  auto ToBool(ValueDomain domain) -> llvm::FunctionCallee;
+
+  // Builds the format specification of one conversion, and the print item that
+  // pairs a value with it. A specification is written either as a bare
+  // conversion kind, leaving every field at its default, or with every field
+  // spelled out; `field_count` selects which, as an overload set would.
+  auto MakeFormatSpec(std::size_t field_count) -> llvm::FunctionCallee;
+  auto MakePrintValueItem(ValueDomain domain) -> llvm::FunctionCallee;
 
  private:
   auto Get(
       const char* name, llvm::Type* result, llvm::ArrayRef<llvm::Type*> params)
       -> llvm::FunctionCallee;
+  auto Get(
+      const std::string& name, llvm::Type* result,
+      llvm::ArrayRef<llvm::Type*> params) -> llvm::FunctionCallee;
 
   llvm::Module* module_;
   llvm::LLVMContext* ctx_;

--- a/include/lyra/lir/compilation_unit.hpp
+++ b/include/lyra/lir/compilation_unit.hpp
@@ -33,9 +33,9 @@ struct Member {
   TypeId type;
 };
 
-// One compiled class: its name, the base it extends, its member slots, its
-// construction logic, and its callable bodies. Mirrors `mir::Class` with every
-// body lowered to a CFG.
+// One compiled class: its name, the base it extends, the members it declares,
+// its construction logic, and its callable bodies. Mirrors `mir::Class` with
+// every body lowered to a CFG.
 struct Class {
   std::string name;
   std::optional<Base> base;

--- a/include/lyra/lir/function.hpp
+++ b/include/lyra/lir/function.hpp
@@ -10,6 +10,7 @@
 #include "lyra/base/arena.hpp"
 #include "lyra/lir/class_id.hpp"
 #include "lyra/lir/integral_constant.hpp"
+#include "lyra/lir/operator.hpp"
 #include "lyra/lir/type_id.hpp"
 #include "lyra/support/builtin_fn.hpp"
 
@@ -29,9 +30,15 @@ struct BlockId {
   auto operator<=>(const BlockId&) const -> std::strong_ordering = default;
 };
 
-// Whether a value is a callable parameter or a temporary the lowering minted
-// for an instruction result.
-enum class LocalKind : std::uint8_t { kParam, kTemp };
+// How a value is realized. A parameter arrives in the callable's signature; a
+// temporary is a transient computed once and consumed. A place local is named
+// storage on the frame. Which one a local is follows a canonical lowering rule,
+// not the source notion of a variable: a local is a place exactly when the
+// lowering needs an address for it -- its address is taken, it is assigned
+// after its initialization, or it holds a control-flow join. LIR is not SSA, so
+// a value produced on several paths is a place each path writes, not a merge of
+// transients.
+enum class LocalKind : std::uint8_t { kParam, kTemp, kPlace };
 
 struct Local {
   std::string name;
@@ -73,8 +80,14 @@ struct FuncRef {
 // materialized at the use site.
 using Operand = std::variant<Use, IntConst, StrConst, FuncRef>;
 
+// A runtime-library entry. A static factory is named by its type namespace as
+// well as its function -- `String::FromPackedArray` and `PackedArray::FromInt`
+// are different entries of one `fn` -- so the qualifying type rides the target.
+// It is absent for an entry that takes a receiver, whose type the receiver
+// already names.
 struct BuiltinTarget {
   support::BuiltinFn fn;
+  std::optional<TypeId> qualifier;
 };
 
 struct MethodTarget {
@@ -111,27 +124,37 @@ struct MemberId {
   auto operator<=>(const MemberId&) const -> std::strong_ordering = default;
 };
 
-// One step of a place's projection chain: it selects a member of the object the
-// projection has reached so far. The place vocabulary is member, index,
-// dereference, slice, and downcast; only member is realized so far, each
-// further step joining this variant as its feature lands.
+// Reaches the storage a reference-like value refers to. A projection chain may
+// only cross a pointer through this step: a member step never implicitly
+// dereferences, so `self.counter` -- whose receiver arrives as a pointer -- is
+// the chain `deref, member`, never `member` alone.
+struct DerefProjection {};
+
+// Selects a member of the object the projection has reached so far.
 struct MemberProjection {
   MemberId member;
 };
 
-using Projection = std::variant<MemberProjection>;
+// One step of a place's projection chain. The place vocabulary is dereference,
+// member, index, slice, and downcast: each names storage reached from the
+// storage the chain has arrived at, never a byte offset from it.
+using Projection = std::variant<DerefProjection, MemberProjection>;
 
-// Storage named by logical identity: a base value plus a projection chain of
-// member / index / dereference / ... steps. A place is what a load, store, or
-// address-of names; the physical address it resolves to is derived below LIR,
-// never encoded here. An empty chain names the base itself.
+// Storage named by logical identity: a base plus a projection chain. The base
+// is either a place local, whose storage the chain starts at, or a
+// reference-like value, which the chain must open with a dereference. A place
+// is what a load, store, or address-of names; the physical address it resolves
+// to is derived below LIR, never encoded here. An empty chain names the base
+// local itself.
 struct Place {
   Operand base;
   std::vector<Projection> chain;
 };
 
 // Reads the value held at `place`. The result's type is the place's type -- the
-// type the projection chain arrives at.
+// type the projection chain arrives at. A place whose storage is a runtime cell
+// object rather than a value is not readable this way; its contents are reached
+// through the library calls that operate on the cell's address.
 struct LoadInstr {
   Place place;
 };
@@ -143,8 +166,44 @@ struct StoreInstr {
   Operand value;
 };
 
-using InstrData =
-    std::variant<CallInstr, AggregateInstr, LoadInstr, StoreInstr>;
+// Names the address of `place`. The result is a borrowed pointer to the place's
+// type. This is how storage itself -- a cell, an aggregate, a member the callee
+// mutates -- is handed to a callee, as opposed to a copy of its contents.
+struct AddrOfInstr {
+  Place place;
+};
+
+// Applies an operator to values. The operator's semantics come from the operand
+// type: the same `kAdd` is a machine add over a machine integer and an
+// X-propagating library add over a four-state packed value.
+struct BinaryInstr {
+  BinaryOp op;
+  Operand lhs;
+  Operand rhs;
+};
+
+struct UnaryInstr {
+  UnaryOp op;
+  Operand operand;
+};
+
+// Reduces a value to a machine boolean, the type a conditional branch tests.
+// This is the explicit form of the contextual conversion a C++ target performs
+// implicitly in a boolean context.
+struct BoolCastInstr {
+  Operand operand;
+};
+
+// Reinterprets a reference-like value as a reference to the result type. It
+// moves no bits; it names the destination type that an implicit conversion
+// would otherwise leave for a consumer to infer.
+struct PointerCastInstr {
+  Operand operand;
+};
+
+using InstrData = std::variant<
+    CallInstr, AggregateInstr, LoadInstr, StoreInstr, AddrOfInstr, BinaryInstr,
+    UnaryInstr, BoolCastInstr, PointerCastInstr>;
 
 // One instruction: it defines `result` (whose type lives on the function's
 // value arena) from `data`.
@@ -160,7 +219,26 @@ struct ReturnTerm {
   bool is_coroutine = false;
 };
 
-using TerminatorData = std::variant<ReturnTerm>;
+// Transfers to `target` unconditionally.
+struct BranchTerm {
+  BlockId target;
+};
+
+// Tests a machine boolean and transfers to one of two successors.
+struct CondBranchTerm {
+  Operand condition;
+  BlockId if_true;
+  BlockId if_false;
+};
+
+// Ends a block control never reaches -- the join of a conditional whose arms
+// all returned, or the tail of a value-returning body that always returns
+// earlier. Reaching it is undefined, which is what lets a target drop the
+// block.
+struct UnreachableTerm {};
+
+using TerminatorData =
+    std::variant<ReturnTerm, BranchTerm, CondBranchTerm, UnreachableTerm>;
 
 struct Terminator {
   TerminatorData data;
@@ -172,9 +250,10 @@ struct BasicBlock {
 };
 
 // A callable lowered to a CFG. `values` holds every value of the body --
-// parameters first, then instruction temporaries; `params` names the parameter
-// subset in signature order, with the receiver `self` at `params[0]`. The entry
-// block is `blocks[0]`.
+// parameters first, then the temporaries and place locals the lowering minted;
+// `params` names the parameter subset in signature order, with the receiver
+// `self` at `params[0]`. The entry block is `blocks[0]`, and a `BlockId`
+// indexes `blocks`.
 struct Function {
   std::string name;
   base::Arena<Local, ValueId> values;
@@ -182,5 +261,10 @@ struct Function {
   TypeId result_type;
   std::vector<BasicBlock> blocks;
 };
+
+// The type of a value operand: the type of the value a use names, or of a
+// constant. A code reference names a callable, not a value, so it has none.
+auto OperandType(const Function& fn, const Operand& operand)
+    -> std::optional<TypeId>;
 
 }  // namespace lyra::lir

--- a/include/lyra/lir/operator.hpp
+++ b/include/lyra/lir/operator.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace lyra::lir {
+
+// The operators that survive into the executable IR: those a target realizes as
+// a machine instruction or a single runtime-library call. An operator's
+// semantics are fixed by its operand type, not by the opcode -- an add over a
+// four-state packed value propagates X, an add over a machine integer does not.
+// Operators with no such realization (reductions, power, the shifts) are lifted
+// to library calls before LIR and never appear here.
+enum class BinaryOp : std::uint8_t {
+  kAdd,
+  kSub,
+  kMul,
+  kDiv,
+  kMod,
+  kBitwiseAnd,
+  kBitwiseOr,
+  kBitwiseXor,
+  kEquality,
+  kInequality,
+  kLessThan,
+  kLessEqual,
+  kGreaterThan,
+  kGreaterEqual,
+  kLogicalAnd,
+  kLogicalOr,
+};
+
+// Unary plus is an identity and is folded away before LIR. Increment and
+// decrement are the successor and predecessor of a value at that value's own
+// width -- the operand of a source-level `++` / `--`, whose read-modify-write
+// and result ordering the lowering has already made explicit.
+enum class UnaryOp : std::uint8_t {
+  kMinus,
+  kBitwiseNot,
+  kLogicalNot,
+  kIncrement,
+  kDecrement,
+};
+
+// The operator's stable spelling. It names the operator in a dump and forms the
+// suffix of the runtime-library entry a value domain realizes it with, so the
+// two can never drift apart.
+auto BinaryOpName(BinaryOp op) -> std::string_view;
+auto UnaryOpName(UnaryOp op) -> std::string_view;
+
+}  // namespace lyra::lir

--- a/include/lyra/lir/type_query.hpp
+++ b/include/lyra/lir/type_query.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <optional>
+
+#include "lyra/base/arena.hpp"
+#include "lyra/lir/type.hpp"
+#include "lyra/lir/type_id.hpp"
+
+namespace lyra::lir {
+
+using TypeArena = base::Arena<Type, TypeId>;
+
+// The type a reference-like type refers to; absent when the type refers to
+// nothing, which is what makes a dereference of it invalid.
+auto Pointee(const TypeArena& types, TypeId type) -> std::optional<TypeId>;
+
+// A type whose storage object has no first-class value in LIR: operations on it
+// consume its address. A storage cell (an observable variable, a net resolution
+// node, a driver slot) and every object-tree node (a class object, a scope, an
+// instance) are such a type -- there is nothing to read out of the storage,
+// write into it, or hand to a callee except where it lives.
+//
+// This is about the storage object, not about how a value is represented. A
+// packed value is a runtime object reached through an opaque handle, and that
+// handle is an ordinary first-class value: a place holding one is loaded and
+// stored like any other. The cell that holds a packed value is what is
+// address-only, never the value itself.
+auto IsAddressOnly(const TypeArena& types, TypeId type) -> bool;
+
+}  // namespace lyra::lir

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
@@ -11,17 +12,16 @@
 #include "lyra/lowering/mir_to_lir/unit_lowerer.hpp"
 #include "lyra/mir/callable_code.hpp"
 #include "lyra/mir/expr_id.hpp"
-
-namespace lyra::mir {
-struct Stmt;
-}  // namespace lyra::mir
+#include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::mir_to_lir {
 
 // Lowers one MIR callable body (a method's code or a class constructor) into a
-// LIR function. The body is flattened: each MIR expression node becomes one LIR
+// LIR function. Structured control flow becomes a CFG, and expression trees
+// become instruction streams: each MIR expression node becomes one LIR
 // instruction defining a temporary, and the parent reads the child temporaries
-// as operands.
+// as operands. A source-level place -- a member, an automatic local -- becomes
+// a LIR place, and the use decides whether it is read, written, or addressed.
 class FunctionLowerer {
  public:
   FunctionLowerer(
@@ -31,19 +31,89 @@ class FunctionLowerer {
   auto Run() -> diag::Result<lir::Function>;
 
  private:
-  auto LowerStmtInto(const mir::Stmt& stmt) -> diag::Result<void>;
-  auto LowerExpr(mir::ExprId id) -> diag::Result<lir::Operand>;
-  auto LowerPlace(mir::ExprId id) -> diag::Result<lir::Place>;
+  // The branch targets a `break` and a `continue` inside one loop transfer to.
+  // A labeled loop is also the target of a labeled break from a nested loop.
+  struct LoopTargets {
+    std::optional<mir::LoopLabelId> label;
+    lir::BlockId continue_target{};
+    lir::BlockId break_target{};
+  };
+
+  // What a source local resolves to. A local is frame storage exactly when the
+  // canonical lowering needs an address for it: when its address is taken, or
+  // when it is assigned after its initialization. Otherwise it stays the value
+  // it was bound to, with no storage.
+  struct PlaceBinding {
+    lir::ValueId slot;
+  };
+  struct ValueBinding {
+    lir::Operand value;
+  };
+  using LocalBinding = std::variant<PlaceBinding, ValueBinding>;
+
+  auto LowerBlockInto(const mir::Block& block) -> diag::Result<void>;
+  auto LowerStmtInto(const mir::Block& block, const mir::Stmt& stmt)
+      -> diag::Result<void>;
+  auto LowerIfInto(const mir::Block& block, const mir::IfStmt& stmt)
+      -> diag::Result<void>;
+  auto LowerForInto(const mir::Block& block, const mir::ForStmt& stmt)
+      -> diag::Result<void>;
+  auto LowerWhileInto(const mir::Block& block, const mir::WhileStmt& stmt)
+      -> diag::Result<void>;
+  auto LowerDoWhileInto(const mir::Block& block, const mir::DoWhileStmt& stmt)
+      -> diag::Result<void>;
+  auto LowerBreakInto(const mir::BreakStmt& stmt) -> diag::Result<void>;
+  auto LowerContinueInto() -> diag::Result<void>;
+
+  // Reads a value out of an expression. An expression naming storage that has
+  // no value of its own -- a cell -- has no reading, and is rejected here.
+  auto LowerExpr(const mir::Block& block, mir::ExprId id)
+      -> diag::Result<lir::Operand>;
+  // Passes an expression to a callee: a cell crosses as its address, every
+  // other value as itself. This is the one use context that addresses a place
+  // without an explicit address-of in the source IR.
+  auto LowerArgument(const mir::Block& block, mir::ExprId id)
+      -> diag::Result<lir::Operand>;
+  auto LowerPlace(const mir::Block& block, mir::ExprId id)
+      -> diag::Result<lir::Place>;
+  // Reduces an expression to the machine boolean a conditional branch tests.
+  auto LowerCondition(const mir::Block& block, mir::ExprId id)
+      -> diag::Result<lir::Operand>;
+
+  auto LowerCall(
+      const mir::Block& block, const mir::CallExpr& call, mir::TypeId type)
+      -> diag::Result<lir::Operand>;
+  auto LowerAssign(const mir::Block& block, const mir::AssignExpr& assign)
+      -> diag::Result<lir::Operand>;
+  auto LowerIncDec(const mir::Block& block, const mir::IncDecExpr& inc_dec)
+      -> diag::Result<lir::Operand>;
+  auto LowerConditional(
+      const mir::Block& block, const mir::ConditionalExpr& cond,
+      mir::TypeId type) -> diag::Result<lir::Operand>;
+
   auto Emit(lir::TypeId type, lir::InstrData data) -> lir::Operand;
+  auto NewPlaceLocal(lir::TypeId type) -> lir::ValueId;
+  void BindLocal(mir::LocalId local, lir::TypeId type, lir::Operand init);
+  auto Load(lir::Place place, lir::TypeId type) -> lir::Operand;
+  void Store(lir::Place place, lir::Operand value);
+
+  auto NewBlock() -> lir::BlockId;
+  void SetCurrent(lir::BlockId id);
+  void Terminate(lir::TerminatorData data);
+  [[nodiscard]] auto Terminated() const -> bool;
 
   UnitLowerer* unit_;
   const mir::CallableCode* code_;
   std::string name_;
   lir::ClassId current_class_;
   lir::Function fn_;
-  lir::BasicBlock block_;
-  std::vector<std::optional<lir::ValueId>> local_to_value_;
-  bool terminated_ = false;
+  lir::BlockId current_{};
+  std::vector<bool> terminated_;
+  std::vector<LoopTargets> loops_;
+  // Which locals the body writes through or addresses, and what each local has
+  // resolved to so far.
+  std::vector<bool> placed_;
+  std::vector<std::optional<LocalBinding>> locals_;
 };
 
 }  // namespace lyra::lowering::mir_to_lir

--- a/include/lyra/lowering/mir_to_lir/unit_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/unit_lowerer.hpp
@@ -10,6 +10,7 @@
 #include "lyra/lir/compilation_unit.hpp"
 #include "lyra/lir/type.hpp"
 #include "lyra/lir/type_id.hpp"
+#include "lyra/lir/type_query.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -40,6 +41,16 @@ class UnitLowerer {
   // type error read at `Run`; it never silently mistranslates.
   auto TranslateType(mir::TypeId id) -> lir::TypeId;
 
+  [[nodiscard]] auto Types() const -> const lir::TypeArena& {
+    return out_.types;
+  }
+
+  // LIR types the lowering needs that no MIR type maps to: the reference an
+  // address-of yields, and the machine boolean a conditional branch tests. Each
+  // is minted once and reused.
+  auto BorrowedPointerTo(lir::TypeId pointee) -> lir::TypeId;
+  auto MachineBoolType() -> lir::TypeId;
+
  private:
   auto TranslateTypeData(const mir::Type& ty) -> lir::TypeData;
   // Records `what` (a human phrase like "a closure") as the unit's first
@@ -53,6 +64,8 @@ class UnitLowerer {
   const mir::CompilationUnit* mir_;
   lir::CompilationUnit out_;
   std::unordered_map<std::uint32_t, lir::TypeId> type_memo_;
+  std::unordered_map<std::uint32_t, lir::TypeId> pointer_memo_;
+  std::optional<lir::TypeId> machine_bool_type_;
   // Set the first time a MIR type with no LIR mirror is reached; surfaced as
   // the unit's failure at `Run`, so translation stays non-throwing and
   // total-shaped while an unmirrored type is still a clean diagnostic, not a

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -45,7 +45,110 @@ auto lyra_rt_make_unit(
 // runtime tree; returns the child as a borrowed scope handle.
 auto lyra_rt_add_owned_child(void* parent, void* child) -> void*;
 
-// Reads / writes a generic instance's member slot by index.
-auto lyra_rt_load_field(void* self, std::uint32_t index) -> void*;
-void lyra_rt_store_field(void* self, std::uint32_t index, void* value);
+// The address of a generic instance's member storage, by class-local index.
+auto lyra_rt_member_addr(void* self, std::uint32_t index) -> void*;
+
+// Publishes a member cell under its source-level name for by-name navigation.
+void lyra_rt_register_signal(void* self, const void* name, void* cell);
+
+// Observable storage cell operations, reached through the cell's address. The
+// entry names the cell's value domain; the runtime never inspects a type tag.
+auto lyra_rt_cell_packed_get(void* cell) -> const void*;
+void lyra_rt_cell_packed_initialize(void* cell, const void* prototype);
+void lyra_rt_cell_packed_set(void* cell, void* services, const void* value);
+auto lyra_rt_cell_string_get(void* cell) -> const void*;
+void lyra_rt_cell_string_initialize(void* cell, const void* prototype);
+void lyra_rt_cell_string_set(void* cell, void* services, const void* value);
+
+// One entry per operator per value domain: the generated module names the entry
+// it means, so no operator code crosses the boundary. Each is the library peer
+// of the C++ operator a native target would emit. The result is a transient
+// value owned by the current call scope.
+auto lyra_rt_packed_add(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_sub(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_mul(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_div(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_mod(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_and(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_or(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_xor(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_eq(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_ne(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_lt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_le(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_gt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_ge(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_logical_and(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_logical_or(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_neg(const void* operand) -> void*;
+auto lyra_rt_packed_not(const void* operand) -> void*;
+auto lyra_rt_packed_logical_not(const void* operand) -> void*;
+auto lyra_rt_packed_inc(const void* operand) -> void*;
+auto lyra_rt_packed_dec(const void* operand) -> void*;
+auto lyra_rt_packed_to_bool(const void* operand) -> bool;
+
+// Value builtins: the operations the source language spells as a call rather
+// than an operator. Named `lyra_rt_<domain>_<builtin>`, the same way an
+// operator entry is, so the generated module derives the symbol it means.
+auto lyra_rt_packed_convert_from(const void* src, const void* prototype)
+    -> void*;
+auto lyra_rt_packed_from_bool(bool value) -> void*;
+auto lyra_rt_packed_to_int64(const void* value) -> std::int64_t;
+auto lyra_rt_packed_is_unknown(const void* value) -> void*;
+auto lyra_rt_packed_pow(const void* base, const void* exponent) -> void*;
+auto lyra_rt_packed_shift_left(const void* value, const void* amount) -> void*;
+auto lyra_rt_packed_logical_shift_right(const void* value, const void* amount)
+    -> void*;
+auto lyra_rt_packed_arithmetic_shift_right(
+    const void* value, const void* amount) -> void*;
+auto lyra_rt_packed_bitwise_xnor(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_logical_implication(const void* lhs, const void* rhs)
+    -> void*;
+auto lyra_rt_packed_logical_equivalence(const void* lhs, const void* rhs)
+    -> void*;
+auto lyra_rt_packed_case_equal(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_wildcard_equals(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_casez_equals(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_casex_equals(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_packed_reduction_and(const void* value) -> void*;
+auto lyra_rt_packed_reduction_or(const void* value) -> void*;
+auto lyra_rt_packed_reduction_xor(const void* value) -> void*;
+auto lyra_rt_packed_reduction_nand(const void* value) -> void*;
+auto lyra_rt_packed_reduction_nor(const void* value) -> void*;
+auto lyra_rt_packed_reduction_xnor(const void* value) -> void*;
+
+auto lyra_rt_string_from_packed_array(const void* bits) -> void*;
+auto lyra_rt_string_len(const void* value) -> void*;
+auto lyra_rt_string_getc(const void* value, const void* index) -> void*;
+auto lyra_rt_string_toupper(const void* value) -> void*;
+auto lyra_rt_string_tolower(const void* value) -> void*;
+auto lyra_rt_string_compare(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_icompare(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_substr(
+    const void* value, const void* first, const void* last) -> void*;
+auto lyra_rt_string_atoi(const void* value) -> void*;
+auto lyra_rt_string_atohex(const void* value) -> void*;
+auto lyra_rt_string_atooct(const void* value) -> void*;
+auto lyra_rt_string_atobin(const void* value) -> void*;
+
+auto lyra_rt_string_add(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_eq(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_ne(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_lt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_le(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_gt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_string_ge(const void* lhs, const void* rhs) -> void*;
+
+// Builds one conversion's format specification, and the print item that pairs a
+// value with it. Each field arrives as a packed value, as the value model
+// routes every compile-time scalar.
+auto lyra_rt_make_format_spec_of_kind(const void* kind) -> void*;
+auto lyra_rt_make_format_spec(
+    const void* kind, const void* width, const void* precision,
+    const void* zero_pad, const void* left_align, const void* timeunit_power)
+    -> void*;
+auto lyra_rt_make_print_value_item_packed(const void* value, const void* spec)
+    -> void*;
+auto lyra_rt_make_print_value_item_string(const void* value, const void* spec)
+    -> void*;
 }

--- a/include/lyra/runtime/member_storage.hpp
+++ b/include/lyra/runtime/member_storage.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <variant>
+
+#include "lyra/runtime/scope_program.hpp"
+#include "lyra/runtime/var.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+// One member's runtime-owned storage, realized from the descriptor its unit
+// definition carries. The instance owns this object and a member place resolves
+// to its address; what the address means follows the member's storage kind. A
+// borrowed handle is a box holding a pointer the instance does not own, so
+// reading the member reads the box; an observable cell is the storage itself,
+// which library calls reach through its address and never read out as a value.
+class MemberStorage {
+ public:
+  explicit MemberStorage(MemberStorageDescriptor descriptor);
+  MemberStorage(const MemberStorage&) = delete;
+  auto operator=(const MemberStorage&) -> MemberStorage& = delete;
+  MemberStorage(MemberStorage&&) = delete;
+  auto operator=(MemberStorage&&) -> MemberStorage& = delete;
+  ~MemberStorage() = default;
+
+  [[nodiscard]] auto Address() -> void*;
+
+ private:
+  std::variant<void*, Var<value::PackedArray>, Var<value::String>> object_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -11,6 +11,7 @@
 
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/hierarchy_segment.hpp"
+#include "lyra/runtime/member_storage.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/scope_program.hpp"
 #include "lyra/value/packed_array.hpp"
@@ -245,26 +246,30 @@ class Instance : public Scope {
 };
 
 // A design-unit instance whose member storage the runtime owns, rather than a
-// backend's native object layout. A generic instance holds one opaque slot per
-// member the definition declares; a member place resolves to one of these slots
-// by index. This is the runtime-owned counterpart of the C++ backend's native
-// member fields: a member is a logical place, and this is its realization when
-// the backend does not lay one out physically.
+// backend's native object layout. The definition describes the storage schema,
+// the instance owns one storage object per member, and a member place resolves
+// to that object's address. This is the runtime-owned counterpart of the C++
+// backend's native member fields: a member is a logical place, and this is its
+// realization when the backend does not lay one out physically.
 class GeneratedInstance : public Instance {
  public:
   GeneratedInstance(
       Scope* parent, HierarchySegment segment, RuntimeServices& services,
       const UnitDefinition* definition)
-      : Instance(parent, std::move(segment), services, definition),
-        slots_(definition->member_slot_count, nullptr) {
+      : Instance(parent, std::move(segment), services, definition) {
+    members_.reserve(definition->members.size);
+    for (const MemberStorageDescriptor& descriptor :
+         definition->members.Descriptors()) {
+      members_.push_back(std::make_unique<MemberStorage>(descriptor));
+    }
   }
 
-  [[nodiscard]] auto Slot(std::uint32_t index) -> void*& {
-    return slots_.at(index);
+  [[nodiscard]] auto MemberAddress(std::uint32_t index) -> void* {
+    return members_.at(index)->Address();
   }
 
  private:
-  std::vector<void*> slots_;
+  std::vector<std::unique_ptr<MemberStorage>> members_;
 };
 
 // A module-local generate naming scope (`if` / `for` / `case` generate block):

--- a/include/lyra/runtime/scope_program.hpp
+++ b/include/lyra/runtime/scope_program.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 
 namespace lyra::runtime {
 
@@ -72,18 +73,56 @@ struct ScopeProgram {
   }
 };
 
+// The runtime value type a storage cell carries. It enumerates the value types
+// the runtime library has, not the type kinds the source language has: several
+// source types share one domain, and a source type the runtime cannot realize
+// has no domain at all. It grows when the runtime gains a value type, never to
+// mirror the source language. `kNone` is the domain of storage that carries no
+// value of its own, such as a box holding a borrowed handle.
+enum class ValueDomain : std::uint8_t { kNone, kPacked, kString };
+
+// How a member's storage is realized. A borrowed handle is a box holding a
+// pointer the instance does not own, the storage behind a companion reference
+// to another scope. An observable cell is the subscribable variable a process
+// reads, writes, and waits on.
+enum class MemberStorageKind : std::uint8_t {
+  kBorrowedHandle,
+  kObservableCell
+};
+
+struct MemberStorageDescriptor {
+  MemberStorageKind kind = MemberStorageKind::kBorrowedHandle;
+  ValueDomain domain = ValueDomain::kNone;
+};
+
+// A unit's member storage schema, in class-local member order: what a generic
+// instance must realize for each member its class declares. Crosses the
+// generated-runtime boundary as plain data -- a pointer plus a length, not a
+// C++ container -- so a non-C++ backend supplies it without depending on a C++
+// type's layout. The pointed-at descriptors are owned by whoever built the
+// definition and outlive every instance of it.
+struct MemberStorageSchema {
+  const MemberStorageDescriptor* data = nullptr;
+  std::uint32_t size = 0;
+
+  [[nodiscard]] constexpr auto Descriptors() const
+      -> std::span<const MemberStorageDescriptor> {
+    return {data, size};
+  }
+};
+
 // The immutable per-specialization definition of a design unit: the root
 // scope's program (held by value, so a unit's whole generated behavior is one
-// constant), the structural-construction entry, and the count of member slots
-// an instance carries. Construction is bootstrap-called (a JIT design) or
-// realized by the backend's own constructor (the C++ backend), distinct from
-// the per-phase lifecycle dispatch. The slot count sizes the runtime-owned
-// storage of a generic instance; a backend that lays members out natively (the
-// C++ backend, whose subclass holds real fields) leaves it zero.
+// constant), the structural-construction entry, and the storage schema of its
+// members. Construction is bootstrap-called (a JIT design) or realized by the
+// backend's own constructor (the C++ backend), distinct from the per-phase
+// lifecycle dispatch. The schema tells a generic instance what storage to own
+// for each member; a backend that lays members out natively (the C++ backend,
+// whose subclass holds real fields) leaves it empty.
 struct UnitDefinition {
   ScopeProgram root;
   ScopeEntry construct = &ScopeNoOp;
-  std::uint32_t member_slot_count = 0;
+  MemberStorageSchema members;
 
   constexpr UnitDefinition() = default;
   constexpr UnitDefinition(ScopeProgram root, ScopeEntry construct)

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -388,11 +388,14 @@ enum class BuiltinFn : std::uint16_t {
 // through a copy-out wrapper at statement position.
 [[nodiscard]] auto IsFileOutputArgBuiltinFn(BuiltinFn id) -> bool;
 
-// Short snake-case name for the id. Used for HIR / MIR dumps and any
-// diagnostic that names the runtime entry; aligns with the SV method
-// spelling where one exists (LRM 6.16 / 7.9 / 7.12 / 6.19.5) and a
-// descriptive name where there is no SV-side surface (`get` / `set` /
-// `mutate` / `services`).
+// The id's stable spelling. It aligns with the SV method spelling where one
+// exists (LRM 6.16 / 7.9 / 7.12 / 6.19.5) and is descriptive where there is no
+// SV-side surface (`get` / `set` / `mutate` / `services`).
+//
+// This is an interface contract, not a display string. It names the entry in a
+// dump and in a diagnostic, and it is the suffix of the runtime-library symbol
+// a generated module calls, so changing it renames a linked symbol. Change it
+// only to correct the entry's identity, never to improve how a dump reads.
 [[nodiscard]] auto BuiltinFnName(BuiltinFn id) -> std::string_view;
 
 }  // namespace lyra::support

--- a/src/lyra/backend/llvm/codegen_function.cpp
+++ b/src/lyra/backend/llvm/codegen_function.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <format>
+#include <optional>
 #include <variant>
 
 #include <llvm/IR/BasicBlock.h>
@@ -9,6 +10,7 @@
 #include <llvm/IR/Type.h>
 
 #include "lyra/backend/llvm/codegen_module.hpp"
+#include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 
 namespace lyra::backend::llvm_backend {
@@ -22,10 +24,29 @@ void CodeGenFunction::Run() {
   for (std::uint32_t i = 0; i < fn_->params.size(); ++i) {
     values_.emplace(fn_->params[i].value, value_->getArg(i));
   }
+  // Every block exists before any is filled, so a branch resolves its successor
+  // regardless of the order the blocks are emitted in.
+  blocks_.reserve(fn_->blocks.size());
   for (std::uint32_t i = 0; i < fn_->blocks.size(); ++i) {
-    auto* bb = llvm::BasicBlock::Create(
-        module_->Context(), std::format("bb{}", i), value_);
-    builder_.SetInsertPoint(bb);
+    blocks_.push_back(
+        llvm::BasicBlock::Create(
+            module_->Context(), std::format("bb{}", i), value_));
+  }
+
+  // A place local is frame storage: its slot is allocated once, in the entry
+  // block, so every path that reaches it names the same address.
+  builder_.SetInsertPoint(blocks_.front());
+  for (std::uint32_t i = 0; i < fn_->values.size(); ++i) {
+    const lir::ValueId id{i};
+    const lir::Local& local = fn_->values.Get(id);
+    if (local.kind == lir::LocalKind::kPlace) {
+      values_.emplace(
+          i, builder_.CreateAlloca(module_->Types().Map(local.type)));
+    }
+  }
+
+  for (std::uint32_t i = 0; i < fn_->blocks.size(); ++i) {
+    builder_.SetInsertPoint(blocks_[i]);
     for (const lir::Instr& instr : fn_->blocks[i].instrs) {
       values_.emplace(instr.result.value, LowerInstr(instr));
     }
@@ -35,14 +56,37 @@ void CodeGenFunction::Run() {
 
 void CodeGenFunction::LowerTerminator(const lir::Terminator& terminator) {
   std::visit(
-      Overloaded{[&](const lir::ReturnTerm& ret) {
-        if (value_->getReturnType()->isVoidTy()) {
-          builder_.CreateRetVoid();
-          return;
-        }
-        builder_.CreateRet(LowerOperand(*ret.value));
-      }},
+      Overloaded{
+          [&](const lir::ReturnTerm& ret) {
+            if (value_->getReturnType()->isVoidTy()) {
+              builder_.CreateRetVoid();
+              return;
+            }
+            builder_.CreateRet(LowerOperand(*ret.value));
+          },
+          [&](const lir::BranchTerm& br) {
+            builder_.CreateBr(blocks_[br.target.value]);
+          },
+          [&](const lir::CondBranchTerm& br) {
+            builder_.CreateCondBr(
+                LowerOperand(br.condition), blocks_[br.if_true.value],
+                blocks_[br.if_false.value]);
+          },
+          [&](const lir::UnreachableTerm&) { builder_.CreateUnreachable(); }},
       terminator.data);
+}
+
+auto CodeGenFunction::OperandType(const lir::Operand& operand) const
+    -> lir::TypeId {
+  const std::optional<lir::TypeId> type = lir::OperandType(*fn_, operand);
+  if (!type) {
+    throw InternalError("llvm codegen: a code reference has no type");
+  }
+  return *type;
+}
+
+auto CodeGenFunction::DomainOf(lir::TypeId type) const -> ValueDomain {
+  return ValueDomainOf(module_->Unit(), type);
 }
 
 }  // namespace lyra::backend::llvm_backend

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <optional>
 #include <variant>
 #include <vector>
 
@@ -14,6 +15,7 @@
 #include "lyra/lir/compilation_unit.hpp"
 #include "lyra/lir/integral_constant.hpp"
 #include "lyra/lir/type.hpp"
+#include "lyra/lir/type_query.hpp"
 
 namespace lyra::backend::llvm_backend {
 
@@ -22,26 +24,109 @@ auto CodeGenFunction::LowerInstr(const lir::Instr& instr) -> llvm::Value* {
   return std::visit(
       Overloaded{
           [&](const lir::CallInstr& call) -> llvm::Value* {
-            return LowerCall(call);
+            return LowerCall(call, result_type);
           },
           [&](const lir::AggregateInstr& agg) -> llvm::Value* {
             return LowerAggregate(agg, result_type);
           },
           [&](const lir::LoadInstr& load) -> llvm::Value* {
-            const auto [base, member] = ResolveMemberSlot(load.place);
-            return builder_.CreateCall(
-                module_->Runtime().LoadField(), {base, member});
+            return builder_.CreateLoad(
+                module_->Types().Map(result_type),
+                ResolvePlaceAddress(load.place));
           },
           [&](const lir::StoreInstr& store) -> llvm::Value* {
-            const auto [base, member] = ResolveMemberSlot(store.place);
-            return builder_.CreateCall(
-                module_->Runtime().StoreField(),
-                {base, member, LowerOperand(store.value)});
+            return builder_.CreateStore(
+                LowerOperand(store.value), ResolvePlaceAddress(store.place));
+          },
+          [&](const lir::AddrOfInstr& addr) -> llvm::Value* {
+            return ResolvePlaceAddress(addr.place);
+          },
+          [&](const lir::BinaryInstr& binary) -> llvm::Value* {
+            return LowerBinary(binary);
+          },
+          [&](const lir::UnaryInstr& unary) -> llvm::Value* {
+            return LowerUnary(unary);
+          },
+          [&](const lir::BoolCastInstr& cast) -> llvm::Value* {
+            return LowerBoolCast(cast);
+          },
+          [&](const lir::PointerCastInstr& cast) -> llvm::Value* {
+            // Every reference crosses as the same opaque handle, so retyping it
+            // moves no bits.
+            return LowerOperand(cast.operand);
           }},
       instr.data);
 }
 
-auto CodeGenFunction::LowerCall(const lir::CallInstr& call) -> llvm::Value* {
+// A place resolves to an address. A place local's storage is its frame slot;
+// any other base is a reference value, whose referent the opening dereference
+// names. Each further dereference reads the reference held in the storage
+// reached so far, and each member step asks the instance for that member's
+// storage.
+auto CodeGenFunction::ResolvePlaceAddress(const lir::Place& place)
+    -> llvm::Value* {
+  auto step = place.chain.begin();
+  llvm::Value* address = nullptr;
+
+  const auto* use = std::get_if<lir::Use>(&place.base);
+  const bool is_place_local =
+      use != nullptr &&
+      fn_->values.Get(use->value).kind == lir::LocalKind::kPlace;
+  if (is_place_local) {
+    address = values_.at(use->value.value);
+  } else {
+    if (step == place.chain.end() ||
+        !std::holds_alternative<lir::DerefProjection>(*step)) {
+      throw InternalError(
+          "llvm codegen: a place over a value base must open with a "
+          "dereference");
+    }
+    address = LowerOperand(place.base);
+    ++step;
+  }
+
+  for (; step != place.chain.end(); ++step) {
+    address = std::visit(
+        Overloaded{
+            [&](const lir::DerefProjection&) -> llvm::Value* {
+              return builder_.CreateLoad(module_->Types().Ptr(), address);
+            },
+            [&](const lir::MemberProjection& member) -> llvm::Value* {
+              return builder_.CreateCall(
+                  module_->Runtime().MemberAddress(),
+                  {address, llvm::ConstantInt::get(
+                                llvm::Type::getInt32Ty(module_->Context()),
+                                member.member.value)});
+            }},
+        *step);
+  }
+  return address;
+}
+
+auto CodeGenFunction::LowerBinary(const lir::BinaryInstr& binary)
+    -> llvm::Value* {
+  const ValueDomain domain = DomainOf(OperandType(binary.lhs));
+  return builder_.CreateCall(
+      module_->Runtime().Binary(domain, binary.op),
+      {LowerOperand(binary.lhs), LowerOperand(binary.rhs)});
+}
+
+auto CodeGenFunction::LowerUnary(const lir::UnaryInstr& unary) -> llvm::Value* {
+  const ValueDomain domain = DomainOf(OperandType(unary.operand));
+  return builder_.CreateCall(
+      module_->Runtime().Unary(domain, unary.op),
+      {LowerOperand(unary.operand)});
+}
+
+auto CodeGenFunction::LowerBoolCast(const lir::BoolCastInstr& cast)
+    -> llvm::Value* {
+  const ValueDomain domain = DomainOf(OperandType(cast.operand));
+  return builder_.CreateCall(
+      module_->Runtime().ToBool(domain), {LowerOperand(cast.operand)});
+}
+
+auto CodeGenFunction::LowerCall(
+    const lir::CallInstr& call, lir::TypeId result_type) -> llvm::Value* {
   std::vector<llvm::Value*> args;
   // A construct that builds a child unit leads with the child's definition
   // reference, which the result type names rather than the operand list.
@@ -54,25 +139,26 @@ auto CodeGenFunction::LowerCall(const lir::CallInstr& call) -> llvm::Value* {
   for (const lir::Operand& arg : call.args) {
     args.push_back(LowerOperand(arg));
   }
-  return builder_.CreateCall(ResolveCallee(call.target), args);
+  return builder_.CreateCall(ResolveCallee(call, result_type), args);
 }
 
 // Every call is a symbol invoked with arguments; the target kinds differ only
 // in how the symbol is resolved.
-auto CodeGenFunction::ResolveCallee(const lir::CallTarget& target)
+auto CodeGenFunction::ResolveCallee(
+    const lir::CallInstr& call, lir::TypeId result_type)
     -> llvm::FunctionCallee {
   return std::visit(
       Overloaded{
           [&](const lir::BuiltinTarget& t) -> llvm::FunctionCallee {
-            return BuiltinCallee(t.fn);
+            return BuiltinCallee(t, call, result_type);
           },
           [&](const lir::MethodTarget& t) -> llvm::FunctionCallee {
             return module_->MethodFunction(t.method.class_id, t.method.index);
           },
-          [&](const lir::ConstructTarget& t) -> llvm::FunctionCallee {
-            return ConstructCallee(t.result);
+          [&](const lir::ConstructTarget&) -> llvm::FunctionCallee {
+            return ConstructCallee(call);
           }},
-      target);
+      call.target);
 }
 
 // An array literal is a value built in place, not a runtime call: its elements
@@ -122,27 +208,6 @@ auto CodeGenFunction::LowerOperand(const lir::Operand& operand)
       operand);
 }
 
-// The JIT realizes a member place as a runtime-owned slot on the base instance,
-// addressed by the member index. Only a single member step is produced so far;
-// a deeper projection chain (index, dereference) is realized when its steps
-// land.
-auto CodeGenFunction::ResolveMemberSlot(const lir::Place& place)
-    -> std::pair<llvm::Value*, llvm::Value*> {
-  if (place.chain.size() != 1) {
-    throw InternalError(
-        "llvm codegen: only a single-step member place is yet lowerable");
-  }
-  const auto* member = std::get_if<lir::MemberProjection>(&place.chain.front());
-  if (member == nullptr) {
-    throw InternalError(
-        "llvm codegen: only a member projection is yet lowerable");
-  }
-  return {
-      LowerOperand(place.base),
-      llvm::ConstantInt::get(
-          llvm::Type::getInt32Ty(module_->Context()), member->member.value)};
-}
-
 // A machine integer is a native LLVM constant. A packed value has no native
 // constant form in the opaque value model -- it is a runtime object -- so its
 // constant is materialized by a runtime constructor rather than emitted inline.
@@ -180,9 +245,10 @@ auto CodeGenFunction::LowerStrConst(const lir::StrConst& constant)
   return builder_.CreateGlobalStringPtr(constant.value);
 }
 
-auto CodeGenFunction::BuiltinCallee(support::BuiltinFn fn)
-    -> llvm::FunctionCallee {
-  switch (fn) {
+auto CodeGenFunction::BuiltinCallee(
+    const lir::BuiltinTarget& target, const lir::CallInstr& call,
+    lir::TypeId result_type) -> llvm::FunctionCallee {
+  switch (target.fn) {
     case support::BuiltinFn::kServices:
       return module_->Runtime().Services();
     case support::BuiltinFn::kFiles:
@@ -201,14 +267,77 @@ auto CodeGenFunction::BuiltinCallee(support::BuiltinFn fn)
       return module_->Runtime().RegisterFinal();
     case support::BuiltinFn::kAddOwnedChild:
       return module_->Runtime().AddOwnedChild();
+    case support::BuiltinFn::kRegisterSignal:
+      return module_->Runtime().RegisterSignal();
+    case support::BuiltinFn::kGet:
+      return module_->Runtime().CellGet(CellDomain(call.args.at(0)));
+    case support::BuiltinFn::kInitialize:
+      return module_->Runtime().CellInitialize(CellDomain(call.args.at(0)));
+    case support::BuiltinFn::kSet:
+      return module_->Runtime().CellSet(CellDomain(call.args.at(0)));
     default:
-      throw InternalError(
-          "llvm codegen: builtin is not yet lowerable to the runtime ABI");
+      return ValueBuiltinCallee(target, call, result_type);
   }
 }
 
-auto CodeGenFunction::ConstructCallee(lir::TypeId result)
+// Every remaining builtin is an operation on a value: a static factory of the
+// type its qualifier names, or a method of its receiver's type. Either way the
+// value domain names the library entry, and the call's own operand and result
+// types are its signature. A value whose domain has no library realization --
+// a container, an aggregate -- is rejected here rather than resolved to a
+// plausible-looking wrong entry.
+auto CodeGenFunction::ValueBuiltinCallee(
+    const lir::BuiltinTarget& target, const lir::CallInstr& call,
+    lir::TypeId result_type) -> llvm::FunctionCallee {
+  if (!target.qualifier.has_value() && call.args.empty()) {
+    throw InternalError(
+        "llvm codegen: a value builtin names its type through a qualifier or a "
+        "receiver, and this call has neither");
+  }
+  // An enumeration's own entries read its declared members, which no library
+  // over the packed representation can answer. They belong to the enumeration's
+  // generated artifact, not to the value domain its representation shares.
+  switch (target.fn) {
+    case support::BuiltinFn::kEnumFirst:
+    case support::BuiltinFn::kEnumLast:
+    case support::BuiltinFn::kEnumNum:
+    case support::BuiltinFn::kEnumName:
+      throw InternalError(
+          "llvm codegen: an enumeration's own entries are not yet lowerable");
+    default:
+      break;
+  }
+  const ValueDomain domain = target.qualifier.has_value()
+                                 ? DomainOf(*target.qualifier)
+                                 : DomainOf(OperandType(call.args.front()));
+  std::vector<llvm::Type*> params;
+  params.reserve(call.args.size());
+  for (const lir::Operand& arg : call.args) {
+    params.push_back(module_->Types().Map(OperandType(arg)));
+  }
+  return module_->Runtime().ValueBuiltin(
+      domain, target.fn, module_->Types().Map(result_type), params);
+}
+
+auto CodeGenFunction::CellDomain(const lir::Operand& cell) const
+    -> ValueDomain {
+  const lir::TypeArena& types = module_->Unit().types;
+  const std::optional<lir::TypeId> pointee =
+      lir::Pointee(types, OperandType(cell));
+  if (!pointee) {
+    throw InternalError("llvm codegen: a cell operation needs a cell address");
+  }
+  const auto* observable =
+      std::get_if<lir::ObservableType>(&types.Get(*pointee).data);
+  if (observable == nullptr) {
+    throw InternalError("llvm codegen: a cell operation needs an observable");
+  }
+  return DomainOf(observable->value);
+}
+
+auto CodeGenFunction::ConstructCallee(const lir::CallInstr& call)
     -> llvm::FunctionCallee {
+  const lir::TypeId result = std::get<lir::ConstructTarget>(call.target).result;
   return std::visit(
       Overloaded{
           [&](const lir::StringType&) -> llvm::FunctionCallee {
@@ -218,14 +347,21 @@ auto CodeGenFunction::ConstructCallee(lir::TypeId result)
             return module_->Runtime().MakeCoroutine();
           },
           [&](const lir::RuntimeLibraryType& r) -> llvm::FunctionCallee {
-            if (r.kind == lir::RuntimeLibraryKind::kPrintLiteralItem) {
-              return module_->Runtime().MakePrintLiteralItem();
+            switch (r.kind) {
+              case lir::RuntimeLibraryKind::kPrintLiteralItem:
+                return module_->Runtime().MakePrintLiteralItem();
+              case lir::RuntimeLibraryKind::kHierarchySegment:
+                return module_->Runtime().MakeSegment();
+              case lir::RuntimeLibraryKind::kFormatSpec:
+                return module_->Runtime().MakeFormatSpec(call.args.size());
+              case lir::RuntimeLibraryKind::kPrintValueItem:
+                return module_->Runtime().MakePrintValueItem(
+                    DomainOf(OperandType(call.args.at(0))));
+              default:
+                throw InternalError(
+                    "llvm codegen: runtime-library construct is not yet "
+                    "lowerable");
             }
-            if (r.kind == lir::RuntimeLibraryKind::kHierarchySegment) {
-              return module_->Runtime().MakeSegment();
-            }
-            throw InternalError(
-                "llvm codegen: runtime-library construct is not yet lowerable");
           },
           [&](const lir::PointerType& p) -> llvm::FunctionCallee {
             if (std::holds_alternative<lir::ExternalUnitObjectType>(

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -1,12 +1,48 @@
 #include "lyra/backend/llvm/runtime_abi.hpp"
 
+#include <format>
+#include <string>
+#include <string_view>
+
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Type.h>
 
 #include "lyra/backend/llvm/codegen_types.hpp"
+#include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
+#include "lyra/lir/compilation_unit.hpp"
+#include "lyra/lir/operator.hpp"
+#include "lyra/lir/type.hpp"
+#include "lyra/lir/type_id.hpp"
 
 namespace lyra::backend::llvm_backend {
+
+auto ValueDomainName(ValueDomain domain) -> std::string_view {
+  switch (domain) {
+    case ValueDomain::kPacked:
+      return "packed";
+    case ValueDomain::kString:
+      return "string";
+  }
+  throw InternalError("llvm codegen: unknown value domain");
+}
+
+auto ValueDomainOf(const lir::CompilationUnit& unit, lir::TypeId type)
+    -> ValueDomain {
+  return std::visit(
+      Overloaded{
+          [](const lir::PackedArrayType&) { return ValueDomain::kPacked; },
+          // An enumeration is a packed value at runtime; only its own entries,
+          // which read its declared members, need more than that.
+          [](const lir::EnumType&) { return ValueDomain::kPacked; },
+          [](const lir::StringType&) { return ValueDomain::kString; },
+          [](const auto&) -> ValueDomain {
+            throw InternalError(
+                "llvm codegen: value type has no runtime library domain");
+          }},
+      unit.types.Get(type).data);
+}
 
 RuntimeAbi::RuntimeAbi(
     llvm::Module& module, llvm::LLVMContext& ctx, CodeGenTypes& types)
@@ -18,6 +54,12 @@ auto RuntimeAbi::Get(
     -> llvm::FunctionCallee {
   return module_->getOrInsertFunction(
       name, llvm::FunctionType::get(result, params, false));
+}
+
+auto RuntimeAbi::Get(
+    const std::string& name, llvm::Type* result,
+    llvm::ArrayRef<llvm::Type*> params) -> llvm::FunctionCallee {
+  return Get(name.c_str(), result, params);
 }
 
 auto RuntimeAbi::Services() -> llvm::FunctionCallee {
@@ -95,16 +137,90 @@ auto RuntimeAbi::AddOwnedChild() -> llvm::FunctionCallee {
       "lyra_rt_add_owned_child", types_->Ptr(), {types_->Ptr(), types_->Ptr()});
 }
 
-auto RuntimeAbi::LoadField() -> llvm::FunctionCallee {
+auto RuntimeAbi::MemberAddress() -> llvm::FunctionCallee {
   return Get(
-      "lyra_rt_load_field", types_->Ptr(),
+      "lyra_rt_member_addr", types_->Ptr(),
       {types_->Ptr(), llvm::Type::getInt32Ty(*ctx_)});
 }
 
-auto RuntimeAbi::StoreField() -> llvm::FunctionCallee {
+auto RuntimeAbi::CellGet(ValueDomain domain) -> llvm::FunctionCallee {
   return Get(
-      "lyra_rt_store_field", types_->Void(),
-      {types_->Ptr(), llvm::Type::getInt32Ty(*ctx_), types_->Ptr()});
+      std::format("lyra_rt_cell_{}_get", ValueDomainName(domain)),
+      types_->Ptr(), {types_->Ptr()});
+}
+
+auto RuntimeAbi::CellInitialize(ValueDomain domain) -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_cell_{}_initialize", ValueDomainName(domain)),
+      types_->Void(), {types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::CellSet(ValueDomain domain) -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_cell_{}_set", ValueDomainName(domain)),
+      types_->Void(), {types_->Ptr(), types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::RegisterSignal() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_register_signal", types_->Void(),
+      {types_->Ptr(), types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::Binary(ValueDomain domain, lir::BinaryOp op)
+    -> llvm::FunctionCallee {
+  return Get(
+      std::format(
+          "lyra_rt_{}_{}", ValueDomainName(domain), lir::BinaryOpName(op)),
+      types_->Ptr(), {types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::Unary(ValueDomain domain, lir::UnaryOp op)
+    -> llvm::FunctionCallee {
+  return Get(
+      std::format(
+          "lyra_rt_{}_{}", ValueDomainName(domain), lir::UnaryOpName(op)),
+      types_->Ptr(), {types_->Ptr()});
+}
+
+auto RuntimeAbi::ValueBuiltin(
+    ValueDomain domain, lyra::support::BuiltinFn fn, llvm::Type* result,
+    llvm::ArrayRef<llvm::Type*> params) -> llvm::FunctionCallee {
+  return Get(
+      std::format(
+          "lyra_rt_{}_{}", ValueDomainName(domain),
+          lyra::support::BuiltinFnName(fn)),
+      result, params);
+}
+
+auto RuntimeAbi::ToBool(ValueDomain domain) -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_{}_to_bool", ValueDomainName(domain)),
+      llvm::Type::getInt1Ty(*ctx_), {types_->Ptr()});
+}
+
+auto RuntimeAbi::MakeFormatSpec(std::size_t field_count)
+    -> llvm::FunctionCallee {
+  if (field_count == 1) {
+    return Get(
+        "lyra_rt_make_format_spec_of_kind", types_->Ptr(), {types_->Ptr()});
+  }
+  if (field_count == 6) {
+    return Get(
+        "lyra_rt_make_format_spec", types_->Ptr(),
+        {types_->Ptr(), types_->Ptr(), types_->Ptr(), types_->Ptr(),
+         types_->Ptr(), types_->Ptr()});
+  }
+  throw InternalError(
+      "llvm codegen: a format specification is built from a kind or from every "
+      "field");
+}
+
+auto RuntimeAbi::MakePrintValueItem(ValueDomain domain)
+    -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_make_print_value_item_{}", ValueDomainName(domain)),
+      types_->Ptr(), {types_->Ptr(), types_->Ptr()});
 }
 
 }  // namespace lyra::backend::llvm_backend

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <llvm/ExecutionEngine/JITSymbol.h>
@@ -17,9 +18,13 @@
 #include <llvm/Support/TargetSelect.h>
 
 #include "lyra/backend/llvm/emit.hpp"
+#include "lyra/backend/llvm/runtime_abi.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/compiler/unit_metadata.hpp"
 #include "lyra/lir/compilation_unit.hpp"
+#include "lyra/lir/type.hpp"
+#include "lyra/lir/type_id.hpp"
+#include "lyra/lir/type_query.hpp"
 #include "lyra/runtime/engine.hpp"
 #include "lyra/runtime/generated_call_scope.hpp"
 #include "lyra/runtime/hierarchy_segment.hpp"
@@ -76,12 +81,137 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_make_segment", &lyra_rt_make_segment);
   add("lyra_rt_make_unit", &lyra_rt_make_unit);
   add("lyra_rt_add_owned_child", &lyra_rt_add_owned_child);
-  add("lyra_rt_load_field", &lyra_rt_load_field);
-  add("lyra_rt_store_field", &lyra_rt_store_field);
+  add("lyra_rt_member_addr", &lyra_rt_member_addr);
+  add("lyra_rt_register_signal", &lyra_rt_register_signal);
+  add("lyra_rt_cell_packed_get", &lyra_rt_cell_packed_get);
+  add("lyra_rt_cell_packed_initialize", &lyra_rt_cell_packed_initialize);
+  add("lyra_rt_cell_packed_set", &lyra_rt_cell_packed_set);
+  add("lyra_rt_cell_string_get", &lyra_rt_cell_string_get);
+  add("lyra_rt_cell_string_initialize", &lyra_rt_cell_string_initialize);
+  add("lyra_rt_cell_string_set", &lyra_rt_cell_string_set);
+  add("lyra_rt_packed_add", &lyra_rt_packed_add);
+  add("lyra_rt_packed_sub", &lyra_rt_packed_sub);
+  add("lyra_rt_packed_mul", &lyra_rt_packed_mul);
+  add("lyra_rt_packed_div", &lyra_rt_packed_div);
+  add("lyra_rt_packed_mod", &lyra_rt_packed_mod);
+  add("lyra_rt_packed_and", &lyra_rt_packed_and);
+  add("lyra_rt_packed_or", &lyra_rt_packed_or);
+  add("lyra_rt_packed_xor", &lyra_rt_packed_xor);
+  add("lyra_rt_packed_eq", &lyra_rt_packed_eq);
+  add("lyra_rt_packed_ne", &lyra_rt_packed_ne);
+  add("lyra_rt_packed_lt", &lyra_rt_packed_lt);
+  add("lyra_rt_packed_le", &lyra_rt_packed_le);
+  add("lyra_rt_packed_gt", &lyra_rt_packed_gt);
+  add("lyra_rt_packed_ge", &lyra_rt_packed_ge);
+  add("lyra_rt_packed_logical_and", &lyra_rt_packed_logical_and);
+  add("lyra_rt_packed_logical_or", &lyra_rt_packed_logical_or);
+  add("lyra_rt_packed_neg", &lyra_rt_packed_neg);
+  add("lyra_rt_packed_not", &lyra_rt_packed_not);
+  add("lyra_rt_packed_logical_not", &lyra_rt_packed_logical_not);
+  add("lyra_rt_packed_inc", &lyra_rt_packed_inc);
+  add("lyra_rt_packed_dec", &lyra_rt_packed_dec);
+  add("lyra_rt_packed_to_bool", &lyra_rt_packed_to_bool);
+  add("lyra_rt_packed_convert_from", &lyra_rt_packed_convert_from);
+  add("lyra_rt_packed_from_bool", &lyra_rt_packed_from_bool);
+  add("lyra_rt_packed_to_int64", &lyra_rt_packed_to_int64);
+  add("lyra_rt_packed_is_unknown", &lyra_rt_packed_is_unknown);
+  add("lyra_rt_packed_pow", &lyra_rt_packed_pow);
+  add("lyra_rt_packed_shift_left", &lyra_rt_packed_shift_left);
+  add("lyra_rt_packed_logical_shift_right",
+      &lyra_rt_packed_logical_shift_right);
+  add("lyra_rt_packed_arithmetic_shift_right",
+      &lyra_rt_packed_arithmetic_shift_right);
+  add("lyra_rt_packed_bitwise_xnor", &lyra_rt_packed_bitwise_xnor);
+  add("lyra_rt_packed_logical_implication",
+      &lyra_rt_packed_logical_implication);
+  add("lyra_rt_packed_logical_equivalence",
+      &lyra_rt_packed_logical_equivalence);
+  add("lyra_rt_packed_case_equal", &lyra_rt_packed_case_equal);
+  add("lyra_rt_packed_wildcard_equals", &lyra_rt_packed_wildcard_equals);
+  add("lyra_rt_packed_casez_equals", &lyra_rt_packed_casez_equals);
+  add("lyra_rt_packed_casex_equals", &lyra_rt_packed_casex_equals);
+  add("lyra_rt_packed_reduction_and", &lyra_rt_packed_reduction_and);
+  add("lyra_rt_packed_reduction_or", &lyra_rt_packed_reduction_or);
+  add("lyra_rt_packed_reduction_xor", &lyra_rt_packed_reduction_xor);
+  add("lyra_rt_packed_reduction_nand", &lyra_rt_packed_reduction_nand);
+  add("lyra_rt_packed_reduction_nor", &lyra_rt_packed_reduction_nor);
+  add("lyra_rt_packed_reduction_xnor", &lyra_rt_packed_reduction_xnor);
+  add("lyra_rt_string_from_packed_array", &lyra_rt_string_from_packed_array);
+  add("lyra_rt_string_len", &lyra_rt_string_len);
+  add("lyra_rt_string_getc", &lyra_rt_string_getc);
+  add("lyra_rt_string_toupper", &lyra_rt_string_toupper);
+  add("lyra_rt_string_tolower", &lyra_rt_string_tolower);
+  add("lyra_rt_string_compare", &lyra_rt_string_compare);
+  add("lyra_rt_string_icompare", &lyra_rt_string_icompare);
+  add("lyra_rt_string_substr", &lyra_rt_string_substr);
+  add("lyra_rt_string_atoi", &lyra_rt_string_atoi);
+  add("lyra_rt_string_atohex", &lyra_rt_string_atohex);
+  add("lyra_rt_string_atooct", &lyra_rt_string_atooct);
+  add("lyra_rt_string_atobin", &lyra_rt_string_atobin);
+  add("lyra_rt_string_add", &lyra_rt_string_add);
+  add("lyra_rt_string_eq", &lyra_rt_string_eq);
+  add("lyra_rt_string_ne", &lyra_rt_string_ne);
+  add("lyra_rt_string_lt", &lyra_rt_string_lt);
+  add("lyra_rt_string_le", &lyra_rt_string_le);
+  add("lyra_rt_string_gt", &lyra_rt_string_gt);
+  add("lyra_rt_string_ge", &lyra_rt_string_ge);
+  add("lyra_rt_make_format_spec_of_kind", &lyra_rt_make_format_spec_of_kind);
+  add("lyra_rt_make_format_spec", &lyra_rt_make_format_spec);
+  add("lyra_rt_make_print_value_item_packed",
+      &lyra_rt_make_print_value_item_packed);
+  add("lyra_rt_make_print_value_item_string",
+      &lyra_rt_make_print_value_item_string);
   Check(
       jit.getMainJITDylib().define(
           llvm::orc::absoluteSymbols(std::move(symbols))),
       "define runtime abi");
+}
+
+// The runtime's spelling of a domain the execution backend classified a type
+// into. The two enumerations are the two sides of one ABI -- the backend names
+// the library entry, the runtime realizes the storage -- and only the backend
+// classifies a LIR type, so the entry a call names and the storage a cell owns
+// cannot disagree.
+auto AbiDomain(backend::llvm_backend::ValueDomain domain)
+    -> runtime::ValueDomain {
+  switch (domain) {
+    case backend::llvm_backend::ValueDomain::kPacked:
+      return runtime::ValueDomain::kPacked;
+    case backend::llvm_backend::ValueDomain::kString:
+      return runtime::ValueDomain::kString;
+  }
+  throw InternalError("jit executor: unknown value domain");
+}
+
+// The storage a generic instance realizes for one declared member, projected
+// from the member's LIR type: an observable cell holds a value other processes
+// subscribe to, and a reference-typed member is a box holding a borrowed
+// handle.
+auto DescribeMember(const lir::CompilationUnit& unit, lir::TypeId type)
+    -> runtime::MemberStorageDescriptor {
+  const auto& data = unit.types.Get(type).data;
+  if (const auto* observable = std::get_if<lir::ObservableType>(&data)) {
+    return runtime::MemberStorageDescriptor{
+        .kind = runtime::MemberStorageKind::kObservableCell,
+        .domain = AbiDomain(
+            backend::llvm_backend::ValueDomainOf(unit, observable->value))};
+  }
+  if (lir::Pointee(unit.types, type).has_value()) {
+    return runtime::MemberStorageDescriptor{
+        .kind = runtime::MemberStorageKind::kBorrowedHandle,
+        .domain = runtime::ValueDomain::kNone};
+  }
+  throw InternalError("jit executor: member type has no storage realization");
+}
+
+auto DescribeMembers(const lir::CompilationUnit& unit, const lir::Class& cls)
+    -> std::vector<runtime::MemberStorageDescriptor> {
+  std::vector<runtime::MemberStorageDescriptor> descriptors;
+  descriptors.reserve(cls.members.size());
+  for (const lir::Member& member : cls.members) {
+    descriptors.push_back(DescribeMember(unit, member.type));
+  }
+  return descriptors;
 }
 
 // Fills a unit's runtime definition from its JIT-compiled entries and its
@@ -121,16 +251,17 @@ void FillDefinition(
   if (auto entry = lookup("constructor")) {
     definition.construct = entry->toPtr<runtime::ScopeEntry>();
   }
-  definition.member_slot_count =
-      static_cast<std::uint32_t>(root_class.members.size());
 }
 
 // One design unit loaded into the JIT: its executable body, its source-level
-// metadata, and the runtime definition built from the two, which owns a stable
-// address the runtime and peer units reference.
+// metadata, the storage schema its instances realize, and the runtime
+// definition built from those, which owns a stable address the runtime and peer
+// units reference. The schema is held here because the definition names it as
+// plain data it does not own.
 struct LoadedUnit {
   const lir::CompilationUnit* unit;
   const compiler::ElaboratedUnitMetadata* metadata;
+  std::vector<runtime::MemberStorageDescriptor> members;
   std::unique_ptr<runtime::UnitDefinition> definition;
 };
 
@@ -153,20 +284,29 @@ auto Execute(
   // whole run; the runtime holds pointers into it. The root is loaded and
   // driven like any other unit, distinguished only as the bootstrap entry
   // below.
+  const auto load = [](const lir::CompilationUnit& unit,
+                       const compiler::ElaboratedUnitMetadata& unit_metadata) {
+    return LoadedUnit{
+        .unit = &unit,
+        .metadata = &unit_metadata,
+        .members = DescribeMembers(unit, unit.classes.Get(unit.root)),
+        .definition = std::make_unique<runtime::UnitDefinition>()};
+  };
+
   std::vector<LoadedUnit> loaded;
   loaded.reserve(units.size() + 1);
   for (std::size_t i = 0; i < units.size(); ++i) {
-    loaded.push_back(
-        LoadedUnit{
-            .unit = &units[i],
-            .metadata = &metadata[i],
-            .definition = std::make_unique<runtime::UnitDefinition>()});
+    loaded.push_back(load(units[i], metadata[i]));
   }
-  loaded.push_back(
-      LoadedUnit{
-          .unit = &root_unit,
-          .metadata = &root_metadata,
-          .definition = std::make_unique<runtime::UnitDefinition>()});
+  loaded.push_back(load(root_unit, root_metadata));
+
+  // The schema is named only once every unit is in place, so no descriptor
+  // vector is reallocated out from under a definition that points at it.
+  for (LoadedUnit& entry : loaded) {
+    entry.definition->members = runtime::MemberStorageSchema{
+        .data = entry.members.data(),
+        .size = static_cast<std::uint32_t>(entry.members.size())};
+  }
 
   for (const LoadedUnit& entry : loaded) {
     auto owned = backend::llvm_backend::EmitModule(*entry.unit).Release();

--- a/src/lyra/lir/dump.cpp
+++ b/src/lyra/lir/dump.cpp
@@ -100,6 +100,24 @@ class LirDumper {
               return std::format(
                   "store {} = {}", FormatPlace(store.place),
                   FormatOperand(store.value));
+            },
+            [&](const AddrOfInstr& addr) -> std::string {
+              return std::format("addrof {}", FormatPlace(addr.place));
+            },
+            [&](const BinaryInstr& bin) -> std::string {
+              return std::format(
+                  "{} {}, {}", BinaryOpName(bin.op), FormatOperand(bin.lhs),
+                  FormatOperand(bin.rhs));
+            },
+            [&](const UnaryInstr& un) -> std::string {
+              return std::format(
+                  "{} {}", UnaryOpName(un.op), FormatOperand(un.operand));
+            },
+            [&](const BoolCastInstr& cast) -> std::string {
+              return std::format("bool {}", FormatOperand(cast.operand));
+            },
+            [&](const PointerCastInstr& cast) -> std::string {
+              return std::format("ptrcast {}", FormatOperand(cast.operand));
             }},
         data);
   }
@@ -107,14 +125,26 @@ class LirDumper {
   [[nodiscard]] static auto FormatTerminator(const Terminator& term)
       -> std::string {
     return std::visit(
-        Overloaded{[&](const ReturnTerm& ret) -> std::string {
-          std::string keyword =
-              ret.is_coroutine ? "return.coroutine" : "return";
-          if (ret.value.has_value()) {
-            return std::format("{} {}", keyword, FormatOperand(*ret.value));
-          }
-          return keyword;
-        }},
+        Overloaded{
+            [&](const ReturnTerm& ret) -> std::string {
+              std::string keyword =
+                  ret.is_coroutine ? "return.coroutine" : "return";
+              if (ret.value.has_value()) {
+                return std::format("{} {}", keyword, FormatOperand(*ret.value));
+              }
+              return keyword;
+            },
+            [](const BranchTerm& br) -> std::string {
+              return std::format("br bb{}", br.target.value);
+            },
+            [&](const CondBranchTerm& br) -> std::string {
+              return std::format(
+                  "br {} ? bb{} : bb{}", FormatOperand(br.condition),
+                  br.if_true.value, br.if_false.value);
+            },
+            [](const UnreachableTerm&) -> std::string {
+              return "unreachable";
+            }},
         term.data);
   }
 
@@ -139,7 +169,11 @@ class LirDumper {
     return std::visit(
         Overloaded{
             [](const BuiltinTarget& b) -> std::string {
-              return std::string(support::BuiltinFnName(b.fn));
+              const std::string name{support::BuiltinFnName(b.fn)};
+              if (!b.qualifier.has_value()) {
+                return name;
+              }
+              return std::format("{}<{}>", name, FormatType(*b.qualifier));
             },
             [&](const MethodTarget& m) -> std::string {
               return unit_->classes.Get(m.method.class_id)
@@ -166,9 +200,11 @@ class LirDumper {
     std::string out = FormatOperand(place.base);
     for (const Projection& step : place.chain) {
       std::visit(
-          Overloaded{[&](const MemberProjection& m) {
-            out += std::format(".member({})", m.member.value);
-          }},
+          Overloaded{
+              [&](const DerefProjection&) { out += ".deref"; },
+              [&](const MemberProjection& m) {
+                out += std::format(".member({})", m.member.value);
+              }},
           step);
     }
     return out;

--- a/src/lyra/lir/function.cpp
+++ b/src/lyra/lir/function.cpp
@@ -1,0 +1,24 @@
+#include "lyra/lir/function.hpp"
+
+#include <optional>
+#include <variant>
+
+#include "lyra/base/overloaded.hpp"
+#include "lyra/lir/type_id.hpp"
+
+namespace lyra::lir {
+
+auto OperandType(const Function& fn, const Operand& operand)
+    -> std::optional<TypeId> {
+  return std::visit(
+      Overloaded{
+          [&](const Use& use) -> std::optional<TypeId> {
+            return fn.values.Get(use.value).type;
+          },
+          [](const IntConst& c) -> std::optional<TypeId> { return c.type; },
+          [](const StrConst& c) -> std::optional<TypeId> { return c.type; },
+          [](const FuncRef&) -> std::optional<TypeId> { return std::nullopt; }},
+      operand);
+}
+
+}  // namespace lyra::lir

--- a/src/lyra/lir/operator.cpp
+++ b/src/lyra/lir/operator.cpp
@@ -1,0 +1,63 @@
+#include "lyra/lir/operator.hpp"
+
+#include <string_view>
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::lir {
+
+auto BinaryOpName(BinaryOp op) -> std::string_view {
+  switch (op) {
+    case BinaryOp::kAdd:
+      return "add";
+    case BinaryOp::kSub:
+      return "sub";
+    case BinaryOp::kMul:
+      return "mul";
+    case BinaryOp::kDiv:
+      return "div";
+    case BinaryOp::kMod:
+      return "mod";
+    case BinaryOp::kBitwiseAnd:
+      return "and";
+    case BinaryOp::kBitwiseOr:
+      return "or";
+    case BinaryOp::kBitwiseXor:
+      return "xor";
+    case BinaryOp::kEquality:
+      return "eq";
+    case BinaryOp::kInequality:
+      return "ne";
+    case BinaryOp::kLessThan:
+      return "lt";
+    case BinaryOp::kLessEqual:
+      return "le";
+    case BinaryOp::kGreaterThan:
+      return "gt";
+    case BinaryOp::kGreaterEqual:
+      return "ge";
+    case BinaryOp::kLogicalAnd:
+      return "logical_and";
+    case BinaryOp::kLogicalOr:
+      return "logical_or";
+  }
+  throw InternalError("lir: unknown binary operator");
+}
+
+auto UnaryOpName(UnaryOp op) -> std::string_view {
+  switch (op) {
+    case UnaryOp::kMinus:
+      return "neg";
+    case UnaryOp::kBitwiseNot:
+      return "not";
+    case UnaryOp::kLogicalNot:
+      return "logical_not";
+    case UnaryOp::kIncrement:
+      return "inc";
+    case UnaryOp::kDecrement:
+      return "dec";
+  }
+  throw InternalError("lir: unknown unary operator");
+}
+
+}  // namespace lyra::lir

--- a/src/lyra/lir/type_query.cpp
+++ b/src/lyra/lir/type_query.cpp
@@ -1,0 +1,42 @@
+#include "lyra/lir/type_query.hpp"
+
+#include <optional>
+#include <variant>
+
+#include "lyra/base/overloaded.hpp"
+#include "lyra/lir/type.hpp"
+#include "lyra/lir/type_id.hpp"
+
+namespace lyra::lir {
+
+auto Pointee(const TypeArena& types, TypeId type) -> std::optional<TypeId> {
+  return std::visit(
+      Overloaded{
+          [](const PointerType& p) -> std::optional<TypeId> {
+            return p.pointee;
+          },
+          [](const RefType& r) -> std::optional<TypeId> { return r.pointee; },
+          [](const ManagedRefType& m) -> std::optional<TypeId> {
+            return m.pointee;
+          },
+          [](const auto&) -> std::optional<TypeId> { return std::nullopt; }},
+      types.Get(type).data);
+}
+
+auto IsAddressOnly(const TypeArena& types, TypeId type) -> bool {
+  return std::visit(
+      Overloaded{
+          [](const ObservableType&) { return true; },
+          [](const ResolvedType&) { return true; },
+          [](const DriverType&) { return true; },
+          [](const ObjectType&) { return true; },
+          [](const ExternalUnitObjectType&) { return true; },
+          [](const ScopeType&) { return true; },
+          [](const InstanceType&) { return true; },
+          [](const GenScopeType&) { return true; },
+          [](const ProceduralStorageScopeType&) { return true; },
+          [](const auto&) { return false; }},
+      types.Get(type).data);
+}
+
+}  // namespace lyra::lir

--- a/src/lyra/lir/verify.cpp
+++ b/src/lyra/lir/verify.cpp
@@ -13,127 +13,150 @@
 #include "lyra/lir/function.hpp"
 #include "lyra/lir/type.hpp"
 #include "lyra/lir/type_id.hpp"
+#include "lyra/lir/type_query.hpp"
 
 namespace lyra::lir {
 
 namespace {
 
-// The class an object-or-pointer-to-object type names, peeling the borrowed
-// pointer a receiver arrives through. A type that is neither an object nor a
-// pointer to one is not projectable by a member step.
 auto AsClassId(const CompilationUnit& unit, TypeId type)
     -> std::optional<ClassId> {
-  return std::visit(
-      Overloaded{
-          [](const ObjectType& o) -> std::optional<ClassId> {
-            return o.class_id;
-          },
-          [&](const PointerType& p) -> std::optional<ClassId> {
-            return AsClassId(unit, p.pointee);
-          },
-          [](const auto&) -> std::optional<ClassId> { return std::nullopt; }},
-      unit.types.Get(type).data);
-}
-
-// A reference-like type crosses as one opaque handle: distinct reference types
-// (a borrowed scope pointer, a borrowed unit pointer) share a representation,
-// so a store between them is a reinterpretation the MIR pointer cast already
-// justified, not a type error.
-auto IsReference(const CompilationUnit& unit, TypeId type) -> bool {
-  return std::visit(
-      Overloaded{
-          [](const PointerType&) { return true; },
-          [](const RefType&) { return true; },
-          [](const ManagedRefType&) { return true; },
-          [](const auto&) { return false; }},
-      unit.types.Get(type).data);
+  const auto* object = std::get_if<ObjectType>(&unit.types.Get(type).data);
+  return object != nullptr ? std::optional{object->class_id} : std::nullopt;
 }
 
 auto IsVoid(const CompilationUnit& unit, TypeId type) -> bool {
   return std::holds_alternative<VoidType>(unit.types.Get(type).data);
 }
 
-auto OperandType(const Function& fn, const Operand& op)
-    -> std::optional<TypeId> {
-  return std::visit(
-      Overloaded{
-          [&](const Use& u) -> std::optional<TypeId> {
-            return fn.values.Get(u.value).type;
-          },
-          [](const IntConst& c) -> std::optional<TypeId> { return c.type; },
-          [](const StrConst& c) -> std::optional<TypeId> { return c.type; },
-          [](const FuncRef&) -> std::optional<TypeId> { return std::nullopt; }},
-      op);
+auto IsPlaceLocal(const Function& fn, const Operand& op) -> bool {
+  const auto* use = std::get_if<Use>(&op);
+  return use != nullptr && fn.values.Get(use->value).kind == LocalKind::kPlace;
 }
 
-// The type a place's projection chain arrives at: the base's storage type,
-// projected one step at a time. Each member step resolves the base to a class
-// and selects the member's declared type.
+// The type of the storage a place names. The base contributes the storage the
+// chain starts from: a place local names its own storage, and any other base is
+// a value, which names storage only once dereferenced. Each dereference reads
+// the reference the chain has reached and names its referent; each member step
+// selects a member of the class the chain has reached.
 auto PlaceType(
     const CompilationUnit& unit, const Function& fn, const Place& place)
     -> TypeId {
   const std::optional<TypeId> base = OperandType(fn, place.base);
   if (!base) {
-    throw InternalError("lir verify: place base has no storage type");
+    throw InternalError("lir verify: place base has no type");
   }
+  const bool opens_with_deref =
+      !place.chain.empty() &&
+      std::holds_alternative<DerefProjection>(place.chain.front());
+  if (!IsPlaceLocal(fn, place.base) && !opens_with_deref) {
+    throw InternalError(
+        "lir verify: a place over a value base must open with a dereference");
+  }
+
   TypeId current = *base;
   for (const Projection& step : place.chain) {
     std::visit(
-        Overloaded{[&](const MemberProjection& m) {
-          const std::optional<ClassId> class_id = AsClassId(unit, current);
-          if (!class_id) {
-            throw InternalError(
-                "lir verify: member projection on a non-object base");
-          }
-          const Class& cls = unit.classes.Get(*class_id);
-          if (m.member.value >= cls.members.size()) {
-            throw InternalError(
-                std::format(
-                    "lir verify: member index {} out of range on class '{}'",
-                    m.member.value, cls.name));
-          }
-          current = cls.members[m.member.value].type;
-        }},
+        Overloaded{
+            [&](const DerefProjection&) {
+              const std::optional<TypeId> pointee =
+                  Pointee(unit.types, current);
+              if (!pointee) {
+                throw InternalError(
+                    "lir verify: dereference of a non-reference type");
+              }
+              current = *pointee;
+            },
+            [&](const MemberProjection& m) {
+              const std::optional<ClassId> class_id = AsClassId(unit, current);
+              if (!class_id) {
+                throw InternalError(
+                    "lir verify: member projection on a non-object base");
+              }
+              const Class& cls = unit.classes.Get(*class_id);
+              if (m.member.value >= cls.members.size()) {
+                throw InternalError(
+                    std::format(
+                        "lir verify: member index {} out of range on class "
+                        "'{}'",
+                        m.member.value, cls.name));
+              }
+              current = cls.members[m.member.value].type;
+            }},
         step);
   }
   return current;
 }
 
+void VerifyInstr(
+    const CompilationUnit& unit, const Function& fn, const Instr& instr) {
+  const TypeId result_type = fn.values.Get(instr.result).type;
+  std::visit(
+      Overloaded{
+          [&](const LoadInstr& load) {
+            const TypeId place_type = PlaceType(unit, fn, load.place);
+            if (IsAddressOnly(unit.types, place_type)) {
+              throw InternalError(
+                  "lir verify: load of a place whose storage is only "
+                  "addressable");
+            }
+            if (result_type != place_type) {
+              throw InternalError(
+                  "lir verify: load result type does not match its place type");
+            }
+          },
+          [&](const StoreInstr& store) {
+            const TypeId place_type = PlaceType(unit, fn, store.place);
+            if (IsAddressOnly(unit.types, place_type)) {
+              throw InternalError(
+                  "lir verify: store into a place whose storage is only "
+                  "addressable");
+            }
+            const std::optional<TypeId> value_type =
+                OperandType(fn, store.value);
+            if (!value_type) {
+              throw InternalError("lir verify: store value has no type");
+            }
+            if (*value_type != place_type) {
+              throw InternalError(
+                  "lir verify: store value type does not match its place type");
+            }
+            if (!IsVoid(unit, result_type)) {
+              throw InternalError("lir verify: store must yield void");
+            }
+          },
+          [&](const AddrOfInstr& addr) {
+            const TypeId place_type = PlaceType(unit, fn, addr.place);
+            const std::optional<TypeId> pointee =
+                Pointee(unit.types, result_type);
+            if (!pointee || *pointee != place_type) {
+              throw InternalError(
+                  "lir verify: address-of result is not a reference to its "
+                  "place type");
+            }
+          },
+          [&](const PointerCastInstr& cast) {
+            const std::optional<TypeId> operand_type =
+                OperandType(fn, cast.operand);
+            if (!operand_type || !Pointee(unit.types, *operand_type)) {
+              throw InternalError(
+                  "lir verify: pointer cast of a non-reference operand");
+            }
+            if (!Pointee(unit.types, result_type)) {
+              throw InternalError(
+                  "lir verify: pointer cast result is not a reference type");
+            }
+          },
+          [](const CallInstr&) {}, [](const AggregateInstr&) {},
+          [](const BinaryInstr&) {}, [](const UnaryInstr&) {},
+          [](const BoolCastInstr&) {}},
+      instr.data);
+}
+
 void VerifyFunction(const CompilationUnit& unit, const Function& fn) {
   for (const BasicBlock& block : fn.blocks) {
     for (const Instr& instr : block.instrs) {
-      const TypeId result_type = fn.values.Get(instr.result).type;
-      std::visit(
-          Overloaded{
-              [&](const LoadInstr& load) {
-                const TypeId place_type = PlaceType(unit, fn, load.place);
-                if (result_type != place_type) {
-                  throw InternalError(
-                      "lir verify: load result type does not match its place "
-                      "type");
-                }
-              },
-              [&](const StoreInstr& store) {
-                const TypeId place_type = PlaceType(unit, fn, store.place);
-                const std::optional<TypeId> value_type =
-                    OperandType(fn, store.value);
-                if (!value_type) {
-                  throw InternalError("lir verify: store value has no type");
-                }
-                const bool compatible = *value_type == place_type ||
-                                        (IsReference(unit, *value_type) &&
-                                         IsReference(unit, place_type));
-                if (!compatible) {
-                  throw InternalError(
-                      "lir verify: store value type is not compatible with its "
-                      "place type");
-                }
-                if (!IsVoid(unit, result_type)) {
-                  throw InternalError("lir verify: store must yield void");
-                }
-              },
-              [](const CallInstr&) {}, [](const AggregateInstr&) {}},
-          instr.data);
+      VerifyInstr(unit, fn, instr);
     }
   }
 }

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -1,28 +1,48 @@
 #include "lyra/lowering/mir_to_lir/function_lowerer.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/lir/function.hpp"
 #include "lyra/lir/integral_constant.hpp"
+#include "lyra/lir/operator.hpp"
 #include "lyra/lir/type_id.hpp"
+#include "lyra/lir/type_query.hpp"
 #include "lyra/lowering/mir_to_lir/unit_lowerer.hpp"
+#include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/inc_dec_op.hpp"
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/local.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/mir/unary_op.hpp"
 #include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::mir_to_lir {
 
 namespace {
+
+auto Unsupported(std::string message) -> std::unexpected<diag::Diagnostic> {
+  return diag::Fail(
+      diag::DiagCode::kUnsupportedExpressionForm, std::move(message));
+}
+
+// The place a place local names: its own storage, with nothing projected off
+// it.
+auto LocalPlace(lir::ValueId local) -> lir::Place {
+  return lir::Place{.base = lir::Use{.value = local}, .chain = {}};
+}
 
 auto TranslateIntegralConstant(const mir::IntegralConstant& c)
     -> lir::IntegralConstant {
@@ -38,33 +58,136 @@ auto TranslateIntegralConstant(const mir::IntegralConstant& c)
                         : lir::IntegralStateKind::kTwoState};
 }
 
+// The operators the executable IR realizes directly. Every other MIR operator
+// is lifted to a library call before this point, so reaching one here is a
+// lowering defect upstream, not an unsupported source form.
+auto TranslateBinaryOp(mir::BinaryOp op) -> std::optional<lir::BinaryOp> {
+  switch (op) {
+    case mir::BinaryOp::kAdd:
+      return lir::BinaryOp::kAdd;
+    case mir::BinaryOp::kSub:
+      return lir::BinaryOp::kSub;
+    case mir::BinaryOp::kMul:
+      return lir::BinaryOp::kMul;
+    case mir::BinaryOp::kDiv:
+      return lir::BinaryOp::kDiv;
+    case mir::BinaryOp::kMod:
+      return lir::BinaryOp::kMod;
+    case mir::BinaryOp::kBitwiseAnd:
+      return lir::BinaryOp::kBitwiseAnd;
+    case mir::BinaryOp::kBitwiseOr:
+      return lir::BinaryOp::kBitwiseOr;
+    case mir::BinaryOp::kBitwiseXor:
+      return lir::BinaryOp::kBitwiseXor;
+    case mir::BinaryOp::kEquality:
+      return lir::BinaryOp::kEquality;
+    case mir::BinaryOp::kInequality:
+      return lir::BinaryOp::kInequality;
+    case mir::BinaryOp::kLessThan:
+      return lir::BinaryOp::kLessThan;
+    case mir::BinaryOp::kLessEqual:
+      return lir::BinaryOp::kLessEqual;
+    case mir::BinaryOp::kGreaterThan:
+      return lir::BinaryOp::kGreaterThan;
+    case mir::BinaryOp::kGreaterEqual:
+      return lir::BinaryOp::kGreaterEqual;
+    case mir::BinaryOp::kLogicalAnd:
+      return lir::BinaryOp::kLogicalAnd;
+    case mir::BinaryOp::kLogicalOr:
+      return lir::BinaryOp::kLogicalOr;
+    default:
+      return std::nullopt;
+  }
+}
+
+auto TranslateUnaryOp(mir::UnaryOp op) -> std::optional<lir::UnaryOp> {
+  switch (op) {
+    case mir::UnaryOp::kMinus:
+      return lir::UnaryOp::kMinus;
+    case mir::UnaryOp::kBitwiseNot:
+      return lir::UnaryOp::kBitwiseNot;
+    case mir::UnaryOp::kLogicalNot:
+      return lir::UnaryOp::kLogicalNot;
+    default:
+      return std::nullopt;
+  }
+}
+
+// The local a place-position expression names, if it names one directly.
+auto PlacedLocal(const mir::Block& block, mir::ExprId id)
+    -> std::optional<mir::LocalId> {
+  const auto* ref = std::get_if<mir::LocalRef>(&block.exprs.Get(id).data);
+  return ref != nullptr ? std::optional{ref->var} : std::nullopt;
+}
+
+// Marks every local the canonical lowering needs an address for: one that is
+// assigned after its initialization, or has its address taken. Such a local is
+// storage, so it must be a place local. A read never makes a local storage: a
+// value read many times is still a value. The whole expression arena is
+// scanned, not just the reachable statements, so a local written only by an
+// unreachable expression is conservatively storage.
+void CollectPlacedLocals(const mir::Block& block, std::vector<bool>& placed) {
+  const auto mark = [&](std::optional<mir::LocalId> local) {
+    if (local.has_value()) {
+      placed[local->value] = true;
+    }
+  };
+  for (std::size_t i = 0; i < block.exprs.size(); ++i) {
+    const mir::Expr& expr =
+        block.exprs.Get(mir::ExprId{static_cast<std::uint32_t>(i)});
+    std::visit(
+        Overloaded{
+            [&](const mir::AssignExpr& e) {
+              mark(PlacedLocal(block, e.target));
+            },
+            [&](const mir::IncDecExpr& e) {
+              mark(PlacedLocal(block, e.target));
+            },
+            [&](const mir::AddressOfExpr& e) {
+              mark(PlacedLocal(block, e.operand));
+            },
+            [](const auto&) {}},
+        expr.data);
+  }
+  for (std::size_t i = 0; i < block.child_scopes.size(); ++i) {
+    CollectPlacedLocals(
+        block.child_scopes.Get(mir::BlockId{static_cast<std::uint32_t>(i)}),
+        placed);
+  }
+}
+
 auto LowerCallTarget(
-    const mir::Callee& callee, lir::ClassId current_class, lir::TypeId result)
-    -> diag::Result<lir::CallTarget> {
+    UnitLowerer& unit, const mir::Callee& callee, lir::ClassId current_class,
+    lir::TypeId result) -> diag::Result<lir::CallTarget> {
   return std::visit(
       Overloaded{
           [&](const mir::Direct& d) -> diag::Result<lir::CallTarget> {
+            std::optional<lir::TypeId> qualifier;
             if (d.qualification.has_value()) {
-              return diag::Fail(
-                  diag::DiagCode::kUnsupportedExpressionForm,
-                  "mir_to_lir: qualified call is not yet lowerable to LIR");
+              qualifier = unit.TranslateType(
+                  std::get<mir::TypeQualifier>(*d.qualification).type);
             }
             return std::visit(
                 Overloaded{
                     [&](const mir::MethodId& m)
                         -> diag::Result<lir::CallTarget> {
+                      if (qualifier.has_value()) {
+                        return Unsupported(
+                            "mir_to_lir: a qualified method call is not yet "
+                            "lowerable to LIR");
+                      }
                       return lir::CallTarget{lir::MethodTarget{
                           .method = lir::MethodRef{
                               .class_id = current_class, .index = m.value}}};
                     },
-                    [](const support::BuiltinFn& fn)
+                    [&](const support::BuiltinFn& fn)
                         -> diag::Result<lir::CallTarget> {
-                      return lir::CallTarget{lir::BuiltinTarget{.fn = fn}};
+                      return lir::CallTarget{
+                          lir::BuiltinTarget{.fn = fn, .qualifier = qualifier}};
                     },
                     [](const mir::StaticCallableTarget&)
                         -> diag::Result<lir::CallTarget> {
-                      return diag::Fail(
-                          diag::DiagCode::kUnsupportedExpressionForm,
+                      return Unsupported(
                           "mir_to_lir: a DPI-C import call is not yet "
                           "lowerable "
                           "to LIR");
@@ -75,8 +198,7 @@ auto LowerCallTarget(
             return lir::CallTarget{lir::ConstructTarget{.result = result}};
           },
           [](const mir::Indirect&) -> diag::Result<lir::CallTarget> {
-            return diag::Fail(
-                diag::DiagCode::kUnsupportedExpressionForm,
+            return Unsupported(
                 "mir_to_lir: indirect (closure) call is not yet lowerable to "
                 "LIR");
           }},
@@ -92,7 +214,8 @@ FunctionLowerer::FunctionLowerer(
       code_(&code),
       name_(std::move(name)),
       current_class_(current_class),
-      local_to_value_(code.locals.size(), std::nullopt) {
+      placed_(code.locals.size(), false),
+      locals_(code.locals.size(), std::nullopt) {
 }
 
 auto FunctionLowerer::Run() -> diag::Result<lir::Function> {
@@ -104,69 +227,637 @@ auto FunctionLowerer::Run() -> diag::Result<lir::Function> {
                         ? unit_->TranslateType(unit_->Mir().builtins.void_type)
                         : unit_->TranslateType(code_->result_type);
 
+  CollectPlacedLocals(code_->body, placed_);
+
+  // A parameter is a declared local whose initial value is the incoming
+  // argument. It arrives as a value in the signature and is bound like any
+  // local: a place if the body assigns or addresses it, otherwise the argument
+  // value itself. The entry block exists first so a spilled parameter's copy
+  // into its place lands there, ahead of the body.
+  SetCurrent(NewBlock());
   for (const mir::LocalId param : code_->params) {
     const mir::LocalDecl& decl = code_->locals.Get(param);
+    const lir::TypeId type = unit_->TranslateType(decl.type);
     const lir::ValueId value = fn_.values.Add(
         lir::Local{
-            .name = decl.name,
-            .type = unit_->TranslateType(decl.type),
-            .kind = lir::LocalKind::kParam});
+            .name = decl.name, .type = type, .kind = lir::LocalKind::kParam});
     fn_.params.push_back(value);
-    local_to_value_[param.value] = value;
+    BindLocal(param, type, lir::Use{.value = value});
   }
 
-  for (const mir::StmtId sid : code_->body.root_stmts) {
-    auto lowered = LowerStmtInto(code_->body.stmts.Get(sid));
+  auto lowered = LowerBlockInto(code_->body);
+  if (!lowered) {
+    return std::unexpected(std::move(lowered.error()));
+  }
+
+  // A block the lowering left open either falls off the end of a void body --
+  // an implicit return -- or is a join control never reaches. A value-returning
+  // body reaches its returns explicitly, so its open blocks are the latter.
+  const bool returns_void =
+      fn_.result_type == unit_->TranslateType(unit_->Mir().builtins.void_type);
+  for (std::size_t i = 0; i < fn_.blocks.size(); ++i) {
+    if (terminated_[i]) {
+      continue;
+    }
+    fn_.blocks[i].terminator = lir::Terminator{
+        .data = returns_void
+                    ? lir::TerminatorData{lir::ReturnTerm{
+                          .value = std::nullopt, .is_coroutine = false}}
+                    : lir::TerminatorData{lir::UnreachableTerm{}}};
+  }
+  return std::move(fn_);
+}
+
+auto FunctionLowerer::NewBlock() -> lir::BlockId {
+  fn_.blocks.emplace_back();
+  terminated_.push_back(false);
+  return lir::BlockId{static_cast<std::uint32_t>(fn_.blocks.size() - 1)};
+}
+
+void FunctionLowerer::SetCurrent(lir::BlockId id) {
+  current_ = id;
+}
+
+void FunctionLowerer::Terminate(lir::TerminatorData data) {
+  if (terminated_[current_.value]) {
+    throw InternalError("mir_to_lir: block terminated twice");
+  }
+  fn_.blocks[current_.value].terminator = lir::Terminator{.data = data};
+  terminated_[current_.value] = true;
+}
+
+auto FunctionLowerer::Terminated() const -> bool {
+  return terminated_[current_.value];
+}
+
+auto FunctionLowerer::Emit(lir::TypeId type, lir::InstrData data)
+    -> lir::Operand {
+  const lir::ValueId result = fn_.values.Add(
+      lir::Local{.name = {}, .type = type, .kind = lir::LocalKind::kTemp});
+  fn_.blocks[current_.value].instrs.push_back(
+      lir::Instr{.result = result, .data = std::move(data)});
+  return lir::Use{.value = result};
+}
+
+auto FunctionLowerer::NewPlaceLocal(lir::TypeId type) -> lir::ValueId {
+  return fn_.values.Add(
+      lir::Local{.name = {}, .type = type, .kind = lir::LocalKind::kPlace});
+}
+
+// Introduces a declared local, holding its initial value. A local the lowering
+// needs an address for -- assigned later, or addressed -- becomes frame storage
+// the initial value is written into; one that is only ever read stays the
+// initial value itself.
+void FunctionLowerer::BindLocal(
+    mir::LocalId local, lir::TypeId type, lir::Operand init) {
+  if (!placed_[local.value]) {
+    locals_[local.value] = LocalBinding{ValueBinding{.value = std::move(init)}};
+    return;
+  }
+  const lir::ValueId slot = NewPlaceLocal(type);
+  locals_[local.value] = LocalBinding{PlaceBinding{.slot = slot}};
+  Store(LocalPlace(slot), std::move(init));
+}
+
+auto FunctionLowerer::Load(lir::Place place, lir::TypeId type) -> lir::Operand {
+  return Emit(type, lir::LoadInstr{.place = std::move(place)});
+}
+
+void FunctionLowerer::Store(lir::Place place, lir::Operand value) {
+  Emit(
+      unit_->TranslateType(unit_->Mir().builtins.void_type),
+      lir::StoreInstr{.place = std::move(place), .value = std::move(value)});
+}
+
+auto FunctionLowerer::LowerBlockInto(const mir::Block& block)
+    -> diag::Result<void> {
+  for (const mir::StmtId sid : block.root_stmts) {
+    if (Terminated()) {
+      // Control left this sequence -- a return, a break, a continue. What
+      // follows in the same brace level is unreachable and has no lowering.
+      break;
+    }
+    auto lowered = LowerStmtInto(block, block.stmts.Get(sid));
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
   }
-  if (!terminated_) {
-    block_.terminator = lir::Terminator{
-        .data = lir::ReturnTerm{.value = std::nullopt, .is_coroutine = false}};
-  }
-  fn_.blocks.push_back(std::move(block_));
-  return std::move(fn_);
+  return {};
 }
 
-auto FunctionLowerer::LowerStmtInto(const mir::Stmt& stmt)
-    -> diag::Result<void> {
+auto FunctionLowerer::LowerStmtInto(
+    const mir::Block& block, const mir::Stmt& stmt) -> diag::Result<void> {
   return std::visit(
       Overloaded{
           [](const mir::EmptyStmt&) -> diag::Result<void> { return {}; },
           [&](const mir::ExprStmt& s) -> diag::Result<void> {
-            auto lowered = LowerExpr(s.expr);
+            auto lowered = LowerExpr(block, s.expr);
             if (!lowered) {
               return std::unexpected(std::move(lowered.error()));
             }
             return {};
           },
+          [&](const mir::BlockStmt& s) -> diag::Result<void> {
+            return LowerBlockInto(block.child_scopes.Get(s.scope));
+          },
+          [&](const mir::LocalDeclStmt& s) -> diag::Result<void> {
+            auto init = LowerExpr(block, s.init);
+            if (!init) {
+              return std::unexpected(std::move(init.error()));
+            }
+            BindLocal(
+                s.target,
+                unit_->TranslateType(code_->locals.Get(s.target).type),
+                *std::move(init));
+            return {};
+          },
+          [&](const mir::IfStmt& s) -> diag::Result<void> {
+            return LowerIfInto(block, s);
+          },
+          [&](const mir::ForStmt& s) -> diag::Result<void> {
+            return LowerForInto(block, s);
+          },
+          [&](const mir::WhileStmt& s) -> diag::Result<void> {
+            return LowerWhileInto(block, s);
+          },
+          [&](const mir::DoWhileStmt& s) -> diag::Result<void> {
+            return LowerDoWhileInto(block, s);
+          },
+          [&](const mir::BreakStmt& s) -> diag::Result<void> {
+            return LowerBreakInto(s);
+          },
+          [&](const mir::ContinueStmt&) -> diag::Result<void> {
+            return LowerContinueInto();
+          },
           [&](const mir::ReturnStmt& s) -> diag::Result<void> {
             std::optional<lir::Operand> value;
             if (s.value.has_value()) {
-              auto lowered = LowerExpr(*s.value);
+              auto lowered = LowerExpr(block, *s.value);
               if (!lowered) {
                 return std::unexpected(std::move(lowered.error()));
               }
               value = *std::move(lowered);
             }
-            block_.terminator = lir::Terminator{
-                .data = lir::ReturnTerm{
+            Terminate(
+                lir::ReturnTerm{
                     .value = std::move(value),
-                    .is_coroutine = s.is_coroutine_return}};
-            terminated_ = true;
+                    .is_coroutine = s.is_coroutine_return});
             return {};
           },
-          [](const auto&) -> diag::Result<void> {
+          [](const mir::SensitivityWaitStmt&) -> diag::Result<void> {
             return diag::Fail(
                 diag::DiagCode::kUnsupportedStatementForm,
-                "mir_to_lir: MIR statement form is not yet lowerable to LIR");
+                "mir_to_lir: a sensitivity wait is not yet lowerable to LIR");
           }},
       stmt.data);
 }
 
-auto FunctionLowerer::LowerExpr(mir::ExprId id) -> diag::Result<lir::Operand> {
-  const mir::Expr& expr = code_->body.exprs.Get(id);
+auto FunctionLowerer::LowerIfInto(
+    const mir::Block& block, const mir::IfStmt& stmt) -> diag::Result<void> {
+  auto condition = LowerCondition(block, stmt.condition);
+  if (!condition) {
+    return std::unexpected(std::move(condition.error()));
+  }
+  const lir::BlockId then_id = NewBlock();
+  const lir::BlockId else_id = NewBlock();
+  const lir::BlockId merge_id = NewBlock();
+  Terminate(
+      lir::CondBranchTerm{
+          .condition = *std::move(condition),
+          .if_true = then_id,
+          .if_false = else_id});
+
+  SetCurrent(then_id);
+  auto then_lowered = LowerBlockInto(block.child_scopes.Get(stmt.then_scope));
+  if (!then_lowered) {
+    return std::unexpected(std::move(then_lowered.error()));
+  }
+  if (!Terminated()) {
+    Terminate(lir::BranchTerm{.target = merge_id});
+  }
+
+  SetCurrent(else_id);
+  if (stmt.else_scope.has_value()) {
+    auto else_lowered =
+        LowerBlockInto(block.child_scopes.Get(*stmt.else_scope));
+    if (!else_lowered) {
+      return std::unexpected(std::move(else_lowered.error()));
+    }
+  }
+  if (!Terminated()) {
+    Terminate(lir::BranchTerm{.target = merge_id});
+  }
+
+  SetCurrent(merge_id);
+  return {};
+}
+
+auto FunctionLowerer::LowerWhileInto(
+    const mir::Block& block, const mir::WhileStmt& stmt) -> diag::Result<void> {
+  const lir::BlockId header_id = NewBlock();
+  const lir::BlockId body_id = NewBlock();
+  const lir::BlockId exit_id = NewBlock();
+  Terminate(lir::BranchTerm{.target = header_id});
+
+  SetCurrent(header_id);
+  auto condition = LowerCondition(block, stmt.condition);
+  if (!condition) {
+    return std::unexpected(std::move(condition.error()));
+  }
+  Terminate(
+      lir::CondBranchTerm{
+          .condition = *std::move(condition),
+          .if_true = body_id,
+          .if_false = exit_id});
+
+  SetCurrent(body_id);
+  loops_.push_back(
+      LoopTargets{
+          .label = std::nullopt,
+          .continue_target = header_id,
+          .break_target = exit_id});
+  auto body = LowerBlockInto(block.child_scopes.Get(stmt.scope));
+  loops_.pop_back();
+  if (!body) {
+    return std::unexpected(std::move(body.error()));
+  }
+  if (!Terminated()) {
+    Terminate(lir::BranchTerm{.target = header_id});
+  }
+
+  SetCurrent(exit_id);
+  return {};
+}
+
+auto FunctionLowerer::LowerDoWhileInto(
+    const mir::Block& block, const mir::DoWhileStmt& stmt)
+    -> diag::Result<void> {
+  const lir::BlockId body_id = NewBlock();
+  const lir::BlockId latch_id = NewBlock();
+  const lir::BlockId exit_id = NewBlock();
+  Terminate(lir::BranchTerm{.target = body_id});
+
+  SetCurrent(body_id);
+  loops_.push_back(
+      LoopTargets{
+          .label = std::nullopt,
+          .continue_target = latch_id,
+          .break_target = exit_id});
+  auto body = LowerBlockInto(block.child_scopes.Get(stmt.scope));
+  loops_.pop_back();
+  if (!body) {
+    return std::unexpected(std::move(body.error()));
+  }
+  if (!Terminated()) {
+    Terminate(lir::BranchTerm{.target = latch_id});
+  }
+
+  SetCurrent(latch_id);
+  auto condition = LowerCondition(block, stmt.condition);
+  if (!condition) {
+    return std::unexpected(std::move(condition.error()));
+  }
+  Terminate(
+      lir::CondBranchTerm{
+          .condition = *std::move(condition),
+          .if_true = body_id,
+          .if_false = exit_id});
+
+  SetCurrent(exit_id);
+  return {};
+}
+
+auto FunctionLowerer::LowerForInto(
+    const mir::Block& block, const mir::ForStmt& stmt) -> diag::Result<void> {
+  for (const mir::ForInit& init : stmt.init) {
+    auto lowered = std::visit(
+        Overloaded{
+            [&](const mir::ForInitDecl& decl) -> diag::Result<void> {
+              auto value = LowerExpr(block, decl.init);
+              if (!value) {
+                return std::unexpected(std::move(value.error()));
+              }
+              BindLocal(
+                  decl.induction_var,
+                  unit_->TranslateType(
+                      code_->locals.Get(decl.induction_var).type),
+                  *std::move(value));
+              return {};
+            },
+            [&](const mir::ForInitExpr& expr) -> diag::Result<void> {
+              auto value = LowerExpr(block, expr.expr);
+              if (!value) {
+                return std::unexpected(std::move(value.error()));
+              }
+              return {};
+            }},
+        init);
+    if (!lowered) {
+      return std::unexpected(std::move(lowered.error()));
+    }
+  }
+
+  const lir::BlockId header_id = NewBlock();
+  const lir::BlockId body_id = NewBlock();
+  const lir::BlockId step_id = NewBlock();
+  const lir::BlockId exit_id = NewBlock();
+  Terminate(lir::BranchTerm{.target = header_id});
+
+  SetCurrent(header_id);
+  if (stmt.condition.has_value()) {
+    auto condition = LowerCondition(block, *stmt.condition);
+    if (!condition) {
+      return std::unexpected(std::move(condition.error()));
+    }
+    Terminate(
+        lir::CondBranchTerm{
+            .condition = *std::move(condition),
+            .if_true = body_id,
+            .if_false = exit_id});
+  } else {
+    Terminate(lir::BranchTerm{.target = body_id});
+  }
+
+  SetCurrent(body_id);
+  loops_.push_back(
+      LoopTargets{
+          .label = stmt.break_label,
+          .continue_target = step_id,
+          .break_target = exit_id});
+  auto body = LowerBlockInto(block.child_scopes.Get(stmt.scope));
+  loops_.pop_back();
+  if (!body) {
+    return std::unexpected(std::move(body.error()));
+  }
+  if (!Terminated()) {
+    Terminate(lir::BranchTerm{.target = step_id});
+  }
+
+  SetCurrent(step_id);
+  for (const mir::ExprId step : stmt.step) {
+    auto lowered = LowerExpr(block, step);
+    if (!lowered) {
+      return std::unexpected(std::move(lowered.error()));
+    }
+  }
+  Terminate(lir::BranchTerm{.target = header_id});
+
+  SetCurrent(exit_id);
+  return {};
+}
+
+auto FunctionLowerer::LowerBreakInto(const mir::BreakStmt& stmt)
+    -> diag::Result<void> {
+  // An unlabeled break leaves the innermost loop; a labeled one leaves the
+  // loop that carries the label, however many loops it is nested inside.
+  for (const LoopTargets& loop : std::views::reverse(loops_)) {
+    if (!stmt.target.has_value() || loop.label == stmt.target) {
+      Terminate(lir::BranchTerm{.target = loop.break_target});
+      return {};
+    }
+  }
+  throw InternalError("mir_to_lir: break outside of any matching loop");
+}
+
+auto FunctionLowerer::LowerContinueInto() -> diag::Result<void> {
+  if (loops_.empty()) {
+    throw InternalError("mir_to_lir: continue outside of any loop");
+  }
+  Terminate(lir::BranchTerm{.target = loops_.back().continue_target});
+  return {};
+}
+
+auto FunctionLowerer::LowerCondition(const mir::Block& block, mir::ExprId id)
+    -> diag::Result<lir::Operand> {
+  auto value = LowerExpr(block, id);
+  if (!value) {
+    return value;
+  }
+  // A value already on the machine-boolean plane is what a branch tests; any
+  // other value needs the reduction a target's boolean context would apply.
+  if (lir::OperandType(fn_, *value) == unit_->MachineBoolType()) {
+    return value;
+  }
+  return Emit(
+      unit_->MachineBoolType(),
+      lir::BoolCastInstr{.operand = *std::move(value)});
+}
+
+auto FunctionLowerer::LowerPlace(const mir::Block& block, mir::ExprId id)
+    -> diag::Result<lir::Place> {
+  const mir::Expr& expr = block.exprs.Get(id);
+  return std::visit(
+      Overloaded{
+          [&](const mir::LocalRef& ref) -> diag::Result<lir::Place> {
+            const std::optional<LocalBinding>& binding = locals_[ref.var.value];
+            const auto* place = binding.has_value()
+                                    ? std::get_if<PlaceBinding>(&*binding)
+                                    : nullptr;
+            if (place == nullptr) {
+              return Unsupported(
+                  "mir_to_lir: local is not addressable storage");
+            }
+            return LocalPlace(place->slot);
+          },
+          [&](const mir::FieldAccessExpr& field) -> diag::Result<lir::Place> {
+            auto receiver = LowerExpr(block, field.receiver);
+            if (!receiver) {
+              return std::unexpected(std::move(receiver.error()));
+            }
+            return lir::Place{
+                .base = *std::move(receiver),
+                .chain = {
+                    lir::Projection{lir::DerefProjection{}},
+                    lir::Projection{lir::MemberProjection{
+                        .member = lir::MemberId{field.field.value}}}}};
+          },
+          [&](const mir::DerefExpr& deref) -> diag::Result<lir::Place> {
+            auto pointer = LowerExpr(block, deref.pointer);
+            if (!pointer) {
+              return std::unexpected(std::move(pointer.error()));
+            }
+            return lir::Place{
+                .base = *std::move(pointer),
+                .chain = {lir::Projection{lir::DerefProjection{}}}};
+          },
+          [](const auto&) -> diag::Result<lir::Place> {
+            return Unsupported("mir_to_lir: expression form names no place");
+          }},
+      expr.data);
+}
+
+auto FunctionLowerer::LowerArgument(const mir::Block& block, mir::ExprId id)
+    -> diag::Result<lir::Operand> {
+  // The parameter's type decides. A parameter of an address-only type asks for
+  // the storage itself -- a cell, a scope -- so the argument is where it lives,
+  // not a reading of it. This is a fact about what the callee takes, not about
+  // the expression that produced the place.
+  const lir::TypeId type = unit_->TranslateType(block.exprs.Get(id).type);
+  if (!lir::IsAddressOnly(unit_->Types(), type)) {
+    return LowerExpr(block, id);
+  }
+  auto place = LowerPlace(block, id);
+  if (!place) {
+    return std::unexpected(std::move(place.error()));
+  }
+  return Emit(
+      unit_->BorrowedPointerTo(type),
+      lir::AddrOfInstr{.place = *std::move(place)});
+}
+
+auto FunctionLowerer::LowerCall(
+    const mir::Block& block, const mir::CallExpr& call, mir::TypeId type)
+    -> diag::Result<lir::Operand> {
+  std::vector<lir::Operand> args;
+  args.reserve(call.arguments.size());
+  for (const mir::ExprId arg : call.arguments) {
+    auto lowered = LowerArgument(block, arg);
+    if (!lowered) {
+      return std::unexpected(std::move(lowered.error()));
+    }
+    args.push_back(*std::move(lowered));
+  }
+  const lir::TypeId result_type = unit_->TranslateType(type);
+
+  // A coroutine is a runtime value like any other: the runtime builds it from
+  // an entry code reference and its environment (the receiver), and it is
+  // reached as an opaque handle. It is constructed through the same Construct
+  // path as any other runtime value; the coroutine call protocol stays the
+  // result type.
+  if (std::holds_alternative<mir::CoroutineType>(
+          unit_->Mir().types.Get(type).data)) {
+    const auto* direct = std::get_if<mir::Direct>(&call.callee);
+    const auto* method = direct != nullptr
+                             ? std::get_if<mir::MethodId>(&direct->target)
+                             : nullptr;
+    if (method == nullptr) {
+      return Unsupported(
+          "mir_to_lir: a coroutine value from a non-method callee is not yet "
+          "lowerable to LIR");
+    }
+    std::vector<lir::Operand> ctor_args;
+    ctor_args.reserve(args.size() + 1);
+    ctor_args.emplace_back(
+        lir::FuncRef{
+            .method = lir::MethodRef{
+                .class_id = current_class_, .index = method->value}});
+    for (lir::Operand& arg : args) {
+      ctor_args.emplace_back(std::move(arg));
+    }
+    return Emit(
+        result_type, lir::CallInstr{
+                         .target = lir::ConstructTarget{.result = result_type},
+                         .args = std::move(ctor_args)});
+  }
+
+  auto target =
+      LowerCallTarget(*unit_, call.callee, current_class_, result_type);
+  if (!target) {
+    return std::unexpected(std::move(target.error()));
+  }
+  return Emit(
+      result_type,
+      lir::CallInstr{.target = *std::move(target), .args = std::move(args)});
+}
+
+auto FunctionLowerer::LowerAssign(
+    const mir::Block& block, const mir::AssignExpr& assign)
+    -> diag::Result<lir::Operand> {
+  const lir::TypeId type =
+      unit_->TranslateType(block.exprs.Get(assign.target).type);
+  auto place = LowerPlace(block, assign.target);
+  if (!place) {
+    return std::unexpected(std::move(place.error()));
+  }
+  auto value = LowerExpr(block, assign.value);
+  if (!value) {
+    return std::unexpected(std::move(value.error()));
+  }
+
+  lir::Operand written = *value;
+  if (assign.compound_op.has_value()) {
+    const std::optional<lir::BinaryOp> op =
+        TranslateBinaryOp(*assign.compound_op);
+    if (!op) {
+      return Unsupported(
+          "mir_to_lir: compound assignment operator has no direct realization");
+    }
+    lir::Operand old = Load(*place, type);
+    written = Emit(
+        type, lir::BinaryInstr{
+                  .op = *op, .lhs = std::move(old), .rhs = *std::move(value)});
+  }
+  Store(*std::move(place), written);
+  return written;
+}
+
+auto FunctionLowerer::LowerIncDec(
+    const mir::Block& block, const mir::IncDecExpr& inc_dec)
+    -> diag::Result<lir::Operand> {
+  const lir::TypeId type =
+      unit_->TranslateType(block.exprs.Get(inc_dec.target).type);
+  auto place = LowerPlace(block, inc_dec.target);
+  if (!place) {
+    return std::unexpected(std::move(place.error()));
+  }
+  const bool is_increment = inc_dec.op == mir::IncDecOp::kPreInc ||
+                            inc_dec.op == mir::IncDecOp::kPostInc;
+  const bool is_prefix = inc_dec.op == mir::IncDecOp::kPreInc ||
+                         inc_dec.op == mir::IncDecOp::kPreDec;
+
+  lir::Operand old = Load(*place, type);
+  lir::Operand updated = Emit(
+      type, lir::UnaryInstr{
+                .op = is_increment ? lir::UnaryOp::kIncrement
+                                   : lir::UnaryOp::kDecrement,
+                .operand = old});
+  Store(*std::move(place), updated);
+  return is_prefix ? updated : old;
+}
+
+auto FunctionLowerer::LowerConditional(
+    const mir::Block& block, const mir::ConditionalExpr& cond, mir::TypeId type)
+    -> diag::Result<lir::Operand> {
+  auto condition = LowerCondition(block, cond.condition);
+  if (!condition) {
+    return std::unexpected(std::move(condition.error()));
+  }
+  // The arms are evaluated only on the path that selects them, so the result is
+  // written through on two paths: it is storage, not a transient.
+  const lir::TypeId result_type = unit_->TranslateType(type);
+  const lir::ValueId slot = NewPlaceLocal(result_type);
+  const lir::BlockId then_id = NewBlock();
+  const lir::BlockId else_id = NewBlock();
+  const lir::BlockId merge_id = NewBlock();
+  Terminate(
+      lir::CondBranchTerm{
+          .condition = *std::move(condition),
+          .if_true = then_id,
+          .if_false = else_id});
+
+  SetCurrent(then_id);
+  auto then_value = LowerExpr(block, cond.then_value);
+  if (!then_value) {
+    return std::unexpected(std::move(then_value.error()));
+  }
+  Store(LocalPlace(slot), *std::move(then_value));
+  Terminate(lir::BranchTerm{.target = merge_id});
+
+  SetCurrent(else_id);
+  auto else_value = LowerExpr(block, cond.else_value);
+  if (!else_value) {
+    return std::unexpected(std::move(else_value.error()));
+  }
+  Store(LocalPlace(slot), *std::move(else_value));
+  Terminate(lir::BranchTerm{.target = merge_id});
+
+  SetCurrent(merge_id);
+  return Load(LocalPlace(slot), result_type);
+}
+
+auto FunctionLowerer::LowerExpr(const mir::Block& block, mir::ExprId id)
+    -> diag::Result<lir::Operand> {
+  const mir::Expr& expr = block.exprs.Get(id);
   const mir::TypeId type = expr.type;
   return std::visit(
       Overloaded{
@@ -180,76 +871,30 @@ auto FunctionLowerer::LowerExpr(mir::ExprId id) -> diag::Result<lir::Operand> {
                 .value = lit.value, .type = unit_->TranslateType(type)}};
           },
           [&](const mir::LocalRef& ref) -> diag::Result<lir::Operand> {
-            const std::optional<lir::ValueId> value =
-                local_to_value_[ref.var.value];
-            if (!value.has_value()) {
-              return diag::Fail(
-                  diag::DiagCode::kUnsupportedExpressionForm,
-                  "mir_to_lir: reference to an unlowered local");
+            const std::optional<LocalBinding>& binding = locals_[ref.var.value];
+            if (!binding.has_value()) {
+              return Unsupported("mir_to_lir: reference to an unlowered local");
             }
-            return lir::Operand{lir::Use{.value = *value}};
+            return std::visit(
+                Overloaded{
+                    [&](const PlaceBinding& place) -> lir::Operand {
+                      return Load(
+                          LocalPlace(place.slot),
+                          fn_.values.Get(place.slot).type);
+                    },
+                    [](const ValueBinding& value) -> lir::Operand {
+                      return value.value;
+                    }},
+                *binding);
           },
           [&](const mir::CallExpr& call) -> diag::Result<lir::Operand> {
-            std::vector<lir::Operand> args;
-            args.reserve(call.arguments.size());
-            for (const mir::ExprId arg : call.arguments) {
-              auto lowered = LowerExpr(arg);
-              if (!lowered) {
-                return std::unexpected(std::move(lowered.error()));
-              }
-              args.push_back(*std::move(lowered));
-            }
-            const lir::TypeId result_type = unit_->TranslateType(type);
-
-            // A coroutine is a runtime value like any other: the runtime builds
-            // it from an entry code reference and its environment (the
-            // receiver), and it is reached as an opaque handle. It is
-            // constructed through the same Construct path as any other runtime
-            // value; the coroutine call protocol stays the result type.
-            if (std::holds_alternative<mir::CoroutineType>(
-                    unit_->Mir().types.Get(type).data)) {
-              const auto* direct = std::get_if<mir::Direct>(&call.callee);
-              const auto* method =
-                  direct != nullptr
-                      ? std::get_if<mir::MethodId>(&direct->target)
-                      : nullptr;
-              if (method == nullptr) {
-                return diag::Fail(
-                    diag::DiagCode::kUnsupportedExpressionForm,
-                    "mir_to_lir: a coroutine value from a non-method callee is "
-                    "not yet lowerable to LIR");
-              }
-              std::vector<lir::Operand> ctor_args;
-              ctor_args.reserve(args.size() + 1);
-              ctor_args.emplace_back(
-                  lir::FuncRef{
-                      .method = lir::MethodRef{
-                          .class_id = current_class_, .index = method->value}});
-              for (lir::Operand& arg : args) {
-                ctor_args.emplace_back(std::move(arg));
-              }
-              return Emit(
-                  result_type,
-                  lir::CallInstr{
-                      .target = lir::ConstructTarget{.result = result_type},
-                      .args = std::move(ctor_args)});
-            }
-
-            auto target =
-                LowerCallTarget(call.callee, current_class_, result_type);
-            if (!target) {
-              return std::unexpected(std::move(target.error()));
-            }
-            return Emit(
-                result_type,
-                lir::CallInstr{
-                    .target = *std::move(target), .args = std::move(args)});
+            return LowerCall(block, call, type);
           },
           [&](const mir::ArrayLiteralExpr& lit) -> diag::Result<lir::Operand> {
             std::vector<lir::Operand> elements;
             elements.reserve(lit.elements.size());
             for (const mir::ExprId elem : lit.elements) {
-              auto lowered = LowerExpr(elem);
+              auto lowered = LowerExpr(block, elem);
               if (!lowered) {
                 return std::unexpected(std::move(lowered.error()));
               }
@@ -260,79 +905,114 @@ auto FunctionLowerer::LowerExpr(mir::ExprId id) -> diag::Result<lir::Operand> {
                 lir::AggregateInstr{.elements = std::move(elements)});
           },
           [&](const mir::PointerCastExpr& c) -> diag::Result<lir::Operand> {
-            // A borrowed-pointer reinterpretation is identity in the
-            // opaque-handle ABI: every pointer crosses as the same handle, so
-            // the cast lowers to its operand unchanged.
-            return LowerExpr(c.operand);
+            auto operand = LowerExpr(block, c.operand);
+            if (!operand) {
+              return operand;
+            }
+            return Emit(
+                unit_->TranslateType(type),
+                lir::PointerCastInstr{.operand = *std::move(operand)});
+          },
+          [&](const mir::CastExpr& c) -> diag::Result<lir::Operand> {
+            // A view change with no runtime transform: every conversion that
+            // reshapes a value is a library call upstream of this node.
+            return LowerExpr(block, c.operand);
           },
           [&](const mir::FieldAccessExpr&) -> diag::Result<lir::Operand> {
-            auto place = LowerPlace(id);
+            const lir::TypeId field_type = unit_->TranslateType(type);
+            if (lir::IsAddressOnly(unit_->Types(), field_type)) {
+              return Unsupported(
+                  "mir_to_lir: a storage cell has no value to read; it is "
+                  "reached through its address");
+            }
+            auto place = LowerPlace(block, id);
+            if (!place) {
+              return std::unexpected(std::move(place.error()));
+            }
+            return Load(*std::move(place), field_type);
+          },
+          [&](const mir::DerefExpr&) -> diag::Result<lir::Operand> {
+            auto place = LowerPlace(block, id);
+            if (!place) {
+              return std::unexpected(std::move(place.error()));
+            }
+            return Load(*std::move(place), unit_->TranslateType(type));
+          },
+          [&](const mir::AddressOfExpr& addr) -> diag::Result<lir::Operand> {
+            auto place = LowerPlace(block, addr.operand);
             if (!place) {
               return std::unexpected(std::move(place.error()));
             }
             return Emit(
                 unit_->TranslateType(type),
-                lir::LoadInstr{.place = *std::move(place)});
+                lir::AddrOfInstr{.place = *std::move(place)});
           },
           [&](const mir::AssignExpr& assign) -> diag::Result<lir::Operand> {
-            if (assign.compound_op.has_value()) {
-              return diag::Fail(
-                  diag::DiagCode::kUnsupportedExpressionForm,
-                  "mir_to_lir: a compound assignment is not yet lowerable to "
-                  "LIR");
+            return LowerAssign(block, assign);
+          },
+          [&](const mir::IncDecExpr& inc_dec) -> diag::Result<lir::Operand> {
+            return LowerIncDec(block, inc_dec);
+          },
+          [&](const mir::UnaryExpr& un) -> diag::Result<lir::Operand> {
+            auto operand = LowerExpr(block, un.operand);
+            if (!operand) {
+              return operand;
             }
-            auto place = LowerPlace(assign.target);
-            if (!place) {
-              return std::unexpected(std::move(place.error()));
+            // LRM 11.4.3: unary plus is an identity.
+            if (un.op == mir::UnaryOp::kPlus) {
+              return operand;
             }
-            auto value = LowerExpr(assign.value);
-            if (!value) {
-              return std::unexpected(std::move(value.error()));
+            const std::optional<lir::UnaryOp> op = TranslateUnaryOp(un.op);
+            if (!op) {
+              return Unsupported(
+                  "mir_to_lir: unary operator has no direct realization");
             }
-            Emit(
-                unit_->TranslateType(unit_->Mir().builtins.void_type),
-                lir::StoreInstr{.place = *std::move(place), .value = *value});
-            return *std::move(value);
+            return Emit(
+                unit_->TranslateType(type),
+                lir::UnaryInstr{.op = *op, .operand = *std::move(operand)});
+          },
+          [&](const mir::BinaryExpr& bin) -> diag::Result<lir::Operand> {
+            const std::optional<lir::BinaryOp> op = TranslateBinaryOp(bin.op);
+            if (!op) {
+              return Unsupported(
+                  "mir_to_lir: binary operator has no direct realization");
+            }
+            auto lhs = LowerExpr(block, bin.lhs);
+            if (!lhs) {
+              return lhs;
+            }
+            auto rhs = LowerExpr(block, bin.rhs);
+            if (!rhs) {
+              return rhs;
+            }
+            return Emit(
+                unit_->TranslateType(type),
+                lir::BinaryInstr{
+                    .op = *op, .lhs = *std::move(lhs), .rhs = *std::move(rhs)});
+          },
+          [&](const mir::BoolCastExpr& cast) -> diag::Result<lir::Operand> {
+            auto operand = LowerExpr(block, cast.operand);
+            if (!operand) {
+              return operand;
+            }
+            return Emit(
+                unit_->MachineBoolType(),
+                lir::BoolCastInstr{.operand = *std::move(operand)});
+          },
+          [&](const mir::ConditionalExpr& cond) -> diag::Result<lir::Operand> {
+            return LowerConditional(block, cond, type);
           },
           [&](const mir::MoveExpr& m) -> diag::Result<lir::Operand> {
             // Move-vs-copy is derived from SSA liveness at this layer; the
             // marker unwraps to its operand and the downstream backend
             // decides the transfer.
-            return LowerExpr(m.operand);
+            return LowerExpr(block, m.operand);
           },
           [](const auto&) -> diag::Result<lir::Operand> {
-            return diag::Fail(
-                diag::DiagCode::kUnsupportedExpressionForm,
+            return Unsupported(
                 "mir_to_lir: MIR expression form is not yet lowerable to LIR");
           }},
       expr.data);
-}
-
-auto FunctionLowerer::LowerPlace(mir::ExprId id) -> diag::Result<lir::Place> {
-  const mir::Expr& expr = code_->body.exprs.Get(id);
-  const auto* field = std::get_if<mir::FieldAccessExpr>(&expr.data);
-  if (field == nullptr) {
-    return diag::Fail(
-        diag::DiagCode::kUnsupportedExpressionForm,
-        "mir_to_lir: only a member access is yet lowerable to a place");
-  }
-  auto base = LowerExpr(field->receiver);
-  if (!base) {
-    return std::unexpected(std::move(base.error()));
-  }
-  return lir::Place{
-      .base = *std::move(base),
-      .chain = {lir::Projection{
-          lir::MemberProjection{.member = lir::MemberId{field->field.value}}}}};
-}
-
-auto FunctionLowerer::Emit(lir::TypeId type, lir::InstrData data)
-    -> lir::Operand {
-  const lir::ValueId result = fn_.values.Add(
-      lir::Local{.name = {}, .type = type, .kind = lir::LocalKind::kTemp});
-  block_.instrs.push_back(
-      lir::Instr{.result = result, .data = std::move(data)});
-  return lir::Use{.value = result};
 }
 
 }  // namespace lyra::lowering::mir_to_lir

--- a/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
@@ -81,6 +81,31 @@ auto UnitLowerer::LowerClass(lir::ClassId class_id, const mir::Class& cls)
   return out;
 }
 
+auto UnitLowerer::BorrowedPointerTo(lir::TypeId pointee) -> lir::TypeId {
+  const auto it = pointer_memo_.find(pointee.value);
+  if (it != pointer_memo_.end()) {
+    return it->second;
+  }
+  const lir::TypeId id = out_.types.Add(
+      lir::Type{
+          .data = lir::PointerType{
+              .pointee = pointee,
+              .ownership = lir::PointerOwnership::kBorrowed,
+              .mutability = lir::Mutability::kMutable}});
+  pointer_memo_.emplace(pointee.value, id);
+  return id;
+}
+
+auto UnitLowerer::MachineBoolType() -> lir::TypeId {
+  if (!machine_bool_type_.has_value()) {
+    machine_bool_type_ = out_.types.Add(
+        lir::Type{
+            .data = lir::MachineIntType{
+                .bit_width = 1, .signedness = lir::Signedness::kUnsigned}});
+  }
+  return *machine_bool_type_;
+}
+
 auto UnitLowerer::LowerBase(const mir::ClassRef& base) -> lir::Base {
   return std::visit(
       Overloaded{[&](const mir::RuntimeLibraryClassRef& r) -> lir::Base {

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -14,6 +14,7 @@
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/scope_program.hpp"
+#include "lyra/runtime/var.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/string.hpp"
@@ -37,6 +38,19 @@ auto RunGeneratedProcess(GeneratedEntry entry, void* env) -> Coroutine<void> {
   co_return;
 }
 
+// A value crossing the boundary is an opaque handle to a runtime object. These
+// name the two directions of that correspondence so the entry points below read
+// as the operation they perform, not as a wall of casts.
+template <typename T>
+auto Read(const void* handle) -> const T& {
+  return *static_cast<const T*>(handle);
+}
+
+template <typename T>
+auto Own(T value) -> void* {
+  return GeneratedCallScope::Current().Arena().New<T>(std::move(value));
+}
+
 }  // namespace
 
 }  // namespace lyra::runtime
@@ -46,13 +60,18 @@ using lyra::runtime::FileTable;
 using lyra::runtime::GeneratedCallScope;
 using lyra::runtime::GeneratedInstance;
 using lyra::runtime::HierarchySegment;
+using lyra::runtime::Own;
+using lyra::runtime::Read;
 using lyra::runtime::RuntimeServices;
 using lyra::runtime::Scope;
 using lyra::runtime::UnitDefinition;
+using lyra::runtime::Var;
 using lyra::value::Format;
+using lyra::value::FormatSpec;
 using lyra::value::PackedArray;
 using lyra::value::PrintItem;
 using lyra::value::PrintLiteralItem;
+using lyra::value::PrintValueItem;
 using lyra::value::String;
 using lyra::value::TimeFormat;
 
@@ -156,11 +175,329 @@ auto lyra_rt_add_owned_child(void* parent, void* child) -> void* {
       std::unique_ptr<Scope>(static_cast<Scope*>(child)));
 }
 
-auto lyra_rt_load_field(void* self, std::uint32_t index) -> void* {
-  return static_cast<GeneratedInstance*>(self)->Slot(index);
+auto lyra_rt_member_addr(void* self, std::uint32_t index) -> void* {
+  return static_cast<GeneratedInstance*>(self)->MemberAddress(index);
 }
 
-void lyra_rt_store_field(void* self, std::uint32_t index, void* value) {
-  static_cast<GeneratedInstance*>(self)->Slot(index) = value;
+void lyra_rt_register_signal(void* self, const void* name, void* cell) {
+  static_cast<Scope*>(self)->RegisterSignal(
+      static_cast<const char*>(name), cell);
+}
+
+auto lyra_rt_cell_packed_get(void* cell) -> const void* {
+  return &static_cast<Var<PackedArray>*>(cell)->Get();
+}
+
+void lyra_rt_cell_packed_initialize(void* cell, const void* prototype) {
+  static_cast<Var<PackedArray>*>(cell)->Initialize(
+      Read<PackedArray>(prototype));
+}
+
+void lyra_rt_cell_packed_set(void* cell, void* services, const void* value) {
+  static_cast<Var<PackedArray>*>(cell)->Set(
+      *static_cast<RuntimeServices*>(services), Read<PackedArray>(value));
+}
+
+auto lyra_rt_cell_string_get(void* cell) -> const void* {
+  return &static_cast<Var<String>*>(cell)->Get();
+}
+
+void lyra_rt_cell_string_initialize(void* cell, const void* prototype) {
+  static_cast<Var<String>*>(cell)->Initialize(Read<String>(prototype));
+}
+
+void lyra_rt_cell_string_set(void* cell, void* services, const void* value) {
+  static_cast<Var<String>*>(cell)->Set(
+      *static_cast<RuntimeServices*>(services), Read<String>(value));
+}
+
+auto lyra_rt_packed_add(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) + Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_sub(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) - Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_mul(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) * Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_div(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) / Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_mod(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) % Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_and(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) & Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_or(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) | Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_xor(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) ^ Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_eq(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) == Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_ne(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) != Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_lt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) < Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_le(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) <= Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_gt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) > Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_ge(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) >= Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_logical_and(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) && Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_logical_or(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs) || Read<PackedArray>(rhs));
+}
+
+auto lyra_rt_packed_neg(const void* operand) -> void* {
+  return Own(-Read<PackedArray>(operand));
+}
+
+auto lyra_rt_packed_not(const void* operand) -> void* {
+  return Own(~Read<PackedArray>(operand));
+}
+
+auto lyra_rt_packed_logical_not(const void* operand) -> void* {
+  return Own(!Read<PackedArray>(operand));
+}
+
+auto lyra_rt_packed_inc(const void* operand) -> void* {
+  PackedArray value = Read<PackedArray>(operand);
+  ++value;
+  return Own(std::move(value));
+}
+
+auto lyra_rt_packed_dec(const void* operand) -> void* {
+  PackedArray value = Read<PackedArray>(operand);
+  --value;
+  return Own(std::move(value));
+}
+
+auto lyra_rt_packed_to_bool(const void* operand) -> bool {
+  return static_cast<bool>(Read<PackedArray>(operand));
+}
+
+auto lyra_rt_packed_convert_from(const void* src, const void* prototype)
+    -> void* {
+  return Own(
+      PackedArray::ConvertFrom(
+          Read<PackedArray>(src), Read<PackedArray>(prototype)));
+}
+
+auto lyra_rt_packed_from_bool(bool value) -> void* {
+  return Own(PackedArray::FromBool(value));
+}
+
+auto lyra_rt_packed_to_int64(const void* value) -> std::int64_t {
+  return Read<PackedArray>(value).ToInt64();
+}
+
+auto lyra_rt_packed_is_unknown(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).IsUnknown());
+}
+
+auto lyra_rt_packed_pow(const void* base, const void* exponent) -> void* {
+  return Own(Read<PackedArray>(base).Pow(Read<PackedArray>(exponent)));
+}
+
+auto lyra_rt_packed_shift_left(const void* value, const void* amount) -> void* {
+  return Own(Read<PackedArray>(value).ShiftLeft(Read<PackedArray>(amount)));
+}
+
+auto lyra_rt_packed_logical_shift_right(const void* value, const void* amount)
+    -> void* {
+  return Own(
+      Read<PackedArray>(value).LogicalShiftRight(Read<PackedArray>(amount)));
+}
+
+auto lyra_rt_packed_arithmetic_shift_right(
+    const void* value, const void* amount) -> void* {
+  return Own(
+      Read<PackedArray>(value).ArithmeticShiftRight(Read<PackedArray>(amount)));
+}
+
+auto lyra_rt_packed_bitwise_xnor(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs).BitwiseXnor(Read<PackedArray>(rhs)));
+}
+
+auto lyra_rt_packed_logical_implication(const void* lhs, const void* rhs)
+    -> void* {
+  return Own(Read<PackedArray>(lhs).LogicalImplication(Read<PackedArray>(rhs)));
+}
+
+auto lyra_rt_packed_logical_equivalence(const void* lhs, const void* rhs)
+    -> void* {
+  return Own(Read<PackedArray>(lhs).LogicalEquivalence(Read<PackedArray>(rhs)));
+}
+
+auto lyra_rt_packed_case_equal(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs).CaseEqual(Read<PackedArray>(rhs)));
+}
+
+auto lyra_rt_packed_wildcard_equals(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs).WildcardEquals(Read<PackedArray>(rhs)));
+}
+
+auto lyra_rt_packed_casez_equals(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs).CasezEquals(Read<PackedArray>(rhs)));
+}
+
+auto lyra_rt_packed_casex_equals(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<PackedArray>(lhs).CasexEquals(Read<PackedArray>(rhs)));
+}
+
+auto lyra_rt_packed_reduction_and(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).ReductionAnd());
+}
+
+auto lyra_rt_packed_reduction_or(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).ReductionOr());
+}
+
+auto lyra_rt_packed_reduction_xor(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).ReductionXor());
+}
+
+auto lyra_rt_packed_reduction_nand(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).ReductionNand());
+}
+
+auto lyra_rt_packed_reduction_nor(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).ReductionNor());
+}
+
+auto lyra_rt_packed_reduction_xnor(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).ReductionXnor());
+}
+
+auto lyra_rt_string_from_packed_array(const void* bits) -> void* {
+  return Own(String::FromPackedArray(Read<PackedArray>(bits)));
+}
+
+auto lyra_rt_string_len(const void* value) -> void* {
+  return Own(Read<String>(value).Len());
+}
+
+auto lyra_rt_string_getc(const void* value, const void* index) -> void* {
+  return Own(Read<String>(value).Getc(Read<PackedArray>(index)));
+}
+
+auto lyra_rt_string_toupper(const void* value) -> void* {
+  return Own(Read<String>(value).Toupper());
+}
+
+auto lyra_rt_string_tolower(const void* value) -> void* {
+  return Own(Read<String>(value).Tolower());
+}
+
+auto lyra_rt_string_compare(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs).Compare(Read<String>(rhs)));
+}
+
+auto lyra_rt_string_icompare(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs).Icompare(Read<String>(rhs)));
+}
+
+auto lyra_rt_string_substr(
+    const void* value, const void* first, const void* last) -> void* {
+  return Own(
+      Read<String>(value).Substr(
+          Read<PackedArray>(first), Read<PackedArray>(last)));
+}
+
+auto lyra_rt_string_atoi(const void* value) -> void* {
+  return Own(Read<String>(value).Atoi());
+}
+
+auto lyra_rt_string_atohex(const void* value) -> void* {
+  return Own(Read<String>(value).Atohex());
+}
+
+auto lyra_rt_string_atooct(const void* value) -> void* {
+  return Own(Read<String>(value).Atooct());
+}
+
+auto lyra_rt_string_atobin(const void* value) -> void* {
+  return Own(Read<String>(value).Atobin());
+}
+
+auto lyra_rt_string_add(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs) + Read<String>(rhs));
+}
+
+auto lyra_rt_string_eq(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs) == Read<String>(rhs));
+}
+
+auto lyra_rt_string_ne(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs) != Read<String>(rhs));
+}
+
+auto lyra_rt_string_lt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs) < Read<String>(rhs));
+}
+
+auto lyra_rt_string_le(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs) <= Read<String>(rhs));
+}
+
+auto lyra_rt_string_gt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs) > Read<String>(rhs));
+}
+
+auto lyra_rt_string_ge(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<String>(lhs) >= Read<String>(rhs));
+}
+
+auto lyra_rt_make_format_spec_of_kind(const void* kind) -> void* {
+  return Own(FormatSpec(Read<PackedArray>(kind)));
+}
+
+auto lyra_rt_make_format_spec(
+    const void* kind, const void* width, const void* precision,
+    const void* zero_pad, const void* left_align, const void* timeunit_power)
+    -> void* {
+  return Own(FormatSpec(
+      Read<PackedArray>(kind), Read<PackedArray>(width),
+      Read<PackedArray>(precision), Read<PackedArray>(zero_pad),
+      Read<PackedArray>(left_align), Read<PackedArray>(timeunit_power)));
+}
+
+auto lyra_rt_make_print_value_item_packed(const void* value, const void* spec)
+    -> void* {
+  return Own(PrintItem(
+      PrintValueItem(Read<PackedArray>(value), Read<FormatSpec>(spec))));
+}
+
+auto lyra_rt_make_print_value_item_string(const void* value, const void* spec)
+    -> void* {
+  return Own(
+      PrintItem(PrintValueItem(Read<String>(value), Read<FormatSpec>(spec))));
 }
 }

--- a/src/lyra/runtime/member_storage.cpp
+++ b/src/lyra/runtime/member_storage.cpp
@@ -1,0 +1,42 @@
+#include "lyra/runtime/member_storage.hpp"
+
+#include <variant>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
+#include "lyra/runtime/scope_program.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+MemberStorage::MemberStorage(MemberStorageDescriptor descriptor) {
+  switch (descriptor.kind) {
+    case MemberStorageKind::kBorrowedHandle:
+      object_.emplace<void*>(nullptr);
+      return;
+    case MemberStorageKind::kObservableCell:
+      switch (descriptor.domain) {
+        case ValueDomain::kPacked:
+          object_.emplace<Var<value::PackedArray>>();
+          return;
+        case ValueDomain::kString:
+          object_.emplace<Var<value::String>>();
+          return;
+        case ValueDomain::kNone:
+          throw InternalError(
+              "MemberStorage: an observable cell needs a value domain");
+      }
+  }
+  throw InternalError("MemberStorage: unknown member storage kind");
+}
+
+auto MemberStorage::Address() -> void* {
+  return std::visit(
+      Overloaded{
+          [](void*& handle) -> void* { return &handle; },
+          [](auto& cell) -> void* { return &cell; }},
+      object_);
+}
+
+}  // namespace lyra::runtime

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -47,6 +47,37 @@ auto WriteHierarchicalSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+// Straight-line procedural code over the integral and string value domains:
+// module and process variables, arithmetic, comparison, a conditional
+// expression, a loop with early exits, a subroutine that writes its own
+// parameter, and a `$display` that formats values rather than a bare literal.
+auto WriteProceduralSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  int total = 0;\n"
+      << "  string name = \"lyra\";\n"
+      << "  bit [3:0] narrow;\n"
+      << "  function automatic int scale(int n);\n"
+      << "    n = n * 10;\n"
+      << "    return n;\n"
+      << "  endfunction\n"
+      << "  initial begin\n"
+      << "    for (int k = 0; k < 5; k++) begin\n"
+      << "      if (k == 2) continue;\n"
+      << "      if (k == 4) break;\n"
+      << "      total = total + k;\n"
+      << "    end\n"
+      << "    narrow = 8'hFF;\n"
+      << "    $display(\"total=%0d\", total);\n"
+      << "    $display(\"pick=%0d\", total > 3 ? 111 : 222);\n"
+      << "    $display(\"scaled=%0d\", scale(4));\n"
+      << "    $display(\"narrow=%0d\", narrow);\n"
+      << "    $display(\"name=%s eq=%0d\", name, name == \"lyra\");\n"
+      << "    if (total > 0 && total < 100) $display(\"in range\");\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -89,6 +120,41 @@ TEST(LyraRun, JitElaboratesHierarchyThroughDesignRoot) {
       << "stdout: " << run.stdout_text;
   EXPECT_NE(run.stdout_text.find("leaf ran"), std::string::npos)
       << "stdout: " << run.stdout_text;
+}
+
+// The execution backend runs procedural code: a variable is a runtime-owned
+// storage cell reached through a member place, an expression is a library call
+// over the value's domain, and structured control flow is a CFG. The two
+// backends must agree, so the same source is run through both and the outputs
+// compared rather than matched against a transcript written here.
+TEST(LyraRun, JitAndCppAgreeOnProceduralCode) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteProceduralSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_NE(jit.stdout_text.find("name=lyra eq=1"), std::string::npos)
+      << "stdout: " << jit.stdout_text;
+  EXPECT_NE(jit.stdout_text.find("scaled=40"), std::string::npos)
+      << "stdout: " << jit.stdout_text;
 }
 
 TEST(LyraCompile, ProducesPortableBuildableProject) {


### PR DESCRIPTION
## Summary

This advances the execution backend from elaborating a hierarchy of empty modules to running procedural code over the integral and string value domains: variables, expressions, structured control flow, and value-carrying formatted output. The work is centered on making LIR a real executable IR rather than a call/aggregate layer, so most of the change is the LIR place model, a control-flow graph, and the runtime ABI that realizes them, with the MIR-to-LIR lowering and the LLVM backend extended to produce and consume them.

The same SystemVerilog source now produces identical output on the C++ backend and the in-process execution backend for variables, arithmetic and comparison, `&&` / `||`, a conditional expression, `if` / `for` / `while` with `break` / `continue`, `++`, strings, integral width conversion, and a `$display` that formats values.

## Design

### Place model

A member access lowers to a place -- a base plus a projection chain -- and the use site decides what to do with it: read the value it holds, write into it, or name where it lives. LIR gains the three operations that name a place (`Load`, `Store`, `AddrOf`) and the `Deref` projection, so crossing a pointer is explicit and a member step never implicitly dereferences. A storage cell (an observable variable, a scope, an object-tree node) is address-only: it has no first-class value in LIR, so it is only ever addressed, never loaded or stored, and the verifier enforces that. Exact store-type checking forced `PointerCast` to become a real instruction carrying its destination type.

### Control-flow graph, no phi

Structured control flow flattens to basic blocks and terminators. LIR is not SSA: a local is a place exactly when the canonical lowering needs an address for it (its address is taken, it is assigned after initialization, or it holds a control-flow join), otherwise it stays a transient value. A conditional's result and a loop-carried variable are places written on each path, so there is no phi; recovering a register where the address is never truly needed is a target-side derivation below LIR (LLVM's mem2reg on the LLVM path).

### Member storage and the runtime ABI

A unit definition describes a member storage schema; a generic instance owns one storage object per member and a member place resolves to its address. The runtime ABI dispatches entirely at codegen: the entry a call names is composed from the value domain and the operator (`lyra_rt_packed_add`, `lyra_rt_string_eq`), never a runtime type tag. A single classifier maps a LIR type to its value domain, shared by the code generator and the executor so the entry a call names and the storage a cell owns cannot disagree.

## Testing

The two backends must agree, so `run_test.cpp` runs the same procedural source through both and compares stdout rather than asserting a transcript. A stale negative test (`errors.dpi_import_unsupported`), invalidated by prior DPI-C scalar-import support and verified failing identically on `origin/main`, is removed; the supported form is covered positively by `dpi_import_int` and the still-unsupported forms by the other DPI error cases.