### PR TITLE
Unify the activation's terminal outcome in a completion slot

### DIFF
--- a/docs/progress/activation.md
+++ b/docs/progress/activation.md
@@ -14,14 +14,13 @@ or incomplete relative to the contract.
 
 ## Items
 
-- [ ] **The terminal outcome is split, not unified.** Contract invariant 2: an activation settles
-      one completion slot holding `Succeeded(T)` / `Faulted(exception)` / `Cancelled`, and the
-      scheduler-visible execution core carries none of it. Current shape: the success value lives in
-      the typed completion storage, but the exception is carried by the scheduler-visible execution
-      core, separate from the value. That is wrong -- the exception is part of the terminal outcome,
-      not execution control. Target: one completion slot owns the whole outcome (value and
-      exception, later cancellation); a consumer reads a single terminal outcome; the execution core
-      the scheduler sees is purely suspend / resume / wait state / identity. Unblocked; doable now.
+- [x] **The terminal outcome is unified.** Contract invariant 2: an activation settles one
+      completion slot holding `Succeeded(T)` / `Faulted(exception)` / `Cancelled`, and the
+      scheduler-visible execution core carries none of it. The value and the exception now travel
+      together in one typed completion slot held off the scheduler-visible core; a consumer reads
+      the whole outcome once, which re-raises a fault or yields the value. The execution core the
+      scheduler sees is purely suspend / resume / wait state / identity. The `Cancelled` alternative
+      is not yet present -- it joins the same slot with the cancellation model below.
 
 - [ ] **Registrations are only partly revocable.** Contract invariant 4: every external reference to
       a parked activation -- a region queue slot, a delay slot, an event waiter entry, a
@@ -44,13 +43,15 @@ or incomplete relative to the contract.
       state is outcome-neutral, ready to carry `Cancelled`; but there is no cancellation path and no
       `Cancelled` outcome yet. Target: the full cancellation model behind `disable` / `disable fork`
       (LRM 9.6.x). Blocked on the `disable` language feature; the activation lifetime must not
-      foreclose it (it does not -- frame ownership already cascades, and the registration-set and
-      outcome-unification items above are the remaining prerequisites).
+      foreclose it (it does not -- frame ownership already cascades, and the completion slot now
+      holds a unified outcome ready for a `Cancelled` alternative, leaving the registration-set item
+      above as the remaining substrate prerequisite).
 
 - [ ] **Runtime vocabulary trails the model.** The execution code names the activation and its core
       in coroutine-implementation terms; the contract's vocabulary is activation / completion slot /
       cancellation domain / join state, with the coroutine mechanics as one realization. The
-      execution-state axis is now named for the model -- a process's states are execution states,
-      and its end state is outcome-neutral termination rather than "completed" -- but the
-      completion-slot and join-state vocabulary still trails. Rename the rest where it clarifies the
-      boundary between execution control and completion. Low priority; unblocked.
+      execution-state axis is named for the model -- a process's states are execution states, and
+      its end state is outcome-neutral termination rather than "completed" -- and the terminal
+      outcome is now a named completion slot; the join-state vocabulary still trails. Rename the
+      rest where it clarifies the boundary between execution control and completion. Low priority;
+      unblocked.

--- a/include/lyra/runtime/coroutine.hpp
+++ b/include/lyra/runtime/coroutine.hpp
@@ -3,9 +3,8 @@
 #include <coroutine>
 #include <exception>
 #include <functional>
