### PR TITLE
Support class constructors and property initializers

### DIFF
--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -28,10 +28,17 @@ struct ClassField {
 // reached through a handle, so it carries no structural position of its own.
 // Each method (LRM 8.6) is a subroutine reached through the instance, so its
 // body reads the receiver and the class's properties through the receiver.
+//
+// `constructor` is the user-written `function new` (LRM 8.7) when the class
+// declares one -- a subroutine like any other, distinguished by naming the
+// construction slot rather than the method set. Absent when the class relies on
+// the implicit default construction; HIR-to-MIR synthesizes the empty body in
+// that case.
 struct ClassDecl {
   std::string name;
   std::vector<ClassField> fields;
   std::vector<SubroutineDecl> methods;
+  std::optional<SubroutineDecl> constructor;
   base::Arena<Expr, ExprId> exprs;
 };
 

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -4,8 +4,6 @@
 #include <string>
 #include <vector>
 
-#include "lyra/base/arena.hpp"
-#include "lyra/hir/expr.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -14,32 +12,33 @@ namespace lyra::hir {
 
 // A class property (LRM 8.4): a named member variable of a class, with its own
 // per-object storage. `initializer`, when present, is the declared `= value`
-// expression in the class's own `exprs` arena; absent means the property takes
-// its type's Table 7-1 default at construction.
+// expression (LRM 8.7): during construction the property is set to this value
+// -- which may read another property through the receiver -- before the user
+// constructor body runs; absent means the property takes its type's Table 7-1
+// default. Property initialization is part of the constructor's execution, so
+// the expression is held in the constructor body's expression arena.
 struct ClassField {
   std::string name;
   TypeId type;
   std::optional<ExprId> initializer;
 };
 
-// A SystemVerilog class declaration (LRM 8). The class's properties, its
-// instance methods, and the expressions their initializers reference;
-// references to a class name resolve to this declaration's id. A class is
-// reached through a handle, so it carries no structural position of its own.
-// Each method (LRM 8.6) is a subroutine reached through the instance, so its
-// body reads the receiver and the class's properties through the receiver.
+// A SystemVerilog class declaration (LRM 8). The class's properties and its
+// instance methods; references to a class name resolve to this declaration's
+// id. A class is reached through a handle, so it carries no structural position
+// of its own. Each method (LRM 8.6) is a subroutine reached through the
+// instance, reading the receiver and the class's properties through it.
 //
-// `constructor` is the user-written `function new` (LRM 8.7) when the class
-// declares one -- a subroutine like any other, distinguished by naming the
-// construction slot rather than the method set. Absent when the class relies on
-// the implicit default construction; HIR-to-MIR synthesizes the empty body in
-// that case.
+// `constructor` is the class's `new` (LRM 8.7). Every class has one: the
+// user-written `function new` when the source declares it, otherwise a
+// synthesized empty constructor, matching the implicit `new` the LRM provides
+// when the source omits one. Property initializers are evaluated as part of its
+// execution, so their expressions live in its body's expression arena.
 struct ClassDecl {
   std::string name;
   std::vector<ClassField> fields;
   std::vector<SubroutineDecl> methods;
-  std::optional<SubroutineDecl> constructor;
-  base::Arena<Expr, ExprId> exprs;
+  SubroutineDecl constructor;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -175,10 +175,11 @@ struct DynamicArrayNewExpr {
 
 // LRM 8.5 class object construction `new`. Allocates a new object of the named
 // class and runs its constructor, yielding a handle. The class is named by its
-// declaration id; `Expr::type` is the class handle type. Carries no constructor
-// arguments (the default `new`).
+// declaration id; `Expr::type` is the class handle type. `arguments` are the
+// constructor actuals (LRM 8.7), empty for the default `new`.
 struct ClassNewExpr {
   ClassId class_id;
+  std::vector<ExprId> arguments;
 };
 
 // LRM 7.9.11 associative-array literal `'{index: value, ..., default: d}`. Each

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -111,6 +111,17 @@ class ProcessLowerer {
   // initializers are drained the same way as for a process body.
   auto Run(const hir::SubroutineDecl& src) -> diag::Result<mir::MethodDecl>;
 
+  // Lowers a user-written constructor body (LRM 8.7) into an already-open
+  // constructor frame. Registers each input formal as a body local -- appending
+  // its MIR local to `params` after the receiver the caller seeded -- then
+  // walks the body's statements into `frame.current_block`, after the
+  // field-init prologue the caller composed there. A non-input constructor
+  // formal is rejected at AST-to-HIR, so one reaching here is a compiler-bug
+  // invariant.
+  auto LowerConstructorBodyInto(
+      const hir::SubroutineDecl& ctor, const WalkFrame& frame,
+      std::vector<mir::LocalId>& params) -> diag::Result<void>;
+
   // Central expression dispatcher. One switch over `hir::Expr::data` routing
   // each kind to its per-family handler; handlers recurse through this
   // method, so sub-expressions reach `frame` through it. An observable-cell

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -125,11 +125,14 @@ auto RenderConstructor(
   };
 
   std::vector<std::string> sig_args;
+  std::vector<std::string> forward_names;
   sig_args.reserve(ctor_code.params.size());
+  forward_names.reserve(ctor_code.params.size());
   // Skip params[0] (self, MIR contract); the C++ ctor's receiver is `this`.
   for (std::size_t i = 1; i < ctor_code.params.size(); ++i) {
     const auto& p = ctor_code.locals.Get(ctor_code.params[i]);
     sig_args.push_back(render_typed_name(p.type, p.name));
+    forward_names.emplace_back(p.name);
   }
 
   std::vector<std::string> init_parts;
@@ -163,15 +166,30 @@ auto RenderConstructor(
                 JoinCommaSeparated(init_parts));
 
   // The C++ ctor is an allocation shell that forwards to the base and the
-  // field members, then hands off to a static `init(self)` -- the same
+  // field members, then hands off to a static `init(self, ...)` -- the same
   // static-over-self shape every method render uses, so a body-local self
-  // reference resolves as `self` here just like in any other body.
+  // reference resolves as `self` here just like in any other body. The
+  // constructor formals ride alongside `self` so the body reaches them the same
+  // way it reaches any parameter.
+  std::vector<std::string> init_params;
+  init_params.reserve(sig_args.size() + 1);
+  init_params.push_back(std::format("{}* self", cpp_name));
+  for (const std::string& arg : sig_args) {
+    init_params.push_back(arg);
+  }
+  std::vector<std::string> init_call_args;
+  init_call_args.reserve(forward_names.size() + 1);
+  init_call_args.emplace_back("this");
+  for (const std::string& name : forward_names) {
+    init_call_args.push_back(name);
+  }
   return std::format(
-      "{0}{1} {{ init(this); }}\n"
-      "{0}static auto init({2}* self) -> void {{\n"
-      "{3}"
+      "{0}{1} {{ init({2}); }}\n"
+      "{0}static auto init({3}) -> void {{\n"
+      "{4}"
       "{0}}}\n",
-      Indent(indent), sig, cpp_name,
+      Indent(indent), sig, JoinCommaSeparated(init_call_args),
+      JoinCommaSeparated(init_params),
       RenderBlockStatements(scope_view, indent + 1));
 }
 

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -849,9 +849,7 @@ class HirDumper {
     for (std::size_t i = 0; i < c.methods.size(); ++i) {
       DumpSubroutine("Method", i, c.methods[i]);
     }
-    if (c.constructor.has_value()) {
-      DumpSubroutine("Constructor", 0, *c.constructor);
-    }
+    DumpSubroutine("Constructor", 0, c.constructor);
     Dedent();
   }
 

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -753,8 +753,14 @@ class HirDumper {
                   "DynamicArrayNewExpr size=Expr[{}]", n.size.value);
             },
             [](const ClassNewExpr& n) -> std::string {
+              std::string args;
+              for (std::size_t i = 0; i < n.arguments.size(); ++i) {
+                if (i != 0) args += ", ";
+                args += std::format("Expr[{}]", n.arguments[i].value);
+              }
               return std::format(
-                  "ClassNewExpr class=Class[{}]", n.class_id.value);
+                  "ClassNewExpr class=Class[{}] args=[{}]", n.class_id.value,
+                  args);
             },
             [](const AssociativeAssignmentPatternExpr& a) -> std::string {
               std::string entries;
@@ -842,6 +848,9 @@ class HirDumper {
     }
     for (std::size_t i = 0; i < c.methods.size(); ++i) {
       DumpSubroutine("Method", i, c.methods[i]);
+    }
+    if (c.constructor.has_value()) {
+      DumpSubroutine("Constructor", 0, *c.constructor);
     }
     Dedent();
   }

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -213,12 +213,15 @@ auto LowerNewClassExpr(
         span, diag::DiagCode::kUnsupportedClassFeature,
         "super.new is not yet supported");
   }
