### PR TITLE
Suspend a process on the execution backend

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -263,6 +263,7 @@ cc_library(
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:OrcJIT",
         "@llvm-project//llvm:OrcTargetProcess",
+        "@llvm-project//llvm:Passes",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:X86AsmParser",
         "@llvm-project//llvm:X86CodeGen",

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -133,6 +133,11 @@ the detail lives in the entry itself.
   the transient values one generated entry creates -- the JIT counterpart of C++ stack/RAII.
   Physical-layout / in-frame value lowering is a later optimization, not a correctness prerequisite;
   cross-suspension and managed-value lifetime is out of scope for the call scope.
+- [jit-process-suspension](jit-process-suspension.md) -- coroutine-ness is the callable's result
+  type, a suspension is a generic LIR control edge whose wakeup is registered by preceding runtime
+  calls, and the LLVM backend states where a body suspends while LLVM's coroutine passes derive the
+  frame, resume state, and spills. The engine resumes a runtime-owned adapter, never a generated
+  frame; a hand-rolled state machine in the emitter and an is-coroutine flag are rejected.
 - [root-unit-elaboration](root-unit-elaboration.md) -- design elaboration is the synthetic `$root`
   unit's `construct` entry, which builds the top-level modules as its owned children; there is no
   design-level free function. Engine / bind / run stay host runner policy and never enter MIR; both

--- a/docs/decisions/jit-process-suspension.md
+++ b/docs/decisions/jit-process-suspension.md
@@ -1,0 +1,157 @@
+# Process suspension on the execution backend: a typed protocol, a suspend edge, and LLVM's coroutine machinery
+
+Date: 2026-07-13 Status: accepted
+
+## Context
+
+A SystemVerilog process suspends: `#5`, `@(posedge clk)`, `wait (cond)`, `@e` each park the process
+and resume it when the scheduler decides. The C++ backend realizes a process as a C++20 coroutine
+and each suspension as a `co_await` over a runtime awaitable, whose `await_suspend` registers the
+wakeup source and yields; the engine holds the coroutine's promise base as the activation token
+(`scheduling.md`, `activation.md`).
+
+The execution backend lowers a process to LIR and then to LLVM IR run in-process. The questions this
+answers are: what carries a body's coroutine-ness through the pipeline, where a suspension appears,
+who synthesizes the resumable form (the frame, the resume state, the values that must survive a
+suspension), and what the scheduler is allowed to resume.
+
+The value-realization precedent applies: [jit-value-realization](jit-value-realization.md) keeps
+runtime values as opaque handles the runtime owns, and treats native in-frame layout as a later
+optimization.
+
+## Decision
+
+### D1. Coroutine-ness is the callable's result type, carried unchanged into LIR
+
+A body whose call protocol is the coroutine one says so in its result type (a coroutine type), the
+way any call protocol is stated (`callable.md`). MIR-to-LIR carries that type through; it does not
+erase it and replace it with a flag. A backend reads the protocol from the type.
+
+### D2. A suspension is a control edge at LIR, not a timing node
+
+Suspension appears as one terminator: it hands control back to the scheduler and names the block the
+body resumes at. It schedules nothing and names no wakeup source. The source is registered by the
+ordinary runtime calls that precede the terminator, so a delay, an event control, and a level wait
+differ only in those calls and share one suspend. This keeps LIR free of a source-language timing
+concept (`lir.md`): a suspend is a generic CFG edge, an event control is a runtime call.
+
+### D3. A wakeup registration is one runtime call per construct, and it is token-implicit
+
+Each suspending construct registers its wakeup through one runtime call named for the construct -- a
+delay, an event control, a level wait -- not for the engine verb it happens to reach. A delay is a
+single registration even though a zero delay enqueues on the inactive region while a positive one
+enqueues at a future time; which construct-neutral verb the engine ends up running is the runtime's
+business, not a distinction the boundary exposes.
+
+The registration acts on the process the runtime currently has running, so no activation token
+appears in LIR or in generated code. The runtime invariant is that the running-process context
+identifies this process for the whole time generated code is executing, so a registration call
+inside a body reaches the right token.
+
+### D4. The LLVM backend states where a body suspends; LLVM's coroutine passes derive how it resumes
+
+A coroutine body is emitted as an ordinary function carrying LLVM coroutine intrinsics: the ramp
+(identity, frame allocation, begin), a suspension at each suspend edge, and a final suspension at
+completion. The coroutine passes then derive the frame layout, the resume state machine, the
+resume/destroy entries, and which values must survive a suspension.
+
+That derivation is theirs, not the emitter's. The emitter stays a mechanical translation
+(`backend_contract.md`): a coroutine result type maps to the coroutine shape, a suspend edge maps to
+a suspension, and no entry branches on a body's kind to invent a signature or a state machine.
+
+### D5. The engine's activation token is runtime-owned, and generated code carries no runtime C++ type in its frame
+
+The token the engine schedules and resumes belongs to a runtime adapter coroutine, not to the
+generated body. The adapter drives the generated coroutine through its handle: the body runs to its
+next suspension, having already registered its wakeup, and the adapter parks until the engine runs
+it again.
+
+The reason is not that a code generator cannot produce a coroutine -- with coroutine intrinsics it
+produces a real one. It is that the activation token is a C++ promise carrying non-trivial members,
+and a generated frame must not have to embed a runtime C++ type's layout, construction, and
+destruction to be schedulable. The adapter owns the promise on the generated body's behalf, so the
+only thing crossing the boundary is a coroutine's resume, done, and destroy -- the stable surface of
+a coroutine handle, not the layout of a runtime class.
+
+This is the boundary, not a stage on the way to removing one. What may be replaced is how the
+adapter drives the body; that the scheduler's token is runtime-owned is the invariant.
+
+## Invariants
+
+1. Coroutine-ness is a type. No flag on a function, a terminator, or a node restates it, and no
+   backend infers it from the presence of a suspension.
+
+2. A suspend edge registers nothing. Every wakeup source is registered by a runtime call preceding
+   the terminator; the terminator is a pure control edge to the resume block.
+
+3. No activation token appears in LIR or in generated code. Registration verbs act on the running
+   process, which the runtime identifies for the whole time generated code runs.
+
+4. The emitter does not synthesize a coroutine's frame, resume state, or spills. It emits coroutine
+   intrinsics; the coroutine passes derive the resumable form.
+
+5. The engine resumes only runtime-owned activation tokens. A code-generator-produced coroutine
+   frame is never the token the engine stores or resumes.
+
+## Rejected
+
+- **A hand-rolled coroutine state machine in the emitter** -- a body given a bespoke signature with
+  a resume-state parameter, an entry switch over that state, and hand-written spill and reload of
+  the values that cross a suspension. It turns a mechanical backend into a compiler pass, and it
+  re-implements, less correctly, what LLVM's coroutine passes already derive. The failure mode is
+  concentrated exactly where it is hardest to see: the values live across a suspension.
+
+- **An `is-coroutine` flag on the LIR function or on a return terminator.** Coroutine-ness is the
+  result type (invariant 1); a flag beside it is a second source of truth, and two facts that must
+  agree drift apart. A flag also appears only because an upstream layer erased the protocol from the
+  type, which is the defect to fix.
+
+- **A suspension terminator that names its wakeup** (a delay/event/wait variant). It reintroduces a
+  scheduling concept as a LIR node, which `lir.md` forbids: the event control is a runtime call and
+  the suspend is a generic edge, not one fused node.
+
+- **The engine resuming a generated coroutine frame directly.** To be the token, a generated frame
+  would have to embed the runtime's C++ promise -- its layout, its construction, its destruction --
+  so the code generator's frame would depend on a runtime class rather than on a coroutine handle's
+  stable surface. The adapter costs one thin frame and removes that dependency (D5).
+
+- **Bundling non-blocking assignment into the suspension model.** A non-blocking assignment does not
+  suspend its process; it submits a deferred closure to the NBA region (`scheduling.md`). Realizing
+  it needs closure and environment lowering on the execution backend -- a separate foundation.
+
+## Scope and consequences
+
+- In scope: delay (`#N`, `#0`), event control (`@(...)`), level wait (`wait (cond)`), and
+  named-event wait (`@e`). They differ only in the registration calls that precede an identical
+  suspend edge. A level wait lowers to a re-check loop -- evaluate, continue if true, else register
+  and suspend, then re-evaluate on resume -- so invariant 2 holds on each iteration.
+
+- **A value that must outlive a suspension is still open.** The coroutine passes persist a body's
+  slots across a suspension, but a value in this backend is an opaque handle into storage the
+  runtime owns for the duration of one stretch of generated code. Persisting the slot does not
+  persist the object it names. Closing this needs the value's storage to outlive the stretch that
+  made it -- the activation-frame question [jit-value-realization](jit-value-realization.md) leaves
+  open -- not more coroutine machinery.
+
+- Deferred, each its own foundation: non-blocking assignment (a deferred closure submit); process
+  re-arming (`always` / `always_ff`); timed task enables (a nested activation with a typed
+  completion, `activation.md`); cancellation and `disable`.
+
+- The two backends share the semantic model -- the same MIR, the same type-carried call protocol --
+  and differ only in realization: the C++ backend's process coroutine is itself the token, because
+  it is compiled by the same toolchain as the runtime and can hold the promise directly; a generated
+  body cannot, so the adapter holds it (D5).
+
+## Cross-references
+
+- `architecture/callable.md` -- the result type is the call protocol; a kind flag beside it is
+  forbidden.
+- `architecture/lir.md` -- suspension as an explicit CFG edge, no source-language timing node, and
+  physical realization below LIR.
+- `architecture/backend_contract.md` -- a backend entry is a mechanical function of one node; a
+  decision that changes the emitted shape is a design failure upstream.
+- `architecture/scheduling.md` -- the engine as a construct-neutral mechanism and the verbs a wakeup
+  registration bottoms out on.
+- `architecture/activation.md` -- the activation and the payload-neutral token the scheduler holds.
+- [jit-value-realization](jit-value-realization.md) -- the opaque-handle baseline, and the
+  cross-suspension value lifetime it leaves open.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -211,15 +211,11 @@ enough to warrant its own focused review.
       kind touches three files (subsystem header, subsystem implementation, dispatcher switch) and
       leaves the pass-class header untouched.
 
-- [x] R14 -- The `return` / `co_return` choice is carried by MIR, not re-decided in the backend.
-      `return` and `co_return` describe the same operation (exit the callable); whether a given
-      `mir::ReturnStmt` renders as one or the other depends only on whether its enclosing callable
-      is a coroutine. `mir::ReturnStmt` carries that as `is_coroutine_return`, set at HIR-to-MIR
-      from the enclosing callable body's coroutine kind; the cpp backend reads it at each return
-      rather than inheriting a render-time walk-state flag. A closure needs no coroutine field of
-      its own -- whether a closure body suspends follows from how the closure is used (a fork-branch
-      reference spawns it as a coroutine; a deferred submit runs it synchronously), which is itself
-      explicit in MIR per `architecture/mir.md`.
+- [x] R14 -- The `return` / `co_return` choice is stated by MIR, not re-decided in the backend. Both
+      describe the same operation (exit the callable), and which one a return is depends only on
+      whether its enclosing callable completes as a coroutine. That is the callable's call protocol,
+      carried by its result type, so every backend reads it from there; no return statement,
+      closure, or lowering frame restates it as a flag of its own.
 
 - [x] R15 -- Give `mir::Process` a `name` field, so the C++ method name, static-frame struct name,
       static-frame field name, and any future LLVM-IR function symbol all flow from a single

--- a/include/lyra/backend/llvm/codegen_function.hpp
+++ b/include/lyra/backend/llvm/codegen_function.hpp
@@ -45,6 +45,21 @@ class CodeGenFunction {
   auto LowerBoolCast(const lir::BoolCastInstr& cast) -> llvm::Value*;
   auto LowerOperand(const lir::Operand& operand) -> llvm::Value*;
 
+  // Whether this body's call protocol is the coroutine one. Such a body is
+  // emitted with LLVM coroutine intrinsics and split into a resumable form by
+  // the coroutine passes; the state machine and the frame are theirs, not this
+  // emitter's.
+  [[nodiscard]] auto IsCoroutine() const -> bool;
+
+  // Emits the coroutine ramp (identity, frame allocation, begin) into the entry
+  // block and builds the shared final-suspend, cleanup, and end blocks a
+  // coroutine body returns through. Runs before the body's blocks are filled.
+  void OpenCoroutine();
+
+  // Emits a suspension: save, `llvm.coro.suspend`, and the switch that resumes
+  // at `resume`, returns to the caller, or enters cleanup.
+  void EmitCoroutineSuspend(llvm::BasicBlock* resume, bool is_final);
+
   // The address a place names. The base contributes the storage the chain
   // starts from -- a place local's own frame slot, or the referent of a
   // reference value
@@ -80,6 +95,15 @@ class CodeGenFunction {
   llvm::IRBuilder<> builder_;
   std::unordered_map<std::uint32_t, llvm::Value*> values_;
   std::vector<llvm::BasicBlock*> blocks_;
+  // A coroutine body's ramp state: the coroutine identity (which names the
+  // frame to release) and its handle, plus the blocks every suspension and
+  // return funnels through. The frame's layout and the resume state machine are
+  // the coroutine passes' to synthesize, never this emitter's.
+  llvm::Value* coro_id_ = nullptr;
+  llvm::Value* coro_handle_ = nullptr;
+  llvm::BasicBlock* coro_final_ = nullptr;
+  llvm::BasicBlock* coro_cleanup_ = nullptr;
+  llvm::BasicBlock* coro_end_ = nullptr;
 };
 
 }  // namespace lyra::backend::llvm_backend

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -61,6 +61,11 @@ class RuntimeAbi {
   auto RegisterInitial() -> llvm::FunctionCallee;
   auto RegisterFinal() -> llvm::FunctionCallee;
 
+  // Registers the running process to wake after a delay, the runtime call a
+  // delay's suspend edge is preceded by. The wakeup source is the running
+  // process, read from the runtime; no token crosses the boundary.
+  auto Delay() -> llvm::FunctionCallee;
+
   // Builds a coroutine from an entry code reference and its environment; the
   // runtime owns the resulting coroutine and returns an opaque handle.
   auto MakeCoroutine() -> llvm::FunctionCallee;

--- a/include/lyra/lir/function.hpp
+++ b/include/lyra/lir/function.hpp
@@ -212,11 +212,11 @@ struct Instr {
   InstrData data;
 };
 
-// Returns from the callable. `is_coroutine` distinguishes a coroutine
-// completion from a plain return; the value, when present, rides the result.
+// Returns from the callable; the value, when present, rides the result. Whether
+// this is a coroutine completion or a plain return is the callable's result
+// type, not a property of the terminator.
 struct ReturnTerm {
   std::optional<Operand> value;
-  bool is_coroutine = false;
 };
 
 // Transfers to `target` unconditionally.
@@ -231,14 +231,23 @@ struct CondBranchTerm {
   BlockId if_false;
 };
 
+// Hands control back to the scheduler and resumes at `resume` when the
+// activation is next run. It schedules nothing and names no wakeup source: the
+// source is registered by the runtime calls that precede this terminator, so a
+// delay, an event control, and a level wait differ only in those calls, never
+// in the suspend.
+struct SuspendTerm {
+  BlockId resume;
+};
+
 // Ends a block control never reaches -- the join of a conditional whose arms
 // all returned, or the tail of a value-returning body that always returns
 // earlier. Reaching it is undefined, which is what lets a target drop the
 // block.
 struct UnreachableTerm {};
 
-using TerminatorData =
-    std::variant<ReturnTerm, BranchTerm, CondBranchTerm, UnreachableTerm>;
+using TerminatorData = std::variant<
+    ReturnTerm, BranchTerm, CondBranchTerm, SuspendTerm, UnreachableTerm>;
 
 struct Terminator {
   TerminatorData data;
@@ -253,7 +262,10 @@ struct BasicBlock {
 // parameters first, then the temporaries and place locals the lowering minted;
 // `params` names the parameter subset in signature order, with the receiver
 // `self` at `params[0]`. The entry block is `blocks[0]`, and a `BlockId`
-// indexes `blocks`.
+// indexes `blocks`. A body whose call protocol is the coroutine one carries
+// that fact in its `result_type` (a `CoroutineType`): it may hold
+// `SuspendTerm`s and its completion is a coroutine completion, which a backend
+// realizes through the scheduling protocol rather than a single call.
 struct Function {
   std::string name;
   base::Arena<Local, ValueId> values;

--- a/include/lyra/lir/type_query.hpp
+++ b/include/lyra/lir/type_query.hpp
@@ -27,4 +27,11 @@ auto Pointee(const TypeArena& types, TypeId type) -> std::optional<TypeId>;
 // address-only, never the value itself.
 auto IsAddressOnly(const TypeArena& types, TypeId type) -> bool;
 
+// Whether a callable's result type states the coroutine call protocol: the body
+// may hand control back to the scheduler and completes as a coroutine, rather
+// than running to a value in one call. The protocol is the type -- nothing else
+// records it -- so every layer that must realize suspension or completion asks
+// this of the result type.
+auto IsCoroutine(const TypeArena& types, TypeId type) -> bool;
+
 }  // namespace lyra::lir

--- a/include/lyra/lowering/hir_to_mir/closure_builder.hpp
+++ b/include/lyra/lowering/hir_to_mir/closure_builder.hpp
@@ -30,11 +30,12 @@ namespace lyra::lowering::hir_to_mir {
 // fields resolves the receiver through the same capture machinery as any
 // binding, so the builder never special-cases it.
 //
-// `coroutine` selects a fork-branch body (LRM 9.3.2): its `return`s render as
-// `co_return` and the terminal is `BuildCoroutine`. `policy` is the capture
-// policy -- a fork branch passes the origins of its own block-item declarations
-// as the snapshot set (those snapshot, deeper-enclosing bindings alias); a
-// synchronous body passes the default (every forwarded binding aliases).
+// A body's call protocol is its result type, fixed when the closure is
+// finished: a fork branch (LRM 9.3.2) finishes with a coroutine result, a
+// synchronous body with its value's type. `policy` is the capture policy -- a
+// fork branch passes the origins of its own block-item declarations as the
+// snapshot set (those snapshot, deeper-enclosing bindings alias); a synchronous
+// body passes the default (every forwarded binding aliases).
 //
 // A closure is a value; how it is invoked -- an immediately-invoked call, a
 // fork spawn, a deferred submit, a with-clause iteration -- is the referencing
@@ -44,7 +45,7 @@ class ClosureBuilder {
  public:
   ClosureBuilder(
       mir::CompilationUnit& unit, const WalkFrame& enclosing,
-      bool coroutine = false, CapturePolicy policy = {});
+      CapturePolicy policy = {});
 
   ClosureBuilder(const ClosureBuilder&) = delete;
   auto operator=(const ClosureBuilder&) -> ClosureBuilder& = delete;

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -61,14 +61,6 @@ struct WalkFrame {
   // callable; replaced at a callable boundary.
   CallableBindings* bindings = nullptr;
 
-  // Whether the enclosing callable body suspends -- a process, a task, or a
-  // closure synthesized to run as a separate concurrent process (fork branch).
-  // Set at body entry and inherited unchanged through nested blocks;
-  // a closure entry re-establishes it from the closure's own `is_coroutine`.
-  // The `ReturnStmt` lowering reads this to fill the stmt's
-  // `is_coroutine_return` attribute (a C++ render hint, ignored by LIR / LLVM).
-  bool is_coroutine_body = false;
-
   // True while lowering an assignment's left-hand side. A queue
   // element-select dispatches to its write-side callee (LRM 7.10.1
   // append-aware) under this flag; the index and other rvalue
@@ -121,12 +113,6 @@ struct WalkFrame {
       -> WalkFrame {
     WalkFrame next = *this;
     next.bindings = callable_bindings;
-    return next;
-  }
-
-  [[nodiscard]] auto WithCoroutineBody(bool is_coroutine) const -> WalkFrame {
-    WalkFrame next = *this;
-    next.is_coroutine_body = is_coroutine;
     return next;
   }
 

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -104,13 +104,11 @@ struct ContinueStmt {};
 
 // LRM 13.4.1 `return [expr];`. `value` carries the returned expression for a
 // value-returning function; it is absent for `return;` and for void functions
-// / tasks. The semantic concept is one across all consumers (LRM, LIR, LLVM
-// `ret`); `is_coroutine_return` is a render hint for the C++ backend only,
-// distinguishing `co_return` from plain `return`. HIR-to-MIR sets it from
-// whether the enclosing callable body is a coroutine; LIR / LLVM ignore it.
+// / tasks. Whether this return completes a coroutine is the enclosing
+// callable's result type, which every consumer already reads; the statement
+// does not restate it.
 struct ReturnStmt {
   std::optional<ExprId> value;
-  bool is_coroutine_return = false;
 };
 
 // One leaf entry of a wait's projection set: an expression yielding a

--- a/include/lyra/mir/type_interner.hpp
+++ b/include/lyra/mir/type_interner.hpp
@@ -67,6 +67,15 @@ class TypeInterner {
     return Intern(CoroutineType{.payload = payload});
   }
 
+  // Whether a callable's result type states the coroutine call protocol: the
+  // body may suspend and completes as a coroutine, rather than running to a
+  // value in one call. The protocol is the type -- nothing else records it --
+  // so every consumer that realizes suspension or completion asks this of the
+  // result type.
+  [[nodiscard]] auto IsCoroutine(TypeId id) const -> bool {
+    return std::holds_alternative<CoroutineType>(Get(id).data);
+  }
+
   auto PointerTo(
       TypeId pointee, PointerOwnership ownership,
       Mutability mutability = Mutability::kMutable) -> TypeId {

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -24,9 +24,25 @@ auto lyra_rt_packed_const(
     -> void*;
 void lyra_rt_writeln(void* files, void* descriptor, void* text);
 void lyra_rt_write(void* files, void* descriptor, void* text);
-auto lyra_rt_make_coroutine(void (*entry)(void*), void* env) -> void*;
+// Wraps a generated process body in a runtime-owned coroutine. `ramp` starts
+// the body's own coroutine: called with the receiver it reaches its members
+// through, it runs to the body's first suspension and yields that coroutine's
+// handle. The runtime owns the coroutine the engine schedules and drives the
+// generated one through its handle; the generated body never owns the
+// scheduler's coroutine.
+auto lyra_rt_make_coroutine(void* (*ramp)(void* env), void* env) -> void*;
 void lyra_rt_register_initial(void* self, void* coroutine);
 void lyra_rt_register_final(void* self, void* coroutine);
+
+// Registers the running process to wake after `ticks` steps of its scope's
+// precision (`precision_power`), the registration a delay's suspend edge is
+// preceded by (LRM 9.4.1). A zero delay re-enqueues on the current slot's
+// inactive region; a positive one scales to the engine's global tick. The
+// counts cross as opaque packed values, like every scalar. The wakeup source is
+// the running process itself, read from the runtime; no token crosses the
+// boundary.
+void lyra_rt_delay(
+    void* services, const void* ticks, const void* precision_power);
 
 // Builds a scope's structural identity from its base label and per-dimension
 // indices (a span of 32-bit index values, empty for a scalar). The segment is

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -229,12 +229,15 @@ auto RenderStmt(
             return std::format("{}continue;\n", Indent(indent));
           },
           [&](const mir::ReturnStmt& s) -> std::string {
-            // `is_coroutine_return` (set at HIR-to-MIR from the enclosing
-            // callable's coroutine-ness, mir/stmt.hpp) is a C++ render hint --
-            // LIR / LLVM ignore it -- choosing `co_return` over `return`. A
-            // value rides the result either way (LRM 13.3 / 13.4.1).
+            // A coroutine completes through `co_return`, which the enclosing
+            // callable's result type states: coroutine-ness is the call
+            // protocol, read from the type rather than restated on the
+            // statement. A value rides the result either way (LRM 13.3 /
+            // 13.4.1).
             const std::string keyword =
-                s.is_coroutine_return ? "co_return" : "return";
+                view.Unit().types.IsCoroutine(view.Code().result_type)
+                    ? "co_return"
+                    : "return";
             if (!s.value.has_value()) {
               return std::format("{}{};\n", Indent(indent), keyword);
             }

--- a/src/lyra/backend/llvm/codegen_function.cpp
+++ b/src/lyra/backend/llvm/codegen_function.cpp
@@ -6,12 +6,19 @@
 #include <variant>
 
 #include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
 
 #include "lyra/backend/llvm/codegen_module.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/lir/compilation_unit.hpp"
+#include "lyra/lir/type_query.hpp"
 
 namespace lyra::backend::llvm_backend {
 
@@ -20,10 +27,15 @@ CodeGenFunction::CodeGenFunction(
     : module_(&module), fn_(&fn), value_(value), builder_(module.Context()) {
 }
 
+auto CodeGenFunction::IsCoroutine() const -> bool {
+  return lir::IsCoroutine(module_->Unit().types, fn_->result_type);
+}
+
 void CodeGenFunction::Run() {
   for (std::uint32_t i = 0; i < fn_->params.size(); ++i) {
     values_.emplace(fn_->params[i].value, value_->getArg(i));
   }
+
   // Every block exists before any is filled, so a branch resolves its successor
   // regardless of the order the blocks are emitted in.
   blocks_.reserve(fn_->blocks.size());
@@ -33,9 +45,20 @@ void CodeGenFunction::Run() {
             module_->Context(), std::format("bb{}", i), value_));
   }
 
+  // A coroutine body opens with its ramp -- identity, frame, begin -- ahead of
+  // the body: a local that must survive a suspension is moved into the
+  // coroutine frame only if it is allocated once the frame exists.
+  llvm::BasicBlock* entry = blocks_.front();
+  if (IsCoroutine()) {
+    entry = llvm::BasicBlock::Create(
+        module_->Context(), "coro.ramp", value_, blocks_.front());
+    builder_.SetInsertPoint(entry);
+    OpenCoroutine();
+  }
+
   // A place local is frame storage: its slot is allocated once, in the entry
   // block, so every path that reaches it names the same address.
-  builder_.SetInsertPoint(blocks_.front());
+  builder_.SetInsertPoint(entry);
   for (std::uint32_t i = 0; i < fn_->values.size(); ++i) {
     const lir::ValueId id{i};
     const lir::Local& local = fn_->values.Get(id);
@@ -43,6 +66,9 @@ void CodeGenFunction::Run() {
       values_.emplace(
           i, builder_.CreateAlloca(module_->Types().Map(local.type)));
     }
+  }
+  if (IsCoroutine()) {
+    builder_.CreateBr(blocks_.front());
   }
 
   for (std::uint32_t i = 0; i < fn_->blocks.size(); ++i) {
@@ -54,10 +80,85 @@ void CodeGenFunction::Run() {
   }
 }
 
+void CodeGenFunction::OpenCoroutine() {
+  llvm::Module& mod = module_->Module();
+  llvm::LLVMContext& ctx = module_->Context();
+  llvm::PointerType* ptr_ty = builder_.getPtrTy();
+  llvm::Type* size_ty = builder_.getInt64Ty();
+
+  // The coroutine passes split only a body that declares itself one.
+  value_->setPresplitCoroutine();
+
+  llvm::Constant* null_ptr = llvm::ConstantPointerNull::get(ptr_ty);
+  coro_id_ = builder_.CreateCall(
+      llvm::Intrinsic::getDeclaration(&mod, llvm::Intrinsic::coro_id),
+      {builder_.getInt32(0), null_ptr, null_ptr, null_ptr});
+  llvm::Value* size = builder_.CreateCall(
+      llvm::Intrinsic::getDeclaration(
+          &mod, llvm::Intrinsic::coro_size, {size_ty}),
+      {});
+  llvm::Value* memory = builder_.CreateCall(
+      mod.getOrInsertFunction("malloc", ptr_ty, size_ty), {size});
+  coro_handle_ = builder_.CreateCall(
+      llvm::Intrinsic::getDeclaration(&mod, llvm::Intrinsic::coro_begin),
+      {coro_id_, memory});
+
+  coro_final_ = llvm::BasicBlock::Create(ctx, "coro.final", value_);
+  coro_cleanup_ = llvm::BasicBlock::Create(ctx, "coro.cleanup", value_);
+  coro_end_ = llvm::BasicBlock::Create(ctx, "coro.end", value_);
+
+  builder_.SetInsertPoint(coro_cleanup_);
+  llvm::Value* frame = builder_.CreateCall(
+      llvm::Intrinsic::getDeclaration(&mod, llvm::Intrinsic::coro_free),
+      {coro_id_, coro_handle_});
+  builder_.CreateCall(
+      mod.getOrInsertFunction("free", builder_.getVoidTy(), ptr_ty), {frame});
+  builder_.CreateBr(coro_end_);
+
+  builder_.SetInsertPoint(coro_end_);
+  builder_.CreateCall(
+      llvm::Intrinsic::getDeclaration(&mod, llvm::Intrinsic::coro_end),
+      {coro_handle_, builder_.getInt1(false)});
+  builder_.CreateRet(coro_handle_);
+
+  // A body that runs to completion suspends one final time, so its owner still
+  // reads the handle as done before destroying it.
+  builder_.SetInsertPoint(coro_final_);
+  EmitCoroutineSuspend(nullptr, true);
+}
+
+void CodeGenFunction::EmitCoroutineSuspend(
+    llvm::BasicBlock* resume, bool is_final) {
+  llvm::Module& mod = module_->Module();
+  llvm::Value* save =
+      is_final ? llvm::cast<llvm::Value>(
+                     llvm::ConstantTokenNone::get(module_->Context()))
+               : llvm::cast<llvm::Value>(builder_.CreateCall(
+                     llvm::Intrinsic::getDeclaration(
+                         &mod, llvm::Intrinsic::coro_save),
+                     {coro_handle_}));
+  llvm::Value* arm = builder_.CreateCall(
+      llvm::Intrinsic::getDeclaration(&mod, llvm::Intrinsic::coro_suspend),
+      {save, builder_.getInt1(is_final)});
+  // The suspension's three arms: the caller regains control (the default), the
+  // body resumes where it left off, or the frame is destroyed.
+  llvm::SwitchInst* arms = builder_.CreateSwitch(arm, coro_end_, 2);
+  if (resume != nullptr) {
+    arms->addCase(builder_.getInt8(0), resume);
+  }
+  arms->addCase(builder_.getInt8(1), coro_cleanup_);
+}
+
 void CodeGenFunction::LowerTerminator(const lir::Terminator& terminator) {
   std::visit(
       Overloaded{
           [&](const lir::ReturnTerm& ret) {
+            if (IsCoroutine()) {
+              // A coroutine completes through its final suspension; its owner
+              // reads completion from the handle, never from a returned value.
+              builder_.CreateBr(coro_final_);
+              return;
+            }
             if (value_->getReturnType()->isVoidTy()) {
               builder_.CreateRetVoid();
               return;
@@ -71,6 +172,12 @@ void CodeGenFunction::LowerTerminator(const lir::Terminator& terminator) {
             builder_.CreateCondBr(
                 LowerOperand(br.condition), blocks_[br.if_true.value],
                 blocks_[br.if_false.value]);
+          },
+          [&](const lir::SuspendTerm& s) {
+            // The wakeup source was registered by the calls preceding this
+            // terminator; the suspension only hands control back and names
+            // where the body resumes.
+            EmitCoroutineSuspend(blocks_[s.resume.value], false);
           },
           [&](const lir::UnreachableTerm&) { builder_.CreateUnreachable(); }},
       terminator.data);

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -265,6 +265,8 @@ auto CodeGenFunction::BuiltinCallee(
       return module_->Runtime().RegisterInitial();
     case support::BuiltinFn::kRegisterFinal:
       return module_->Runtime().RegisterFinal();
+    case support::BuiltinFn::kDelay:
+      return module_->Runtime().Delay();
     case support::BuiltinFn::kAddOwnedChild:
       return module_->Runtime().AddOwnedChild();
     case support::BuiltinFn::kRegisterSignal:

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -106,6 +106,12 @@ auto RuntimeAbi::MakeCoroutine() -> llvm::FunctionCallee {
       "lyra_rt_make_coroutine", types_->Ptr(), {types_->Ptr(), types_->Ptr()});
 }
 
+auto RuntimeAbi::Delay() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_delay", types_->Void(),
+      {types_->Ptr(), types_->Ptr(), types_->Ptr()});
+}
+
 auto RuntimeAbi::MakeString() -> llvm::FunctionCallee {
   return Get("lyra_rt_make_string", types_->Ptr(), {types_->Ptr()});
 }

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -9,13 +9,22 @@
 #include <variant>
 #include <vector>
 
+#include <llvm/Analysis/CGSCCPassManager.h>
+#include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/IRTransformLayer.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/Error.h>
 #include <llvm/Support/TargetSelect.h>
+#include <llvm/Transforms/Coroutines/CoroCleanup.h>
+#include <llvm/Transforms/Coroutines/CoroEarly.h>
+#include <llvm/Transforms/Coroutines/CoroSplit.h>
 
 #include "lyra/backend/llvm/emit.hpp"
 #include "lyra/backend/llvm/runtime_abi.hpp"
@@ -55,6 +64,44 @@ void Check(llvm::Error error, std::string_view what) {
   }
 }
 
+// Splits every generated coroutine body into its resumable form before the
+// module is compiled. A process body reaches the JIT as an ordinary function
+// carrying coroutine intrinsics; the coroutine passes derive its frame, its
+// resume state, and the values that must survive a suspension. That derivation
+// is theirs -- the compiler states where a body suspends, never how it resumes.
+void LowerCoroutines(llvm::orc::LLJIT& jit) {
+  jit.getIRTransformLayer().setTransform(
+      [](llvm::orc::ThreadSafeModule module,
+         const llvm::orc::MaterializationResponsibility&)
+          -> llvm::Expected<llvm::orc::ThreadSafeModule> {
+        module.withModuleDo([](llvm::Module& ir) {
+          llvm::PassBuilder builder;
+          llvm::LoopAnalysisManager loops;
+          llvm::FunctionAnalysisManager functions;
+          llvm::CGSCCAnalysisManager call_graph;
+          llvm::ModuleAnalysisManager modules;
+          builder.registerModuleAnalyses(modules);
+          builder.registerCGSCCAnalyses(call_graph);
+          builder.registerFunctionAnalyses(functions);
+          builder.registerLoopAnalyses(loops);
+          builder.crossRegisterProxies(loops, functions, call_graph, modules);
+
+          // Only the coroutine lowering runs: it is what makes a suspending
+          // body executable, so it is a translation step, not an optimization
+          // the module could also be correct without.
+          llvm::ModulePassManager passes;
+          passes.addPass(llvm::CoroEarlyPass());
+          llvm::CGSCCPassManager split;
+          split.addPass(llvm::CoroSplitPass());
+          passes.addPass(
+              llvm::createModuleToPostOrderCGSCCPassAdaptor(std::move(split)));
+          passes.addPass(llvm::CoroCleanupPass());
+          passes.run(ir, modules);
+        });
+        return std::move(module);
+      });
+}
+
 // Binds the runtime ABI the generated module calls to the definitions linked
 // into this process. Absolute addresses resolve every generated call without
 // relying on the host's exported dynamic symbol table.
@@ -78,6 +125,7 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_make_coroutine", &lyra_rt_make_coroutine);
   add("lyra_rt_register_initial", &lyra_rt_register_initial);
   add("lyra_rt_register_final", &lyra_rt_register_final);
+  add("lyra_rt_delay", &lyra_rt_delay);
   add("lyra_rt_make_segment", &lyra_rt_make_segment);
   add("lyra_rt_make_unit", &lyra_rt_make_unit);
   add("lyra_rt_add_owned_child", &lyra_rt_add_owned_child);
@@ -276,6 +324,7 @@ auto Execute(
   llvm::InitializeNativeTargetAsmPrinter();
 
   auto jit = Unwrap(llvm::orc::LLJITBuilder().create(), "create jit");
+  LowerCoroutines(*jit);
   DefineRuntimeAbi(*jit);
 
   // Every unit -- the source units and the design-root -- becomes one module in

--- a/src/lyra/lir/dump.cpp
+++ b/src/lyra/lir/dump.cpp
@@ -127,12 +127,10 @@ class LirDumper {
     return std::visit(
         Overloaded{
             [&](const ReturnTerm& ret) -> std::string {
-              std::string keyword =
-                  ret.is_coroutine ? "return.coroutine" : "return";
               if (ret.value.has_value()) {
-                return std::format("{} {}", keyword, FormatOperand(*ret.value));
+                return std::format("return {}", FormatOperand(*ret.value));
               }
-              return keyword;
+              return "return";
             },
             [](const BranchTerm& br) -> std::string {
               return std::format("br bb{}", br.target.value);
@@ -141,6 +139,9 @@ class LirDumper {
               return std::format(
                   "br {} ? bb{} : bb{}", FormatOperand(br.condition),
                   br.if_true.value, br.if_false.value);
+            },
+            [](const SuspendTerm& s) -> std::string {
+              return std::format("suspend -> bb{}", s.resume.value);
             },
             [](const UnreachableTerm&) -> std::string {
               return "unreachable";

--- a/src/lyra/lir/type_query.cpp
+++ b/src/lyra/lir/type_query.cpp
@@ -39,4 +39,8 @@ auto IsAddressOnly(const TypeArena& types, TypeId type) -> bool {
       types.Get(type).data);
 }
 
+auto IsCoroutine(const TypeArena& types, TypeId type) -> bool {
+  return std::holds_alternative<CoroutineType>(types.Get(type).data);
+}
+
 }  // namespace lyra::lir

--- a/src/lyra/lir/verify.cpp
+++ b/src/lyra/lir/verify.cpp
@@ -154,9 +154,19 @@ void VerifyInstr(
 }
 
 void VerifyFunction(const CompilationUnit& unit, const Function& fn) {
+  const bool is_coroutine = IsCoroutine(unit.types, fn.result_type);
   for (const BasicBlock& block : fn.blocks) {
     for (const Instr& instr : block.instrs) {
       VerifyInstr(unit, fn, instr);
+    }
+    // Only a body whose call protocol is the coroutine one can hand control
+    // back to the scheduler; a suspension anywhere else has no one to resume
+    // it.
+    if (std::holds_alternative<SuspendTerm>(block.terminator.data) &&
+        !is_coroutine) {
+      throw InternalError(
+          "lir verify: a suspension appears in a body whose result type is not "
+          "a coroutine");
     }
   }
 }

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -17,7 +17,7 @@
 namespace lyra::lowering::hir_to_mir {
 
 ClosureBuilder::ClosureBuilder(
-    mir::CompilationUnit& unit, const WalkFrame& enclosing, bool coroutine,
+    mir::CompilationUnit& unit, const WalkFrame& enclosing,
     CapturePolicy policy)
     : unit_(&unit),
       outer_(enclosing.current_block),
@@ -27,8 +27,7 @@ ClosureBuilder::ClosureBuilder(
           unit, closure_decl_, closure_id_, *enclosing.bindings, *outer_,
           std::move(policy)),
       frame_(enclosing.WithBlock(&closure_decl_.invoke.body)
-                 .WithBindings(&bindings_)
-                 .WithCoroutineBody(coroutine)) {
+                 .WithBindings(&bindings_)) {
 }
 
 auto ClosureBuilder::AddParam(
@@ -70,8 +69,7 @@ auto ClosureBuilder::Build(mir::ExprId result) -> mir::Expr {
 }
 
 auto ClosureBuilder::BuildCoroutine() -> mir::Expr {
-  closure_decl_.invoke.body.AppendStmt(
-      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
+  closure_decl_.invoke.body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
   return Finish(unit_->builtins.coroutine_void);
 }
 

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -200,8 +200,7 @@ auto LowerContinuousAssign(
 
   mir::Block body_block;
   const WalkFrame body_frame =
-      ctor_frame.WithBindings(&bindings).WithCoroutineBody(true).WithBlock(
-          &body_block);
+      ctor_frame.WithBindings(&bindings).WithBlock(&body_block);
 
   auto rhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(src.rhs), body_frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
@@ -252,8 +251,7 @@ auto LowerContinuousAssign(
           .condition = std::nullopt,
           .step = {},
           .scope = body_scope_id});
-  code.body.AppendStmt(
-      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
+  code.body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
   code.params = {self_id};
   code.result_type = unit.builtins.coroutine_void;
   return mir::MethodDecl{

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -178,15 +178,14 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
       mir::LocalDecl{
           .name = "self", .type = parent.current_class->self_pointer_type});
   code.params = {self_id};
-  const WalkFrame body_frame = parent.WithBlock(&code.body)
-                                   .WithBindings(&bindings)
-                                   .WithCoroutineBody(true);
+  const WalkFrame body_frame =
+      parent.WithBlock(&code.body).WithBindings(&bindings);
   auto lowered = LowerStraightLineBodyInto(process, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
-  // A process is a coroutine; it completes by falling off its end through
-  // `co_return`, a real body statement (LRM 9.2).
-  code.body.AppendStmt(
-      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
+  // A process completes by falling off its end, which is a real body statement
+  // rather than an implicit exit (LRM 9.2). Its coroutine result type is what
+  // makes that return a coroutine completion.
+  code.body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
   code.result_type = process.Module().Unit().builtins.coroutine_void;
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
@@ -213,9 +212,8 @@ auto LowerForeverProcess(
   code.params = {self_id};
   mir::Block body_block;
   {
-    const WalkFrame body_frame = parent.WithBlock(&body_block)
-                                     .WithBindings(&bindings)
-                                     .WithCoroutineBody(true);
+    const WalkFrame body_frame =
+        parent.WithBlock(&body_block).WithBindings(&bindings);
     auto lowered = LowerStraightLineBodyInto(process, body_frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     if (implicit_sensitivity != nullptr) {
@@ -233,8 +231,7 @@ auto LowerForeverProcess(
           .condition = std::nullopt,
           .step = {},
           .scope = body_scope_id});
-  code.body.AppendStmt(
-      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
+  code.body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
   code.result_type = process.Module().Unit().builtins.coroutine_void;
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
@@ -270,12 +267,11 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
       BindingOriginId::Receiver(),
       mir::LocalDecl{
           .name = "self", .type = parent.current_class->self_pointer_type});
-  // A task body suspends on timing controls and renders as a coroutine; a
-  // function body executes synchronously.
+  // A task body suspends on timing controls, so its call protocol is the
+  // coroutine one; a function body executes synchronously.
   const bool body_is_coroutine = src.kind == hir::SubroutineKind::kTask;
-  const WalkFrame body_frame = parent.WithBlock(&code.body)
-                                   .WithBindings(&bindings)
-                                   .WithCoroutineBody(body_is_coroutine);
+  const WalkFrame body_frame =
+      parent.WithBlock(&code.body).WithBindings(&bindings);
 
   // Formals normalize into the signature's data flow (LRM 13.5). An `input` and
   // a `ref` / `const ref` are parameters (the latter carries a `Ref<T>`); an
@@ -364,20 +360,14 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
   auto lowered = LowerStraightLineBodyInto(*this, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
 
-  // Close the body with a trailing return of the fall-through payload. Absent
-  // when the payload is empty (a void function or a task with no outputs); the
-  // backend then supplies the bare `co_return;` for a coroutine.
+  // Close the body with a trailing return of the fall-through payload, or with
+  // a bare return when the payload is empty (a void function, or a task with no
+  // outputs, which completes by falling off its end -- LRM 13.3). Either way
+  // the completion is a real body statement, not a backend-appended epilogue.
   if (auto trailing = BuildReturnPayload(code.body, std::nullopt)) {
-    code.body.AppendStmt(
-        mir::ReturnStmt{
-            .value = trailing,
-            .is_coroutine_return = body_frame.is_coroutine_body});
+    code.body.AppendStmt(mir::ReturnStmt{.value = trailing});
   } else if (body_is_coroutine) {
-    // A task is a coroutine with no result value: it completes by falling off
-    // its end through `co_return` (LRM 13.3). The completion is a real body
-    // statement, not a backend-appended epilogue.
-    code.body.AppendStmt(
-        mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
+    code.body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
   }
 
   code.params = std::move(params);

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -138,9 +138,7 @@ auto LowerReturnStmt(
   const std::optional<mir::ExprId> payload =
       process.BuildReturnPayload(block, explicit_value);
   return mir::Stmt{
-      .label = std::move(label),
-      .data = mir::ReturnStmt{
-          .value = payload, .is_coroutine_return = frame.is_coroutine_body}};
+      .label = std::move(label), .data = mir::ReturnStmt{.value = payload}};
 }
 
 auto LowerBreakStmt(

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -94,8 +94,7 @@ auto LowerForkStmt(
     // returns inside it become `co_return`. The branch policy snapshots the
     // fork's own block-item declarations and aliases deeper enclosing
     // variables (LRM 6.21).
-    ClosureBuilder closure(
-        process.Module().Unit(), fork_frame, true, branch_policy);
+    ClosureBuilder closure(process.Module().Unit(), fork_frame, branch_policy);
     auto lowered = process.LowerStmt(branch, closure.Frame());
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -220,12 +220,11 @@ FunctionLowerer::FunctionLowerer(
 
 auto FunctionLowerer::Run() -> diag::Result<lir::Function> {
   fn_.name = std::move(name_);
-  // A coroutine-bodied callable lowers to its step body, which returns void;
-  // the coroutine value is a closure built where the callable is referenced.
-  fn_.result_type = std::holds_alternative<mir::CoroutineType>(
-                        unit_->Mir().types.Get(code_->result_type).data)
-                        ? unit_->TranslateType(unit_->Mir().builtins.void_type)
-                        : unit_->TranslateType(code_->result_type);
+  // A coroutine-bodied callable keeps its coroutine result type: coroutine-ness
+  // is the call protocol carried by the type, so a backend realizes suspension
+  // and completion from the type, never from a separate flag.
+  fn_.result_type = unit_->TranslateType(code_->result_type);
+  const bool is_coroutine = unit_->Mir().types.IsCoroutine(code_->result_type);
 
   CollectPlacedLocals(code_->body, placed_);
 
@@ -250,20 +249,22 @@ auto FunctionLowerer::Run() -> diag::Result<lir::Function> {
     return std::unexpected(std::move(lowered.error()));
   }
 
-  // A block the lowering left open either falls off the end of a void body --
-  // an implicit return -- or is a join control never reaches. A value-returning
-  // body reaches its returns explicitly, so its open blocks are the latter.
-  const bool returns_void =
+  // A block the lowering left open either falls off the end of a void or
+  // coroutine body -- an implicit return -- or is a join control never reaches.
+  // A value-returning body reaches its returns explicitly, so its open blocks
+  // are the latter.
+  const bool falls_through_to_return =
+      is_coroutine ||
       fn_.result_type == unit_->TranslateType(unit_->Mir().builtins.void_type);
   for (std::size_t i = 0; i < fn_.blocks.size(); ++i) {
     if (terminated_[i]) {
       continue;
     }
     fn_.blocks[i].terminator = lir::Terminator{
-        .data = returns_void
-                    ? lir::TerminatorData{lir::ReturnTerm{
-                          .value = std::nullopt, .is_coroutine = false}}
-                    : lir::TerminatorData{lir::UnreachableTerm{}}};
+        .data =
+            falls_through_to_return
+                ? lir::TerminatorData{lir::ReturnTerm{.value = std::nullopt}}
+                : lir::TerminatorData{lir::UnreachableTerm{}}};
   }
   return std::move(fn_);
 }
@@ -398,10 +399,7 @@ auto FunctionLowerer::LowerStmtInto(
               }
               value = *std::move(lowered);
             }
-            Terminate(
-                lir::ReturnTerm{
-                    .value = std::move(value),
-                    .is_coroutine = s.is_coroutine_return});
+            Terminate(lir::ReturnTerm{.value = std::move(value)});
             return {};
           },
           [](const mir::SensitivityWaitStmt&) -> diag::Result<void> {
@@ -1010,6 +1008,26 @@ auto FunctionLowerer::LowerExpr(const mir::Block& block, mir::ExprId id)
             // operand here. Whether the transfer is realized as a move or a
             // copy is decided below LIR, not at this layer.
             return LowerExpr(block, m.operand);
+          },
+          [&](const mir::AwaitExpr& await) -> diag::Result<lir::Operand> {
+            // An await is two facts: the awaitable's effect -- registering the
+            // wakeup source through an ordinary runtime call -- and the suspend
+            // itself, a control edge back to the scheduler that resumes at the
+            // next block. The registration runs first, so a delay, an event
+            // control, and a level wait differ only in the awaitable's call.
+            if (type != unit_->Mir().builtins.void_type) {
+              return Unsupported(
+                  "mir_to_lir: a value-carrying await is not yet lowerable to "
+                  "LIR");
+            }
+            auto registration = LowerExpr(block, await.awaitable);
+            if (!registration) {
+              return registration;
+            }
+            const lir::BlockId resume = NewBlock();
+            Terminate(lir::SuspendTerm{.resume = resume});
+            SetCurrent(resume);
+            return registration;
           },
           [](const auto&) -> diag::Result<lir::Operand> {
             return Unsupported(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -1026,13 +1026,11 @@ class MirDumper {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));
             },
             [&](const ReturnStmt& s) {
-              const std::string flavor =
-                  s.is_coroutine_return ? " coroutine" : "";
               if (s.value.has_value()) {
                 Line(
                     std::format(
-                        "Stmt[{}] ReturnStmt{} value=Expr[{}]", id.value,
-                        flavor, s.value->value));
+                        "Stmt[{}] ReturnStmt value=Expr[{}]", id.value,
+                        s.value->value));
                 Indent();
                 Line(
                     std::format(
@@ -1040,7 +1038,7 @@ class MirDumper {
                         FormatExpr(enclosing, *s.value)));
                 Dedent();
               } else {
-                Line(std::format("Stmt[{}] ReturnStmt{}", id.value, flavor));
+                Line(std::format("Stmt[{}] ReturnStmt", id.value));
               }
             },
             [&](const SensitivityWaitStmt& s) {

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -1,5 +1,6 @@
 #include "lyra/runtime/jit_execution.hpp"
 
+#include <coroutine>
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -7,10 +8,13 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/base/time.hpp"
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/delay.hpp"
 #include "lyra/runtime/file_table.hpp"
 #include "lyra/runtime/generated_call_scope.hpp"
 #include "lyra/runtime/hierarchy_segment.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/scope_program.hpp"
@@ -23,17 +27,44 @@ namespace lyra::runtime {
 
 namespace {
 
-using GeneratedEntry = void (*)(void*);
+using GeneratedRamp = void* (*)(void* env);
 
-// The one C++ coroutine function the runtime owns on the generated side's
-// behalf: a generated process cannot build a coroutine frame, so it hands over
-// a plain entry plus its environment and the runtime wraps them. Lazy like
-// every Coroutine, so the body runs only when the engine resumes it; the
-// generated-call scope is entered there, around the generated call.
-auto RunGeneratedProcess(GeneratedEntry entry, void* env) -> Coroutine<void> {
+// The runtime-owned coroutine that is the process the engine schedules, and
+// which drives the generated body's own coroutine.
+//
+// The engine's activation token is a C++ promise carrying non-trivial members.
+// A generated body is free of it: it holds only its own coroutine, and this
+// adapter owns the promise on its behalf. So the frame a code generator lays
+// out never has to embed a runtime C++ type -- only a coroutine's resume, done,
+// and destroy cross the boundary. That is what this adapter buys, and why the
+// engine resumes it rather than the generated coroutine.
+//
+// The generated body runs to its next suspension, having already registered its
+// own wakeup; the adapter then parks, and resumes it when the engine runs the
+// adapter again.
+//
+// Every stretch of generated code -- starting the body, resuming it, tearing it
+// down -- runs in its own generated-call scope, so a value it materializes is
+// released when that stretch returns; a value that must outlive a suspension
+// does not live there.
+auto RunGeneratedProcess(GeneratedRamp ramp, void* env) -> Coroutine<void> {
+  void* frame = nullptr;
   {
     GeneratedCallScope scope;
-    entry(env);
+    frame = ramp(env);
+  }
+  const std::coroutine_handle<> generated =
+      std::coroutine_handle<>::from_address(frame);
+  while (!generated.done()) {
+    co_await std::suspend_always{};
+    {
+      GeneratedCallScope scope;
+      generated.resume();
+    }
+  }
+  {
+    GeneratedCallScope scope;
+    generated.destroy();
   }
   co_return;
 }
@@ -56,6 +87,7 @@ auto Own(T value) -> void* {
 }  // namespace lyra::runtime
 
 using lyra::runtime::Coroutine;
+using lyra::runtime::CoroutineHandle;
 using lyra::runtime::FileTable;
 using lyra::runtime::GeneratedCallScope;
 using lyra::runtime::GeneratedInstance;
@@ -129,9 +161,25 @@ void lyra_rt_write(void* files, void* descriptor, void* text) {
       *static_cast<PackedArray*>(descriptor), *static_cast<String*>(text));
 }
 
-auto lyra_rt_make_coroutine(void (*entry)(void*), void* env) -> void* {
+auto lyra_rt_make_coroutine(void* (*ramp)(void*), void* env) -> void* {
   return GeneratedCallScope::Current().Arena().New<Coroutine<void>>(
-      lyra::runtime::RunGeneratedProcess(entry, env));
+      lyra::runtime::RunGeneratedProcess(ramp, env));
+}
+
+void lyra_rt_delay(
+    void* services, const void* ticks, const void* precision_power) {
+  auto& svc = *static_cast<RuntimeServices*>(services);
+  const CoroutineHandle token = svc.CurrentProcess().TopHandle();
+  const std::int64_t tick_count = Read<PackedArray>(ticks).ToInt64();
+  if (tick_count == 0) {
+    svc.ScheduleInactive(token);
+    return;
+  }
+  const lyra::SimDuration global = lyra::runtime::ScaleToGlobalTicks(
+      static_cast<lyra::SimDuration>(tick_count),
+      static_cast<std::int8_t>(Read<PackedArray>(precision_power).ToInt64()),
+      svc.GlobalPrecisionPower());
+  svc.ScheduleAtTime(svc.Now() + global, token);
 }
 
 void lyra_rt_register_initial(void* self, void* coroutine) {

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -78,6 +78,33 @@ auto WriteProceduralSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+// Timing control: two processes suspend on delays and resume in simulation-time
+// order, and a `#0` re-enters this slot's inactive region. Running it exercises
+// the execution backend's suspend/resume protocol -- a process parks, the
+// scheduler advances time, and the process resumes at its next block -- across
+// interleaved processes, which straight-line code never reaches.
+auto WriteTimingSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  int a;\n"
+      << "  int b;\n"
+      << "  initial begin\n"
+      << "    a = 1;\n"
+      << "    #10;\n"
+      << "    a = 2;\n"
+      << "    $display(\"a=%0d\", a);\n"
+      << "  end\n"
+      << "  initial begin\n"
+      << "    b = 1;\n"
+      << "    #5;\n"
+      << "    b = 2;\n"
+      << "    $display(\"b=%0d\", b);\n"
+      << "    #0;\n"
+      << "    $display(\"b0 done\");\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -154,6 +181,38 @@ TEST(LyraRun, JitAndCppAgreeOnProceduralCode) {
   EXPECT_NE(jit.stdout_text.find("name=lyra eq=1"), std::string::npos)
       << "stdout: " << jit.stdout_text;
   EXPECT_NE(jit.stdout_text.find("scaled=40"), std::string::npos)
+      << "stdout: " << jit.stdout_text;
+}
+
+// A process that consumes time suspends and resumes on the execution backend,
+// and multiple such processes are driven by one scheduler on one time axis. The
+// two backends must agree on both the values and their simulation-time order,
+// so the same timed source is run through both and the outputs compared.
+TEST(LyraRun, JitAndCppAgreeOnTimingControl) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteTimingSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(jit.stdout_text, "b=2\nb0 done\na=2\n")
       << "stdout: " << jit.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

A process can now consume time on the execution backend: a body that hits `#5` parks, the scheduler advances, and the body resumes where it left off. The same source run through the JIT and through the C++ backend produces identical output, which is what the new differential test asserts. Event control, level wait, and named-event wait still reject at MIR-to-LIR; they differ from a delay only in the runtime call that precedes an identical suspend edge, so they are the next slices rather than new machinery.

## Design

Coroutine-ness is the callable's result type, and nothing else. It was previously restated as `mir::ReturnStmt::is_coroutine_return` -- a field whose own comment described it as a render hint for one backend, which is exactly what the backend contract forbids MIR from carrying. That flag, and the lowering machinery that existed only to set it, are gone; the C++ backend reads `co_return` from the enclosing callable's result type, and MIR-to-LIR carries that type through rather than erasing it to void. Each layer now names the predicate once instead of hand-rolling the same `holds_alternative` in four places.

A suspension is a control edge. `SuspendTerm` hands control back to the scheduler and names the resume block; it schedules nothing and names no wakeup. The wakeup is registered by an ordinary runtime call that precedes the terminator, so a delay, an event control, and a level wait will differ only in that call. The registration acts on the process the runtime currently has running, so no activation token appears in LIR or in generated code. The LIR verifier rejects a suspension in a body whose result type is not a coroutine.

The LLVM backend states where a body suspends; LLVM derives how it resumes. A coroutine body is emitted as an ordinary function carrying coroutine intrinsics, and the coroutine passes -- run as a lowering step in the JIT pipeline, not as part of an optimization pipeline -- derive the frame, the resume state machine, and the values that must survive a suspension. The emitter gained no signature special case and no hand-written state machine: the function's `ptr(ptr)` shape falls out of the type mapping, because a coroutine type maps to an opaque handle like every other runtime value.

The engine still resumes a runtime-owned adapter rather than a generated frame. The reason is not that a code generator cannot produce a coroutine -- with intrinsics it produces a real one -- but that the activation token is a C++ promise carrying non-trivial members, and a generated frame should not have to embed a runtime class's layout, construction, and destruction to be schedulable. The adapter owns the promise on the body's behalf, so only a coroutine handle's resume, done, and destroy cross the boundary.

## Testing

`JitAndCppAgreeOnTimingControl` runs two processes that suspend on delays and resume in simulation-time order, plus a `#0` that re-enters the inactive region, through both backends and compares their output. A value that must outlive a suspension is still unsupported: the coroutine passes persist a body's slots, but a value here is an opaque handle into storage the runtime owns for one stretch of generated code, so persisting the slot does not persist the object. That is the activation-frame question the value-realization decision leaves open, and it is recorded in the new decision entry.