### PR TITLE
Support the data-query and array-query functions

### DIFF
--- a/docs/progress/query-functions.md
+++ b/docs/progress/query-functions.md
@@ -11,20 +11,27 @@ current state.
 
 ## Semantic model
 
-These functions split on one axis, fixed by the LRM:
+The split is not between queries but between the facts a query reports. Whatever the operand's type
+fixes is an **elaboration-time constant**; only what the value's current state decides is read at
+run time.
 
-- A query whose operand is a type, or a value of fixed-size type, is an **elaboration-time
-  constant**. The operand is never evaluated (LRM 20.6.2: `$bits` is "determined without actual
-  evaluation of the expression"; 20.6.1: `$typename`'s expression "is never evaluated"). The result
-  is a property of the type, fixed per specialization -- a type cannot depend on a genvar, and any
-  dimension argument is itself a constant expression -- so it is a literal at the query site, not a
-  runtime read. This is distinct from the select-bound rule (a bound may be a genvar-dependent
-  runtime value and is lowered faithfully): a query operand has no runtime form to be faithful to.
-- A query whose operand is a dynamically sized value (dynamic array, queue, associative array,
-  string) reports the array's **current state** and is a genuine runtime query (LRM 20.7: "When used
-  on a dynamic array or queue dimension, these functions return information about the current
-  state"; 20.6.2: `$bits` of a dynamically sized value returns its current bit count, 0 when empty).
-  It is an error to apply these directly to a dynamically sized type identifier.
+- The operand is never evaluated (LRM 20.6.2: `$bits` is "determined without actual evaluation of
+  the expression"; 20.6.1: `$typename`'s expression "is never evaluated"), and it may be a data type
+  rather than a value, which has no runtime form at all. A type cannot depend on a genvar, so every
+  type-fixed result is a literal at the query site. This is distinct from the select-bound rule (a
+  bound may be a genvar-dependent runtime value and is lowered faithfully): a query operand has no
+  runtime form to be faithful to.
+- A dynamically sized dimension (dynamic array, queue, associative array, string) reports its
+  **current state** (LRM 20.7: "When used on a dynamic array or queue dimension, these functions
+  return information about the current state"; 20.6.2: `$bits` of a dynamically sized value returns
+  its current bit count, 0 when empty). Only the dimension's extent is such a fact. Its direction
+  follows from its kind -- a queue or dynamic array dimension ascends from 0 -- and an associative
+  dimension's index space follows from its index type, so those remain constants even though the
+  dimension is dynamic. It is an error to apply these directly to a dynamically sized type
+  identifier, which the frontend rejects.
+- The dimension argument need not be a constant expression, and neither the LRM nor the frontend
+  requires one. An index the simulation supplies selects among the per-dimension results, which the
+  operand's type still fixes.
 
 `$dimensions` and `$unpacked_dimensions` count dimensions, a type property, so they are constant for
 every operand, dynamic included.
@@ -35,15 +42,40 @@ every operand, dynamic included.
       The operand is not evaluated; the result is the bit count of the operand's type, usable
       wherever an integer constant is, including as a part-select bound. Unblocks the `ibex_top`
       reduction over a `$bits`-derived part-select tracked in `ibex.md`.
-- [ ] Q2 -- The array query functions on a fixed-size dimension, as elaboration-time constants (LRM
+- [x] Q2 -- The array query functions on a fixed-size dimension, as elaboration-time constants (LRM
       20.7): `$left`, `$right`, `$low`, `$high`, `$increment`, `$size`, with the optional constant
       dimension argument, plus `$dimensions` and `$unpacked_dimensions` for every type. Covers
       packed and unpacked, single- and multi-dimensional shapes.
-- [ ] Q3 -- `$typename` as an elaboration-time string constant (LRM 20.6.1), for a type or an
+- [x] Q3 -- `$typename` as an elaboration-time string constant (LRM 20.6.1), for a type or an
       expression operand.
-- [ ] Q4 -- The runtime forms over a dynamically sized operand: `$bits` of a dynamically sized value
+- [x] Q4 -- The runtime forms over a dynamically sized operand: `$bits` of a dynamically sized value
       (0 when empty), and the array queries on a dynamic / queue / associative dimension reporting
-      current state (LRM 20.6.2, 20.7).
+      current state (LRM 20.6.2, 20.7). Only a dimension's extent depends on the current state; its
+      direction follows from its kind, and an associative dimension's index space from its index
+      type, so those stay elaboration-time constants. An associative dimension reports its index
+      type's default while no index is allocated, which is the `'x` LRM 20.7 requires when that type
+      is 4-state.
+- [x] Q5 -- A dimension named by an expression the running simulation supplies (LRM 20.7 does not
+      require the dimension to be a constant expression). The query selects among the per-dimension
+      results, which the operand's type still fixes; an index the type has no dimension for reads
+      `'x`.
+- [ ] Q6 -- A dimension named at run time over an array that has a dynamically sized dimension. LRM
+      20.7.1 makes it an error for such an index to name that dimension; an index only the
+      simulation knows cannot be held to that rule at elaboration, so the form is rejected rather
+      than half-served. Reporting the error when the index actually lands on that dimension is what
+      the form needs.
+- [ ] Q7 -- `$bits` of a value whose elements are themselves dynamically sized (a dynamic array of
+      dynamic arrays, a queue of strings). Every other dynamically sized operand reports its element
+      count times the bits one element occupies; a dynamically sized element has no such fixed
+      width, so the count has to be summed over the elements.
+
+## LRM ambiguity
+
+LRM 20.7 lists the dimensions these functions accept as fixed-size, dynamic, associative, or queue,
+and does not say which of those a `string` is, while LRM 20.7's `$dimensions` counts a string as one
+dimension. A string dimension is treated here as its characters: `$size` is the character count and
+the dimension ascends from 0, which agrees with the frontend's own typing and with `$bits` of the
+same string.
 
 ## Out of scope
 

--- a/include/lyra/lowering/ast_to_hir/expression/query.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/query.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+// Lowering of the LRM 20.6 data-query and 20.7 array-query system functions
+// (`$bits`, `$typename`, `$left` / `$right` / `$low` / `$high` / `$increment` /
+// `$size`, `$dimensions` / `$unpacked_dimensions`).
+
+#include <optional>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/walk_frame.hpp"
+
+namespace slang::ast {
+class CallExpression;
+}  // namespace slang::ast
+
+namespace lyra::lowering::ast_to_hir {
+
+// A query reports a property of a type or of an array's shape rather than
+// computing over a value, so its operand is never evaluated (LRM 20.6.1,
+// 20.6.2) and may be a data type, which has no value form. The call is
+// therefore resolved ahead of the argument loop, and returns nullopt when it is
+// not a query.
+//
+// Whatever the operand's type fixes, the query reports as an elaboration-time
+// constant: a type's bit count or name, a dimension count, and every property
+// of a fixed-size dimension -- and also a dynamically sized dimension's
+// direction, which its kind fixes even though its extent is unknown. What is
+// left is the extent itself, which the query reads from the value's current
+// state as an ordinary expression over the container's element count.
+//
+// A dimension the running simulation names (LRM 20.7 does not require a
+// constant one) selects among those per-dimension constants, which the
+// operand's type still fixes whichever of them the index lands on.
+template <ExprLowerer Lowerer>
+auto LowerQueryExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    diag::SourceSpan span) -> diag::Result<std::optional<hir::Expr>>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -134,6 +134,13 @@ class ModuleLowerer {
     return unit_;
   }
 
+  // The slang instance body this unit is lowered from. A constant expression
+  // the lowering must evaluate itself -- an LRM 20.7 dimension index -- is
+  // evaluated against it.
+  [[nodiscard]] auto Body() const -> const slang::ast::InstanceBodySymbol& {
+    return *body_;
+  }
+
   // Lowers a slang type to a HIR TypeId, memoizing by slang canonical pointer.
   // The slang-keyed cache and the unit's type table are coordinated together:
   // the dedup invariant (same slang canonical -> same HIR TypeId) is enforced
@@ -141,6 +148,12 @@ class ModuleLowerer {
   // directly.
   auto InternType(const slang::ast::Type& type, diag::SourceSpan span)
       -> diag::Result<hir::TypeId>;
+
+  // Adds a type the lowering itself composes rather than reads off the
+  // frontend -- the array of a type's per-dimension query results that an LRM
+  // 20.7 query selects from when its dimension is named at run time. There is
+  // no frontend type to key the cache on, so it is added directly.
+  auto AddComposedType(hir::TypeData data) -> hir::TypeId;
 
   // Registers a class declaration on first encounter and returns its id,
   // memoizing by slang class pointer. The id is declared before the body is

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -63,6 +63,12 @@ enum class BuiltinFn : std::uint16_t {
   kAssocLast,
   kAssocNext,
   kAssocPrev,
+  // The smallest and largest currently allocated index (LRM 20.7 `$low` /
+  // `$high` over an associative dimension). Each takes the value to report when
+  // no index is allocated -- the index type's default, which is `'x` for a
+  // 4-state index, as LRM 20.7 requires.
+  kAssocMinIndex,
+  kAssocMaxIndex,
   // LRM 6.16 string methods.
   kGetc,
   kPutc,
@@ -414,10 +420,14 @@ enum class BuiltinFn : std::uint16_t {
 // `reverse`) take no closure.
 [[nodiscard]] auto ArrayMethodTakesClosure(BuiltinFn id) -> bool;
 
-// True iff the LRM 7.12 method yields a new value whose result shape the
-// producer supplies (the reduction, locator, and map families). The ordering
-// family (`sort` / `rsort` / `reverse`) mutates in place and yields none.
-[[nodiscard]] auto ArrayMethodProducesValue(BuiltinFn id) -> bool;
+// True iff the entry yields a value whose shape the call site must supply as a
+// trailing prototype argument, because the receiver does not determine it: the
+// LRM 7.12 reduction, locator, and map families (an index locator's key, a
+// map's chosen element, an empty reduction's zero) and the associative index
+// queries (the value an unallocated dimension reports). The LRM 7.12 ordering
+// family
+// (`sort` / `rsort` / `reverse`) mutates in place and yields no value.
+[[nodiscard]] auto BuiltinFnTakesResultPrototype(BuiltinFn id) -> bool;
 
 // True iff `id` is an associative-array traversal entry (LRM 7.9.4 -- 7.9.7).
 // The traversal family lowers to an immediately-invoked closure (mutates the

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -285,6 +285,17 @@ class AssociativeArray {
     return data_.rbegin()->first;
   }
 
+  // LRM 20.7 `$low` / `$high` over an associative dimension: the smallest and
+  // largest currently allocated index. With none allocated the dimension has no
+  // index to report and the query reads `unallocated` -- the index type's
+  // default, which is `'x` for a 4-state index type, as LRM 20.7 requires.
+  [[nodiscard]] auto MinIndex(const K& unallocated) const -> K {
+    return FirstKey().value_or(unallocated);
+  }
+  [[nodiscard]] auto MaxIndex(const K& unallocated) const -> K {
+    return LastKey().value_or(unallocated);
+  }
+
   // LRM 7.9.6 / 7.9.7: the smallest stored key strictly greater than `probe`
   // (next) or the largest strictly less (prev), or absent when none exists.
   // `probe` shares the stored keys' index type, so the bound lookup runs

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -216,6 +216,10 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Next";
     case support::BuiltinFn::kAssocPrev:
       return "Prev";
+    case support::BuiltinFn::kAssocMinIndex:
+      return "MinIndex";
+    case support::BuiltinFn::kAssocMaxIndex:
+      return "MaxIndex";
     case support::BuiltinFn::kDelay:
       return "Delay";
     case support::BuiltinFn::kSimTime:

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -25,8 +25,8 @@
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
-#include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/expression/query.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
@@ -76,32 +76,6 @@ auto ClassMethodIndex(const slang::ast::SubroutineSymbol& method)
   throw InternalError("ClassMethodIndex: method not found in its class");
 }
 
-// `$bits` of a fixed-size operand is the bit count of its type (LRM 20.6.2),
-// folded to an integer constant here; the operand is never evaluated. A
-// dynamically sized value operand is a runtime query of the current bit count
-// and is not yet supported (a dynamically sized type operand is rejected
-// earlier by the frontend).
-auto LowerBitsQuery(
-    ModuleLowerer& module, WalkFrame frame,
-    const slang::ast::CallExpression& call, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  const slang::ast::Type& operand_type = *call.arguments()[0]->type;
-  if (!operand_type.isFixedSize()) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "$bits of a dynamically sized value is not yet supported");
-  }
-  auto type_id = module.InternType(*call.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  // slang types `$bits` as `integer` (4-state); coerce the bit count to that
-  // type so the folded constant's state domain matches its declared type rather
-  // than the 2-state value it is built from.
-  const slang::ConstantValue width = call.type->coerceValue(
-      slang::ConstantValue{
-          slang::SVInt(32, operand_type.getBitstreamWidth(), true)});
-  return MakeConstantValueExpr(module.Unit(), frame, width, *type_id, span);
-}
-
 }  // namespace
 
 template <ExprLowerer Lowerer>
@@ -110,17 +84,12 @@ auto LowerCallExpr(
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto& module = lowerer.Module();
 
-  // A query whose operand may be a type is resolved before the argument loop: a
-  // `DataType` operand has no value form and cannot be lowered as one. `$bits`
-  // is the first such function (LRM 20.6.2).
-  if (call.isSystemCall()) {
-    const auto& info =
-        std::get<slang::ast::CallExpression::SystemCallInfo>(call.subroutine);
-    if (info.subroutine != nullptr &&
-        info.subroutine->knownNameId == slang::parsing::KnownSystemName::Bits) {
-      return LowerBitsQuery(module, frame, call, span);
-    }
-  }
+  // The LRM 20.6 / 20.7 queries are resolved before the argument loop: their
+  // operand is never evaluated and may be a data type, which has no value form
+  // to lower.
+  auto query = LowerQueryExpr(lowerer, frame, call, span);
+  if (!query) return std::unexpected(std::move(query.error()));
+  if (query->has_value()) return *std::move(*query);
 
   std::vector<std::optional<hir::ExprId>> arg_ids;
   arg_ids.reserve(call.arguments().size());

--- a/src/lyra/lowering/ast_to_hir/expression/query.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/query.cpp
@@ -1,0 +1,574 @@
+#include "lyra/lowering/ast_to_hir/expression/query.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <slang/ast/EvalContext.h>
+#include <slang/ast/Expression.h>
+#include <slang/ast/SystemSubroutine.h>
+#include <slang/ast/expressions/CallExpression.h>
+#include <slang/ast/types/Type.h>
+#include <slang/ast/types/TypePrinter.h>
+#include <slang/numeric/ConstantValue.h>
+#include <slang/numeric/SVInt.h>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/conversion.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/hir/type.hpp"
+#include "lyra/hir/type_id.hpp"
+#include "lyra/lowering/ast_to_hir/constant_value.hpp"
+#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/support/builtin_fn.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+using slang::parsing::KnownSystemName;
+
+// The LRM 20.6 / 20.7 query family. Each member reports a property of its
+// operand's type or of one of that type's dimensions.
+enum class QueryKind : std::uint8_t {
+  kBits,
+  kTypename,
+  kDimensions,
+  kUnpackedDimensions,
+  kLeft,
+  kRight,
+  kLow,
+  kHigh,
+  kIncrement,
+  kSize,
+};
+
+auto ClassifyQuery(KnownSystemName name) -> std::optional<QueryKind> {
+  switch (name) {
+    case KnownSystemName::Bits:
+      return QueryKind::kBits;
+    case KnownSystemName::Typename:
+      return QueryKind::kTypename;
+    case KnownSystemName::Dimensions:
+      return QueryKind::kDimensions;
+    case KnownSystemName::UnpackedDimensions:
+      return QueryKind::kUnpackedDimensions;
+    case KnownSystemName::Left:
+      return QueryKind::kLeft;
+    case KnownSystemName::Right:
+      return QueryKind::kRight;
+    case KnownSystemName::Low:
+      return QueryKind::kLow;
+    case KnownSystemName::High:
+      return QueryKind::kHigh;
+    case KnownSystemName::Increment:
+      return QueryKind::kIncrement;
+    case KnownSystemName::Size:
+      return QueryKind::kSize;
+    default:
+      return std::nullopt;
+  }
+}
+
+// The type whose own range is the dimension the query names. Dimension 1 is the
+// operand itself and each further one unwraps an array element (LRM 20.7: the
+// slowest varying dimension is dimension 1). Null when the operand has no such
+// dimension.
+auto DimensionType(const slang::ast::Type& operand, std::int32_t index)
+    -> const slang::ast::Type* {
+  const slang::ast::Type* type = &operand;
+  for (std::int32_t i = 1; i < index; ++i) {
+    if (!type->isArray()) {
+      return nullptr;
+    }
+    type = type->getArrayElementType();
+  }
+  return type;
+}
+
+// A dimension with declared bounds; its six query results all follow from them
+// (LRM 20.7). `$increment` is 1 when the left bound is at or above the right
+// one and -1 otherwise; `$low` and `$high` follow it, and `$size` spans them.
+auto FixedDimensionValue(QueryKind query, slang::ConstantRange range)
+    -> std::int64_t {
+  const std::int64_t left = range.left;
+  const std::int64_t right = range.right;
+  const std::int64_t increment = left >= right ? 1 : -1;
+  const std::int64_t low = increment == 1 ? right : left;
+  const std::int64_t high = increment == 1 ? left : right;
+  switch (query) {
+    case QueryKind::kLeft:
+      return left;
+    case QueryKind::kRight:
+      return right;
+    case QueryKind::kLow:
+      return low;
+    case QueryKind::kHigh:
+      return high;
+    case QueryKind::kIncrement:
+      return increment;
+    case QueryKind::kSize:
+      return high - low + 1;
+    default:
+      throw InternalError("FixedDimensionValue: not a dimension function");
+  }
+}
+
+// LRM 20.7: `$dimensions` counts every dimension of the operand's type,
+// `$unpacked_dimensions` stops at the packed ones. A string or a non-scalar
+// integral is itself one packed dimension; any other leaf contributes none.
+auto DimensionCount(const slang::ast::Type& operand, bool unpacked_only)
+    -> std::uint64_t {
+  std::uint64_t count = 0;
+  const slang::ast::Type* type = &operand;
+  while (type->isArray()) {
+    if (unpacked_only && !type->isUnpackedArray()) {
+      break;
+    }
+    ++count;
+    type = type->getArrayElementType();
+  }
+  if (!unpacked_only &&
+      (type->isString() || (type->isIntegral() && !type->isScalar()))) {
+    ++count;
+  }
+  return count;
+}
+
+// The dimension index the call names, defaulting to 1 when the call omits it
+// (LRM 20.7). Nullopt when the index is an expression whose value only
+// simulation knows -- legal, but then the query is not an elaboration-time
+// constant.
+auto ConstantDimensionIndex(
+    const ModuleLowerer& module, const slang::ast::CallExpression& call)
+    -> std::optional<std::int64_t> {
+  if (call.arguments().size() < 2) {
+    return 1;
+  }
+  slang::ast::EvalContext eval_context(module.Body());
+  const slang::ConstantValue index = call.arguments()[1]->eval(eval_context);
+  if (!index || !index.isInteger()) {
+    return std::nullopt;
+  }
+  return index.integer().as<std::int64_t>();
+}
+
+// A value of the type slang gave the call, so the literal carries that type's
+// state domain: LRM 20.7 types a dimension function's result as `integer`, a
+// 4-state type, and LRM 20.6.1 types `$typename`'s as `string`.
+auto MakeQueryConstant(
+    ModuleLowerer& module, WalkFrame frame,
+    const slang::ast::CallExpression& call, const slang::ConstantValue& value,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto type_id = module.InternType(*call.type, span);
+  if (!type_id) {
+    return std::unexpected(std::move(type_id.error()));
+  }
+  return MakeConstantValueExpr(
+      module.Unit(), frame, call.type->coerceValue(value), *type_id, span);
+}
+
+auto MakeQueryInt(
+    ModuleLowerer& module, WalkFrame frame,
+    const slang::ast::CallExpression& call, std::int64_t value,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  return MakeQueryConstant(
+      module, frame, call,
+      slang::ConstantValue{
+          slang::SVInt(32, static_cast<std::uint64_t>(value), true)},
+      span);
+}
+
+// The number of elements the operand currently holds, as a value of the query's
+// result type: LRM 6.16.1 `len()` for a string, the LRM 7.5.1 / 7.9.2 / 7.10.2
+// `size()` for the container families. Both yield an SV `int`, which the
+// conversion lands in the `integer` the query reports.
+template <ExprLowerer Lowerer>
+auto BuildElementCountExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  ModuleLowerer& module = lowerer.Module();
+  auto operand_or = lowerer.LowerExpr(*call.arguments()[0], frame);
+  if (!operand_or) {
+    return std::unexpected(std::move(operand_or.error()));
+  }
+  const bool is_string = module.Unit().types.Get(operand_or->type).Kind() ==
+                         hir::TypeKind::kString;
+  const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
+
+  auto result_type = module.InternType(*call.type, span);
+  if (!result_type) {
+    return std::unexpected(std::move(result_type.error()));
+  }
+  const hir::ExprId count_id = frame.Exprs().Add(
+      hir::Expr{
+          .type = module.Unit().builtins.int_type,
+          .data =
+              hir::CallExpr{
+                  .callee =
+                      hir::BuiltinMethodRef{
+                          .method = is_string ? support::BuiltinFn::kLen
+                                              : support::BuiltinFn::kSize},
+                  .arguments = {operand_id}},
+          .span = span});
+  return hir::Expr{
+      .type = *result_type,
+      .data =
+          hir::ConversionExpr{
+              .operand = count_id, .kind = hir::ConversionKind::kImplicit},
+      .span = span};
+}
+
+auto MakeQueryBinary(
+    WalkFrame frame, hir::BinaryOp op, hir::Expr lhs, hir::Expr rhs,
+    diag::SourceSpan span) -> hir::Expr {
+  const hir::TypeId type = lhs.type;
+  return hir::Expr{
+      .type = type,
+      .data =
+          hir::BinaryExpr{
+              .op = op,
+              .lhs = frame.Exprs().Add(std::move(lhs)),
+              .rhs = frame.Exprs().Add(std::move(rhs))},
+      .span = span};
+}
+
+// LRM 20.7 over a dimension whose size only the running simulation knows. The
+// dimension's direction is still fixed by its kind -- a queue or dynamic array
+// dimension ascends from 0 -- so `$left`, `$low`, and `$increment` remain
+// constants; only the dimension's extent has to be read from the value.
+template <ExprLowerer Lowerer>
+auto LowerOrderedDynamicDimensionQuery(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    QueryKind query, diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  ModuleLowerer& module = lowerer.Module();
+  switch (query) {
+    case QueryKind::kLeft:
+    case QueryKind::kLow:
+      return MakeQueryInt(module, frame, call, 0, span);
+    case QueryKind::kIncrement:
+      return MakeQueryInt(module, frame, call, -1, span);
+    case QueryKind::kSize:
+      return BuildElementCountExpr(lowerer, frame, call, span);
+    case QueryKind::kRight:
+    case QueryKind::kHigh: {
+      // The last position of an ascending dimension, which is -1 when the
+      // dimension is currently empty (LRM 20.7).
+      auto count_or = BuildElementCountExpr(lowerer, frame, call, span);
+      if (!count_or) {
+        return std::unexpected(std::move(count_or.error()));
+      }
+      auto one_or = MakeQueryInt(module, frame, call, 1, span);
+      if (!one_or) {
+        return std::unexpected(std::move(one_or.error()));
+      }
+      return MakeQueryBinary(
+          frame, hir::BinaryOp::kSub, *std::move(count_or), *std::move(one_or),
+          span);
+    }
+    default:
+      throw InternalError(
+          "LowerOrderedDynamicDimensionQuery: not a dimension function");
+  }
+}
+
+// The largest value the index type can hold, which is the highest index an
+// associative dimension can ever be given (LRM 20.7 `$right`). All ones, less
+// the sign bit when the index type is signed.
+auto HighestIndexValue(const slang::ast::Type& index_type) -> slang::SVInt {
+  slang::SVInt value(index_type.getBitWidth(), 0, index_type.isSigned());
+  value.setAllOnes();
+  if (index_type.isSigned()) {
+    value = value.lshr(1);
+  }
+  return value;
+}
+
+// LRM 20.7 over an associative dimension. The index space is a property of the
+// index type: it ascends from 0 up to that type's highest value, which leaves
+// `$left`, `$right`, and `$increment` constants. What the array currently holds
+// decides only how many indices are allocated and which of them are the
+// smallest and the largest. Every result here is typed as the index type, not
+// `integer`.
+template <ExprLowerer Lowerer>
+auto LowerAssociativeDimensionQuery(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    const slang::ast::Type& dimension, QueryKind query, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  ModuleLowerer& module = lowerer.Module();
+  switch (query) {
+    case QueryKind::kLeft:
+      return MakeQueryInt(module, frame, call, 0, span);
+    case QueryKind::kIncrement:
+      return MakeQueryInt(module, frame, call, -1, span);
+    case QueryKind::kRight:
+      return MakeQueryConstant(
+          module, frame, call,
+          slang::ConstantValue{
+              HighestIndexValue(*dimension.getAssociativeIndexType())},
+          span);
+    case QueryKind::kSize:
+      return BuildElementCountExpr(lowerer, frame, call, span);
+    case QueryKind::kLow:
+    case QueryKind::kHigh: {
+      auto operand_or = lowerer.LowerExpr(*call.arguments()[0], frame);
+      if (!operand_or) {
+        return std::unexpected(std::move(operand_or.error()));
+      }
+      auto result_type = module.InternType(*call.type, span);
+      if (!result_type) {
+        return std::unexpected(std::move(result_type.error()));
+      }
+      return hir::Expr{
+          .type = *result_type,
+          .data =
+              hir::CallExpr{
+                  .callee =
+                      hir::BuiltinMethodRef{
+                          .method = query == QueryKind::kLow
+                                        ? support::BuiltinFn::kAssocMinIndex
+                                        : support::BuiltinFn::kAssocMaxIndex},
+                  .arguments = {frame.Exprs().Add(*std::move(operand_or))}},
+          .span = span};
+    }
+    default:
+      throw InternalError(
+          "LowerAssociativeDimensionQuery: not a dimension function");
+  }
+}
+
+// LRM 20.6.2 over a dynamically sized value: the bit count of what it currently
+// holds. Every element occupies the same fixed number of bits -- a string's is
+// a byte -- so the count is the element count times that width. An element
+// whose own size only the running simulation knows has no such width.
+template <ExprLowerer Lowerer>
+auto LowerDynamicBitsQuery(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  const slang::ast::Type& operand_type = *call.arguments()[0]->type;
+  std::uint64_t element_bits = 8;
+  if (!operand_type.isString()) {
+    const slang::ast::Type& element = *operand_type.getArrayElementType();
+    if (!element.isFixedSize()) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "$bits of a value whose elements are themselves dynamically sized is "
+          "not yet supported");
+    }
+    element_bits = element.getBitstreamWidth();
+  }
+
+  auto count_or = BuildElementCountExpr(lowerer, frame, call, span);
+  if (!count_or) {
+    return std::unexpected(std::move(count_or.error()));
+  }
+  auto width_or = MakeQueryInt(
+      lowerer.Module(), frame, call, static_cast<std::int64_t>(element_bits),
+      span);
+  if (!width_or) {
+    return std::unexpected(std::move(width_or.error()));
+  }
+  return MakeQueryBinary(
+      frame, hir::BinaryOp::kMul, *std::move(count_or), *std::move(width_or),
+      span);
+}
+
+// LRM 20.6.2: the bit count of the operand's type, taken without evaluating the
+// operand. A dynamically sized operand instead reports the bit count of what it
+// currently holds.
+template <ExprLowerer Lowerer>
+auto LowerBitsQuery(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  const slang::ast::Type& operand_type = *call.arguments()[0]->type;
+  if (!operand_type.isFixedSize()) {
+    return LowerDynamicBitsQuery(lowerer, frame, call, span);
+  }
+  return MakeQueryConstant(
+      lowerer.Module(), frame, call,
+      slang::ConstantValue{
+          slang::SVInt(32, operand_type.getBitstreamWidth(), true)},
+      span);
+}
+
+// LRM 20.6.1: the operand's resolved type name. The string is canonical, and
+// the rules that make it so -- a typedef resolved back to what it names, the
+// default signing dropped, a user-defined name qualified by its declaring scope
+// -- are the frontend type printer's.
+auto LowerTypenameQuery(
+    ModuleLowerer& module, WalkFrame frame,
+    const slang::ast::CallExpression& call, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  slang::ast::TypePrinter printer;
+  printer.append(*call.arguments()[0]->type);
+  return MakeQueryConstant(
+      module, frame, call, slang::ConstantValue{printer.toString()}, span);
+}
+
+auto LowerDimensionCountQuery(
+    ModuleLowerer& module, WalkFrame frame,
+    const slang::ast::CallExpression& call, bool unpacked_only,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  return MakeQueryInt(
+      module, frame, call,
+      static_cast<std::int64_t>(
+          DimensionCount(*call.arguments()[0]->type, unpacked_only)),
+      span);
+}
+
+// LRM 20.7 with a dimension the running simulation names. Which dimensions the
+// operand has is still a property of its type, so each one's result is a
+// constant and the query is a select, by the index, out of the array of them.
+// The array is declared over `[1 : dimension count]`, so the index selects
+// directly; an index the type has no dimension for falls outside that range and
+// reads the element default, which for the `integer` a dimension function
+// reports is `'x` -- what LRM 20.7 requires of an out-of-range dimension.
+template <ExprLowerer Lowerer>
+auto LowerComposedDimensionQuery(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    QueryKind query, diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  ModuleLowerer& module = lowerer.Module();
+  const slang::ast::Type& operand_type = *call.arguments()[0]->type;
+  const auto dimension_count =
+      static_cast<std::int64_t>(DimensionCount(operand_type, false));
+
+  slang::ConstantValue::Elements rows;
+  rows.reserve(static_cast<std::size_t>(dimension_count));
+  for (std::int64_t i = 1; i <= dimension_count; ++i) {
+    const slang::ast::Type* dimension =
+        DimensionType(operand_type, static_cast<std::int32_t>(i));
+    // A dimension whose extent only the running simulation knows has no
+    // constant result to tabulate. LRM 20.7.1 forbids naming such a dimension
+    // beyond the first, but an index the simulation supplies cannot be held to
+    // that rule at elaboration.
+    if (dimension == nullptr || !dimension->hasFixedRange() ||
+        dimension->isScalar()) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "an array query whose dimension is not a constant expression is not "
+          "yet supported over an array with a dynamically sized dimension");
+    }
+    rows.emplace_back(call.type->coerceValue(
+        slang::ConstantValue{slang::SVInt(
+            32,
+            static_cast<std::uint64_t>(
+                FixedDimensionValue(query, dimension->getFixedRange())),
+            true)}));
+  }
+
+  auto element_type = module.InternType(*call.type, span);
+  if (!element_type) {
+    return std::unexpected(std::move(element_type.error()));
+  }
+  const hir::TypeId table_type = module.AddComposedType(
+      hir::UnpackedArrayType{
+          .element_type = *element_type,
+          .dim = hir::UnpackedRange{.left = 1, .right = dimension_count}});
+  auto table_or = MakeConstantValueExpr(
+      module.Unit(), frame, slang::ConstantValue{std::move(rows)}, table_type,
+      span);
+  if (!table_or) {
+    return std::unexpected(std::move(table_or.error()));
+  }
+  auto index_or = lowerer.LowerExpr(*call.arguments()[1], frame);
+  if (!index_or) {
+    return std::unexpected(std::move(index_or.error()));
+  }
+  return hir::Expr{
+      .type = *element_type,
+      .data =
+          hir::ElementSelectExpr{
+              .base_value = frame.Exprs().Add(*std::move(table_or)),
+              .index = frame.Exprs().Add(*std::move(index_or))},
+      .span = span};
+}
+
+template <ExprLowerer Lowerer>
+auto LowerDimensionQuery(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    QueryKind query, diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  ModuleLowerer& module = lowerer.Module();
+  const std::optional<std::int64_t> index =
+      ConstantDimensionIndex(module, call);
+  if (!index.has_value()) {
+    return LowerComposedDimensionQuery(lowerer, frame, call, query, span);
+  }
+
+  // A constant index names a dimension the frontend has already checked the
+  // operand has, so failing to reach it means this unwrapping and the
+  // frontend's disagree.
+  const slang::ast::Type* dimension = DimensionType(
+      *call.arguments()[0]->type, static_cast<std::int32_t>(*index));
+  if (dimension == nullptr) {
+    throw InternalError("LowerDimensionQuery: dimension index out of range");
+  }
+
+  if (dimension->hasFixedRange() && !dimension->isScalar()) {
+    return MakeQueryInt(
+        module, frame, call,
+        FixedDimensionValue(query, dimension->getFixedRange()), span);
+  }
+  if (dimension->isAssociativeArray()) {
+    return LowerAssociativeDimensionQuery(
+        lowerer, frame, call, *dimension, query, span);
+  }
+  return LowerOrderedDynamicDimensionQuery(lowerer, frame, call, query, span);
+}
+
+}  // namespace
+
+template <ExprLowerer Lowerer>
+auto LowerQueryExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    diag::SourceSpan span) -> diag::Result<std::optional<hir::Expr>> {
+  if (!call.isSystemCall()) {
+    return std::optional<hir::Expr>{};
+  }
+  const auto& info =
+      std::get<slang::ast::CallExpression::SystemCallInfo>(call.subroutine);
+  if (info.subroutine == nullptr) {
+    return std::optional<hir::Expr>{};
+  }
+  const std::optional<QueryKind> query =
+      ClassifyQuery(info.subroutine->knownNameId);
+  if (!query.has_value()) {
+    return std::optional<hir::Expr>{};
+  }
+
+  ModuleLowerer& module = lowerer.Module();
+  diag::Result<hir::Expr> result = [&] {
+    switch (*query) {
+      case QueryKind::kBits:
+        return LowerBitsQuery(lowerer, frame, call, span);
+      case QueryKind::kTypename:
+        return LowerTypenameQuery(module, frame, call, span);
+      case QueryKind::kDimensions:
+        return LowerDimensionCountQuery(module, frame, call, false, span);
+      case QueryKind::kUnpackedDimensions:
+        return LowerDimensionCountQuery(module, frame, call, true, span);
+      default:
+        return LowerDimensionQuery(lowerer, frame, call, *query, span);
+    }
+  }();
+  if (!result) {
+    return std::unexpected(std::move(result.error()));
+  }
+  return std::optional<hir::Expr>{*std::move(result)};
+}
+
+template auto LowerQueryExpr(
+    ProcessLowerer& lowerer, WalkFrame frame,
+    const slang::ast::CallExpression& call, diag::SourceSpan span)
+    -> diag::Result<std::optional<hir::Expr>>;
+template auto LowerQueryExpr(
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const slang::ast::CallExpression& call, diag::SourceSpan span)
+    -> diag::Result<std::optional<hir::Expr>>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -575,6 +575,10 @@ auto ModuleLowerer::InternClass(
   return id;
 }
 