-  if (const auto* call = nc.constructorCall();
-      call != nullptr &&
-      !call->as<slang::ast::CallExpression>().arguments().empty()) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedClassFeature,
-        "class constructor arguments are not yet supported");
+  std::vector<hir::ExprId> arguments;
+  if (const auto* call = nc.constructorCall(); call != nullptr) {
+    const auto& actuals = call->as<slang::ast::CallExpression>().arguments();
+    arguments.reserve(actuals.size());
+    for (const auto* actual : actuals) {
+      auto arg_or = lowerer.LowerExpr(*actual, frame);
+      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+      arguments.push_back(frame.Exprs().Add(*std::move(arg_or)));
+    }
   }
   const auto& cls = nc.type->getCanonicalType().as<slang::ast::ClassType>();
   auto class_id = module.InternClass(cls, span);
@@ -227,7 +230,9 @@ auto LowerNewClassExpr(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
-      .data = hir::ClassNewExpr{.class_id = *class_id},
+      .data =
+          hir::ClassNewExpr{
+              .class_id = *class_id, .arguments = std::move(arguments)},
       .span = span,
   };
 }

--- a/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
@@ -141,19 +141,20 @@ auto LowerStatementListStmt(
         body_frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
   }
 
-  if (frame.current_structural_scope == nullptr) {
-    throw InternalError(
-        "LowerStatementListStmt: statement list has no enclosing structural "
-        "scope to register its lexical scope against");
+  // A class method / constructor body sits inside no structural scope (LRM 8):
+  // its lexical scopes are not hierarchically addressable and no consumer reads
+  // the scope record, so the block registers none -- matching the guard the
+  // body's root scope already gets. In a structural scope the record is
+  // registered and the block names it.
+  std::optional<hir::ProceduralScopeId> scope_id;
+  if (frame.current_structural_scope != nullptr) {
+    scope_id = frame.current_structural_scope->procedural_scopes.Add(
+        hir::ProceduralScopeDecl{
+            .label = std::nullopt,
+            .direct_declarations = std::move(nested_declarations),
+            .direct_child_scopes = std::move(nested_children)});
+    frame.current_scope_children->push_back(*scope_id);
   }
-  const hir::ProceduralScopeId scope_id =
-      frame.current_structural_scope->procedural_scopes.Add(
-          hir::ProceduralScopeDecl{
-              .label = std::nullopt,
-              .direct_declarations = std::move(nested_declarations),
-              .direct_child_scopes = std::move(nested_children)});
-
-  frame.current_scope_children->push_back(scope_id);
 
   return hir::Stmt{
       .label = std::nullopt,
@@ -204,19 +205,20 @@ auto LowerBlockStmt(
         body_frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
   }
 
-  if (frame.current_structural_scope == nullptr) {
-    throw InternalError(
-        "LowerBlockStmt: begin/end body has no enclosing structural scope "
-        "to register its lexical scope against");
+  // A class method / constructor body sits inside no structural scope (LRM 8):
+  // its begin/end lexical scopes are not hierarchically addressable and no
+  // consumer reads the scope record, so the block registers none -- matching
+  // the guard the body's root scope already gets. In a structural scope the
+  // record is registered and the block names it.
+  std::optional<hir::ProceduralScopeId> scope_id;
+  if (frame.current_structural_scope != nullptr) {
+    scope_id = frame.current_structural_scope->procedural_scopes.Add(
+        hir::ProceduralScopeDecl{
+            .label = label,
+            .direct_declarations = std::move(nested_declarations),
+            .direct_child_scopes = std::move(nested_children)});
+    frame.current_scope_children->push_back(*scope_id);
   }
-  const hir::ProceduralScopeId scope_id =
-      frame.current_structural_scope->procedural_scopes.Add(
-          hir::ProceduralScopeDecl{
-              .label = label,
-              .direct_declarations = std::move(nested_declarations),
-              .direct_child_scopes = std::move(nested_children)});
-
-  frame.current_scope_children->push_back(scope_id);
 
   return hir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -487,9 +487,18 @@ auto ModuleLowerer::InternClass(
       continue;
     }
     if (method.flags.has(slang::ast::MethodFlags::Constructor)) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedClassFeature,
-          "user-defined class constructors are not yet supported");
+      for (const auto* formal : method.getArguments()) {
+        if (formal->direction != slang::ast::ArgumentDirection::In) {
+          return diag::Fail(
+              span, diag::DiagCode::kUnsupportedClassFeature,
+              "a constructor with an output / inout / ref argument is not yet "
+              "supported");
+        }
+      }
+      auto ctor_decl = LowerSubroutineDecl(*this, method, WalkFrame{});
+      if (!ctor_decl) return std::unexpected(std::move(ctor_decl.error()));
+      decl.constructor = *std::move(ctor_decl);
+      continue;
     }
     if (method.flags.has(slang::ast::MethodFlags::Static)) {
       return diag::Fail(

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -21,10 +21,15 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
+#include "lyra/hir/class_decl.hpp"
 #include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -447,6 +452,28 @@ auto TranslateTypeData(
   }
 }
 
+// LRM 8.7: a class the source declares without a `function new` still has a
+// constructor -- the implicit `new`, whose only effect is the property
+// initialization every class performs. It is modeled as a constructor with no
+// formals and an empty body; the initialization itself is composed onto the
+// body separately, the same way it is for a user-written constructor.
+auto SynthesizeDefaultConstructor(hir::TypeId void_type, diag::SourceSpan span)
+    -> hir::SubroutineDecl {
+  hir::ProceduralBody body;
+  body.root_stmt = body.stmts.Add(
+      hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::BlockStmt{.statements = {}, .scope = std::nullopt},
+          .span = span});
+  return hir::SubroutineDecl{
+      .name = "new",
+      .kind = hir::SubroutineKind::kFunction,
+      .result_type = void_type,
+      .params = {},
+      .result_var = std::nullopt,
+      .body = std::move(body)};
+}
+
 }  // namespace
 
 auto ModuleLowerer::InternClass(
@@ -467,11 +494,6 @@ auto ModuleLowerer::InternClass(
           span, diag::DiagCode::kUnsupportedClassFeature,
           "static class properties are not yet supported");
     }