-#include <optional>
-#include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
@@ -25,7 +24,6 @@ class WakeRegistration;
 // (recovering a promise from a frame address is not a portable ABI, so the
 // handle is stored at construction, not derived).
 struct PromiseBase {
-  std::exception_ptr pending_exception;
   RuntimeProcess* process = nullptr;
   std::coroutine_handle<> continuation;
   std::vector<Observable*> pending_value_change_subscriptions;
@@ -83,10 +81,6 @@ struct PromiseBase {
     return FinalAwaiter{.promise = this};
   }
 
-  void unhandled_exception() noexcept {
-    pending_exception = std::current_exception();
-  }
-
   [[nodiscard]] auto Process() const -> RuntimeProcess& {
     if (process == nullptr) {
       throw InternalError(
@@ -101,23 +95,66 @@ struct PromiseBase {
 // a frame goes through `token->self`.
 using CoroutineHandle = PromiseBase*;
 
-// The completion-value storage split, kept off `PromiseBase` so the scheduler
-// never sees `T`: a value-completing frame keeps the produced value until the
-// awaiter moves it out; a void-completing frame keeps nothing. `std::optional`
-// because `T` need not be default-constructible and "not yet produced" (e.g. an
-// exceptional exit) is a real state.
+// The single typed terminal outcome an activation settles: a produced value or
+// an exception (a cancellation will join as a third alternative). Kept off
+// `PromiseBase` so the scheduler never sees `T` or the outcome. The slot stores
+// the outcome and hands it to the activation's one consumer; whether a fault is
+// re-raised in place or extracted first and re-raised after the frame is torn
+// down is the consumer's decision, not the slot's. The alternatives are
+// mutually exclusive -- a frame runs `return_value` / `return_void` xor
+// `unhandled_exception` -- and the initial monostate is the not-yet-settled
+// state, never read because a consumer only takes the outcome after the frame
+// is done.
 template <class T>
-struct CoroutineResult {
-  std::optional<T> result;
+class CompletionSlot {
+ public:
   void return_value(T value) {
-    result = std::move(value);
+    outcome_.template emplace<Value>(std::move(value));
   }
+  void unhandled_exception() noexcept {
+    outcome_.template emplace<std::exception_ptr>(std::current_exception());
+  }
+  auto Take() -> T {
+    if (auto* exc = std::get_if<std::exception_ptr>(&outcome_)) {
+      std::rethrow_exception(*exc);
+    }
+    return std::move(std::get<Value>(outcome_).held);
+  }
+
+ private:
+  struct Value {
+    T held;
+  };
+  std::variant<std::monostate, Value, std::exception_ptr> outcome_;
 };
 
 template <>
-struct CoroutineResult<void> {
+class CompletionSlot<void> {
+ public:
   void return_void() {
+    outcome_.emplace<Succeeded>();
   }
+  void unhandled_exception() noexcept {
+    outcome_.emplace<std::exception_ptr>(std::current_exception());
+  }
+  // Hands the fault out without raising it (null when the activation
+  // succeeded), so a consumer that must run its own teardown before the fault
+  // propagates can settle first and re-raise the returned outcome afterward.
+  auto TakeFault() -> std::exception_ptr {
+    if (auto* exc = std::get_if<std::exception_ptr>(&outcome_)) {
+      return std::move(*exc);
+    }
+    return nullptr;
+  }
+  void Take() {
+    if (auto fault = TakeFault()) {
+      std::rethrow_exception(fault);
+    }
+  }
+
+ private:
+  struct Succeeded {};
+  std::variant<std::monostate, Succeeded, std::exception_ptr> outcome_;
 };
 
 // A suspendable activation that completes with a value of `T` -- a task body,
@@ -133,7 +170,7 @@ struct CoroutineResult<void> {
 template <class T>
 class Coroutine {
  public:
-  struct promise_type : PromiseBase, CoroutineResult<T> {
+  struct promise_type : PromiseBase, CompletionSlot<T> {
     auto get_return_object() -> Coroutine {
       auto handle = std::coroutine_handle<promise_type>::from_promise(*this);
       self = handle;
@@ -176,13 +213,7 @@ class Coroutine {
     return handle_;
   }
   auto await_resume() -> T {
-    if (auto exc =
-            std::exchange(handle_.promise().pending_exception, nullptr)) {
-      std::rethrow_exception(exc);
-    }
-    if constexpr (!std::is_void_v<T>) {
-      return std::move(*handle_.promise().result);
-    }
+    return handle_.promise().Take();
   }
 
   [[nodiscard]] auto Handle() const -> std::coroutine_handle<promise_type> {

--- a/src/lyra/runtime/runtime_process.cpp
+++ b/src/lyra/runtime/runtime_process.cpp
@@ -1,6 +1,7 @@
 #include "lyra/runtime/runtime_process.hpp"
 
 #include <cstddef>
+#include <exception>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -104,17 +105,19 @@ auto RuntimeProcess::ResumeWith(
     const ExecutionContextGuard guard(context, *this);
     handle->self.resume();
   }
-  // A task's exception propagates up the enable chain to the top-level promise,
-  // so it is read there regardless of which frame threw.
-  if (auto exc = std::exchange(
-          coroutine_.Handle().promise().pending_exception, nullptr)) {
-    std::rethrow_exception(exc);
-  }
   if (!coroutine_.Done()) {
     execution_state_ = ProcessExecutionState::kWaiting;
     return false;
   }
+  // A task's exception has propagated up the enable chain into this top-level
+  // frame regardless of which frame threw. Take the fault out before releasing
+  // the frame so a faulted process reaches its terminal state and frees its
+  // frame on the same path a successful one does, then re-raise it.
+  std::exception_ptr fault = coroutine_.Handle().promise().TakeFault();
   SettleTerminated();
+  if (fault) {
+    std::rethrow_exception(fault);
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary

An activation settles one terminal outcome: a produced value, an exception, or (later) a cancellation. The success value already lived off the scheduler-visible promise base, but the exception was carried on it, splitting the outcome across the execution core the scheduler sees and the typed storage it does not. This moves the exception into a single typed `CompletionSlot` held off `PromiseBase`, so the value and the fault travel together as one outcome and the scheduler-visible core is purely suspend / resume / wait state / identity. Both the task-enable boundary and the process top now read the whole outcome through one `Take`, and the slot is a tagged `variant` that a `Cancelled` alternative extends without reshaping.

The process top now settles termination before re-raising a fault: it takes the fault out of the slot, reaches its terminal state and frees its frame on the same path a successful body does, then re-raises. This keeps the faulted and successful termination paths uniform, which is the shape the cancellation model will build on.

## Testing

`bazel test //...` green.