### PR TITLE
Wait on a value change through a runtime call

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -77,7 +77,15 @@ the detail lives in the entry itself.
   closed-namespace identifier (`support::BuiltinFn`) shared by HIR and MIR.
 - [address-of-primitive](address-of-primitive.md) -- MIR carries an explicit place-to-pointer
   operator (`AddressOfExpr`), dual to `DerefExpr`; the backend never injects `&`.
-- [event-control-unification](event-control-unification.md) -- unified treatment of event control.
+- [event-control-unification](event-control-unification.md) -- unified treatment of event control:
+  every value-change wait (`always_comb` / `@*`, `@(...)`, `wait (cond)`, a continuous assignment)
+  is one shape over a per-leaf `(observable, bit_range, edge)` set. Its MIR carrier is superseded by
+  the next entry.
+- [value-change-wait-as-runtime-call](value-change-wait-as-runtime-call.md) -- that wait is an
+  ordinary runtime call taking the trigger set, awaited like every other suspending call; MIR
+  carries no event-control node, and one enum for edge polarity is shared by compiler and runtime. A
+  dedicated MIR statement, a per-leaf registration call, and an engine subscription verb are
+  rejected.
 - [generic-lowering-machinery](generic-lowering-machinery.md) -- generic arena and shared
   context-free expression-handler templates over the pass class; node types stay typed.
 - [arena-reference-lifetime](arena-reference-lifetime.md) -- `Arena::Get` is a transient view; the

--- a/docs/decisions/event-control-unification.md
+++ b/docs/decisions/event-control-unification.md
@@ -6,7 +6,11 @@
 
 ## Status
 
-Accepted
+Accepted. The unification -- one shape for every value-change wait, per-leaf
+`(observable, bit_range, edge)`, frontend LSB-reduce, runtime per-leaf filtering -- stands. What
+carries that shape in MIR is superseded by
+[value-change-wait-as-runtime-call](value-change-wait-as-runtime-call.md): the wait is a runtime
+call awaited like any other suspending call, not a MIR statement kind.
 
 ## Why this decision matters
 

--- a/docs/decisions/jit-process-suspension.md
+++ b/docs/decisions/jit-process-suspension.md
@@ -131,11 +131,13 @@ adapter drives the body; that the scheduler's token is runtime-owned is the inva
   runtime owns for the duration of one stretch of generated code. Persisting the slot does not
   persist the object it names. Closing this needs the value's storage to outlive the stretch that
   made it -- the activation-frame question [jit-value-realization](jit-value-realization.md) leaves
-  open -- not more coroutine machinery.
+  open -- not more coroutine machinery. It is what a loop-carried value around a suspension needs,
+  so a body as ordinary as a clock generator (`repeat (n) begin #d; clk = ~clk; end`) is blocked on
+  it, and a design that must run today spells the clock out.
 
-- Deferred, each its own foundation: non-blocking assignment (a deferred closure submit); process
-  re-arming (`always` / `always_ff`); timed task enables (a nested activation with a typed
-  completion, `activation.md`); cancellation and `disable`.
+- Deferred, each its own foundation: non-blocking assignment (a deferred closure submit); timed task
+  enables (a nested activation with a typed completion, `activation.md`); cancellation and
+  `disable`.
 
 - The two backends share the semantic model -- the same MIR, the same type-carried call protocol --
   and differ only in realization: the C++ backend's process coroutine is itself the token, because

--- a/docs/decisions/value-change-wait-as-runtime-call.md
+++ b/docs/decisions/value-change-wait-as-runtime-call.md
@@ -1,0 +1,128 @@
+# A value-change wait is a runtime call, not a MIR node
+
+Date: 2026-07-14 Status: accepted
+
+## Context
+
+[event-control-unification](event-control-unification.md) collapsed the four SV constructs that wait
+on a signal -- an `always_comb` / `always_latch` body, an `@*`, an `@(...)`, a `wait (cond)`, and
+the continuous-assignment body that shares their machinery -- into one shape: subscribe to a leaf
+set of `(observable cell, bit projection, edge polarity)`, suspend, wake when a relevant leaf
+changes. That unification stands.
+
+It carried the shape in a dedicated MIR statement holding the leaf list. That carrier is what this
+decision replaces.
+
+The C++ backend could render the statement because it is free to write whatever text it likes: it
+fabricated the runtime's name, the trigger brace-initializers, and the `co_await`, all from one
+opaque node. An execution backend cannot fabricate, and the question forced the issue: to lower the
+statement it would have to synthesize the wait's realization -- the subscription call and the
+suspension -- out of a node that states neither. Two backends would each be inventing that
+expansion, free to invent it differently.
+
+Every other suspending construct had already moved to the generic shape. A delay is an awaited call
+to the runtime's delay entry; a named-event wait is an awaited call to the event's await. Only the
+value-change wait was still a node.
+
+## Decision
+
+A value-change wait is an ordinary runtime call, awaited like every other suspending call:
+
+```text
+await( wait_entry(services, [trigger(leaf) for leaf in leaves]) )
+```
+
+A **trigger** is one leaf of the wait: the observable cell it watches, the bit projection of that
+cell's packed encoding it watches, and the edge polarity it watches for. It is a runtime-library
+value the IR constructs and forwards without inspecting -- the same category as a print item or a
+format specification, built by a construct call and passed as an array. MIR carries no node kind for
+an event control, and none for a trigger; the existing call, construct, array-literal, and await
+primitives express the whole thing.
+
+Every construct that waits on a signal produces this identical call, so a backend that can translate
+one translates all of them, and adding a value-change construct adds no backend code. Reaching the
+execution backend needed no new IR concept below MIR: the wait is a call, the suspension is the
+suspend edge every await already lowers to.
+
+The edge polarity is one enum shared by the compiler and the runtime, not a per-layer copy with
+conversions between them. It is the compile-time/runtime agreement about what a leaf's polarity
+means, like the standard file descriptors or the DPI ABI classes.
+
+### The whole trigger set goes in one call
+
+The registration takes the set, not one call per leaf, because the registration must name the frame
+to resume and only the suspension protocol knows it. A C++ coroutine is handed its own frame when it
+suspends; a wait inside an enabled task must resume the task's frame, not the enabling process's,
+and nothing outside the awaiting frame can tell which. A registration that ran as a statement before
+the suspension would have to ask the runtime which process is running, and the answer -- the
+process's engine-visible frame -- is the wrong frame for a nested wait.
+
+### The engine handle is an argument, and the two backends read it differently
+
+The call carries the engine handle as its first argument, the way every runtime effect does. The C++
+realization does not consult it: the language hands the awaitable its frame. The execution backend's
+realization needs it, because the frame it suspends is not a frame the engine ever sees -- the
+engine resumes the runtime-owned coroutine that drives it
+([jit-process-suspension](jit-process-suspension.md) D5) -- so the process to wake is the running
+one, which only the runtime can name.
+
+This is the same asymmetry the delay already has, and it is a property of the two execution models,
+not a defect in the call: one backend gets the frame from the language, the other asks the runtime
+for it.
+
+## Consequences
+
+- The execution backend runs every value-change construct: `@(...)` with edges and event lists,
+  `@*`, `always_comb` / `always_latch`, `wait (cond)`, and continuous assignment. An `always`
+  re-arms through its forever loop with no scheduler involvement.
+- The C++ backend's bespoke renderer for the wait is gone; the wait renders through the same generic
+  call, construct, and array-literal paths as every other runtime effect. The generated text is more
+  verbose (an edge is a packed literal, not a named enumerator), which is the standing trade of the
+  uniform value model and a debug concern, not a semantic one.
+- The trigger set lives only for the duration of the registration call. The runtime copies each
+  leaf's projection into the cell's subscriber record, so nothing points back into the set once the
+  call returns -- which is why a wait needs no value to survive its own suspension.
+- An empty trigger set is legal and means "never wake up" (`always_comb c = 7;`): the body runs
+  once, then the process suspends forever. It is the zero case of the same loop, not a special form.
+
+## Rejected
+
+- **A dedicated MIR statement carrying the leaf set.** The carrier this replaces. It is a node kind
+  invented to model a scheduling discipline, so every backend has to synthesize the wait's
+  realization out of one opaque node -- which is a decision in value emission, and two backends are
+  free to decide differently. A wait is a call against the runtime library's API, and the existing
+  call vocabulary carries it with nothing added.
+
+- **One registration call per leaf, then a bare suspension.** It reads as the more primitive shape
+  and it matches how the execution backend's registration works. But a per-leaf call runs before the
+  suspension, so it cannot be handed the awaiting frame and must ask the runtime which process is
+  running -- and that answer is wrong for a wait inside an enabled task, whose task frame is the one
+  the engine must resume. Passing the whole set to one call keeps the registration inside the
+  suspension protocol, where the frame is known.
+
+- **A subscription verb on the engine.** Symmetric with the wake verb, and it would give the C++
+  realization a use for the engine handle it otherwise ignores. Rejected because the subscription
+  touches no engine state: the waiter lists live on the cells and the pending set lives on the
+  frame. A verb that needs nothing from the engine is not an engine verb, and adding one to give an
+  argument something to do is the argument wagging the design.
+
+- **Dropping the engine handle from the call so the C++ realization has no unused argument.** The
+  execution backend cannot then name the process to wake, and having its backend fabricate the
+  handle at the call site is the injection
+  [runtime-effects-as-generic-calls](runtime-effects-as-generic-calls.md) rejects. The handle is a
+  real input to the wait; that one realization can answer the question without it is a property of
+  C++ coroutines, not evidence the input is spurious.
+
+## Cross-references
+
+- [event-control-unification](event-control-unification.md) -- the unification this refines: one
+  shape for every value-change wait, per-leaf projection and edge, frontend LSB-reduce, runtime
+  per-leaf filtering.
+- [runtime-effects-as-generic-calls](runtime-effects-as-generic-calls.md) -- a runtime effect is an
+  ordinary call whose first argument is the engine handle; a backend never injects it.
+- [jit-process-suspension](jit-process-suspension.md) -- the suspend edge every await lowers to, and
+  why the engine resumes a runtime-owned coroutine rather than a generated frame.
+- `architecture/mir.md` -- a node kind invented for a runtime library's shape or a scheduling
+  discipline is forbidden; the falsifier is whether a mechanical backend can translate the node
+  without decisions.
+- `architecture/lir.md` -- an event control reaching LIR is an upstream leak, never a LIR node.

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -31,10 +31,13 @@ infrastructure surface, built.
       string value domains -- variables, expressions, structured control flow, and value-carrying
       formatted output -- with control flow lowered to a control-flow graph. It calls foreign C: a
       DPI-C import lowers to an external-linkage symbol, marshals the by-value carriers, and