-    if (prop.getInitializer() != nullptr) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedClassFeature,
-          "class property initializers are not yet supported");
-    }
     auto field_type = InternType(prop.getType(), span);
     if (!field_type) return std::unexpected(std::move(field_type.error()));
     decl.fields.push_back(
@@ -480,6 +502,7 @@ auto ModuleLowerer::InternClass(
             .type = *field_type,
             .initializer = std::nullopt});
   }
+  std::optional<hir::SubroutineDecl> user_constructor;
   for (const auto& method : cls.membersOfType<slang::ast::SubroutineSymbol>()) {
     // Every class carries compiler-generated built-ins (the randomize family,
     // LRM 18.6); they are provided by the runtime, not lowered from source.
@@ -497,7 +520,7 @@ auto ModuleLowerer::InternClass(
       }
       auto ctor_decl = LowerSubroutineDecl(*this, method, WalkFrame{});
       if (!ctor_decl) return std::unexpected(std::move(ctor_decl.error()));
-      decl.constructor = *std::move(ctor_decl);
+      user_constructor = *std::move(ctor_decl);
       continue;
     }
     if (method.flags.has(slang::ast::MethodFlags::Static)) {
@@ -520,6 +543,34 @@ auto ModuleLowerer::InternClass(
     if (!method_decl) return std::unexpected(std::move(method_decl.error()));
     decl.methods.push_back(*std::move(method_decl));
   }
+
+  hir::SubroutineDecl constructor =
+      user_constructor.has_value()
+          ? *std::move(user_constructor)
+          : SynthesizeDefaultConstructor(unit_.builtins.void_type, span);
+
+  // A property initializer (LRM 8.7) runs during construction and may read
+  // another property through the receiver, so it lowers on the procedural path
+  // -- the one that resolves a property name to a receiver-relative reference
+  // -- into the constructor body's expression arena that holds it. The class is
+  // the containing symbol so any structural name in the initializer routes from
+  // the class's position.
+  ProcessLowerer init_lowerer(*this, cls);
+  const WalkFrame init_frame = WalkFrame{}.WithProceduralBody(
+      &constructor.body, &constructor.body.exprs);
+  std::size_t field_index = 0;
+  for (const auto& prop :
+       cls.membersOfType<slang::ast::ClassPropertySymbol>()) {
+    if (const auto* init = prop.getInitializer(); init != nullptr) {
+      auto init_expr = init_lowerer.LowerExpr(*init, init_frame);
+      if (!init_expr) return std::unexpected(std::move(init_expr.error()));
+      decl.fields[field_index].initializer =
+          constructor.body.exprs.Add(*std::move(init_expr));
+    }
+    ++field_index;
+  }
+  decl.constructor = std::move(constructor);
+
   unit_.classes.Define(id, std::move(decl));
   return id;
 }

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -84,39 +85,44 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
     ctor_block.AppendStmt(mir::ExprStmt{.expr = assign});
   }
 
