### PR TITLE
Reclaim managed class handles via shared ownership

### DIFF
--- a/docs/decisions/object-model.md
+++ b/docs/decisions/object-model.md
@@ -97,6 +97,10 @@ cyclic garbage is part of the model, not a gap.
   (acyclic, reference-counted) one. Its lifetime is realized by precise tracing garbage collection,
   and cyclic object graphs are reclaimed by reachability. The lifetime contract and the storage
   discipline that makes tracing precise are owned by `../architecture/object_lifetime.md`.
+- A backend may realize the managed reference through shared ownership as an implementation staging
+  mechanism while other pipeline surfaces mature. This staging does not satisfy the terminal
+  managed-lifetime requirement -- cyclic reclamation remains precise tracing's job -- and does not
+  enter the semantic model any consumer reads.
 
 ## Cross-references
 

--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -77,6 +77,34 @@ each stage establishes, not how.
       record, its identity aligned with compilation-unit specialization (a stable id within a unit,
       a by-name canonical key across units) -- the same shape a parameterized module uses.
 
+## Managed-object lifetime: current implementation status
+
+The managed-object lifetime sub-step above states the terminal semantic target (precise tracing with
+cyclic reclamation). Current backend coverage:
+
+- C++ backend: shared-ownership interim. Acyclic garbage is reclaimed as the last handle drops; a
+  cycle of handles that becomes unreachable is not reclaimed. Sufficient to unblock class surface
+  work whose semantics do not depend on cyclic reclamation, which covers every SV class feature
+  planned in this workstream.
+- LLVM / JIT backend: managed execution is not implemented; a program that constructs an SV class
+  object is not lowerable through this path.
+
+Precise-tracing storage discipline and collector are deferred until a driver appears (a workload
+that hits cycle leaks in practice, or LLVM / JIT SV-class execution becoming a priority). The design
+space explored while scoping this deferral surfaced:
+
+- Runtime `Traceable` inheritance protocol is rejected: it would force every managed-carrying
+  emitted type into a runtime vtable shape and violates the mechanical-translation contract.
+- Extending the lifetime-extended-automatic-scope promoter to also spill managed locals is rejected:
+  it entangles lexical retained scope with GC root publication, two separate concerns.
+- Conservative scanning of native stack or coroutine frames is rejected by the object-lifetime
+  contract (precise-tracing invariant).
+- Candidate mechanisms for the terminal design include typed activation containers with
+  compiler-emitted descriptors, LIR-level explicit safepoint edges, per-safepoint liveness maps,
+  LLVM stackmap / statepoint integration, and coarser strategies that trace whole frames without
+  per-safepoint liveness. The trade-off between precision and infrastructure cost has not been
+  settled.
+
 ## Open Questions and Deferred Choices
 
 - Nullability stays a value-level fact, not a type axis, until an analysis that reads it (e.g.

--- a/include/lyra/runtime/gc_ref.hpp
+++ b/include/lyra/runtime/gc_ref.hpp
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <memory>
 #include <utility>
-#include <vector>
 
 namespace lyra::runtime {
 
@@ -11,55 +10,42 @@ namespace lyra::runtime {
 // heap object whose lifetime the simulator owns. Null is a legal value, copies
 // are shallow (two handles refer to the same object), and identity is compared
 // by object address.
+//
+// Realized as a shared owner: the last handle to drop releases the object. A
+// cycle of handles that becomes unreachable is not reclaimed.
 template <typename T>
 class GcRef {
  public:
   GcRef() = default;
-  // `null` (LRM 8.4) flows in as a null pointer; the implicit conversion lets a
-  // handle be assigned, initialized, and compared against `null` directly.
   GcRef(std::nullptr_t) {  // NOLINT(google-explicit-constructor)
   }
-  explicit GcRef(T* object) : object_(object) {
+  explicit GcRef(std::shared_ptr<T> ptr) : ptr_(std::move(ptr)) {
   }
 
   auto operator->() const -> T* {
-    return object_;
+    return ptr_.get();
   }
   auto operator*() const -> T& {
-    return *object_;
+    return *ptr_;
   }
   [[nodiscard]] auto Get() const -> T* {
-    return object_;
+    return ptr_.get();
   }
 
   friend auto operator==(const GcRef& a, const GcRef& b) -> bool {
-    return a.object_ == b.object_;
+    return a.ptr_.get() == b.ptr_.get();
   }
   friend auto operator!=(const GcRef& a, const GcRef& b) -> bool {
-    return a.object_ != b.object_;
+    return a.ptr_.get() != b.ptr_.get();
   }
 
  private:
-  T* object_ = nullptr;
+  std::shared_ptr<T> ptr_;
 };
 
-// The managed heap. Every allocation is retained for the life of the run and
-// reclaimed at shutdown, so a handle never dangles.
-namespace detail {
-inline auto ManagedHeap() -> std::vector<std::shared_ptr<void>>& {
-  static std::vector<std::shared_ptr<void>> heap;
-  return heap;
-}
-}  // namespace detail
-
-// Allocates a class object on the managed heap and returns a handle to it. The
-// object is retained by the heap, so the returned handle never dangles.
 template <typename T, typename... Args>
 auto GcNew(Args&&... args) -> GcRef<T> {
-  auto object = std::make_shared<T>(std::forward<Args>(args)...);
-  T* raw = object.get();
-  detail::ManagedHeap().push_back(std::move(object));
-  return GcRef<T>(raw);
+  return GcRef<T>(std::make_shared<T>(std::forward<Args>(args)...));
 }
 
 }  // namespace lyra::runtime

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -23,6 +23,15 @@ cc_test(
 )
 
 cc_test(
+    name = "runtime_gc_ref_test",
+    srcs = ["runtime/gc_ref_test.cpp"],
+    deps = [
+        "//:runtime",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "run_tests",
     srcs = ["run_test.cpp"],
     data = ["//:lyra"],

--- a/tests/cases/cpp/class_self_ref/case.yaml
+++ b/tests/cases/cpp/class_self_ref/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.class_self_ref
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    head_val: 1
+    tail_val: 2
+    chain_matches_tail: 1
+    tail_next_is_null: 1

--- a/tests/cases/cpp/class_self_ref/main.sv
+++ b/tests/cases/cpp/class_self_ref/main.sv
@@ -1,0 +1,29 @@
+// SystemVerilog class with a handle field of its own type (LRM 8): the emit
+// must forward-declare the class before its field of a handle to it is
+// materialized, and the runtime handle representation must accept the
+// forward-declared pointee.
+module Top;
+  class Node;
+    int value;
+    Node next;
+  endclass
+
+  int head_val;
+  int tail_val;
+  bit chain_matches_tail;
+  bit tail_next_is_null;
+
+  initial begin
+    Node head;
+    Node tail;
+    head = new;
+    tail = new;
+    head.value = 1;
+    tail.value = 2;
+    head.next = tail;
+    head_val = head.value;
+    tail_val = head.next.value;
+    chain_matches_tail = (head.next == tail);
+    tail_next_is_null = (tail.next == null);
+  end
+endmodule

--- a/tests/runtime/gc_ref_test.cpp
+++ b/tests/runtime/gc_ref_test.cpp
@@ -1,0 +1,91 @@
+#include "lyra/runtime/gc_ref.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Counted {
+  static inline int alive = 0;
+  Counted() {
+    ++alive;
+  }
+  Counted(const Counted&) = delete;
+  auto operator=(const Counted&) -> Counted& = delete;
+  Counted(Counted&&) = delete;
+  auto operator=(Counted&&) -> Counted& = delete;
+  ~Counted() {
+    --alive;
+  }
+};
+
+class GcRefTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    Counted::alive = 0;
+  }
+};
+
+TEST_F(GcRefTest, LastHandleDropReleasesObject) {
+  {
+    auto a = lyra::runtime::GcNew<Counted>();
+    EXPECT_EQ(Counted::alive, 1);
+  }
+  EXPECT_EQ(Counted::alive, 0);
+}
+
+TEST_F(GcRefTest, HandleCopyRetainsObject) {
+  {
+    auto a = lyra::runtime::GcNew<Counted>();
+    {
+      auto b = a;
+      EXPECT_EQ(Counted::alive, 1);
+    }
+    EXPECT_EQ(Counted::alive, 1);
+  }
+  EXPECT_EQ(Counted::alive, 0);
+}
+
+TEST_F(GcRefTest, HandleReassignmentReleasesPrevious) {
+  auto a = lyra::runtime::GcNew<Counted>();
+  a = lyra::runtime::GcNew<Counted>();
+  EXPECT_EQ(Counted::alive, 1);
+}
+
+TEST_F(GcRefTest, IdentityByObjectAddress) {
+  auto a = lyra::runtime::GcNew<Counted>();
+  auto b = a;
+  auto c = lyra::runtime::GcNew<Counted>();
+  EXPECT_EQ(a, b);
+  EXPECT_NE(a, c);
+}
+
+TEST_F(GcRefTest, NullHandleEquality) {
+  lyra::runtime::GcRef<Counted> a;
+  lyra::runtime::GcRef<Counted> b(nullptr);
+  EXPECT_EQ(a, b);
+  auto c = lyra::runtime::GcNew<Counted>();
+  EXPECT_NE(a, c);
+  c = nullptr;
+  EXPECT_EQ(c, a);
+  EXPECT_EQ(Counted::alive, 0);
+}
+
+struct Node {
+  int value = 0;
+  lyra::runtime::GcRef<Node> next;
+};
+
+TEST_F(GcRefTest, SelfReferentialAcyclicChainReclaims) {
+  auto head = lyra::runtime::GcNew<Node>();
+  auto tail = lyra::runtime::GcNew<Node>();
+  head->value = 1;
+  tail->value = 2;
+  head->next = tail;
+  EXPECT_EQ(head->next->value, 2);
+  head = nullptr;
+  tail = nullptr;
+  auto probe = lyra::runtime::GcNew<Counted>();
+  EXPECT_EQ(Counted::alive, 1);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

The managed heap that backed SV class handles retained every allocation until process exit: GcNew pushed each object into a global vector that was never released. shared_ptr-backed GcRef now releases the object when the last handle drops, so acyclic garbage is reclaimed as it becomes unreachable and the common allocate-and-discard case no longer grows without bound. Cyclic garbage still leaks; reclaiming it stays in the terminal precise-tracing design.

## Design

GcRef<T> and GcNew<T> keep their names and MIR-facing type mapping unchanged. No MIR, LIR, or HIR change is needed, and the C++ backend renders identically to before; the change is scoped to the runtime header.

This is an implementation staging mechanism, not the terminal managed lifetime the object-model decision commits to. Precise-tracing collection that reclaims cyclic garbage remains the target for the C++ backend, and the LLVM / JIT path still does not lower ManagedRefType at all. Both are recorded in the progress doc, and the decision doc gains a one-line clarification that a backend may realize the reference through shared ownership while other pipeline surfaces mature.

## Testing

A runtime unit test verifies handle reclamation directly, using a Counted type that tracks live instance counts. Cases covered: last-handle-drop releases the object, copy retains, reassignment releases the previous owner, identity is by object address, null equality, and self-referential acyclic chains reclaim once broken.

A new SV case class_self_ref exercises the emit path for a class with a handle field of its own type (`class Node; Node next; endclass`), verifying that the shared-ownership rewrite does not disturb the C++ backend's forward-declaration emit pattern.