+auto ModuleLowerer::AddComposedType(hir::TypeData data) -> hir::TypeId {
+  return unit_.types.Add(hir::Type{.data = std::move(data)});
+}
+
 auto ModuleLowerer::InternType(
     const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<hir::TypeId> {

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -178,14 +178,11 @@ auto ArrayMethodReceiverElementType(const hir::Type& ty)
   return std::nullopt;
 }
 
-// The canonical-default prototype type for a value-producing LRM 7.12 method
-// (decision: array-manipulation-entry-stream): a locator / map result is a
-// container, so its element type is the prototype; a reduction result is the
-// scalar itself. The producer supplies the prototype because the result shape
-// (an index locator's key, a map's chosen element, an empty reduction's zero)
-// is not always recoverable from the receiver.
-auto ArrayMethodResultProtoType(
-    const ModuleLowerer& module, mir::TypeId result_type) -> mir::TypeId {
+// The canonical-default prototype type for an entry whose result shape the
+// receiver does not determine: a container result contributes its element type
+// as the prototype; a scalar result is its own prototype.
+auto ResultPrototypeType(const ModuleLowerer& module, mir::TypeId result_type)
+    -> mir::TypeId {
   return std::visit(
       Overloaded{
           [](const mir::UnpackedArrayType& t) { return t.element_type; },
@@ -494,21 +491,20 @@ auto LowerBuiltinMethodCall(
         c.with_clause.has_value() ? &*c.with_clause : nullptr);
     if (!closure_or) return std::unexpected(std::move(closure_or.error()));
     args.push_back(block.exprs.Add(*std::move(closure_or)));
-    // LRM 7.12 reduction / locator / map: the producer supplies the result's
-    // canonical default, since the result shape (an index locator's key, a
-    // map's chosen element, an empty reduction's zero) is not recoverable from
-    // the receiver (decision: array-manipulation-entry-stream). The ordering
-    // family produces no value and takes none.
-    if (support::ArrayMethodProducesValue(b.method)) {
-      const mir::TypeId proto_type =
-          ArrayMethodResultProtoType(module, result_type);
-      args.push_back(
-          block.exprs.Add(BuildDefaultValueExpr(module, frame, proto_type)));
-    }
   } else if (c.with_clause.has_value()) {
     throw InternalError(
         "BuiltinMethodRef with-clause on a method kind that does not "
         "accept a with-clause (LRM 7.12.1 family only)");
+  }
+
+  // The producer supplies the result's canonical default whenever the receiver
+  // does not determine the result's shape -- an LRM 7.12 index locator's key, a
+  // map's chosen element, an empty reduction's zero, or the index an empty
+  // associative dimension reports (LRM 20.7).
+  if (support::BuiltinFnTakesResultPrototype(b.method)) {
+    const mir::TypeId proto_type = ResultPrototypeType(module, result_type);
+    args.push_back(
+        block.exprs.Add(BuildDefaultValueExpr(module, frame, proto_type)));
   }
 
   // LRM 15.5.3: `e.triggered` reads the triggered flag out of

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -65,8 +65,10 @@ auto ArrayMethodTakesClosure(BuiltinFn id) -> bool {
   }
 }
 
-auto ArrayMethodProducesValue(BuiltinFn id) -> bool {
+auto BuiltinFnTakesResultPrototype(BuiltinFn id) -> bool {
   switch (id) {
+    case BuiltinFn::kAssocMinIndex:
+    case BuiltinFn::kAssocMaxIndex:
     case BuiltinFn::kSum:
     case BuiltinFn::kProduct:
     case BuiltinFn::kAnd:
@@ -188,6 +190,10 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "assoc_next";
     case BuiltinFn::kAssocPrev:
       return "assoc_prev";
+    case BuiltinFn::kAssocMinIndex:
+      return "assoc_min_index";
+    case BuiltinFn::kAssocMaxIndex:
+      return "assoc_max_index";
     case BuiltinFn::kGetc:
       return "getc";
     case BuiltinFn::kPutc:

--- a/tests/cases/cpp/query_array_shape/case.yaml
+++ b/tests/cases/cpp/query_array_shape/case.yaml
@@ -1,0 +1,48 @@
+id: cpp.query_array_shape
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    ram_dims: 2
+    ram_updims: 1
+    ram_left: 0
+    ram_right: 9
+    ram_low: 0
+    ram_high: 9
+    ram_incr: -1
+    ram_size: 10
+    word_size: 16
+    word_left: 16
+    word_right: 1
+    word_low: 1
+    word_high: 16
+    word_incr: 1
+    p2d_dims: 2
+    p2d_updims: 0
+    p2d_size: 4
+    p2d_inner_size: 8
+    p2d_left: 3
+    p2d_incr: 1
+    desc_size: 6
+    desc_left: 7
+    desc_right: 2
+    desc_low: 2
+    desc_high: 7
+    desc_incr: 1
+    desc_dims: 2
+    desc_updims: 1
+    plain_size: 32
+    plain_left: 31
+    plain_dims: 1
+    flag_dims: 0
+    s_dims: 1
+    s_updims: 0
+    rt_size: 16
+    rt_left: 16
+    rt_incr: 1
+    rt_out_of_range: "32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/tests/cases/cpp/query_array_shape/main.sv
+++ b/tests/cases/cpp/query_array_shape/main.sv
@@ -1,0 +1,89 @@
+// LRM 20.7 array query functions over fixed-size dimensions, and the dimension
+// counts. Each result is a property of the operand's type, so the operand is
+// never evaluated and every call is an elaboration-time constant. Dimension 1
+// is the slowest varying one; the optional second argument names a deeper one.
+// `$increment` is 1 for a descending dimension and -1 for an ascending one, and
+// `$low` / `$high` follow it, so a descending unpacked range reports the same
+// shape a packed one does.
+module Top;
+  typedef logic [16:1] Word;
+
+  Word             ram      [0:9];
+  logic [3:0][7:0] packed2d;
+  int              desc     [7:2];
+  int              plain;
+  bit              flag;
+  string           s;
+
+  int ram_dims, ram_updims;
+  int ram_left, ram_right, ram_low, ram_high, ram_incr, ram_size;
+  int word_size, word_left, word_right, word_low, word_high, word_incr;
+
+  int p2d_dims, p2d_updims, p2d_size, p2d_inner_size, p2d_left, p2d_incr;
+
+  int desc_size, desc_left, desc_right, desc_low, desc_high, desc_incr;
+  int desc_dims, desc_updims;
+
+  int plain_size, plain_left, plain_dims;
+  int flag_dims;
+  int s_dims, s_updims;
+
+  // LRM 20.7 does not require the dimension to be a constant expression. Which
+  // dimensions the operand has is still a property of its type, so the query
+  // selects among their results by the index; an index the type has no
+  // dimension for reads `'x`.
+  int d;
+  integer rt_size, rt_left, rt_incr, rt_out_of_range;
+
+  initial begin
+    ram_dims = $dimensions(ram);
+    ram_updims = $unpacked_dimensions(ram);
+    ram_left = $left(ram);
+    ram_right = $right(ram);
+    ram_low = $low(ram);
+    ram_high = $high(ram);
+    ram_incr = $increment(ram);
+    ram_size = $size(ram);
+
+    word_size = $size(ram, 2);
+    word_left = $left(ram, 2);
+    word_right = $right(ram, 2);
+    word_low = $low(ram, 2);
+    word_high = $high(ram, 2);
+    word_incr = $increment(ram, 2);
+
+    p2d_dims = $dimensions(packed2d);
+    p2d_updims = $unpacked_dimensions(packed2d);
+    p2d_size = $size(packed2d);
+    p2d_inner_size = $size(packed2d, 2);
+    p2d_left = $left(packed2d);
+    p2d_incr = $increment(packed2d);
+
+    desc_size = $size(desc);
+    desc_left = $left(desc);
+    desc_right = $right(desc);
+    desc_low = $low(desc);
+    desc_high = $high(desc);
+    desc_incr = $increment(desc);
+    desc_dims = $dimensions(desc);
+    desc_updims = $unpacked_dimensions(desc);
+
+    // An integral type of predefined width is one packed dimension of that
+    // width; a scalar has no dimension at all.
+    plain_size = $size(plain);
+    plain_left = $left(plain);
+    plain_dims = $dimensions(plain);
+    flag_dims = $dimensions(flag);
+
+    // A string is one dimension, and it is a packed one.
+    s_dims = $dimensions(s);
+    s_updims = $unpacked_dimensions(s);
+
+    d = 2;
+    rt_size = $size(ram, d);
+    rt_left = $left(ram, d);
+    rt_incr = $increment(ram, d);
+    d = 5;
+    rt_out_of_range = $size(ram, d);
+  end
+endmodule

--- a/tests/cases/cpp/query_bits/case.yaml
+++ b/tests/cases/cpp/query_bits/case.yaml
@@ -16,3 +16,9 @@ expect:
     slice_rt: 5
     red_rt: 0
     ca_red: 0
+    bits_dyn: 128
+    bits_queue: 96
+    bits_string: 40
+    bits_assoc: 64
+    bits_narrow: 7
+    bits_empty: 0

--- a/tests/cases/cpp/query_bits/main.sv
+++ b/tests/cases/cpp/query_bits/main.sv
@@ -23,6 +23,22 @@ module Top;
   logic ca_red;
   assign ca_red = ^q[$bits(mubi_t)-1:1];
 
+  // LRM 20.6.2: a dynamically sized operand reports the bit count of what it
+  // currently holds -- its element count times the bits one element occupies --
+  // and 0 while it holds nothing. A string's element is a byte.
+  int    dyn[];
+  int    que[$];
+  string str;
+  int    map[int];
+  bit [6:0] narrow[$];
+
+  int bits_dyn;
+  int bits_queue;
+  int bits_string;
+  int bits_assoc;
+  int bits_narrow;
+  int bits_empty;
+
   initial begin
     q = 4'b1010;
     bits_type_rt = $bits(mubi_t);
@@ -32,5 +48,23 @@ module Top;
     bits_2d_rt = $bits(m2d);
     slice_rt = q[$bits(mubi_t)-1:1];
     red_rt = ^q[$bits(mubi_t)-1:1];
+
+    dyn = new[4];
+    que.push_back(1);
+    que.push_back(2);
+    que.push_back(3);
+    str = "hello";
+    map[10] = 1;
+    map[20] = 2;
+    narrow.push_back(7'h5);
+
+    bits_dyn = $bits(dyn);
+    bits_queue = $bits(que);
+    bits_string = $bits(str);
+    bits_assoc = $bits(map);
+    bits_narrow = $bits(narrow);
+
+    que.delete();
+    bits_empty = $bits(que);
   end
 endmodule

--- a/tests/cases/cpp/query_dynamic_shape/case.yaml
+++ b/tests/cases/cpp/query_dynamic_shape/case.yaml
@@ -1,0 +1,36 @@
+id: cpp.query_dynamic_shape
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    dyn_size: 4
+    dyn_left: 0
+    dyn_right: 3
+    dyn_low: 0
+    dyn_high: 3
+    dyn_incr: -1
+    que_size: 3
+    que_right: 2
+    que_high: 2
+    str_size: 5
+    str_left: 0
+    str_right: 4
+    empty_size: 0
+    empty_right: -1
+    empty_high: -1
+    map_size: 3
+    map_left: 0
+    map_right: 2147483647
+    map_low: -3
+    map_high: 10
+    map_incr: -1
+    map4_low: "8'h0F"
+    map4_high: "8'hA0"
+    map4_right: "8'hFF"
+    unallocated_low: "8'bxxxxxxxx"
+    unallocated_high: "8'bxxxxxxxx"

--- a/tests/cases/cpp/query_dynamic_shape/main.sv
+++ b/tests/cases/cpp/query_dynamic_shape/main.sv
@@ -1,0 +1,79 @@
+// LRM 20.7 array query functions over a dynamically sized dimension. The
+// dimension's direction is a property of its kind, not of its contents: a queue
+// or dynamic array dimension ascends from 0, so `$left` and `$low` are 0 and
+// `$increment` is -1 whatever the array holds. Only the extent depends on the
+// current state, so `$size` reads it and `$right` / `$high` are the last
+// position -- which is -1 while the dimension is empty.
+//
+// An associative dimension's index space belongs to its index type instead: it
+// ascends from 0 to that type's highest value. What the array holds decides only
+// how many indices are allocated and which are the smallest and largest, so
+// `$low` / `$high` report those and read the index type's default -- `'x` for a
+// 4-state index type -- while none is allocated.
+module Top;
+  int    dyn[];
+  int    que[$];
+  string str;
+
+  int    map[int];
+  int    map4[logic [7:0]];
+
+  int dyn_size, dyn_left, dyn_right, dyn_low, dyn_high, dyn_incr;
+  int que_size, que_right, que_high;
+  int str_size, str_left, str_right;
+  int empty_size, empty_right, empty_high;
+
+  int map_size, map_left, map_right, map_low, map_high, map_incr;
+  logic [7:0] map4_low, map4_high, map4_right;
+  logic [7:0] unallocated_low, unallocated_high;
+
+  initial begin
+    dyn = new[4];
+    que.push_back(10);
+    que.push_back(20);
+    que.push_back(30);
+    str = "hello";
+
+    dyn_size = $size(dyn);
+    dyn_left = $left(dyn);
+    dyn_right = $right(dyn);
+    dyn_low = $low(dyn);
+    dyn_high = $high(dyn);
+    dyn_incr = $increment(dyn);
+
+    que_size = $size(que);
+    que_right = $right(que);
+    que_high = $high(que);
+
+    str_size = $size(str);
+    str_left = $left(str);
+    str_right = $right(str);
+
+    // A negative index sorts below a positive one: the index type is signed.
+    map[10] = 1;
+    map[-3] = 2;
+    map[7] = 3;
+    map_size = $size(map);
+    map_left = $left(map);
+    map_right = $right(map);
+    map_low = $low(map);
+    map_high = $high(map);
+    map_incr = $increment(map);
+
+    map4[8'hA0] = 1;
+    map4[8'h0F] = 2;
+    map4_low = $low(map4);
+    map4_high = $high(map4);
+    map4_right = $right(map4);
+
+    // Nothing allocated: the index reported is the index type's default.
+    map4.delete();
+    unallocated_low = $low(map4);
+    unallocated_high = $high(map4);
+
+    que.delete();
+    empty_size = $size(que);
+    empty_right = $right(que);
+    empty_high = $high(que);
+  end
+endmodule

--- a/tests/cases/cpp/query_typename/case.yaml
+++ b/tests/cases/cpp/query_typename/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.query_typename
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    tn_arr: "bit$[2:0]"
+    tn_dyn: "int$[]"
+    tn_enum: "enum{A=2'd0,B=2'd1,C=2'd3}Top.e_t"
+    tn_struct: "struct packed{bit a;bit[2:0] b;}Top.sp_t"
+    tn_string: "string"
+    tn_type: "bit[3:0]"
+    tn_expr: "int"

--- a/tests/cases/cpp/query_typename/main.sv
+++ b/tests/cases/cpp/query_typename/main.sv
@@ -1,0 +1,33 @@
+// LRM 20.6.1 `$typename`: the resolved type of the operand, as a string. The
+// operand is never evaluated, so it may be a data type as readily as a value,
+// and an expression operand reports its self-determined type. The string is
+// canonical: a typedef resolves back to the type it names, an anonymous
+// unpacked array's element name is a `$` placeholder, a user-defined name is
+// qualified by its declaring scope, and an enum's members carry their values.
+module Top;
+  typedef bit node;
+  typedef enum bit [1:0] {A, B, C = 3} e_t;
+  typedef struct packed {
+    bit a;
+    bit [2:0] b;
+  } sp_t;
+
+  node   arr[2:0];
+  int    dyn[];
+  e_t    e;
+  sp_t   sp;
+  string s;
+  int    i;
+
+  string tn_arr, tn_dyn, tn_enum, tn_struct, tn_string, tn_type, tn_expr;
+
+  initial begin
+    tn_arr = $typename(arr);
+    tn_dyn = $typename(dyn);
+    tn_enum = $typename(e);
+    tn_struct = $typename(sp);
+    tn_string = $typename(s);
+    tn_type = $typename(bit [3:0]);
+    tn_expr = $typename(i + i);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Completes the LRM 20.6 / 20.7 query family beyond the `$bits`-of-a-fixed-size-type core that already existed. Adds `$typename`, the array dimension functions (`$left`, `$right`, `$low`, `$high`, `$increment`, `$size`), and the dimension counts (`$dimensions`, `$unpacked_dimensions`), each over every operand family: fixed-size packed and unpacked shapes, dynamic arrays, queues, strings, and associative arrays, with the dimension named by a constant or by an expression only the running simulation supplies.

## Design

A query reports a property of its operand rather than computing over it, so the operand is never evaluated (LRM 20.6.1 / 20.6.2) and may even be a data type with no value form. The split that matters is not between functions but between the facts they report: whatever the operand's type fixes is folded to a literal at AST-to-HIR, and only what the value's current state decides is read at run time.

That makes almost everything a compile-time constant. A dynamically sized dimension's direction still follows from its kind -- a queue or dynamic array dimension ascends from 0 -- and an associative dimension's index space from its index type, so `$left` / `$right` / `$increment` stay constants even there. What is genuinely runtime is only a dimension's extent, which lowers to an ordinary expression over the container's element count: `$size(q)` is `q.size()`, `$right(q)` is `q.size() - 1` (naturally -1 when empty), and `$bits` of a dynamically sized value is its element count times the fixed bits one element occupies. No new MIR node kind, and no runtime library entry beyond the smallest and largest currently allocated associative index, which is the one fact existing primitives cannot compose. An empty associative dimension reports its index type's default, which is the `'x` LRM 20.7 requires when that type is 4-state.

A dimension named at run time selects out of a constant table of the per-dimension results; an index the type has no dimension for lands outside the table's declared range and reads the element default, which for the `integer` a dimension function reports is `'x` -- exactly LRM 20.7's out-of-range rule, with no bounds check written by hand.

## Testing

`bazel test //...` green. Every value cross-checked against Verilator where Verilator implements the form; the fixed-size shapes and the dynamic-array / queue dimensions match byte-for-byte. Where Verilator diverges from the LRM (its `$typename` enum/struct spelling, its self-inconsistent string dimensions, its wrong out-of-range dimension result) or does not implement the form at all (`$bits` of any dynamically sized value, every associative query), the slang-consistent LRM behavior is used and documented.

Two remaining corners are tracked as open items rather than half-served: a runtime-named dimension over an array that has a dynamically sized dimension (LRM 20.7.1 makes that an error only the running index can determine), and `$bits` of a value whose elements are themselves dynamically sized.