-  // Pre-declare each method's static-lifetime body locals as members on
-  // this class before any method body lowers. A static local has per-
-  // instance storage that outlives every activation of its body (LRM
-  // 13.3.1); an SV class has no named-procedural-block hierarchy, so every
-  // static lives directly on the enclosing SV class. The mangled name
-  // (`<method>__<source>_<hir_id>`) keeps sibling methods that reuse a
-  // source identifier from colliding on the field arena; the `hir_id`
-  // suffix distinguishes nested-block reuses too.
+  // Pre-declare a callable's static-lifetime body locals as members on this
+  // class before any body lowers. A static local has per-instance storage that
+  // outlives every activation of its body (LRM 13.3.1); an SV class has no
+  // named-procedural-block hierarchy, so every static lives directly on the
+  // enclosing SV class. The mangled name (`<callable>__<source>_<hir_id>`)
+  // keeps sibling callables that reuse a source identifier from colliding on
+  // the field arena; the `hir_id` suffix distinguishes nested-block reuses too.
   //
-  // The materialization table is empty because there are no procedural-
-  // storage scopes inside class methods; the per-method plans still need a
-  // reference for the API.
-  ProceduralScopeMaterializationTable method_scopes;
-  std::vector<CallableStoragePlan> method_plans;
-  method_plans.reserve(hir_class.methods.size());
-  for (const auto& method : hir_class.methods) {
+  // The materialization table is empty because there are no procedural-storage
+  // scopes inside class bodies; the per-callable plans still need a reference
+  // for the API.
+  ProceduralScopeMaterializationTable class_scopes;
+  const auto plan_static_storage = [&](std::string_view callable_name,
+                                       const hir::ProceduralBody& body) {
     std::vector<std::optional<StaticStoragePlacement>> placements(
-        method.body.procedural_vars.size());
-    for (std::size_t j = 0; j < method.body.procedural_vars.size(); ++j) {
+        body.procedural_vars.size());
+    for (std::size_t j = 0; j < body.procedural_vars.size(); ++j) {
       const hir::ProceduralVarId var_id{static_cast<std::uint32_t>(j)};
-      const auto& v = method.body.procedural_vars.Get(var_id);
+      const auto& v = body.procedural_vars.Get(var_id);
       if (v.lifetime != hir::VariableLifetime::kStatic) {
         continue;
       }
       const std::string mangled =
-          std::format("{}__{}_{}", method.name, v.name, j);
+          std::format("{}__{}_{}", callable_name, v.name, j);
       const mir::TypeId type = module.TranslateType(v.type);
       const mir::FieldId mid =
           mir_class.fields.Add(mir::FieldDecl{.name = mangled, .type = type});
       placements[j] = StaticStoragePlacement{
           .owner = StorageOwner{EnclosingClass{}}, .field = mid};
     }
-    method_plans.emplace_back(method_scopes, std::move(placements));
+    return placements;
+  };
+
+  std::vector<CallableStoragePlan> method_plans;
+  method_plans.reserve(hir_class.methods.size());
+  for (const auto& method : hir_class.methods) {
+    method_plans.emplace_back(
+        class_scopes, plan_static_storage(method.name, method.body));
   }
 
   // Each instance method (LRM 8.6) is lowered as a callable this class owns: it
@@ -144,7 +150,32 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
     }
   }
 