-      resolves the symbol through the execution session (`dpi.md`). Still open on the execution
-      backend: the remaining value domains (reals, enumerations, aggregates, containers), time
-      control and process suspension, subroutine reference arguments, closures, by-pointer DPI-C
-      marshaling, and native layout for value members (the baseline keeps runtime-owned cells).
+      resolves the symbol through the execution session (`dpi.md`). It suspends a process on a
+      delay, on a value change (`@(...)`, `@*`, `always_comb`, a continuous assignment), and on a
+      level wait. Still open on the execution backend: the remaining value domains (reals,
+      enumerations, aggregates, containers), a value whose lifetime crosses a suspension (so a
+      loop-carried value around a wait, which a clock generator needs), named events, non-blocking
+      assignment, subroutine reference arguments, closures, by-pointer DPI-C marshaling, and native
+      layout for value members (the baseline keeps runtime-owned cells).
 - [ ] Per-unit artifact emission -- one artifact per unit specialization, assembled by linking,
       replacing the transitional single-`main.cpp` aggregation. Contract in
       `../architecture/emission_model.md` (inv 1).

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -66,6 +66,15 @@ class RuntimeAbi {
   // process, read from the runtime; no token crosses the boundary.
   auto Delay() -> llvm::FunctionCallee;
 
+  // Registers the running process to wake on any leaf of a trigger set, the
+  // runtime call a value-change wait's suspend edge is preceded by. Like a
+  // delay, the wakeup source is the running process, read from the runtime.
+  auto WaitAny() -> llvm::FunctionCallee;
+
+  // Builds one leaf of a wait: the observable cell it watches, the bit
+  // projection of that cell it watches, and the edge polarity it watches for.
+  auto MakeTrigger() -> llvm::FunctionCallee;
+
   // Builds a coroutine from an entry code reference and its environment; the
   // runtime owns the resulting coroutine and returns an opaque handle.
   auto MakeCoroutine() -> llvm::FunctionCallee;

--- a/include/lyra/hir/continuous_assign.hpp
+++ b/include/lyra/hir/continuous_assign.hpp
@@ -23,9 +23,9 @@ struct ContinuousAssignId {
 // scope-level expression (parameter values, variable initialisers) is stored.
 // The `lhs` form is restricted to a structural-var-rooted addressable
 // expression. HIR -> MIR translates this into a synthesised process body
-// `forever { lhs = rhs; SensitivityWaitStmt(sensitivity_list); }`, registered
-// as a startup activation, giving continuous assignment the same runtime
-// mental model as always_comb (LRM 9.2.2.2.1).
+// `forever { lhs = rhs; wait on sensitivity_list; }`, registered as a startup
+// activation, giving continuous assignment the same runtime mental model as
+// always_comb (LRM 9.2.2.2.1).
 struct ContinuousAssign {
   diag::SourceSpan span;
   ExprId lhs;

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -15,6 +15,7 @@
 #include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/value_ref.hpp"
+#include "lyra/support/event_edge.hpp"
 
 namespace lyra::hir {
 
@@ -185,13 +186,6 @@ struct DelayControl {
   ExprId duration;
 };
 
-enum class EventEdge : std::uint8_t {
-  kAnyChange,
-  kPosedge,
-  kNegedge,
-  kBothEdges,
-};
-
 // One leaf entry of a wait's projection set. Identity-only: which structural
 // variable, the flat-bit footprint of its packed encoding the leaf observes,
 // and what edge polarity the leaf was subscribed under. An absent footprint
@@ -203,7 +197,7 @@ enum class EventEdge : std::uint8_t {
 struct SensitivityEntry {
   ReferenceRoute ref;
   std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint;
-  EventEdge edge_kind = EventEdge::kAnyChange;
+  support::EventEdge edge_kind = support::EventEdge::kAnyChange;
 };
 
 // One entry of an explicit `@(...)` event control. `signal` is the SV
@@ -215,7 +209,7 @@ struct SensitivityEntry {
 // wait that enforces LRM 9.4.2 correctness.
 struct EventTrigger {
   ExprId signal;
-  EventEdge edge;
+  support::EventEdge edge;
   std::vector<SensitivityEntry> sensitivity_list;
 };
 

--- a/include/lyra/lir/type.hpp
+++ b/include/lyra/lir/type.hpp
@@ -47,6 +47,7 @@ enum class RuntimeLibraryKind : std::uint8_t {
   kHierarchySegment,
   kDpiBitBuffer,
   kDpiLogicBuffer,
+  kTrigger,
 };
 
 struct PackedRange {

--- a/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
+++ b/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
@@ -10,15 +10,19 @@ namespace lyra::lowering::hir_to_mir {
 
 class StructuralScopeLowerer;
 
-// Materialises a mir::SensitivityWaitStmt from a HIR sensitivity entry list.
-// Lowering picks the observable-pointer expression per leaf so the backend
-// renders one stored expression rather than re-deriving the shape from the
-// leaf's type: a plain field becomes an `AddressOf(FieldAccess(...))`, and
-// a borrowed-pointer slot (a cross-unit reference sealed in the resolve
-// phase, or another sealed pointer) is the bare `FieldAccess`. The single
-// convergence point for always_comb / always_latch (LRM 9.2.2.2.1) and `@*`
-// (LRM 9.4.2.2).
-auto MakeSensitivityWaitStmt(
+// Materialises the value-change wait a HIR sensitivity entry list suspends on:
+// an awaited runtime call taking one trigger per leaf. Every SV construct that
+// waits on a signal converges here -- `always_comb` / `always_latch` (LRM
+// 9.2.2.2.1), `@*` (LRM 9.4.2.2), `@(...)` (LRM 9.4.2), `wait (cond)` (LRM
+// 9.4.3), and a continuous assignment -- so they all produce the identical
+// wait.
+//
+// Lowering picks the observable-pointer expression per leaf so a backend
+// forwards one stored expression rather than re-deriving the shape from the
+// leaf's type: a plain field becomes an `AddressOf(FieldAccess(...))`, and a
+// borrowed-pointer slot (a cross-unit reference sealed in the resolve phase, or
+// another sealed pointer) is the bare `FieldAccess`.
+auto MakeValueChangeWaitStmt(
     mir::Block& target_block, const WalkFrame& frame,
     const StructuralScopeLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt;

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -52,6 +52,7 @@ struct BuiltinMirTypes {
   TypeId format_arg;
   TypeId time_format;
   TypeId hierarchy_segment;
+  TypeId trigger;
   TypeId coroutine_void;
   TypeId wildcard_index;
 };
@@ -134,6 +135,8 @@ struct CompilationUnit {
             .hierarchy_segment = types.Intern(
                 RuntimeLibraryType{
                     .kind = RuntimeLibraryKind::kHierarchySegment}),
+            .trigger = types.Intern(
+                RuntimeLibraryType{.kind = RuntimeLibraryKind::kTrigger}),
             .coroutine_void = TypeId{},
             .wildcard_index = types.Intern(WildcardIndexType{}),
         } {

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -79,13 +79,6 @@ struct ForStmt {
   std::optional<LoopLabelId> break_label = std::nullopt;
 };
 
-enum class EventEdge : std::uint8_t {
-  kAnyChange,
-  kPosedge,
-  kNegedge,
-  kBothEdges,
-};
-
 struct WhileStmt {
   ExprId condition;
   BlockId scope;
@@ -111,36 +104,9 @@ struct ReturnStmt {
   std::optional<ExprId> value;
 };
 
-// One leaf entry of a wait's projection set: an expression yielding a
-// borrowed pointer to the observable cell the leaf subscribes to, plus the
-// observed bit projection of its packed encoding as a `(lsb_bit_offset,
-// bit_width)` pair, and the edge polarity the leaf was subscribed under (LRM
-// 9.4.2 / 9.4.2.2 / 9.4.3). A `bit_width` of 0 is the whole signal observed
-// on any change; an edge reduces to the bit at `lsb_bit_offset`. The
-// projection is resolved at HIR-to-MIR from the SV-level footprint so a
-// backend emits the pair directly. `kAnyChange` is the edge for implicit
-// sensitivity. The pointer expression's exact shape -- `AddressOf` of a
-// place, a bare borrowed-pointer member access, or a call that resolves an
-// upward reference to its current observable -- is stated by HIR-to-MIR so
-// the backend never re-derives it from the leaf's type.
-struct SensitivityRead {
-  ExprId observable_ptr{};
-  std::uint64_t lsb_bit_offset = 0;
-  std::uint64_t bit_width = 0;
-  EventEdge edge_kind = EventEdge::kAnyChange;
-};
-
-// Suspends the enclosing process until any signal in `reads` changes. Lowered
-// only at the tail of an always_comb / always_latch body's forever loop. An
-// empty `reads` list legitimately means "never wake up": the body runs once
-// (at time 0) then the process hangs forever.
-struct SensitivityWaitStmt {
-  std::vector<SensitivityRead> reads;
-};
-
 using StmtData = std::variant<
     EmptyStmt, LocalDeclStmt, ExprStmt, BlockStmt, IfStmt, ForStmt, WhileStmt,
-    DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt, SensitivityWaitStmt>;
+    DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -351,6 +351,12 @@ enum class RuntimeLibraryKind : std::uint8_t {
   // the value-layer format step for `%t` directives. Threaded into `Format` as
   // an explicit operand from the engine's current state.
   kTimeFormat,
+  // LRM 9.4.2 / 9.4.2.2 / 9.4.3 one leaf of a value-change wait:
+  // `lyra::runtime::Trigger`, pairing the observable cell with the observed bit
+  // projection of its packed encoding and the edge polarity it is subscribed
+  // under. A wait registers a set of these, and the runtime wakes the process
+  // when any leaf's projection changes as its edge demands.
+  kTrigger,
   // LRM 23.3.3.5 / 27.6 elaborated hierarchy segment:
   // `lyra::runtime::HierarchySegment`, the per-scope structured identity each
   // child carries from construction (base name plus per-dimension indices).

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -44,6 +44,22 @@ void lyra_rt_register_final(void* self, void* coroutine);
 void lyra_rt_delay(
     void* services, const void* ticks, const void* precision_power);
 
+// Builds one leaf of a value-change wait: the observable cell it watches, the
+// bit projection of that cell's packed encoding it watches as a
+// `(lsb_bit_offset, bit_width)` pair, and the edge polarity it watches for (LRM
+// 9.4.2). The scalars cross as opaque packed values, like every scalar. The
+// trigger is a transient runtime value owned by the current call scope.
+auto lyra_rt_make_trigger(
+    void* observable, const void* edge, const void* lsb_bit_offset,
+    const void* bit_width) -> void*;
+
+// Registers the running process to wake when any leaf of `triggers` changes as
+// its edge demands, the registration a value-change wait's suspend edge is
+// preceded by (LRM 9.4.2 / 9.4.2.2 / 9.4.3). An empty span means "never wake
+// up". The wakeup source is the running process itself, read from the runtime;
+// no token crosses the boundary.
+void lyra_rt_wait_any(void* services, LyraSpan triggers);
+
 // Builds a scope's structural identity from its base label and per-dimension
 // indices (a span of 32-bit index values, empty for a scalar). The segment is
 // a transient runtime value owned by the current call scope.

--- a/include/lyra/runtime/net.hpp
+++ b/include/lyra/runtime/net.hpp
@@ -132,8 +132,9 @@ class ResolvedNet : public Observable {
       resolved_ = std::move(next);
       if (changed) {
         services.TriggerValueChange(
-            *this, [](std::uint64_t, std::uint64_t, Edge edge) -> bool {
-              return edge == Edge::kAnyChange;
+            *this,
+            [](std::uint64_t, std::uint64_t, support::EventEdge edge) -> bool {
+              return edge == support::EventEdge::kAnyChange;
             });
       }
     }

--- a/include/lyra/runtime/registration.hpp
+++ b/include/lyra/runtime/registration.hpp
@@ -40,7 +40,7 @@ struct Registration {
   // which bit projection of the observable it watches. A membership that
   // carries no condition -- an event, a join, a scheduler queue -- leaves these
   // unset.
-  Edge edge = Edge::kAnyChange;
+  support::EventEdge edge = support::EventEdge::kAnyChange;
   std::uint64_t lsb_bit_offset = 0;
   std::uint64_t bit_width = 0;
 

--- a/include/lyra/runtime/trigger.hpp
+++ b/include/lyra/runtime/trigger.hpp
@@ -3,18 +3,12 @@
 #include <cstdint>
 #include <functional>
 
+#include "lyra/support/event_edge.hpp"
+#include "lyra/value/packed_array.hpp"
+
 namespace lyra::runtime {
 
 class Observable;
-
-// LRM 9.4.2 edge specifier on `@(...)`. Stored per-trigger on the wait so the
-// observable can decide which subscribed waiters to wake on a value change.
-enum class Edge : std::uint8_t {
-  kAnyChange,
-  kPosedge,
-  kNegedge,
-  kBothEdges,
-};
 
 // One leaf subscription on a single `Observable`. The projection is described
 // by `(lsb_bit_offset, bit_width)` in the observable's flat-bit address space.
@@ -23,21 +17,32 @@ enum class Edge : std::uint8_t {
 // whole-var expression). For explicit projections (bit-select, range-select,
 // LRM 9.4.2 LSB-reduced edge), `bit_width` is the projection's actual width.
 //
-// Multiple Triggers in a single `EventControlAwaitable` model an event-list
-// `@(a or posedge b[3])` or a multi-leaf expression `@({clk_a, clk_b})`; the
-// process resumes when any leaf passes its per-leaf classifier.
+// Multiple Triggers in a single wait model an event-list `@(a or posedge b[3])`
+// or a multi-leaf expression `@({clk_a, clk_b})`; the process resumes when any
+// leaf passes its per-leaf classifier.
 struct Trigger {
   Observable* observable = nullptr;
-  Edge edge = Edge::kAnyChange;
+  support::EventEdge edge = support::EventEdge::kAnyChange;
   std::uint64_t lsb_bit_offset = 0;
   std::uint64_t bit_width = 0;
+
+  Trigger() = default;
+
+  // Each field beside the cell arrives as a PackedArray literal -- the value
+  // model routes compile-time scalars as SV values, the same way the runtime
+  // effect entries take their int args -- and converts to its native field type
+  // here.
+  Trigger(
+      Observable* observable, const value::PackedArray& edge,
+      const value::PackedArray& lsb_bit_offset,
+      const value::PackedArray& bit_width);
 };
 
 // Per-leaf fire decision: receives a waiter's `(lsb_bit_offset, bit_width,
 // edge)` and returns whether to wake it. The caller (the producer of the
 // value change -- typically `Var<PackedArray>::Set`) captures the
 // value context (old/new) so the `Observable` stays value-type agnostic.
-using EdgeClassifier =
-    std::function<bool(std::uint64_t lsb, std::uint64_t width, Edge edge)>;
+using EdgeClassifier = std::function<bool(
+    std::uint64_t lsb, std::uint64_t width, support::EventEdge edge)>;
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <concepts>
 #include <cstdint>
-#include <initializer_list>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -54,15 +54,16 @@ inline auto ClassifyEdge(
   return EdgeTransition::kChangeOnly;
 }
 
-inline auto EdgeMatches(Edge subscribed, EdgeTransition transition) -> bool {
+inline auto EdgeMatches(
+    support::EventEdge subscribed, EdgeTransition transition) -> bool {
   switch (subscribed) {
-    case Edge::kAnyChange:
+    case support::EventEdge::kAnyChange:
       return true;
-    case Edge::kPosedge:
+    case support::EventEdge::kPosedge:
       return transition == EdgeTransition::kPosedge;
-    case Edge::kNegedge:
+    case support::EventEdge::kNegedge:
       return transition == EdgeTransition::kNegedge;
-    case Edge::kBothEdges:
+    case support::EventEdge::kBothEdges:
       return transition == EdgeTransition::kPosedge ||
              transition == EdgeTransition::kNegedge;
   }
@@ -79,8 +80,8 @@ class Observable {
   ~Observable() = default;
 
   void Subscribe(
-      CoroutineHandle handle, Edge edge, std::uint64_t lsb_bit_offset,
-      std::uint64_t bit_width) {
+      CoroutineHandle handle, support::EventEdge edge,
+      std::uint64_t lsb_bit_offset, std::uint64_t bit_width) {
     Registration& reg = handle->Park(waiters_);
     reg.edge = edge;
     reg.lsb_bit_offset = lsb_bit_offset;
@@ -229,18 +230,37 @@ class Ref {
   T* plain_ = nullptr;
 };
 
-// Suspends the calling frame until one of the supplied Triggers fires
-// (matching its edge). Subscribing registers each Observable in the frame's own
-// wait-registration set, so waking or destroying the frame revokes every
-// subscription; the engine has no idea what kind of wait this is.
+// Makes `frame` runnable again when any leaf of `triggers` changes as its edge
+// demands (LRM 9.4.2 / 9.4.2.2 / 9.4.3). Each subscription registers on the
+// frame's own wait-registration set, so waking or destroying the frame revokes
+// every leaf and the one that wakes it drops the siblings; the engine has no
+// idea what kind of wait this is. Each leaf's projection is copied into the
+// cell's subscriber record, so `triggers` is only read for the duration of this
+// call.
 //
-// An empty trigger list is legal -- the frame suspends forever (used by
-// `always_comb` / `always_latch` with no inferred reads,
-// e.g. `always_comb c = 7;`).
-class EventControlAwaitable {
+// An empty trigger set is legal and means "never wake up" -- an `always_comb`
+// whose body reads nothing (`always_comb c = 7;`) runs once, then suspends
+// forever.
+inline void SubscribeValueChange(
+    CoroutineHandle frame, std::span<const Trigger> triggers) {
+  for (const Trigger& trigger : triggers) {
+    if (trigger.observable == nullptr) {
+      throw InternalError(
+          "SubscribeValueChange: a trigger names no observable cell");
+    }
+    trigger.observable->Subscribe(
+        frame, trigger.edge, trigger.lsb_bit_offset, trigger.bit_width);
+  }
+}
+
+// Suspends the calling frame on a value-change wait. The registration happens
+// in `await_suspend`, where the frame that must be resumed is in hand: a wait
+// inside an enabled task has to resume the task's frame, not the enabling
+// process's, and only the language knows which frame is awaiting.
+class ValueChangeWaitAwaitable {
  public:
-  explicit EventControlAwaitable(std::vector<Trigger> triggers)
-      : triggers_(std::move(triggers)) {
+  explicit ValueChangeWaitAwaitable(std::span<const Trigger> triggers)
+      : triggers_(triggers.begin(), triggers.end()) {
   }
 
   [[nodiscard]] static auto await_ready() noexcept -> bool {
@@ -249,16 +269,7 @@ class EventControlAwaitable {
 
   template <class P>
   void await_suspend(std::coroutine_handle<P> handle) {
-    CoroutineHandle token = &handle.promise();
-    for (const auto& trigger : triggers_) {
-      if (trigger.observable == nullptr) {
-        throw InternalError(
-            "EventControlAwaitable::await_suspend: observable pointer is "
-            "null");
-      }
-      trigger.observable->Subscribe(
-          token, trigger.edge, trigger.lsb_bit_offset, trigger.bit_width);
-    }
+    SubscribeValueChange(&handle.promise(), triggers_);
   }
 
   static void await_resume() noexcept {
@@ -268,9 +279,15 @@ class EventControlAwaitable {
   std::vector<Trigger> triggers_;
 };
 
-inline auto WaitAny(std::initializer_list<Trigger> triggers)
-    -> EventControlAwaitable {
-  return EventControlAwaitable{std::vector<Trigger>(triggers)};
+// A wait's registration names the process to wake. A C++ coroutine is handed
+// its own frame at the suspension, so this realization reads the frame from the
+// language and never consults the engine handle the call carries; an execution
+// backend, whose generated frame the engine never sees, needs that handle to
+// ask the runtime which process is running.
+inline auto WaitAny(
+    RuntimeServices&,  // NOLINT(readability-named-parameter)
+    std::span<const Trigger> triggers) -> ValueChangeWaitAwaitable {
+  return ValueChangeWaitAwaitable{triggers};
 }
 
 // Builds the per-leaf classifier that the Observable invokes per waiter.
@@ -282,8 +299,9 @@ inline auto MakePackedArrayEdgeClassifier(
     const value::PackedArray& old_val, const value::PackedArray& new_val)
     -> EdgeClassifier {
   return [&old_val, &new_val](
-             std::uint64_t lsb, std::uint64_t width, Edge edge) -> bool {
-    if (edge == Edge::kAnyChange) {
+             std::uint64_t lsb, std::uint64_t width,
+             support::EventEdge edge) -> bool {
+    if (edge == support::EventEdge::kAnyChange) {
       if (width == 0U) {
         return true;
       }
@@ -332,8 +350,9 @@ void Var<T>::Set(RuntimeServices& services, const T& new_val) {
   } else {
     if (AssignIfChanged(new_val)) {
       services.TriggerValueChange(
-          *this, [](std::uint64_t, std::uint64_t, Edge edge) -> bool {
-            return edge == Edge::kAnyChange;
+          *this,
+          [](std::uint64_t, std::uint64_t, support::EventEdge edge) -> bool {
+            return edge == support::EventEdge::kAnyChange;
           });
     }
   }

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -212,6 +212,13 @@ enum class BuiltinFn : std::uint16_t {
   // precision steps, and the calling scope's precision power; the runtime
   // scales to the design-global tick (LRM 3.14.3).
   kDelay,
+  // LRM 9.4.2 / 9.4.2.2 / 9.4.3 value-change wait. The runtime free function
+  // every wait on a signal suspends on -- an `@(...)`, an `@*`, an
+  // `always_comb` / `always_latch` body, a `wait (cond)`, a continuous
+  // assignment. The call takes the engine handle and the trigger set, one
+  // entry per observed leaf; the process resumes when any leaf changes as its
+  // edge demands.
+  kWaitAny,
   // LRM 20.3 simulation-time read functions. Each takes the engine handle
   // and the calling scope's unit power; the runtime scales the design-global
   // tick down to that unit. `$time` rounds and yields a 64-bit `time`,

--- a/include/lyra/support/event_edge.hpp
+++ b/include/lyra/support/event_edge.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::support {
+
+// LRM 9.4.2 edge specifier on `@(...)`. Shared vocabulary: the compiler encodes
+// each observed leaf's polarity, and the runtime decides which subscribed
+// waiters a value change wakes. `kAnyChange` is the polarity of an implicit
+// sensitivity (an `always_comb` / `always_latch` body, an `@*`, a `wait
+// (cond)`, a continuous assignment), which no edge keyword names.
+enum class EventEdge : std::uint8_t {
+  kAnyChange,
+  kPosedge,
+  kNegedge,
+  kBothEdges,
+};
+
+}  // namespace lyra::support

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -218,6 +218,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Prev";
     case support::BuiltinFn::kDelay:
       return "Delay";
+    case support::BuiltinFn::kWaitAny:
+      return "WaitAny";
     case support::BuiltinFn::kSimTime:
       return "SimTimeInUnit";
     case support::BuiltinFn::kSTime:
@@ -373,6 +375,7 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
     case support::BuiltinFn::kFromSvLogic:
       return "lyra::value";
     case support::BuiltinFn::kDelay:
+    case support::BuiltinFn::kWaitAny:
     case support::BuiltinFn::kSimTime:
     case support::BuiltinFn::kSTime:
     case support::BuiltinFn::kRealTime:

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <format>
 #include <string>
-#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -11,7 +10,6 @@
 #include "lyra/backend/cpp/render_expr.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/backend/cpp/scope_view.hpp"
-#include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/mir/stmt.hpp"
 
@@ -39,20 +37,6 @@ auto RenderForInit(const ScopeView& view, const mir::ForInit& init)
           },
       },
       init);
-}
-
-auto RenderEventEdgeAsRuntime(mir::EventEdge edge) -> std::string_view {
-  switch (edge) {
-    case mir::EventEdge::kAnyChange:
-      return "lyra::runtime::Edge::kAnyChange";
-    case mir::EventEdge::kPosedge:
-      return "lyra::runtime::Edge::kPosedge";
-    case mir::EventEdge::kNegedge:
-      return "lyra::runtime::Edge::kNegedge";
-    case mir::EventEdge::kBothEdges:
-      return "lyra::runtime::Edge::kBothEdges";
-  }
-  throw InternalError("RenderEventEdgeAsRuntime: unknown EventEdge value");
 }
 
 auto RenderLocalDeclStmt(
@@ -165,24 +149,6 @@ auto RenderDoWhileStmt(
   return result;
 }
 
-auto RenderSensitivityWaitStmt(
-    const ScopeView& view, const mir::SensitivityWaitStmt& s,
-    std::size_t indent) -> std::string {
-  std::string result =
-      std::format("{}co_await lyra::runtime::WaitAny({{", Indent(indent));
-  for (std::size_t i = 0; i < s.reads.size(); ++i) {
-    const auto& read = s.reads[i];
-    if (i != 0) result += ", ";
-    result += std::format(
-        "{{{}, {}, {}ULL, {}ULL}}",
-        RenderExpr(view, view.Expr(read.observable_ptr)),
-        RenderEventEdgeAsRuntime(read.edge_kind), read.lsb_bit_offset,
-        read.bit_width);
-  }
-  result += "});\n";
-  return result;
-}
-
 }  // namespace
 
 auto RenderStmt(
@@ -244,9 +210,6 @@ auto RenderStmt(
             return std::format(
                 "{}{} {};\n", Indent(indent), keyword,
                 RenderExpr(view, view.Expr(*s.value)));
-          },
-          [&](const mir::SensitivityWaitStmt& s) -> std::string {
-            return RenderSensitivityWaitStmt(view, s, indent);
           },
       },
       stmt.data);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -202,6 +202,8 @@ auto RenderTypeAsCpp(
                 return std::string{"lyra::value::TimeFormat"};
               case mir::RuntimeLibraryKind::kHierarchySegment:
                 return std::string{"lyra::runtime::HierarchySegment"};
+              case mir::RuntimeLibraryKind::kTrigger:
+                return std::string{"lyra::runtime::Trigger"};
               case mir::RuntimeLibraryKind::kScopeProgram:
                 return std::string{"lyra::runtime::ScopeProgram"};
               case mir::RuntimeLibraryKind::kUnitDefinition:

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -302,6 +302,8 @@ auto CodeGenFunction::BuiltinCallee(
       return module_->Runtime().RegisterFinal();
     case support::BuiltinFn::kDelay:
       return module_->Runtime().Delay();
+    case support::BuiltinFn::kWaitAny:
+      return module_->Runtime().WaitAny();
     case support::BuiltinFn::kAddOwnedChild:
       return module_->Runtime().AddOwnedChild();
     case support::BuiltinFn::kRegisterSignal:
@@ -389,6 +391,8 @@ auto CodeGenFunction::ConstructCallee(const lir::CallInstr& call)
                 return module_->Runtime().MakePrintLiteralItem();
               case lir::RuntimeLibraryKind::kHierarchySegment:
                 return module_->Runtime().MakeSegment();
+              case lir::RuntimeLibraryKind::kTrigger:
+                return module_->Runtime().MakeTrigger();
               case lir::RuntimeLibraryKind::kFormatSpec:
                 return module_->Runtime().MakeFormatSpec(call.args.size());
               case lir::RuntimeLibraryKind::kPrintValueItem:

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -112,6 +112,17 @@ auto RuntimeAbi::Delay() -> llvm::FunctionCallee {
       {types_->Ptr(), types_->Ptr(), types_->Ptr()});
 }
 
+auto RuntimeAbi::WaitAny() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_wait_any", types_->Void(), {types_->Ptr(), types_->Span()});
+}
+
+auto RuntimeAbi::MakeTrigger() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_make_trigger", types_->Ptr(),
+      {types_->Ptr(), types_->Ptr(), types_->Ptr(), types_->Ptr()});
+}
+
 auto RuntimeAbi::MakeString() -> llvm::FunctionCallee {
   return Get("lyra_rt_make_string", types_->Ptr(), {types_->Ptr()});
 }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -443,15 +443,15 @@ class HirDumper {
     return std::format("[{}:{}]", footprint->first, footprint->second);
   }
 
-  static auto FormatEventEdge(EventEdge edge) -> std::string_view {
+  static auto FormatEventEdge(support::EventEdge edge) -> std::string_view {
     switch (edge) {
-      case EventEdge::kAnyChange:
+      case support::EventEdge::kAnyChange:
         return "any";
-      case EventEdge::kPosedge:
+      case support::EventEdge::kPosedge:
         return "posedge";
-      case EventEdge::kNegedge:
+      case support::EventEdge::kNegedge:
         return "negedge";
-      case EventEdge::kBothEdges:
+      case support::EventEdge::kBothEdges:
         return "edge";
     }
     throw InternalError("HirDumper::FormatEventEdge: unknown EventEdge");

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -128,6 +128,8 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_register_initial", &lyra_rt_register_initial);
   add("lyra_rt_register_final", &lyra_rt_register_final);
   add("lyra_rt_delay", &lyra_rt_delay);
+  add("lyra_rt_make_trigger", &lyra_rt_make_trigger);
+  add("lyra_rt_wait_any", &lyra_rt_wait_any);
   add("lyra_rt_make_segment", &lyra_rt_make_segment);
   add("lyra_rt_make_unit", &lyra_rt_make_unit);
   add("lyra_rt_add_owned_child", &lyra_rt_add_owned_child);

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -19,16 +19,16 @@ namespace lyra::lowering::ast_to_hir {
 
 namespace {
 
-auto LowerEventEdge(slang::ast::EdgeKind kind) -> hir::EventEdge {
+auto LowerEventEdge(slang::ast::EdgeKind kind) -> support::EventEdge {
   switch (kind) {
     case slang::ast::EdgeKind::None:
-      return hir::EventEdge::kAnyChange;
+      return support::EventEdge::kAnyChange;
     case slang::ast::EdgeKind::PosEdge:
-      return hir::EventEdge::kPosedge;
+      return support::EventEdge::kPosedge;
     case slang::ast::EdgeKind::NegEdge:
-      return hir::EventEdge::kNegedge;
+      return support::EventEdge::kNegedge;
     case slang::ast::EdgeKind::BothEdges:
-      return hir::EventEdge::kBothEdges;
+      return support::EventEdge::kBothEdges;
   }
   throw InternalError("LowerEventEdge: unknown slang EdgeKind value");
 }

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -240,7 +240,7 @@ auto LowerContinuousAssign(
   }
   body_block.AppendStmt(mir::ExprStmt{.expr = effect_id});
 
-  body_block.AppendStmt(MakeSensitivityWaitStmt(
+  body_block.AppendStmt(MakeValueChangeWaitStmt(
       body_block, body_frame, lowerer, src.sensitivity_list));
 
   const mir::BlockId body_scope_id =

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -197,10 +197,10 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
       .visibility = process.Visibility()};
 }
 
-// Wraps the body in a `forever` loop. `implicit_sensitivity`, if present,
-// is materialised into a `SensitivityWaitStmt` appended after the lowered
-// body -- the always_comb / always_latch (LRM 9.2.2.2.1) tail. `always` /
-// `always_ff` pass nullptr because the body itself carries any timing.
+// Wraps the body in a `forever` loop. `implicit_sensitivity`, if present, is
+// materialised into a value-change wait appended after the lowered body -- the
+// always_comb / always_latch (LRM 9.2.2.2.1) tail. `always` / `always_ff` pass
+// nullptr because the body itself carries any timing.
 auto LowerForeverProcess(
     ProcessLowerer& process,
     const std::vector<hir::SensitivityEntry>* implicit_sensitivity)
@@ -220,7 +220,7 @@ auto LowerForeverProcess(
     auto lowered = LowerStraightLineBodyInto(process, body_frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     if (implicit_sensitivity != nullptr) {
-      body_block.AppendStmt(MakeSensitivityWaitStmt(
+      body_block.AppendStmt(MakeValueChangeWaitStmt(
           body_block, body_frame, process.EnclosingScopeLowerer(),
           *implicit_sensitivity));
     }

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -4,63 +4,96 @@
 #include <utility>
 #include <vector>
 
-#include "lyra/base/internal_error.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/endpoint.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
+#include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-auto LowerEventEdge(hir::EventEdge edge) -> mir::EventEdge {
-  switch (edge) {
-    case hir::EventEdge::kAnyChange:
-      return mir::EventEdge::kAnyChange;
-    case hir::EventEdge::kPosedge:
-      return mir::EventEdge::kPosedge;
-    case hir::EventEdge::kNegedge:
-      return mir::EventEdge::kNegedge;
-    case hir::EventEdge::kBothEdges:
-      return mir::EventEdge::kBothEdges;
-  }
-  throw InternalError("LowerEventEdge: unknown hir::EventEdge value");
+// One leaf of the wait: the observable cell it watches, the bit projection of
+// that cell's packed encoding it watches, and the edge polarity it watches for.
+// LRM 9.4.2 / 9.4.2.2 / 9.4.3: a bit-addressed footprint becomes
+// `(lsb, hi - lsb + 1)`; a whole-signal read (no footprint) is width 0, which
+// the runtime reads as the whole cell.
+auto BuildTriggerExpr(
+    mir::Block& block, const WalkFrame& frame, mir::CompilationUnit& unit,
+    const StructuralScopeLowerer& lowerer, const hir::SensitivityEntry& entry)
+    -> mir::ExprId {
+  const mir::ExprId observable_ptr = EndpointObservablePtr(
+      block, frame, unit, BindEndpoint(lowerer, frame, entry.ref));
+  const std::int64_t lsb_bit_offset =
+      entry.footprint.has_value()
+          ? static_cast<std::int64_t>(entry.footprint->first)
+          : 0;
+  const std::int64_t bit_width =
+      entry.footprint.has_value()
+          ? static_cast<std::int64_t>(
+                entry.footprint->second - entry.footprint->first + 1)
+          : 0;
+  const auto int_literal = [&](std::int64_t value) {
+    return block.exprs.Add(mir::MakeIntLiteral(unit.builtins.int_type, value));
+  };
+  return block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::Construct{},
+                  .arguments =
+                      {observable_ptr,
+                       int_literal(static_cast<std::int64_t>(entry.edge_kind)),
+                       int_literal(lsb_bit_offset), int_literal(bit_width)}},
+          .type = unit.builtins.trigger});
 }
 
 }  // namespace
 
-auto MakeSensitivityWaitStmt(
+auto MakeValueChangeWaitStmt(
     mir::Block& target_block, const WalkFrame& frame,
     const StructuralScopeLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt {
   auto& unit = lowerer.Module().Unit();
-  std::vector<mir::SensitivityRead> reads;
-  reads.reserve(sensitivity_list.size());
+
+  std::vector<mir::ExprId> triggers;
+  triggers.reserve(sensitivity_list.size());
   for (const auto& entry : sensitivity_list) {
-    const mir::ExprId observable_ptr_id = EndpointObservablePtr(
-        target_block, frame, unit, BindEndpoint(lowerer, frame, entry.ref));
-    // LRM 9.4.2 / 9.4.2.2 / 9.4.3: a bit-addressed footprint becomes
-    // `(lsb, hi - lsb + 1)`; a whole-signal read (no footprint) is encoded
-    // as width 0 (the any-change form at the runtime trigger).
-    const std::uint64_t lsb_bit_offset =
-        entry.footprint.has_value() ? entry.footprint->first : 0;
-    const std::uint64_t bit_width =
-        entry.footprint.has_value()
-            ? entry.footprint->second - entry.footprint->first + 1
-            : 0;
-    reads.push_back(
-        mir::SensitivityRead{
-            .observable_ptr = observable_ptr_id,
-            .lsb_bit_offset = lsb_bit_offset,
-            .bit_width = bit_width,
-            .edge_kind = LowerEventEdge(entry.edge_kind)});
+    triggers.push_back(
+        BuildTriggerExpr(target_block, frame, unit, lowerer, entry));
   }
+  const mir::TypeId triggers_type = unit.types.Intern(
+      mir::UnpackedArrayType{
+          .element_type = unit.builtins.trigger,
+          .dim = mir::UnpackedRange::ZeroBased(triggers.size())});
+  const mir::ExprId triggers_id = target_block.exprs.Add(
+      mir::Expr{
+          .data = mir::ArrayLiteralExpr{.elements = std::move(triggers)},
+          .type = triggers_type});
+
+  const mir::ExprId services_id =
+      target_block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame));
+  const mir::ExprId call_id = target_block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::Direct{.target = support::BuiltinFn::kWaitAny},
+                  .arguments = {services_id, triggers_id}},
+          .type = unit.builtins.void_type});
+  const mir::ExprId await_id = target_block.exprs.Add(
+      mir::Expr{
+          .data = mir::AwaitExpr{.awaitable = call_id},
+          .type = unit.builtins.void_type});
+
   return mir::Stmt{
-      .label = std::nullopt,
-      .data = mir::SensitivityWaitStmt{.reads = std::move(reads)}};
+      .label = std::nullopt, .data = mir::ExprStmt{.expr = await_id}};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -102,8 +102,8 @@ auto LowerTimedWaitWrapper(
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
 
-// LRM 15.5.2 `@e body;`: a suspending named-event await in place of the `@*`
-// SensitivityWaitStmt.
+// LRM 15.5.2 `@e body;`: the wait is on a named event's waiter list, not on a
+// value change, so it awaits the event rather than a trigger set.
 auto LowerNamedEventTimedStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::TimedStmt& t, const hir::NamedEventControl& nec)
@@ -138,9 +138,10 @@ auto LowerNamedEventTimedStmt(
       });
 }
 
-// LRM 9.4.2 `@(...) body`. Single-leaf trigger expressions lower directly to
-// a SensitivityWaitStmt over the union of leaves; multi-leaf forms require a
-// snapshot wrapper not yet implemented.
+// LRM 9.4.2 `@(...) body`. Single-leaf trigger expressions lower directly to a
+// wait over the union of the event list's leaves; a multi-leaf expression needs
+// a snapshot wrapper that is not yet implemented, because a leaf changing does
+// not entail the expression's result changing.
 auto LowerEventTimedStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     diag::SourceSpan span, const hir::TimedStmt& t, const hir::EventControl& ec)
@@ -163,14 +164,14 @@ auto LowerEventTimedStmt(
             // the expression. A whole-signal footprint already reduces to the
             // LSB at the runtime trigger, so only a bit-addressed footprint
             // needs collapsing.
-            if (leaf.edge_kind != hir::EventEdge::kAnyChange &&
+            if (leaf.edge_kind != support::EventEdge::kAnyChange &&
                 leaf.footprint.has_value()) {
               leaf.footprint = {{leaf.footprint->first, leaf.footprint->first}};
             }
             union_reads.push_back(leaf);
           }
         }
-        return MakeSensitivityWaitStmt(
+        return MakeValueChangeWaitStmt(
             child_block, child_frame, process.EnclosingScopeLowerer(),
             union_reads);
       });
@@ -185,7 +186,7 @@ auto LowerImplicitEventTimedStmt(
       process, frame, std::move(label), t.stmt,
       [&](mir::Block& child_block,
           WalkFrame child_frame) -> diag::Result<mir::Stmt> {
-        return MakeSensitivityWaitStmt(
+        return MakeValueChangeWaitStmt(
             child_block, child_frame, process.EnclosingScopeLowerer(),
             ie.sensitivity_list);
       });
@@ -308,7 +309,7 @@ auto LowerWaitStmt(
 
   mir::Block inner_block;
   const WalkFrame inner_frame = wrapper_frame.WithBlock(&inner_block);
-  inner_block.AppendStmt(MakeSensitivityWaitStmt(
+  inner_block.AppendStmt(MakeValueChangeWaitStmt(
       inner_block, inner_frame, process.EnclosingScopeLowerer(), reads));
 
   const mir::BlockId inner_scope_id =

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -404,11 +404,6 @@ auto FunctionLowerer::LowerStmtInto(
             }
             Terminate(lir::ReturnTerm{.value = std::move(value)});
             return {};
-          },
-          [](const mir::SensitivityWaitStmt&) -> diag::Result<void> {
-            return diag::Fail(
-                diag::DiagCode::kUnsupportedStatementForm,
-                "mir_to_lir: a sensitivity wait is not yet lowerable to LIR");
           }},
       stmt.data);
 }

--- a/src/lyra/lowering/mir_to_lir/translate_type.cpp
+++ b/src/lyra/lowering/mir_to_lir/translate_type.cpp
@@ -94,6 +94,8 @@ auto TranslateRuntimeLibraryKind(mir::RuntimeLibraryKind k)
       return lir::RuntimeLibraryKind::kDpiBitBuffer;
     case mir::RuntimeLibraryKind::kDpiLogicBuffer:
       return lir::RuntimeLibraryKind::kDpiLogicBuffer;
+    case mir::RuntimeLibraryKind::kTrigger:
+      return lir::RuntimeLibraryKind::kTrigger;
     case mir::RuntimeLibraryKind::kScopeProgram:
     case mir::RuntimeLibraryKind::kUnitDefinition:
     case mir::RuntimeLibraryKind::kScopeMetadata:

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -261,6 +261,8 @@ class MirDumper {
                   return "RuntimeLibrary(TimeFormat)";
                 case RuntimeLibraryKind::kHierarchySegment:
                   return "RuntimeLibrary(HierarchySegment)";
+                case RuntimeLibraryKind::kTrigger:
+                  return "RuntimeLibrary(Trigger)";
                 case RuntimeLibraryKind::kScopeProgram:
                   return "RuntimeLibrary(ScopeProgram)";
                 case RuntimeLibraryKind::kUnitDefinition:
@@ -369,20 +371,6 @@ class MirDumper {
         return "s";
     }
     throw InternalError("MirDumper::FormatTimeScale: unknown TimeScale");
-  }
-
-  static auto FormatEventEdge(EventEdge edge) -> std::string_view {
-    switch (edge) {
-      case EventEdge::kAnyChange:
-        return "any";
-      case EventEdge::kPosedge:
-        return "posedge";
-      case EventEdge::kNegedge:
-        return "negedge";
-      case EventEdge::kBothEdges:
-        return "edge";
-    }
-    throw InternalError("MirDumper::FormatEventEdge: unknown EventEdge");
   }
 
   static auto FormatUnaryOp(UnaryOp op) -> std::string {
@@ -1046,20 +1034,6 @@ class MirDumper {
               } else {
                 Line(std::format("Stmt[{}] ReturnStmt", id.value));
               }
-            },
-            [&](const SensitivityWaitStmt& s) {
-              Line(std::format("Stmt[{}] SensitivityWaitStmt", id.value));
-              Indent();
-              for (const auto& r : s.reads) {
-                Line(
-                    std::format(
-                        "observable=Expr[{}] {} lsb={} width={} edge={}",
-                        r.observable_ptr.value,
-                        FormatExpr(enclosing, r.observable_ptr),
-                        r.lsb_bit_offset, r.bit_width,
-                        FormatEventEdge(r.edge_kind)));
-              }
-              Dedent();
             },
         },
         stmt.data);

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -92,10 +92,13 @@ using lyra::runtime::FileTable;
 using lyra::runtime::GeneratedCallScope;
 using lyra::runtime::GeneratedInstance;
 using lyra::runtime::HierarchySegment;
+using lyra::runtime::Observable;
 using lyra::runtime::Own;
 using lyra::runtime::Read;
 using lyra::runtime::RuntimeServices;
 using lyra::runtime::Scope;
+using lyra::runtime::SubscribeValueChange;
+using lyra::runtime::Trigger;
 using lyra::runtime::UnitDefinition;
 using lyra::runtime::Var;
 using lyra::value::Format;
@@ -180,6 +183,29 @@ void lyra_rt_delay(
       static_cast<std::int8_t>(Read<PackedArray>(precision_power).ToInt64()),
       svc.GlobalPrecisionPower());
   svc.ScheduleAtTime(svc.Now() + global, token);
+}
+
+auto lyra_rt_make_trigger(
+    void* observable, const void* edge, const void* lsb_bit_offset,
+    const void* bit_width) -> void* {
+  return Own(Trigger(
+      static_cast<Observable*>(observable), Read<PackedArray>(edge),
+      Read<PackedArray>(lsb_bit_offset), Read<PackedArray>(bit_width)));
+}
+
+// The generated frame the process suspends is not a frame the engine ever sees
+// -- it resumes the runtime-owned coroutine that drives it -- so the process to
+// wake is the running one, read from the runtime.
+void lyra_rt_wait_any(void* services, LyraSpan triggers) {
+  auto& svc = *static_cast<RuntimeServices*>(services);
+  const std::span<Trigger* const> handles(
+      static_cast<Trigger* const*>(triggers.data), triggers.count);
+  std::vector<Trigger> collected;
+  collected.reserve(triggers.count);
+  for (const Trigger* handle : handles) {
+    collected.push_back(*handle);
+  }
+  SubscribeValueChange(svc.CurrentProcess().TopHandle(), collected);
 }
 
 void lyra_rt_register_initial(void* self, void* coroutine) {

--- a/src/lyra/runtime/trigger.cpp
+++ b/src/lyra/runtime/trigger.cpp
@@ -1,0 +1,19 @@
+#include "lyra/runtime/trigger.hpp"
+
+#include <cstdint>
+
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::runtime {
+
+Trigger::Trigger(
+    Observable* observable, const value::PackedArray& edge,
+    const value::PackedArray& lsb_bit_offset,
+    const value::PackedArray& bit_width)
+    : observable(observable),
+      edge(static_cast<support::EventEdge>(edge.ToInt64())),
+      lsb_bit_offset(static_cast<std::uint64_t>(lsb_bit_offset.ToInt64())),
+      bit_width(static_cast<std::uint64_t>(bit_width.ToInt64())) {
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -290,6 +290,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "value_plusargs";
     case BuiltinFn::kDelay:
       return "delay";
+    case BuiltinFn::kWaitAny:
+      return "wait_any";
     case BuiltinFn::kSimTime:
       return "sim_time";
     case BuiltinFn::kSTime:

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -135,6 +135,41 @@ auto WriteDpiImportForeign(const std::filesystem::path& path) -> void {
       << "int slen(const char* s) { return (int)strlen(s); }\n";
 }
 
+// Every SV construct that waits on a value change at once: an implicit
+// sensitivity (`always_comb`), an explicit event list with two edges, and a
+// `wait (cond)` re-check loop, all driven by a delayed clock. The clock is
+// unrolled rather than looped because a loop-carried value across a suspension
+// is a lifetime the execution backend does not yet give a generated frame.
+auto WriteValueChangeWaitSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  logic clk = 0;\n"
+      << "  logic rst = 0;\n"
+      << "  logic go = 0;\n"
+      << "  int count = 0;\n"
+      << "  int doubled = 0;\n"
+      << "  always_comb doubled = count * 2;\n"
+      << "  always @(posedge clk or posedge rst) begin\n"
+      << "    count = count + 1;\n"
+      << "    $display(\"edge count=%0d doubled=%0d\", count, doubled);\n"
+      << "  end\n"
+      << "  initial begin\n"
+      << "    wait (go);\n"
+      << "    $display(\"released at go\");\n"
+      << "    #5;\n"
+      << "    clk = 1;\n"
+      << "    #5;\n"
+      << "    clk = 0;\n"
+      << "    #5;\n"
+      << "    rst = 1;\n"
+      << "  end\n"
+      << "  initial begin\n"
+      << "    #2;\n"
+      << "    go = 1;\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -287,6 +322,41 @@ TEST(LyraRun, JitAndCppAgreeOnDpiScalarImports) {
   EXPECT_NE(jit.stdout_text.find("widen=4294967297"), std::string::npos)
       << "stdout: " << jit.stdout_text;
   EXPECT_NE(jit.stdout_text.find("len=4"), std::string::npos)
+      << "stdout: " << jit.stdout_text;
+}
+
+// A process suspended on a value change resumes when a leaf it subscribed to
+// changes as its edge demands, and a leaf it did not subscribe to leaves it
+// parked. The two backends must agree on which changes wake which process and
+// in what simulation-time order, so the same source runs through both and the
+// outputs are compared.
+TEST(LyraRun, JitAndCppAgreeOnValueChangeWait) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteValueChangeWaitSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "released at go\nedge count=1 doubled=0\nedge count=2 doubled=2\n")
       << "stdout: " << jit.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

A value-change wait -- an `always_comb` / `always_latch` body, an `@*`, an `@(...)` event control, a `wait (cond)`, and the continuous-assignment body that shares their machinery -- is now an ordinary runtime call, awaited like every other suspending call, instead of a dedicated MIR statement. This lets the execution backend run every value-change construct with no new IR concept: the wait is a call, and the suspension is the same suspend edge every await already lowers to. The C++ backend loses its bespoke renderer for the wait and goes through the same generic call, construct, and array-literal paths as every other runtime effect.

## Design

The prior shape carried the wait in a MIR statement holding the leaf list. The C++ backend could render that because it fabricates whatever text it likes, but an execution backend would have to synthesize the wait's realization -- the subscription calls and the suspension -- out of one node that states neither, and two backends would each be free to invent that expansion differently. That is exactly the node-invented-for-a-scheduling-discipline shape the MIR contract forbids, whose falsifier is "could a mechanical backend translate this without decisions?".

The wait now lowers to `await( wait_any(services, [trigger(leaf) for leaf in leaves]) )`. A trigger is a runtime-library value the IR builds with a construct call and forwards without inspecting -- the same category as a print item or a format specification -- carrying the observable cell, the observed bit projection, and the edge polarity. The whole trigger set goes in one call rather than one call per leaf, because the registration must name the frame to resume and only the suspension protocol knows it: a wait inside an enabled task must resume the task's frame, not the enabling process's. The call carries the engine handle as its first argument the way every runtime effect does; the C++ realization gets its frame from the language and ignores the handle, while the execution backend needs it to ask the runtime which process is running, since the frame it suspends is one the engine never sees.

The edge polarity, previously duplicated as three per-layer enums (HIR, MIR, runtime) with conversions between them, collapses to one `support::EventEdge` shared by compiler and runtime -- the compile-time/runtime agreement about what a leaf's polarity means, like the standard file descriptors or the DPI ABI classes.

This refines the earlier event-control unification, which stands (one shape, per-leaf projection and edge, frontend LSB-reduce, runtime per-leaf filtering); only the MIR carrier changes. The reasoning is recorded in a new decision entry, and the earlier entry is marked superseded rather than rewritten.

## Testing

`bazel test //...` is green. A new end-to-end case runs an `always_comb`, a two-edge event list, and a `wait (cond)` re-check loop through both backends and asserts identical stdout. The clock in that case is unrolled rather than looped: a loop-carried value across a suspension is a lifetime the execution backend does not yet give a generated frame (the same cross-suspension-value gap the suspension decision leaves open), so a `repeat (n) begin #d; clk = ~clk; end` clock generator does not yet run on the JIT and is the next foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)