### PR TITLE
Complete runtime-index and nested query functions

### DIFF
--- a/docs/progress/query-functions.md
+++ b/docs/progress/query-functions.md
@@ -59,15 +59,16 @@ every operand, dynamic included.
       require the dimension to be a constant expression). The query selects among the per-dimension
       results, which the operand's type still fixes; an index the type has no dimension for reads
       `'x`.
-- [ ] Q6 -- A dimension named at run time over an array that has a dynamically sized dimension. LRM
-      20.7.1 makes it an error for such an index to name that dimension; an index only the
-      simulation knows cannot be held to that rule at elaboration, so the form is rejected rather
-      than half-served. Reporting the error when the index actually lands on that dimension is what
-      the form needs.
-- [ ] Q7 -- `$bits` of a value whose elements are themselves dynamically sized (a dynamic array of
-      dynamic arrays, a queue of strings). Every other dynamically sized operand reports its element
-      count times the bits one element occupies; a dynamically sized element has no such fixed
-      width, so the count has to be summed over the elements.
+- [x] Q6 -- A dimension named at run time over an array whose top dimension is dynamic. The top
+      dimension's extent is read from the value, a deeper fixed dimension keeps its constant shape,
+      and an index the type has no dimension for reads `'x`. A variable-sized dimension _below_ the
+      top is out of scope: LRM 20.7.1 makes naming it an error, since each outer element carries its
+      own extent, and a run-time index could land there. That operand shape is rejected up front
+      rather than half-served; reporting the error only when the index actually lands on the deeper
+      dimension is what the residual case needs.
+- [x] Q7 -- `$bits` of a value whose elements are themselves dynamically sized (a dynamic array of
+      dynamic arrays, a queue of strings). The bit count sums each element's own current width, one
+      query layer down, so an operand of any nesting depth reports its live size and 0 while empty.
 
 ## LRM ambiguity
 

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -23,6 +23,11 @@ enum class BuiltinFn : std::uint16_t {
   // String's LRM 6.16.1 `len` is its own mandated spelling.
   kSize,
   kLen,
+  // LRM 20.6.2 `$bits` over a dynamically sized value: the bit count of what it
+  // currently holds. Sums each element's own bit count, so an element that is
+  // itself dynamically sized contributes its current width. The fixed-size case
+  // folds at elaboration and never reaches this entry.
+  kBitstreamWidth,
   // LRM 7.12 / 7.5 / 7.10 container ops.
   kToOwned,
   kDelete,

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -522,6 +522,17 @@ class AssociativeArray {
     return PackedArray::Bit(HasUnknown());
   }
 
+  // LRM 20.6.2 `$bits`: the current bit count sums the allocated entries' value
+  // bit counts (a key is not part of the stored bitstream), so a dynamically
+  // sized value contributes its current width.
+  [[nodiscard]] auto BitstreamWidth() const -> PackedArray {
+    PackedArray total = PackedArray::Int(0);
+    for (const auto& [key, value] : data_) {
+      total = total + value.BitstreamWidth();
+    }
+    return total;
+  }
+
  private:
   [[nodiscard]] auto IsInvalidKey(const K& key) const -> bool {
     // LRM 7.8.6: a key carrying x/z is invalid. Decided by the key's own x/z
@@ -594,6 +605,7 @@ struct Formatter<AssociativeArray<K, V>> {
 static_assert(LyraValue<AssociativeArray<String, PackedArray>>);
 static_assert(LyraValue<AssociativeArray<PackedArray, PackedArray>>);
 static_assert(Sized<AssociativeArray<String, PackedArray>>);
+static_assert(BitstreamSizable<AssociativeArray<String, PackedArray>>);
 static_assert(AssocIndexable<AssociativeArray<String, PackedArray>, String>);
 static_assert(Defaultable<AssociativeArray<String, PackedArray>>);
 static_assert(KeyTraversal<AssociativeArray<String, PackedArray>, String>);

--- a/include/lyra/value/chandle.hpp
+++ b/include/lyra/value/chandle.hpp
@@ -70,6 +70,10 @@ class Chandle {
     return false;
   }
 
+  [[nodiscard]] static auto IsUnknown() -> PackedArray {
+    return PackedArray::Bit(false);
+  }
+
   // LRM 6.14: a chandle is always initialized to `null`. Satisfies the
   // container OOB-shield contract so a chandle can be an associative-array
   // element.

--- a/include/lyra/value/concepts.hpp
+++ b/include/lyra/value/concepts.hpp
@@ -62,13 +62,16 @@ concept LyraValue = Storable<T> && requires(const T& a, const T& b) {
   // operator (`CaseEqualComparable`) even when their internal algorithm
   // coincides.
   { a.IsBitIdentical(b) } -> std::same_as<bool>;
-  // LRM 20.9 `$isunknown` predicate: does any bit of this value's
-  // representation carry an X or Z. Universal: 2-state types implement
-  // it as `return false`; 4-state types scan their bit pattern;
-  // aggregate types recurse into elements. Lowering emits the call
-  // uniformly across every value type, and downstream optimization
-  // constant-folds the 2-state case.
+  // LRM 20.9 unknown detection: does any bit of this value's representation
+  // carry an X or Z. 2-state types answer no; 4-state types scan their bit
+  // pattern; aggregates recurse into elements. Two forms of the one question:
+  // the host-bool `HasUnknown` is the internal predicate that operator
+  // realizations and the engine's change detection read, and `IsUnknown` is
+  // the SV `$isunknown` value form (a 1-bit packed result) the lowering
+  // renders on any operand. Both are universal, so every value type exposes
+  // both; downstream optimization constant-folds the 2-state case.
   { a.HasUnknown() } -> std::same_as<bool>;
+  { a.IsUnknown() } -> std::same_as<PackedArray>;
 };
 
 // LRM 11.4.5 `===` / `!==` (Any data type except `real` and `shortreal`). A
@@ -110,6 +113,19 @@ concept Sized = requires(const T& t) {
 template <typename T>
 concept Lengthable = requires(const T& t) {
   { t.Len() } -> std::same_as<PackedArray>;
+};
+
+// BitstreamSizable: the bit-stream types (LRM 6.24.3 -- integral, packed, or
+// string, and unpacked / dynamic / associative / queue / struct compositions of
+// those, recursively) expose the LRM 20.6.2 `$bits` bit count of what the value
+// currently holds, in the SV `int` shape. `real` / `shortreal`, chandle, and
+// event are not bit-stream types and do not participate. A composite is
+// bit-stream sizable exactly when its elements are, so a container's method
+// well-forms only over a bit-stream element type; the concept pins the method's
+// shape, and element-type drift surfaces when the body instantiates.
+template <typename T>
+concept BitstreamSizable = requires(const T& t) {
+  { t.BitstreamWidth() } -> std::same_as<PackedArray>;
 };
 
 // Indexable: single-element access by integer position. The container

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -217,6 +217,16 @@ class DynamicArray {
     return PackedArray::Bit(HasUnknown());
   }
 
+  // LRM 20.6.2 `$bits`: the current bit count is the sum of the elements' own
+  // bit counts, so a dynamically sized element contributes its current width.
+  [[nodiscard]] auto BitstreamWidth() const -> PackedArray {
+    PackedArray total = PackedArray::Int(0);
+    for (const auto& e : data_) {
+      total = total + e.BitstreamWidth();
+    }
+    return total;
+  }
+
   // LRM 7.5.3: empties the array, resulting in a zero-sized array. Body is
   // identical to ResetToDefault (LRM Table 6-7 default for dynamic array is
   // the empty array), but the two surface names track distinct contracts:
@@ -425,6 +435,7 @@ struct Formatter<DynamicArray<T>> {
 
 static_assert(LyraValue<DynamicArray<PackedArray>>);
 static_assert(Sized<DynamicArray<PackedArray>>);
+static_assert(BitstreamSizable<DynamicArray<PackedArray>>);
 static_assert(Indexable<DynamicArray<PackedArray>>);
 static_assert(Sliceable<DynamicArray<PackedArray>>);
 static_assert(SliceableRef<DynamicArray<PackedArray>>);

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -173,6 +173,13 @@ class PackedArray {
   [[nodiscard]] auto Dims() const -> std::span<const PackedRange>;
   [[nodiscard]] auto IsFourState() const -> bool;
 
+  // LRM 20.6.2 `$bits`: a packed value occupies its declared bit width. It is
+  // the leaf of the recursive bit count a dynamically sized container reports
+  // over its elements.
+  [[nodiscard]] auto BitstreamWidth() const -> PackedArray {
+    return PackedArray::Int(static_cast<std::int32_t>(BitWidth()));
+  }
+
   // Restore the value to this shape's canonical default in place: all-zero
   // for 2-state, all-X for 4-state (LRM Table 6-7 / Table 7-1). The declared
   // type (dimensions, signedness, state domain) is preserved.
@@ -641,6 +648,7 @@ class PackedArrayRef {
 };
 
 static_assert(LyraValue<PackedArray>);
+static_assert(BitstreamSizable<PackedArray>);
 static_assert(Indexable<PackedArray>);
 static_assert(Sliceable<PackedArray>);
 static_assert(SliceableRef<PackedArray>);

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -173,6 +173,16 @@ class Queue {
     return PackedArray::Bit(HasUnknown());
   }
 
+  // LRM 20.6.2 `$bits`: the current bit count is the sum of the elements' own
+  // bit counts, so a dynamically sized element contributes its current width.
+  [[nodiscard]] auto BitstreamWidth() const -> PackedArray {
+    PackedArray total = PackedArray::Int(0);
+    for (const auto& e : data_) {
+      total = total + e.BitstreamWidth();
+    }
+    return total;
+  }
+
   // LRM Table 6-7: a queue's default is the empty queue. When this container
   // is itself the discard sink of an outer container, the outer scrubs it to
   // canonical state before handing out a reference.
@@ -548,6 +558,7 @@ struct Formatter<Queue<T>> {
 
 static_assert(LyraValue<Queue<PackedArray>>);
 static_assert(Sized<Queue<PackedArray>>);
+static_assert(BitstreamSizable<Queue<PackedArray>>);
 static_assert(Indexable<Queue<PackedArray>>);
 // A queue's `Slice(anchor, extent, form)` is dynamic-width -- the runtime
 // derives the element count from the bounds (LRM 7.10.1) -- not the fixed-width

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -119,6 +119,12 @@ class String {
   }
 
   // LRM 6.16.1: len() yields an SV int.
+  // LRM 20.6.2 `$bits`: a string occupies 8 bits per character (LRM 6.16, a
+  // string element is a byte).
+  [[nodiscard]] auto BitstreamWidth() const -> PackedArray {
+    return PackedArray::Int(static_cast<std::int32_t>(8 * impl_.size()));
+  }
+
   [[nodiscard]] auto Len() const -> PackedArray {
     return PackedArray::Int(static_cast<std::int32_t>(impl_.size()));
   }
@@ -365,6 +371,7 @@ inline auto String::ElementRef(const PackedArray& i_arg) -> StringCharRef {
 
 static_assert(LyraValue<String>);
 static_assert(Lengthable<String>);
+static_assert(BitstreamSizable<String>);
 static_assert(Indexable<String>);
 
 // Defined here rather than alongside the rest of `UnpackedArray` because it is

--- a/include/lyra/value/tuple.hpp
+++ b/include/lyra/value/tuple.hpp
@@ -74,11 +74,25 @@ class Tuple {
     }(std::index_sequence_for<Ts...>{});
   }
 
+  // LRM 20.6.2 `$bits`: a product occupies the sum of its members' bit counts.
+  // A member that is itself dynamically sized contributes its current width.
+  [[nodiscard]] auto BitstreamWidth() const -> PackedArray {
+    return [&]<std::size_t... I>(std::index_sequence<I...>) {
+      PackedArray total = PackedArray::Int(0);
+      ((total = total + std::get<I>(data_).BitstreamWidth()), ...);
+      return total;
+    }(std::index_sequence_for<Ts...>{});
+  }
+
   // LRM 20.9 `$isunknown`: any member carrying an X / Z bit propagates up.
   [[nodiscard]] auto HasUnknown() const -> bool {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
       return (std::get<I>(data_).HasUnknown() || ...);
     }(std::index_sequence_for<Ts...>{});
+  }
+
+  [[nodiscard]] auto IsUnknown() const -> PackedArray {
+    return PackedArray::Bit(HasUnknown());
   }
 
   // LRM Table 7-1 unpacked-struct default: member-wise reset, each component to
@@ -97,6 +111,7 @@ class Tuple {
 
 static_assert(LyraValue<Tuple<PackedArray, PackedArray>>);
 static_assert(CaseEqualComparable<Tuple<PackedArray, PackedArray>>);
+static_assert(BitstreamSizable<Tuple<PackedArray, PackedArray>>);
 static_assert(Defaultable<Tuple<PackedArray, PackedArray>>);
 
 }  // namespace lyra::value

--- a/include/lyra/value/union.hpp
+++ b/include/lyra/value/union.hpp
@@ -138,6 +138,10 @@ class Union {
         [](const auto& active) -> bool { return active.HasUnknown(); }, data_);
   }
 
+  [[nodiscard]] auto IsUnknown() const -> PackedArray {
+    return PackedArray::Bit(HasUnknown());
+  }
+
  private:
   std::variant<Ts...> data_;
 };

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -243,6 +243,17 @@ class UnpackedArray {
     return PackedArray::Bit(HasUnknown());
   }
 
+  // LRM 20.6.2 `$bits`: the current bit count is the sum of the elements' own
+  // bit counts. A fixed-size unpacked array folds at elaboration; this path
+  // serves the case where an element is itself dynamically sized.
+  [[nodiscard]] auto BitstreamWidth() const -> PackedArray {
+    PackedArray total = PackedArray::Int(0);
+    for (const auto& e : data_) {
+      total = total + e.BitstreamWidth();
+    }
+    return total;
+  }
+
   // LRM 7.12.2 ordering: an in-place positional permutation at constant size (a
   // fixed array never grows or shrinks). `reverse` takes no closure; `sort` /
   // `rsort` order by the closure-projected key with the ordinal position as
@@ -507,6 +518,7 @@ struct Formatter<UnpackedArray<T>> {
 
 static_assert(LyraValue<UnpackedArray<PackedArray>>);
 static_assert(Sized<UnpackedArray<PackedArray>>);
+static_assert(BitstreamSizable<UnpackedArray<PackedArray>>);
 static_assert(RangedIndexable<UnpackedArray<PackedArray>>);
 static_assert(RangedSliceable<UnpackedArray<PackedArray>>);
 static_assert(RangedSliceableRef<UnpackedArray<PackedArray>>);

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -155,6 +155,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "SliceRef";
     case support::BuiltinFn::kSize:
       return "Size";
+    case support::BuiltinFn::kBitstreamWidth:
+      return "BitstreamWidth";
     case support::BuiltinFn::kToOwned:
       return "ToOwned";
     case support::BuiltinFn::kDelete:

--- a/src/lyra/lowering/ast_to_hir/expression/query.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/query.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <slang/ast/EvalContext.h>
 #include <slang/ast/Expression.h>
@@ -344,39 +345,40 @@ auto LowerAssociativeDimensionQuery(
 }
 
 // LRM 20.6.2 over a dynamically sized value: the bit count of what it currently
-// holds. Every element occupies the same fixed number of bits -- a string's is
-// a byte -- so the count is the element count times that width. An element
-// whose own size only the running simulation knows has no such width.
+// holds, read at run time. The value reports it by summing each element's own
+// bit count, so an element that is itself dynamically sized contributes its
+// current width -- the same query one layer down -- and the lowering never
+// inspects the element shape. The read lands in the `integer` the query
+// reports.
 template <ExprLowerer Lowerer>
 auto LowerDynamicBitsQuery(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  const slang::ast::Type& operand_type = *call.arguments()[0]->type;
-  std::uint64_t element_bits = 8;
-  if (!operand_type.isString()) {
-    const slang::ast::Type& element = *operand_type.getArrayElementType();
-    if (!element.isFixedSize()) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "$bits of a value whose elements are themselves dynamically sized is "
-          "not yet supported");
-    }
-    element_bits = element.getBitstreamWidth();
+  ModuleLowerer& module = lowerer.Module();
+  auto operand_or = lowerer.LowerExpr(*call.arguments()[0], frame);
+  if (!operand_or) {
+    return std::unexpected(std::move(operand_or.error()));
   }
-
-  auto count_or = BuildElementCountExpr(lowerer, frame, call, span);
-  if (!count_or) {
-    return std::unexpected(std::move(count_or.error()));
+  auto result_type = module.InternType(*call.type, span);
+  if (!result_type) {
+    return std::unexpected(std::move(result_type.error()));
   }
-  auto width_or = MakeQueryInt(
-      lowerer.Module(), frame, call, static_cast<std::int64_t>(element_bits),
-      span);
-  if (!width_or) {
-    return std::unexpected(std::move(width_or.error()));
-  }
-  return MakeQueryBinary(
-      frame, hir::BinaryOp::kMul, *std::move(count_or), *std::move(width_or),
-      span);
+  const hir::ExprId width_id = frame.Exprs().Add(
+      hir::Expr{
+          .type = module.Unit().builtins.int_type,
+          .data =
+              hir::CallExpr{
+                  .callee =
+                      hir::BuiltinMethodRef{
+                          .method = support::BuiltinFn::kBitstreamWidth},
+                  .arguments = {frame.Exprs().Add(*std::move(operand_or))}},
+          .span = span});
+  return hir::Expr{
+      .type = *result_type,
+      .data =
+          hir::ConversionExpr{
+              .operand = width_id, .kind = hir::ConversionKind::kImplicit},
+      .span = span};
 }
 
 // LRM 20.6.2: the bit count of the operand's type, taken without evaluating the
@@ -422,13 +424,39 @@ auto LowerDimensionCountQuery(
       span);
 }
 
+// The query's result for the dimension whose own range is `dimension` (LRM
+// 20.7). A fixed dimension folds to a constant; the operand's own top
+// dimension, when it is dynamic or associative, reads the value's current
+// state. The caller guarantees `dimension` is either fixed-size or the
+// operand's top dimension -- a variable-sized dimension below the top has no
+// single extent (LRM 20.7.1) and is rejected before reaching here.
+template <ExprLowerer Lowerer>
+auto LowerDimensionResult(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    const slang::ast::Type& dimension, QueryKind query, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  ModuleLowerer& module = lowerer.Module();
+  if (dimension.hasFixedRange() && !dimension.isScalar()) {
+    return MakeQueryInt(
+        module, frame, call,
+        FixedDimensionValue(query, dimension.getFixedRange()), span);
+  }
+  if (dimension.isAssociativeArray()) {
+    return LowerAssociativeDimensionQuery(
+        lowerer, frame, call, dimension, query, span);
+  }
+  return LowerOrderedDynamicDimensionQuery(lowerer, frame, call, query, span);
+}
+
 // LRM 20.7 with a dimension the running simulation names. Which dimensions the
-// operand has is still a property of its type, so each one's result is a
-// constant and the query is a select, by the index, out of the array of them.
-// The array is declared over `[1 : dimension count]`, so the index selects
-// directly; an index the type has no dimension for falls outside that range and
-// reads the element default, which for the `integer` a dimension function
-// reports is `'x` -- what LRM 20.7 requires of an out-of-range dimension.
+// operand has is a property of its type, so each dimension's result is built at
+// lowering -- a constant for a fixed dimension, a current-state read for a
+// dynamic top dimension -- and the query is a select, by the index, out of the
+// array of them. The array is declared over `[1 : dimension count]`, so the
+// index selects directly; an index the type has no dimension for falls outside
+// that range and reads the element default, which for the `integer` a dimension
+// function reports is `'x` -- what LRM 20.7 requires of an out-of-range
+// dimension.
 template <ExprLowerer Lowerer>
 auto LowerComposedDimensionQuery(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
@@ -438,28 +466,31 @@ auto LowerComposedDimensionQuery(
   const auto dimension_count =
       static_cast<std::int64_t>(DimensionCount(operand_type, false));
 
-  slang::ConstantValue::Elements rows;
+  std::vector<hir::ExprId> rows;
   rows.reserve(static_cast<std::size_t>(dimension_count));
   for (std::int64_t i = 1; i <= dimension_count; ++i) {
     const slang::ast::Type* dimension =
         DimensionType(operand_type, static_cast<std::int32_t>(i));
-    // A dimension whose extent only the running simulation knows has no
-    // constant result to tabulate. LRM 20.7.1 forbids naming such a dimension
-    // beyond the first, but an index the simulation supplies cannot be held to
-    // that rule at elaboration.
-    if (dimension == nullptr || !dimension->hasFixedRange() ||
-        dimension->isScalar()) {
+    if (dimension == nullptr) {
+      throw InternalError(
+          "LowerComposedDimensionQuery: dimension index out of range");
+    }
+    // LRM 20.7.1: a variable-sized dimension below the top has no single extent
+    // -- each outer element carries its own -- so naming it is an error. A
+    // run-time index could land there, and the value-build table cannot carry a
+    // per-arm error, so the operand shape is rejected rather than half-served.
+    if (i != 1 && !dimension->hasFixedRange()) {
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
-          "an array query whose dimension is not a constant expression is not "
-          "yet supported over an array with a dynamically sized dimension");
+          "an array query with a run-time dimension index is not yet supported "
+          "over an array with a variable-sized dimension below the top");
     }
-    rows.emplace_back(call.type->coerceValue(
-        slang::ConstantValue{slang::SVInt(
-            32,
-            static_cast<std::uint64_t>(
-                FixedDimensionValue(query, dimension->getFixedRange())),
-            true)}));
+    auto row_or =
+        LowerDimensionResult(lowerer, frame, call, *dimension, query, span);
+    if (!row_or) {
+      return std::unexpected(std::move(row_or.error()));
+    }
+    rows.push_back(frame.Exprs().Add(*std::move(row_or)));
   }
 
   auto element_type = module.InternType(*call.type, span);
@@ -470,12 +501,11 @@ auto LowerComposedDimensionQuery(
       hir::UnpackedArrayType{
           .element_type = *element_type,
           .dim = hir::UnpackedRange{.left = 1, .right = dimension_count}});
-  auto table_or = MakeConstantValueExpr(
-      module.Unit(), frame, slang::ConstantValue{std::move(rows)}, table_type,
-      span);
-  if (!table_or) {
-    return std::unexpected(std::move(table_or.error()));
-  }
+  const hir::ExprId table_id = frame.Exprs().Add(
+      hir::Expr{
+          .type = table_type,
+          .data = hir::AssignmentPatternExpr{.elements = std::move(rows)},
+          .span = span});
   auto index_or = lowerer.LowerExpr(*call.arguments()[1], frame);
   if (!index_or) {
     return std::unexpected(std::move(index_or.error()));
@@ -484,7 +514,7 @@ auto LowerComposedDimensionQuery(
       .type = *element_type,
       .data =
           hir::ElementSelectExpr{
-              .base_value = frame.Exprs().Add(*std::move(table_or)),
+              .base_value = table_id,
               .index = frame.Exprs().Add(*std::move(index_or))},
       .span = span};
 }
@@ -508,17 +538,7 @@ auto LowerDimensionQuery(
   if (dimension == nullptr) {
     throw InternalError("LowerDimensionQuery: dimension index out of range");
   }
-
-  if (dimension->hasFixedRange() && !dimension->isScalar()) {
-    return MakeQueryInt(
-        module, frame, call,
-        FixedDimensionValue(query, dimension->getFixedRange()), span);
-  }
-  if (dimension->isAssociativeArray()) {
-    return LowerAssociativeDimensionQuery(
-        lowerer, frame, call, *dimension, query, span);
-  }
-  return LowerOrderedDynamicDimensionQuery(lowerer, frame, call, query, span);
+  return LowerDimensionResult(lowerer, frame, call, *dimension, query, span);
 }
 
 }  // namespace

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -128,6 +128,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "size";
     case BuiltinFn::kLen:
       return "len";
+    case BuiltinFn::kBitstreamWidth:
+      return "bitstream_width";
     case BuiltinFn::kToOwned:
       return "to_owned";
     case BuiltinFn::kDelete:

--- a/tests/cases/cpp/isunknown/case.yaml
+++ b/tests/cases/cpp/isunknown/case.yaml
@@ -13,3 +13,5 @@ expect:
     r_z: 1
     ca_known: 0
     ca_xz: 1
+    r_struct_known: 0
+    r_struct_x: 1

--- a/tests/cases/cpp/isunknown/main.sv
+++ b/tests/cases/cpp/isunknown/main.sv
@@ -9,6 +9,13 @@ module Top;
   bit ca_known;
   bit ca_xz;
 
+  // LRM 20.9 $isunknown over an unpacked struct: an X / Z anywhere in a member
+  // propagates up.
+  typedef struct { int a; logic [3:0] b; } sp_t;
+  sp_t sp;
+  bit r_struct_known;
+  bit r_struct_x;
+
   // LRM 20.9 $isunknown in a continuous assignment (simulation-time value
   // expression driving a net).
   assign ca_known = $isunknown(bus_known);
@@ -24,5 +31,11 @@ module Top;
     r_z = $isunknown(a);
     bus_known = 4'b1010;
     bus_xz = 4'b1z10;
+
+    sp.a = 1;
+    sp.b = 4'b0101;
+    r_struct_known = $isunknown(sp);
+    sp.b = 4'b01x1;
+    r_struct_x = $isunknown(sp);
   end
 endmodule

--- a/tests/cases/cpp/query_bits/case.yaml
+++ b/tests/cases/cpp/query_bits/case.yaml
@@ -22,3 +22,6 @@ expect:
     bits_assoc: 64
     bits_narrow: 7
     bits_empty: 0
+    bits_nest: 256
+    bits_strq: 56
+    bits_fixnest: 160

--- a/tests/cases/cpp/query_bits/main.sv
+++ b/tests/cases/cpp/query_bits/main.sv
@@ -39,6 +39,17 @@ module Top;
   int bits_narrow;
   int bits_empty;
 
+  // LRM 20.6.2 over a value whose elements are themselves dynamically sized:
+  // each element contributes its current bit count, so the total sums the
+  // elements' widths rather than multiplying by one fixed element width.
+  int    nest[][];
+  string strq[$];
+  int    fixnest[2][];
+
+  int bits_nest;
+  int bits_strq;
+  int bits_fixnest;
+
   initial begin
     q = 4'b1010;
     bits_type_rt = $bits(mubi_t);
@@ -66,5 +77,17 @@ module Top;
 
     que.delete();
     bits_empty = $bits(que);
+
+    nest = new[2];
+    nest[0] = new[3];
+    nest[1] = new[5];
+    strq.push_back("hi");
+    strq.push_back("world");
+    fixnest[0] = new[1];
+    fixnest[1] = new[4];
+
+    bits_nest = $bits(nest);
+    bits_strq = $bits(strq);
+    bits_fixnest = $bits(fixnest);
   end
 endmodule

--- a/tests/cases/cpp/query_dynamic_shape/case.yaml
+++ b/tests/cases/cpp/query_dynamic_shape/case.yaml
@@ -34,3 +34,7 @@ expect:
     map4_right: "8'hFF"
     unallocated_low: "8'bxxxxxxxx"
     unallocated_high: "8'bxxxxxxxx"
+    rt_top1: 3
+    rt_top2: 5
+    rt_top3: 32
+    rt_top_oor: "32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/tests/cases/cpp/query_dynamic_shape/main.sv
+++ b/tests/cases/cpp/query_dynamic_shape/main.sv
@@ -27,6 +27,15 @@ module Top;
   logic [7:0] map4_low, map4_high, map4_right;
   logic [7:0] unallocated_low, unallocated_high;
 
+  // LRM 20.7 with a run-time dimension index over an array whose top dimension
+  // is dynamic. `int [][5]` has three dimensions -- the dynamic outer, the
+  // fixed unpacked `[5]`, and the element `int`'s packed `[31:0]`. The top
+  // dimension's extent is read from the value; the deeper fixed dimensions keep
+  // their constant shape; an index the type has no dimension for reads `'x`.
+  int rt_top[][5];
+  int rt_dim;
+  integer rt_top1, rt_top2, rt_top3, rt_top_oor;
+
   initial begin
     dyn = new[4];
     que.push_back(10);
@@ -75,5 +84,15 @@ module Top;
     empty_size = $size(que);
     empty_right = $right(que);
     empty_high = $high(que);
+
+    rt_top = new[3];
+    rt_dim = 1;
+    rt_top1 = $size(rt_top, rt_dim);
+    rt_dim = 2;
+    rt_top2 = $size(rt_top, rt_dim);
+    rt_dim = 3;
+    rt_top3 = $size(rt_top, rt_dim);
+    rt_dim = 4;
+    rt_top_oor = $size(rt_top, rt_dim);
   end
 endmodule

--- a/tests/cases/errors/query_runtime_dim_subtop_dynamic/case.yaml
+++ b/tests/cases/errors/query_runtime_dim_subtop_dynamic/case.yaml
@@ -1,0 +1,16 @@
+id: errors.query_runtime_dim_subtop_dynamic
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "variable-sized dimension below the top"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/query_runtime_dim_subtop_dynamic/main.sv
+++ b/tests/cases/errors/query_runtime_dim_subtop_dynamic/main.sv
@@ -1,0 +1,14 @@
+// LRM 20.7.1: naming a variable-sized dimension below the top is an error,
+// since each outer element carries its own extent. A run-time dimension index
+// could land on such a dimension, so the query over this operand shape is
+// rejected rather than half-served.
+module Top;
+  int a[3][];
+  int d;
+  int rt;
+  initial begin
+    a[0] = new[4];
+    d = 2;
+    rt = $size(a, d);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Closes the remaining gaps in the LRM 20.6 / 20.7 query-function family. `$bits` now works over a value whose elements are themselves dynamically sized (a dynamic array of dynamic arrays, a queue of strings) by reading the bit count as a value method that sums each element's own current width, one query layer down; the fixed-size case still folds at elaboration. The run-time dimension index (LRM 20.7 does not require a constant one) now also works over an array whose top dimension is dynamic: the top dimension's extent is read from the value, deeper fixed dimensions keep their constant shape, and an index the type has no dimension for reads `'x`.

## Design

`$bits` of a dynamically sized value is placed where the facts it needs live: entirely in the runtime value (element count and per-element width), so it is a method on the value type reached through an ordinary call, the same shape `$size` uses. The run-time dimension query builds each dimension's result at lowering -- a constant for a fixed dimension, a current-state read for a dynamic top dimension -- into an unpacked array selected by the index, since the dimension structure is a fact of the operand's type. A variable-sized dimension below the top has no single extent (LRM 20.7.1 makes naming it an error, since each outer element carries its own), and the value-build table cannot carry a per-arm error, so that operand shape is rejected up front.

The audit that this prompted surfaced that `IsUnknown` (the SV `$isunknown` value form) was a universal value contract with no concept enforcing it, so `$isunknown` of an unpacked struct failed to compile in emitted code. It is now part of the `LyraValue` concept alongside its bool sibling, with `BitstreamWidth` its own `BitstreamSizable` concept, so a value type missing either fails at the static assert rather than deep in generated code.

## Testing

`bazel test //...` green. Runtime-index and nested `$bits` behavior is cross-checked against the LRM where Verilator diverges or does not implement the form; the sub-top variable-dimension rejection has an error-case test, and `$isunknown` over an unpacked struct is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)