-  ctor_code.params = {self_id};
+  // The user-written `function new` body (LRM 8.7) runs after each property
+  // takes its default, so its statements follow the field-init prologue already
+  // in the constructor body. Its input formals extend the constructor signature
+  // past the receiver. Absent when the class relies on implicit default
+  // construction.
+  std::vector<mir::LocalId> ctor_params{self_id};
+  if (hir_class.constructor.has_value()) {
+    const hir::SubroutineDecl& ctor = *hir_class.constructor;
+    const CallableStoragePlan ctor_plan(
+        class_scopes, plan_static_storage("<ctor>", ctor.body));
+    ProcessLowerer ctor_lowerer(
+        module, nullptr, mir_class.time_resolution, ctor.body, "<ctor>",
+        mir::MethodVisibility::kInternal, frame, ctor_plan);
+    auto ctor_body_or =
+        ctor_lowerer.LowerConstructorBodyInto(ctor, frame, ctor_params);
+    if (!ctor_body_or) {
+      return std::unexpected(std::move(ctor_body_or.error()));
+    }
+    for (const auto& pending : ctor_lowerer.TakePendingStaticInitializers()) {
+      auto integ = IntegratePendingStaticInitializer(
+          ctor_lowerer, ctor.body, frame, pending);
+      if (!integ) return std::unexpected(std::move(integ.error()));
+    }
+  }
+
+  ctor_code.params = std::move(ctor_params);
   ctor_code.result_type = module.Unit().builtins.void_type;
   const mir::MethodId ctor_method_id = mir_class.methods.Add(
       mir::MethodDecl{

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -67,22 +67,19 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
                               .WithBlock(&ctor_block)
                               .WithBindings(&ctor_bindings);
 
-  // A class property owns its storage directly -- it is not an observable cell,
-  // so it is a plain value-typed member and its construction-time default is a
-  // plain assignment through `self`, not an observable `Set`.
+  // Declare each class property (LRM 8.4) as a value-typed member -- a property
+  // owns its storage directly and is not an observable cell. Declaration order
+  // is preserved so a receiver-relative property reference in an initializer or
+  // a method body indexes the same member.
+  std::vector<mir::FieldId> field_ids;
+  std::vector<mir::TypeId> field_types;
+  field_ids.reserve(hir_class.fields.size());
+  field_types.reserve(hir_class.fields.size());
   for (const auto& field : hir_class.fields) {
     const mir::TypeId field_type = module.TranslateType(field.type);
-    const mir::FieldId field_id = mir_class.fields.Add(
-        mir::FieldDecl{.name = field.name, .type = field_type});
-    const mir::ExprId default_id = ctor_block.exprs.Add(
-        BuildDefaultValueFromHir(module, frame, field.type));
-    const mir::ExprId self_ref =
-        ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_pointer_type));
-    const mir::ExprId target = ctor_block.exprs.Add(
-        mir::MakeFieldAccessExpr(self_ref, field_id, field_type));
-    const mir::ExprId assign = ctor_block.exprs.Add(
-        mir::MakeAssignExpr(target, default_id, field_type));
-    ctor_block.AppendStmt(mir::ExprStmt{.expr = assign});
+    field_ids.push_back(mir_class.fields.Add(
+        mir::FieldDecl{.name = field.name, .type = field_type}));
+    field_types.push_back(field_type);
   }
 
   // Pre-declare a callable's static-lifetime body locals as members on this
@@ -92,6 +89,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   // enclosing SV class. The mangled name (`<callable>__<source>_<hir_id>`)
   // keeps sibling callables that reuse a source identifier from colliding on
   // the field arena; the `hir_id` suffix distinguishes nested-block reuses too.
+  // These trail the property members, so property indices stay stable.
   //
   // The materialization table is empty because there are no procedural-storage
   // scopes inside class bodies; the per-callable plans still need a reference
@@ -125,6 +123,40 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
         class_scopes, plan_static_storage(method.name, method.body));
   }
 
+  const hir::SubroutineDecl& ctor = hir_class.constructor;
+  const CallableStoragePlan ctor_plan(
+      class_scopes, plan_static_storage("<ctor>", ctor.body));
+  ProcessLowerer ctor_lowerer(
+      module, nullptr, mir_class.time_resolution, ctor.body, "<ctor>",
+      mir::MethodVisibility::kInternal, frame, ctor_plan);
+
+  // Initialize each property in declaration order before the constructor body
+  // runs (LRM 8.7): a property with an explicit initializer takes that value --
+  // lowered through the constructor lowerer so a property read resolves against
+  // the receiver -- and one without takes its type's Table 7-1 default. The
+  // ordering is the single declaration-order pass because an initializer may
+  // read an earlier property whose own initialization has already run.
+  for (std::size_t i = 0; i < hir_class.fields.size(); ++i) {
+    const hir::ClassField& field = hir_class.fields[i];
+    mir::ExprId value_id{};
+    if (field.initializer.has_value()) {
+      auto value_or = ctor_lowerer.LowerExpr(
+          ctor.body.exprs.Get(*field.initializer), frame);
+      if (!value_or) return std::unexpected(std::move(value_or.error()));
+      value_id = ctor_block.exprs.Add(*std::move(value_or));
+    } else {
+      value_id = ctor_block.exprs.Add(
+          BuildDefaultValueFromHir(module, frame, field.type));
+    }
+    const mir::ExprId self_ref =
+        ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_pointer_type));
+    const mir::ExprId target = ctor_block.exprs.Add(
+        mir::MakeFieldAccessExpr(self_ref, field_ids[i], field_types[i]));
+    const mir::ExprId assign = ctor_block.exprs.Add(
+        mir::MakeAssignExpr(target, value_id, field_types[i]));
+    ctor_block.AppendStmt(mir::ExprStmt{.expr = assign});
+  }
+
   // Each instance method (LRM 8.6) is lowered as a callable this class owns: it
   // resolves the body's `self` to the managed handle, and the method's
   // declaration-order position becomes its `MethodId`, so a call site naming
@@ -150,29 +182,20 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
     }
   }
 
-  // The user-written `function new` body (LRM 8.7) runs after each property
-  // takes its default, so its statements follow the field-init prologue already
-  // in the constructor body. Its input formals extend the constructor signature
-  // past the receiver. Absent when the class relies on implicit default
-  // construction.
+  // The constructor body (LRM 8.7) runs after each property is initialized, so
+  // its statements follow the field-init prologue already in the constructor
+  // body. Its input formals extend the constructor signature past the receiver;
+  // a synthesized default constructor contributes an empty body and no formals.
   std::vector<mir::LocalId> ctor_params{self_id};
-  if (hir_class.constructor.has_value()) {
-    const hir::SubroutineDecl& ctor = *hir_class.constructor;
-    const CallableStoragePlan ctor_plan(
-        class_scopes, plan_static_storage("<ctor>", ctor.body));
-    ProcessLowerer ctor_lowerer(
-        module, nullptr, mir_class.time_resolution, ctor.body, "<ctor>",
-        mir::MethodVisibility::kInternal, frame, ctor_plan);
-    auto ctor_body_or =
-        ctor_lowerer.LowerConstructorBodyInto(ctor, frame, ctor_params);
-    if (!ctor_body_or) {
-      return std::unexpected(std::move(ctor_body_or.error()));
-    }
-    for (const auto& pending : ctor_lowerer.TakePendingStaticInitializers()) {
-      auto integ = IntegratePendingStaticInitializer(
-          ctor_lowerer, ctor.body, frame, pending);
-      if (!integ) return std::unexpected(std::move(integ.error()));
-    }
+  auto ctor_body_or =
+      ctor_lowerer.LowerConstructorBodyInto(ctor, frame, ctor_params);
+  if (!ctor_body_or) {
+    return std::unexpected(std::move(ctor_body_or.error()));
+  }
+  for (const auto& pending : ctor_lowerer.TakePendingStaticInitializers()) {
+    auto integ = IntegratePendingStaticInitializer(
+        ctor_lowerer, ctor.body, frame, pending);
+    if (!integ) return std::unexpected(std::move(integ.error()));
   }
 
   ctor_code.params = std::move(ctor_params);

--- a/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
@@ -1,5 +1,6 @@
 #include <concepts>
 #include <utility>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
@@ -129,13 +130,24 @@ auto LowerExprImpl(L& lowerer, const hir::Expr& expr, WalkFrame frame)
             return LowerHirAssociativeAssignmentPatternExpr(
                 lowerer, frame, a, result_type);
           },
-          [&](const hir::ClassNewExpr&) -> diag::Result<mir::Expr> {
+          [&](const hir::ClassNewExpr& n) -> diag::Result<mir::Expr> {
             // `new` allocates a managed object and runs its constructor: a
             // construction whose result type (a managed reference) names what
-            // to build, with no constructor arguments.
+            // to build; the actuals flow to the constructor's formals.
+            std::vector<mir::ExprId> args;
+            args.reserve(n.arguments.size());
+            for (const hir::ExprId arg_hid : n.arguments) {
+              auto arg_or =
+                  lowerer.LowerExpr(lowerer.HirExprs().Get(arg_hid), frame);
+              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+              args.push_back(
+                  frame.current_block->exprs.Add(*std::move(arg_or)));
+            }
             return mir::Expr{
                 .data =
-                    mir::CallExpr{.callee = mir::Construct{}, .arguments = {}},
+                    mir::CallExpr{
+                        .callee = mir::Construct{},
+                        .arguments = std::move(args)},
                 .type = result_type};
           },
       },

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -389,6 +389,26 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
       .visibility = Visibility()};
 }
 
+auto ProcessLowerer::LowerConstructorBodyInto(
+    const hir::SubroutineDecl& ctor, const WalkFrame& frame,
+    std::vector<mir::LocalId>& params) -> diag::Result<void> {
+  for (const auto& param : ctor.params) {
+    if (param.direction != hir::ParamDirection::kInput) {
+      throw InternalError(
+          "ProcessLowerer::LowerConstructorBodyInto: a non-input constructor "
+          "formal reached MIR lowering; AST-to-HIR rejects these");
+    }
+    const auto& hir_var = ctor.body.procedural_vars.Get(param.var);
+    const mir::TypeId value_type = module_->TranslateType(hir_var.type);
+    const mir::LocalId mir_var = frame.bindings->Declare(
+        BindingOriginId::Procedural(param.var),
+        mir::LocalDecl{.name = hir_var.name, .type = value_type});
+    MapProceduralVar(param.var, AutomaticVarBinding{.type = value_type});
+    params.push_back(mir_var);
+  }
+  return LowerStraightLineBodyInto(*this, frame);
+}
+
 auto ProcessLowerer::BuildReturnPayload(
     mir::Block& block, std::optional<mir::ExprId> explicit_value)
     -> std::optional<mir::ExprId> {

--- a/tests/cases/cpp/class_ctor_args/case.yaml
+++ b/tests/cases/cpp/class_ctor_args/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_ctor_args
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    gx: 3
+    gy: 7

--- a/tests/cases/cpp/class_ctor_args/main.sv
+++ b/tests/cases/cpp/class_ctor_args/main.sv
@@ -1,0 +1,25 @@
+// A user-defined constructor (LRM 8.7): `function new` with input formals and a
+// body, invoked as `new(actual_args)`. The constructor runs the body after
+// each property takes its default, and the arguments flow to the formals.
+// Products are copied into module variables so the test asserts the feature's
+// effect, not a print side effect.
+module Top;
+  class Point;
+    int x;
+    int y;
+    function new(int a, int b);
+      x = a;
+      y = b + a;
+    endfunction
+  endclass
+
+  int gx;
+  int gy;
+
+  initial begin
+    Point p;
+    p = new(3, 4);
+    gx = p.x;
+    gy = p.y;
+  end
+endmodule

--- a/tests/cases/cpp/class_property_init/case.yaml
+++ b/tests/cases/cpp/class_property_init/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.class_property_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    gx: 5
+    gy: 6
+    gz: 16
+    gp: 7
+    gq: 14

--- a/tests/cases/cpp/class_property_init/main.sv
+++ b/tests/cases/cpp/class_property_init/main.sv
@@ -1,0 +1,41 @@
+// Class property initializers (LRM 8.7). During construction each property is
+// set in declaration order: a property with an explicit `= value` takes that
+// value -- and the initializer may read an earlier property through the
+// implicit receiver -- while one without takes its type's default. All property
+// initialization happens before the user constructor body runs. A class that
+// declares no `function new` still initializes its properties through the
+// implicit constructor. Products are copied into module variables so the test
+// asserts the feature's effect, not a print side effect.
+module Top;
+  class WithCtor;
+    int x = 5;
+    int y = x + 1;
+    int z;
+    function new(int a);
+      z = a + y;
+    endfunction
+  endclass
+
+  class NoCtor;
+    int p = 7;
+    int q = p + p;
+  endclass
+
+  int gx;
+  int gy;
+  int gz;
+  int gp;
+  int gq;
+
+  initial begin
+    WithCtor w;
+    NoCtor n;
+    w = new(10);
+    n = new;
+    gx = w.x;
+    gy = w.y;
+    gz = w.z;
+    gp = n.p;
+    gq = n.q;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Brings user-defined class constructors and class property initializers (LRM 8.7) to the class object model. A `function new` is lowered like any callable and its arguments flow from a `new(...)` call site to the formals; every class property initializer is evaluated during construction, in declaration order, before the constructor body runs, and an initializer may read an earlier property through the implicit receiver. A property without an initializer takes its type's Table 6-7 default, expressed as the same construction-time assignment so a backend reads one uniform mechanism.

## Design

Every class now has a constructor in the object model: the user-written `function new` when the source declares one, otherwise a synthesized empty constructor matching the implicit `new` the LRM provides. Property initialization is the constructor's prologue: HIR-to-MIR emits one assignment per property in declaration order into the constructor body, choosing the lowered initializer or the type default per property, then the constructor body follows. Because an initializer may name another property through the receiver, its expression lowers on the procedural path and lives in the constructor body's expression arena, where the constructor lowerer reads it.

## Testing

`bazel test //...` green. New end-to-end cases cover constructor arguments and property initializers, including an initializer that reads an earlier property through the receiver, a property without an initializer, and a class that relies on the implicit constructor.