### PR TITLE
Lower packages as HIR compilation units

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -204,7 +204,7 @@ threaded down, a per-callable-body temp counter) is defined separately under "Re
     _Current implementation:_ the dispatcher is a method on the pass class declared in its header.
     Subsystem `.cpp` files include the pass class header to accept the instance by reference and to
     recurse via `lowerer.LowerExpr(...)` / `lowerer.LowerStmt(...)` /
-    `lowerer.Module().InternType(...)`. `proc.Module()` returns the `ModuleLowerer&` the
+    `lowerer.Owner().InternType(...)`. `proc.Owner()` returns the `UnitLowerer&` the
     `ProcessLowerer` captured at construction.
 
 13. A per-kind handler whose logic is shared across pass classes is one function template
@@ -478,9 +478,9 @@ The three kinds of class members correspond to distinct access patterns:
   depend on the adjacent layer it was deliberately built to be independent of.
 - **Root output** is the IR the pass exists to produce. It lives as an owned member on the pass
   class with lifetime equal to the pass instance; every handler shares one. The class exposes read
-  access via a `const` accessor (`Unit()` returning `const hir::ModuleUnit&`, or its equivalent per
-  pass) -- the same interface downstream consumers use after `Run` returns. Writes that affect only
-  one member are forbidden as trivial wrappers; writes that coordinate multiple pieces of class
+  access via a `const` accessor (`Unit()` returning `const hir::CompilationUnit&`, or its equivalent
+  per pass) -- the same interface downstream consumers use after `Run` returns. Writes that affect
+  only one member are forbidden as trivial wrappers; writes that coordinate multiple pieces of class
   state are exposed as narrow methods that encapsulate the invariant (the canonical example:
   `InternType` ties the output's type table together with a slang-keyed cache, so the dedup
   invariant is enforced structurally). `Run` moves the root output out at the end; after `Run`

--- a/docs/decisions/lowering-organization.md
+++ b/docs/decisions/lowering-organization.md
@@ -39,7 +39,7 @@ not mutated.
 **The class owns its registries and the root output; nested builders live on the stack.** Every
 class member is one of three kinds: facts (constructor-injected, never mutated), registries
 (append-only accumulators with `Add` / `Lookup`), or the root output the pass is constructing. The
-root output (`hir::ModuleUnit`, `mir::CompilationUnit`, etc.) is the deliverable; it lives as a
+root output (`hir::CompilationUnit`, `mir::CompilationUnit`, etc.) is the deliverable; it lives as a
 class member with lifetime equal to the pass instance, is shared by every handler, and is moved out
 of the class by `Run`'s return -- after which the class holds no IR pointer. Nested IR scopes opened
 mid-walk (a procedural scope for an if-branch, a closure body, a fork-branch body) are
@@ -254,7 +254,7 @@ stylistic.
   recompiles.
 - Adding a new family creates a new subsystem header / implementation pair and adds switch cases in
   the central dispatcher; existing subsystems are not touched.
-- `TypeIdOfSlangExpr` is replaced by `ModuleLowerer::InternType`, a class method that encapsulates
+- `TypeIdOfSlangExpr` is replaced by `UnitLowerer::InternType`, a class method that encapsulates
   both the slang-keyed dedup cache and the output's type table together (the dedup invariant is
   enforced structurally, not by caller discipline). `MakeRefExpr` becomes a subsystem-local helper
   in `references.cpp` (its only consumer). `MakeReturnConventionType` becomes a subsystem-local

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -167,6 +167,8 @@ Tracked in `operators.md` and `integral.md`.
 
 ### packages
 
+Tracked in `packages.md`.
+
 - [ ] packages/basic -- package-level declarations and cross-package import (LRM 26). No package
       lowering exists.
 - [ ] packages/functions -- functions exported from packages (LRM 26.3); rides on packages/basic.

--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -33,9 +33,10 @@ orchestration.
 
 Two frontiers are open. On the C++ backend the import surface (D1-D3) is in, so export (D4) is the
 next C++-backend deliverable, then DPI tasks (D5). On the execution backend scalar import (D10) is
-in: a foreign call lowers to an external-linkage symbol and the by-value carriers marshal, so the
-next deliverable there is the rest of the import surface (D11) -- by-pointer marshaling, and the
-`real` carrier once that backend carries the real value domain.
+in: a foreign call lowers to an external-linkage symbol and the by-value carriers marshal. The rest
+of the import surface (D11) is blocked, and not by anything DPI owns: by-pointer marshaling is
+expressed as a closure, which that backend does not yet lower at all (`architecture-reset.md`). D4
+is the actionable DPI item today.
 
 ## Sub-Steps
 
@@ -73,7 +74,7 @@ from an external main.
 
 - [ ] D4 -- Package / `$unit`-scoped export with foreign-linkage wrappers: scalar 2-state, `real`,
       and `string` (LRM 35.5). Generated ABI header and driver linkage of the user C that calls the
-      export.
+      export. Rides on the package unit and package callable established in `packages.md` (PK1-PK2).
 - [ ] D4a -- Module-scoped export with instance-bound dispatch (LRM 35.5.3): the exported subroutine
       reads the state of the specific instance the foreign call targets, so the wrapper resolves
       that instance's context from the scope the foreign side set. This is the `mhpmcounter_num` /
@@ -123,7 +124,11 @@ surface at a time; export and tasks follow once the C++-backend items fix their 
       (`architecture-reset.md`).
 - [ ] D11 -- General and 4-state / wide import marshaling on the execution backend: the D2 and D3
       surface -- `output` / `inout` copy-back, `chandle`, and canonical `svBitVecVal*` /
-      `svLogicVecVal*` buffers. A `real` import rides on the real value domain, not on this item.
+      `svLogicVecVal*` buffers. Blocked on closures reaching that backend: a by-pointer argument is
+      marshaled by a sequence of statements in expression position, which MIR expresses as a
+      closure, so nothing on this path lowers today. The DPI-specific remainder once that lands is
+      the buffer constructors and the canonical-plane marshaling primitives. A `real` import rides
+      on the real value domain, not on this item.
 - [ ] D12 -- Export and DPI tasks on the execution backend, once the C++-backend export and task
       items (D4-D6) define the shape.
 

--- a/docs/progress/packages.md
+++ b/docs/progress/packages.md
@@ -1,0 +1,84 @@
+# Packages
+
+Tracks the SystemVerilog `package` (LRM 26) and the `$unit` compilation-unit scope (LRM 3.12.1).
+
+A package is a namespace: a compilation unit that owns a set of named declarations -- parameters and
+localparams, typedefs and enums, functions and tasks, and variables -- with no instances, no
+receiver, and no construction. Its C++ peer is a `namespace`, where a module's peer is a `class`. A
+package is referenced by name from other units (`pkg::item`, or a name brought into scope by
+`import`). The reference behaves like the equivalent C++ name: a compile-time constant or a type
+folds or interns at elaboration in the referencing unit (as a `constexpr` value or a `using` alias
+does), so it manifests no cross-unit entity; a function or a variable is a real cross-unit symbol
+the referencing unit reaches by name, and it is these that require the package to be a first-class
+unit with a body to emit. `$unit`-scope declarations -- those lying outside any design element --
+are the same concept without a name: an anonymous package.
+
+Done when the LRM 26 surface reproduces on both backends: a package declaration and each item kind
+it may hold; the reference forms (explicit `pkg::item` scope resolution, explicit
+`import pkg::item`, and wildcard `import pkg::*`); and `$unit`-scope declarations. Classes declared
+inside a package ride on the class workstream and are out of scope here.
+
+## Actionable
+
+PK1 (compile-time contents) and PK2 (the package as a first-class unit, carrying functions) are both
+actionable. PK1 is the smaller entry point; PK2 is the load-bearing architectural cut that PK3
+onward build on.
+
+## Sub-Steps
+
+The `PK*` IDs are stable references. They do not impose a total order; the inline notes record the
+real dependencies. PK2 establishes the package as a lyra compilation unit, which PK3 and the
+callable-bearing part of PK4 reuse; PK1 is independent of it.
+
+- [ ] PK1 -- Package compile-time contents referenced from another unit: a localparam / parameter, a
+      typedef, and an enum constant, reached by explicit `pkg::item` or brought into scope by
+      `import`. These fold to a value or intern as a type at elaboration in the referencing unit,
+      the way a C++ `constexpr` or `using` does, so they manifest no cross-unit entity and need no
+      package unit. The item locks this behavior with coverage across the reference forms and the
+      item kinds.
+- [ ] PK2 -- A package becomes a first-class lyra compilation unit, and package functions and tasks
+      are called from other units (LRM 26.3). A `pkg::func()` is the first cross-unit subroutine
+      call: it targets a receiver-less (static) callable owned by another unit's namespace, resolved
+      and linked by name, exactly as an instantiated child names its unit by name. Establishes the
+      package-as-unit collection and lowering that PK3 reuses. Argument passing and return reuse the
+      subroutine boundary already established for unit-local subroutines.
+- [ ] PK3 -- Package variables. A package variable is static storage owned by the namespace -- one
+      program-global cell, shared, not a member of any instance -- read and written from other units
+      by name. It is the same type-associated storage a class static property uses, not a
+      package-specific singleton object.
+- [ ] PK4 -- The `import` forms for the remaining item kinds and the LRM 26.3 name-search and
+      shadowing rules. An import brings a name into a scope's lookup; it does not create a new kind
+      of reference, so a name resolved through an import lowers identically to the explicit
+      `pkg::item` form. Import of compile-time contents is covered by PK1; this item covers import
+      of the callable and variable entities once PK2 and PK3 exist, plus the search-order and
+      shadowing rules.
+- [ ] PK5 -- `$unit`-scope declarations (LRM 3.12.1): declarations outside any design element,
+      visible across the compilation-unit file set. Modeled as an implicit anonymous package so they
+      ride the same unit, by-name reference, storage, and callable mechanisms as a named package; no
+      second scope system.
+
+## Blocked
+
+Nothing blocked. PK1 and PK2 are both actionable now.
+
+## Out of Scope
+
+- Classes declared inside a package (LRM 26.2). The class is an ordinary type-level member of the
+  namespace; its own semantics ride the class workstream, not this one.
+- Package / `$unit`-scoped DPI export wrappers. The export makes a package-scoped subroutine
+  callable from foreign C; it rides on PK1-PK2 for the package unit and the callable, and is tracked
+  as the next C++-backend deliverable in `dpi.md`.
+
+## Cross-references
+
+- LRM anchors: 26.1 (overview), 26.2 (package declarations), 26.3 (referencing package contents;
+  `import`; search order), 26.4 (search order precedence); 3.12.1 (`$unit` compilation-unit scope).
+- Architecture contracts the work must satisfy: `../architecture/compilation_unit_model.md` (a
+  package is a compilation unit; its interface is its set of exported declarations, generalizing the
+  module-centric "parameters and ports" wording), `../architecture/object_model.md` (a namespace is
+  the type-associated member scope, here standing alone as a unit root rather than attached to an
+  object type), `../architecture/reference_resolution.md` and `../architecture/emission_model.md`
+  (by-name cross-unit resolution and per-unit emission), `../architecture/north_star.md` (the
+  cross-unit dependency is explicitly declared, per the incremental / parallel constraints).
+- Unblocks: `ibex.md` (the Ibex design leans on `ibex_pkg`), `dpi.md` D4 (package / `$unit`-scoped
+  export hangs off the package unit and callable established here).

--- a/include/lyra/compiler/compile.hpp
+++ b/include/lyra/compiler/compile.hpp
@@ -9,7 +9,7 @@
 #include "lyra/compiler/unit_metadata.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/frontend/load.hpp"
-#include "lyra/hir/module_unit.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/lir/compilation_unit.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
@@ -31,7 +31,7 @@ enum class StopAfter : std::uint8_t { kParse, kHir, kMir, kLir };
 // for the duration of any Diagnostic-resolution work.
 struct CompileArtifacts {
   std::optional<frontend::ParseResult> parse;
-  std::optional<std::vector<hir::ModuleUnit>> hir_units;
+  std::optional<std::vector<hir::CompilationUnit>> hir_units;
   std::optional<std::vector<mir::CompilationUnit>> mir_units;
   // The synthesized design-root unit, present exactly when `mir_units` is. Its
   // constructor elaborates the design by building the top-level units as its

--- a/include/lyra/hir/compilation_unit.hpp
+++ b/include/lyra/hir/compilation_unit.hpp
@@ -15,7 +15,7 @@ namespace lyra::hir {
 
 // Canonical TypeIds for primitives the lowering frequently materializes
 // (literal int type, void result of system tasks, etc.). Populated by
-// `ModuleUnit`'s constructor; consumers read them off the unit.
+// `CompilationUnit`'s constructor; consumers read them off the unit.
 struct BuiltinHirTypes {
   TypeId scalar_bit;
   TypeId scalar_logic;
@@ -28,7 +28,7 @@ struct BuiltinHirTypes {
   TypeId wildcard_index;
 };
 
-struct ModuleUnit {
+struct CompilationUnit {
   std::string name;
   base::Arena<Type, TypeId> types;
   BuiltinHirTypes builtins;
@@ -37,7 +37,7 @@ struct ModuleUnit {
   // its body is built, so its identity must exist before its definition.
   base::Registry<ClassDecl, ClassId> classes;
 
-  explicit ModuleUnit(std::string name)
+  explicit CompilationUnit(std::string name)
       : name(std::move(name)), builtins(MakeBuiltins(types)) {
   }
 

--- a/include/lyra/hir/dump.hpp
+++ b/include/lyra/hir/dump.hpp
@@ -3,10 +3,10 @@
 #include <string>
 #include <vector>
 
-#include "lyra/hir/module_unit.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 
 namespace lyra::hir {
 
-auto DumpHir(const std::vector<ModuleUnit>& units) -> std::string;
+auto DumpHir(const std::vector<CompilationUnit>& units) -> std::string;
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/constant_value.hpp
+++ b/include/lyra/lowering/ast_to_hir/constant_value.hpp
@@ -4,9 +4,9 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/constant_value.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/type_id.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
@@ -31,7 +31,7 @@ auto MakeConstantValue(const slang::ConstantValue& cv, diag::SourceSpan span)
 // wherever a slang-folded constant is spliced into the HIR -- parameter and
 // enum-value references, and defaulted port connections.
 auto MakeConstantValueExpr(
-    const hir::ModuleUnit& unit, WalkFrame frame,
+    const hir::CompilationUnit& unit, WalkFrame frame,
     const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
 

--- a/include/lyra/lowering/ast_to_hir/expression/assignment.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/assignment.hpp
@@ -7,8 +7,8 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -34,7 +34,7 @@ auto LowerIncDecExprProc(
 // (process / subroutine body) targets from continuous-assign targets
 // (LRM 10.3 -- structural-var only).
 auto ValidateAssignableImpl(
-    ModuleLowerer& module, bool procedural_context,
+    UnitLowerer& unit_lowerer, bool procedural_context,
     const slang::ast::Expression& expr) -> diag::Result<void>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp
@@ -12,7 +12,7 @@ class Expression;
 
 namespace lyra::lowering::ast_to_hir {
 
-class ModuleLowerer;
+class UnitLowerer;
 
 // The duck-typed contract a pass class fulfils for context-free expression
 // lowering: recurse into a sub-expression and reach the enclosing module. Both
@@ -30,7 +30,7 @@ concept ExprLowerer =
       {
         lowerer.LowerExpr(expr, frame)
       } -> std::same_as<diag::Result<hir::Expr>>;
-      lowerer.Module();
+      lowerer.Owner();
     };
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/expression/references.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/references.hpp
@@ -2,13 +2,13 @@
 
 // Lowering of name resolution expressions: NamedValue (LRM 6.6 names) and
 // HierarchicalValue (LRM 23.6 hierarchical references). Routed reference
-// construction lives on ModuleLowerer; this file handles the expression-level
+// construction lives on UnitLowerer; this file handles the expression-level
 // resolution into DirectMemberRef / ProceduralVarRef / RoutedRef per context.
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -27,12 +27,12 @@ auto LowerNamedValueProc(
 // the referrer's structural scope), so this entry is generic over the calling
 // context rather than split into Proc / Structural variants.
 auto LowerHierarchicalValue(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::HierarchicalValueExpression& hve)
     -> diag::Result<hir::Expr>;
 
 auto LowerNamedValueStructural(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::NamedValueExpression& named) -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -7,11 +7,12 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/frontend/slang_source_mapper.hpp"
-#include "lyra/hir/module_unit.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 
 namespace slang::ast {
 class InstanceBodySymbol;
+class PackageSymbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
@@ -71,7 +72,21 @@ auto RejectDpiExports(const LowerCompilationFacts& facts) -> diag::Result<void>;
 auto LowerUnit(
     const LowerCompilationFacts& facts,
     const slang::ast::InstanceBodySymbol& body)
-    -> diag::Result<hir::ModuleUnit>;
+    -> diag::Result<hir::CompilationUnit>;
+
+// The packages the design declares (LRM 26). A package is a namespace
+// compilation unit: it owns declarations reached by name from other units, and
+// unlike a module it is never instantiated, so the list comes from the
+// declaration set, not the instance tree.
+auto CollectPackages(const LowerCompilationFacts& facts)
+    -> std::vector<const slang::ast::PackageSymbol*>;
+
+// Lowers one package to its HIR unit. Like `LowerUnit`, it reads only the
+// package's own scope and the shared frontend.
+auto LowerPackageUnit(
+    const LowerCompilationFacts& facts,
+    const slang::ast::PackageSymbol& package)
+    -> diag::Result<hir::CompilationUnit>;
 
 // A top-level block is an auto-promoted, uninstantiated module. These names
 // are a subset of the compiled units: a unit reached only through

--- a/include/lyra/lowering/ast_to_hir/process_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/process_lowerer.hpp
@@ -19,7 +19,7 @@
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/type_id.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -33,7 +33,7 @@ namespace lyra::lowering::ast_to_hir {
 class ProcessLowerer {
  public:
   ProcessLowerer(
-      ModuleLowerer& module, const slang::ast::Symbol& containing_symbol);
+      UnitLowerer& unit_lowerer, const slang::ast::Symbol& containing_symbol);
 
   // Lowers a procedural block to a complete hir::Process (initial / final /
   // always / always_comb / always_latch / always_ff). Stack-allocates the
@@ -64,11 +64,11 @@ class ProcessLowerer {
       const -> std::optional<hir::ProceduralVarId>;
 
   // Accessors.
-  [[nodiscard]] auto Module() -> ModuleLowerer& {
-    return *module_;
+  [[nodiscard]] auto Owner() -> UnitLowerer& {
+    return *owner_;
   }
-  [[nodiscard]] auto Module() const -> const ModuleLowerer& {
-    return *module_;
+  [[nodiscard]] auto Owner() const -> const UnitLowerer& {
+    return *owner_;
   }
   [[nodiscard]] auto ContainingSymbol() const -> const slang::ast::Symbol& {
     return *containing_symbol_;
@@ -89,7 +89,7 @@ class ProcessLowerer {
 
  private:
   // Facts.
-  ModuleLowerer* module_;
+  UnitLowerer* owner_;
   const slang::ast::Symbol* containing_symbol_;
 
   // Registry.

--- a/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
@@ -15,7 +15,7 @@
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/structural_scope.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -35,7 +35,7 @@ namespace lyra::lowering::ast_to_hir {
 class StructuralScopeLowerer {
  public:
   StructuralScopeLowerer(
-      ModuleLowerer& module, const slang::ast::Scope& slang_scope);
+      UnitLowerer& unit_lowerer, const slang::ast::Scope& slang_scope);
 
   // Stack-allocates the output `hir::StructuralScope`, walks every member of
   // `slang_scope_` into it, and returns it. `parent_frame` is the caller's walk
@@ -44,11 +44,11 @@ class StructuralScopeLowerer {
   auto Run(WalkFrame parent_frame) -> diag::Result<hir::StructuralScope>;
 
   // Accessors for inner Lowerers and helpers.
-  [[nodiscard]] auto Module() -> ModuleLowerer& {
-    return *module_;
+  [[nodiscard]] auto Owner() -> UnitLowerer& {
+    return *owner_;
   }
-  [[nodiscard]] auto Module() const -> const ModuleLowerer& {
-    return *module_;
+  [[nodiscard]] auto Owner() const -> const UnitLowerer& {
+    return *owner_;
   }
 
   // Walker entry for structural-context expression lowering (continuous
@@ -115,7 +115,7 @@ class StructuralScopeLowerer {
       -> diag::Result<hir::Generate>;
 
   // Facts.
-  ModuleLowerer* module_;
+  UnitLowerer* owner_;
   const slang::ast::Scope* slang_scope_;
   ScopeFrameId frame_;
   // The internal variables of this body's `ref` / `const ref` ports, keyed by

--- a/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
+++ b/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
@@ -11,7 +11,7 @@ class SubroutineSymbol;
 
 namespace lyra::lowering::ast_to_hir {
 
-class ModuleLowerer;
+class UnitLowerer;
 
 // Lowers a slang subroutine (LRM 13) into a hir::SubroutineDecl: its result
 // type, its formals as body-local procedural vars carrying their direction, the
@@ -21,7 +21,7 @@ class ModuleLowerer;
 // records the result where it belongs (a scope's subroutine arena, a class's
 // method list).
 auto LowerSubroutineDecl(
-    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym,
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
     WalkFrame frame) -> diag::Result<hir::SubroutineDecl>;
 
 // Lowers a slang `import "DPI-C"` subroutine (LRM 35.4) into a bodyless
@@ -30,7 +30,7 @@ auto LowerSubroutineDecl(
 // DPI import has no SV body; the caller records the result in the scope's
 // `foreign_imports` arena, never in its subroutine arena.
 auto LowerForeignImport(
-    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym)
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
     -> diag::Result<hir::ForeignImportDecl>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
@@ -15,8 +15,8 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/frontend/slang_source_mapper.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
@@ -75,9 +75,9 @@ struct OwnedChildBinding {
 using OwnedChildBindings =
     std::unordered_map<const slang::ast::Symbol*, OwnedChildBinding>;
 
-// Shared lowering-pass facts threaded into every ModuleLowerer. SourceMapper
+// Shared lowering-pass facts threaded into every UnitLowerer. SourceMapper
 // translates slang source locations; SensitivityAnalyzer is shared across
-// every module's analysis (caches reads); disable_assertions is the policy
+// every unit's analysis (caches reads); disable_assertions is the policy
 // that elides assertion constructs instead of rejecting them. Subset of
 // `LowerCompilationFacts` that excludes the slang Compilation handle (which
 // only the driver-level CompilationLowerer needs to walk top instances).
@@ -110,35 +110,36 @@ class LoweringFacts {
   bool disable_assertions_;
 };
 
-// Per-module lowerer.
+// Per-unit lowerer, over a module instance body or a package.
 //
 // Facts: the shared lowering facts (source mapper + sensitivity analyzer) and
-// a reference to the slang instance body being walked.
+// a reference to the slang scope being walked.
 // Registries: type cache (slang canonical type -> hir TypeId), structural-var
 // / subroutine / loop-var / owned-child binding tables, per-frame cross-unit
 // ref slot tables, and a scope-frame counter.
-// Root output: the in-progress `hir::ModuleUnit`. Constructed in the ctor with
-// the module's name and an initial builtins table; populated by `Run`; moved
+// Root output: the in-progress `hir::CompilationUnit`. Constructed in the ctor
+// with the unit's name and an initial builtins table; populated by `Run`; moved
 // out by `Run`'s return. After `Run` returns the class holds no IR pointer.
-class ModuleLowerer {
+class UnitLowerer {
  public:
-  ModuleLowerer(
-      const LoweringFacts& facts, const slang::ast::InstanceBodySymbol& body);
+  UnitLowerer(
+      const LoweringFacts& facts, const slang::ast::Scope& scope,
+      std::string name);
 
-  auto Run() -> diag::Result<hir::ModuleUnit>;
+  auto Run() -> diag::Result<hir::CompilationUnit>;
 
   // Read access to the in-progress unit. Handlers reach the unit's type vocab
   // and builtins through this accessor; downstream consumers post-Run use the
-  // same `hir::ModuleUnit` interface.
-  [[nodiscard]] auto Unit() const -> const hir::ModuleUnit& {
+  // same `hir::CompilationUnit` interface.
+  [[nodiscard]] auto Unit() const -> const hir::CompilationUnit& {
     return unit_;
   }
 
-  // The slang instance body this unit is lowered from. A constant expression
-  // the lowering must evaluate itself -- an LRM 20.7 dimension index -- is
-  // evaluated against it.
-  [[nodiscard]] auto Body() const -> const slang::ast::InstanceBodySymbol& {
-    return *body_;
+  // The slang scope this unit is lowered from -- a module instance body or a
+  // package. A constant expression the lowering must evaluate itself (an LRM
+  // 20.7 dimension index) is evaluated against its symbol.
+  [[nodiscard]] auto SourceScope() const -> const slang::ast::Scope& {
+    return *scope_;
   }
 
   // Lowers a slang type to a HIR TypeId, memoizing by slang canonical pointer.
@@ -273,10 +274,10 @@ class ModuleLowerer {
  private:
   // Facts.
   LoweringFacts facts_;
-  const slang::ast::InstanceBodySymbol* body_;
+  const slang::ast::Scope* scope_;
 
   // Root output.
-  hir::ModuleUnit unit_;
+  hir::CompilationUnit unit_;
 
   // Registries.
   std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;

--- a/include/lyra/lowering/ast_to_hir/walk_frame.hpp
+++ b/include/lyra/lowering/ast_to_hir/walk_frame.hpp
@@ -29,7 +29,7 @@ class Scope;
 namespace lyra::lowering::ast_to_hir {
 
 // Lowering-only identity for a structural scope on the walk. Monotonically
-// assigned by ModuleLowerer when a scope is entered; never reused; never
+// assigned by UnitLowerer when a scope is entered; never reused; never
 // stored in HIR. Used to compute structural hops between scopes.
 struct ScopeFrameId {
   std::uint32_t value;
@@ -60,11 +60,11 @@ struct ActiveIterationClause {
 // `current_procedural_body` (inside a process or subroutine task). Exactly
 // one is non-null at any walker entry, determined by the surrounding Lowerer
 // context. Handlers writing into a nested scope go through these pointers;
-// writes to the root output go through narrow methods on ModuleLowerer
-// (`module.InternType(...)` for type dedup, etc.).
+// writes to the root output go through narrow methods on `UnitLowerer`
+// (interning a type for dedup, etc.).
 struct WalkFrame {
   // The structural-scope nesting chain. Each entry is a ScopeFrameId minted
-  // by ModuleLowerer when a scope is entered. Used to compute structural
+  // by UnitLowerer when a scope is entered. Used to compute structural
   // hops: HopsTo(target) walks back to find target in the chain.
   std::vector<ScopeFrameId> structural_chain;
 

--- a/include/lyra/lowering/hir_to_mir/case_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/case_cascade.hpp
@@ -9,7 +9,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/condition.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
@@ -34,7 +34,7 @@ struct CaseSnapshotRefs {
 // single var-decl-with-init) so the cpp backend's packed-init gap does not
 // bite when the selector unifies to a packed-explicit type.
 auto AppendCaseSnapshot(
-    const ModuleLowerer& module, WalkFrame frame, mir::ExprId cond_expr_id)
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::ExprId cond_expr_id)
     -> CaseSnapshotRefs;
 
 // Builds (sel <op> L_0) || (sel <op> L_1) || ... into the enclosing scope

--- a/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
@@ -2,7 +2,7 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/class_decl.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/type_id.hpp"
@@ -25,9 +25,9 @@ namespace lyra::lowering::hir_to_mir {
 class ClassDeclLowerer {
  public:
   ClassDeclLowerer(
-      ModuleLowerer& module, mir::ClassId class_id, mir::TypeId object_type,
+      UnitLowerer& unit_lowerer, mir::ClassId class_id, mir::TypeId object_type,
       const hir::ClassDecl& hir_class)
-      : module_(&module),
+      : owner_(&unit_lowerer),
         class_id_(class_id),
         object_type_(object_type),
         hir_class_(&hir_class) {
@@ -39,7 +39,7 @@ class ClassDeclLowerer {
   auto Run() -> diag::Result<mir::Class>;
 
  private:
-  ModuleLowerer* module_;
+  UnitLowerer* owner_;
   mir::ClassId class_id_;
   mir::TypeId object_type_;
   const hir::ClassDecl* hir_class_;

--- a/include/lyra/lowering/hir_to_mir/completion_payload.hpp
+++ b/include/lyra/lowering/hir_to_mir/completion_payload.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include "lyra/hir/subroutine.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/type_id.hpp"
 
@@ -15,7 +15,7 @@ namespace lyra::lowering::hir_to_mir {
 // the callee body and every call site share, so neither re-derives the layout
 // independently (LRM 13.5).
 auto CompletionComponentTypes(
-    const ModuleLowerer& module, const hir::SubroutineDecl& decl)
+    const UnitLowerer& unit_lowerer, const hir::SubroutineDecl& decl)
     -> std::vector<mir::TypeId>;
 
 // Normalizes a completion payload by component count: no component is `Void`,

--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "lyra/hir/type_id.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/expr_id.hpp"
@@ -35,7 +35,7 @@ namespace lyra::lowering::hir_to_mir {
 // sugar is decomposed into a primitive Expr at the HIR-to-MIR boundary so
 // downstream layers see one shape (an Expr) instead of two.
 [[nodiscard]] auto BuildDefaultValueExpr(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId type)
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId type)
     -> mir::Expr;
 
 // Default-construct a value from its source (HIR) type, honoring
@@ -46,7 +46,7 @@ namespace lyra::lowering::hir_to_mir {
 // serves only placeholder and transient-product defaults, where the source
 // initializer does not apply.
 [[nodiscard]] auto BuildDefaultValueFromHir(
-    const ModuleLowerer& module, WalkFrame frame, hir::TypeId hir_type)
+    const UnitLowerer& unit_lowerer, WalkFrame frame, hir::TypeId hir_type)
     -> mir::Expr;
 
 // Wraps a list of element ExprIds destined for an array container constructor
@@ -58,7 +58,7 @@ namespace lyra::lowering::hir_to_mir {
 // elements ride in an `ArrayLiteralExpr` that the renderer emits as
 // `std::array<T, N>{...}`.
 [[nodiscard]] auto BuildArrayConstructionCall(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
     std::vector<mir::ExprId> elements) -> mir::Expr;
 
 // Builds the construction call for an associative-array literal (LRM 7.9.11).
@@ -70,7 +70,7 @@ namespace lyra::lowering::hir_to_mir {
 // element type default. Interns the tuple and tuple-array MIR types, so the
 // module must be the mutable in-progress unit.
 [[nodiscard]] auto BuildAssociativeConstructionCall(
-    ModuleLowerer& module, WalkFrame frame, mir::TypeId assoc_type,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId assoc_type,
     std::vector<std::pair<mir::ExprId, mir::ExprId>> entries,
     std::optional<mir::ExprId> user_default) -> mir::Expr;
 

--- a/include/lyra/lowering/hir_to_mir/deferred_check_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/deferred_check_cascade.hpp
@@ -28,7 +28,7 @@ struct DeferredCheckBranch {
 // `priority case`); the cascade tags its synthesized warning emit with that
 // location so the diagnostic dispatcher attributes and rate-limits per site.
 auto BuildDeferredCheckCascade(
-    ModuleLowerer& module, WalkFrame frame, mir::Block wrapper,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::Block wrapper,
     std::vector<DeferredCheckBranch> branches,
     std::optional<mir::Block> tail_else, hir::UniquePriorityCheck check,
     std::optional<std::string> outer_label, diag::SourceSpan span) -> mir::Stmt;

--- a/include/lyra/lowering/hir_to_mir/expression/assignment.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/assignment.hpp
@@ -9,8 +9,8 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/expr_id.hpp"
@@ -28,7 +28,7 @@ auto LowerHirAssignExprProc(
 // (procedural-local NBA is not supported). Used by the LHS-destructuring
 // desugar, which submits each part as its own NBA closure.
 auto BuildNbaSubmitClosureExpr(
-    ModuleLowerer& module, WalkFrame frame, mir::ExprId lhs_in_outer,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::ExprId lhs_in_outer,
     mir::ExprId rhs_id_in_outer, mir::TypeId rhs_type) -> mir::Expr;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
@@ -31,7 +31,7 @@ concept ExprLowerer =
       {
         lowerer.HirExprs()
       } -> std::convertible_to<const base::Arena<hir::Expr, hir::ExprId>&>;
-      lowerer.Module();
+      lowerer.Owner();
     };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -18,8 +18,8 @@
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/field.hpp"
@@ -81,12 +81,12 @@ class ProcessLowerer {
   // -- static placements and the shared scope materialization table that
   // chain queries route through.
   ProcessLowerer(
-      ModuleLowerer& module,
+      UnitLowerer& unit_lowerer,
       const StructuralScopeLowerer* enclosing_scope_lowerer,
       TimeResolution time_resolution, const hir::ProceduralBody& hir_body,
       std::string callable_name, mir::MethodVisibility visibility,
       WalkFrame owner_ctor_frame, const CallableStoragePlan& storage_plan)
-      : module_(&module),
+      : owner_(&unit_lowerer),
         enclosing_scope_lowerer_(enclosing_scope_lowerer),
         time_resolution_(time_resolution),
         hir_body_(&hir_body),
@@ -154,11 +154,11 @@ class ProcessLowerer {
     return hir_body_->exprs;
   }
 
-  [[nodiscard]] auto Module() -> ModuleLowerer& {
-    return *module_;
+  [[nodiscard]] auto Owner() -> UnitLowerer& {
+    return *owner_;
   }
-  [[nodiscard]] auto Module() const -> const ModuleLowerer& {
-    return *module_;
+  [[nodiscard]] auto Owner() const -> const UnitLowerer& {
+    return *owner_;
   }
 
   // The lowering pass for the structural scope this body sits inside; its
@@ -336,7 +336,7 @@ class ProcessLowerer {
       -> std::optional<mir::ExprId>;
 
  private:
-  ModuleLowerer* module_;
+  UnitLowerer* owner_;
   const StructuralScopeLowerer* enclosing_scope_lowerer_;
   TimeResolution time_resolution_;
   const hir::ProceduralBody* hir_body_;

--- a/include/lyra/lowering/hir_to_mir/services_call.hpp
+++ b/include/lyra/lowering/hir_to_mir/services_call.hpp
@@ -4,7 +4,7 @@
 
 #include "lyra/diag/source_manager.hpp"
 #include "lyra/diag/source_span.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 
@@ -31,8 +31,8 @@ namespace lyra::lowering::hir_to_mir {
 // -- thread it as the engine handle. It needs only the module and the walk
 // frame, not the pass class, so it serves the process body and structural-scope
 // (continuous-assign) call paths identically.
-auto BuildServicesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
-    -> mir::Expr;
+auto BuildServicesCallExpr(
+    const UnitLowerer& unit_lowerer, const WalkFrame& frame) -> mir::Expr;
 
 // Builds the file-IO broker expression `services.Files()`: a `Files` method
 // call on the engine handle, typed as the unit's `files` builtin. Returns the
@@ -40,7 +40,7 @@ auto BuildServicesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
 // interned into `frame.current_block` as a child. LRM 21.3 file-IO ops and
 // LRM 21.2.1 / 21.3.1 sink writes thread the resulting handle as the receiver
 // of their FileTable methods.
-auto BuildFilesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
+auto BuildFilesCallExpr(const UnitLowerer& unit_lowerer, const WalkFrame& frame)
     -> mir::Expr;
 
 // Builds the diagnostic broker expression `services.Diagnostic()`: a
@@ -50,7 +50,7 @@ auto BuildFilesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
 // child. LRM 20.10 `$info` / `$warning` / `$error` thread the resulting
 // handle as the receiver of their severity-fixed Emit methods.
 auto BuildDiagnosticCallExpr(
-    const ModuleLowerer& module, const WalkFrame& frame) -> mir::Expr;
+    const UnitLowerer& unit_lowerer, const WalkFrame& frame) -> mir::Expr;
 
 // Builds the format-text expression `value::Format(items,
 // services.TimeFormat())`: a value-layer free call over the print-item array

--- a/include/lyra/lowering/hir_to_mir/snapshot_local.hpp
+++ b/include/lyra/lowering/hir_to_mir/snapshot_local.hpp
@@ -5,7 +5,7 @@
 
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/local.hpp"
@@ -24,7 +24,7 @@ namespace lyra::lowering::hir_to_mir {
 // closure can forward it; without one it is anonymous (used only within
 // `wrapper`).
 auto SnapshotExprToLocal(
-    const ModuleLowerer& module, WalkFrame frame, mir::Block& wrapper,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::Block& wrapper,
     std::string name, mir::TypeId type, mir::ExprId expr_id,
     std::optional<BindingOriginId> origin = std::nullopt) -> mir::LocalId;
 
@@ -36,7 +36,7 @@ auto SnapshotExprToLocal(
 // time: every value goes through the same path, and the closure layer only ever
 // forwards an ordinary local -- the snapshot is not a special capture form.
 auto SnapshotIntoClosure(
-    ModuleLowerer& module, const WalkFrame& outer_frame,
+    UnitLowerer& unit_lowerer, const WalkFrame& outer_frame,
     ClosureBuilder& closure, mir::ExprId outer_expr, std::string name)
     -> mir::ExprId;
 

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -14,7 +14,7 @@
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/expr.hpp"
@@ -71,9 +71,9 @@ struct RoutedRefMeta {
 class StructuralScopeLowerer {
  public:
   StructuralScopeLowerer(
-      ModuleLowerer& module, const StructuralScopeLowerer* parent,
+      UnitLowerer& unit_lowerer, const StructuralScopeLowerer* parent,
       std::string name, const hir::StructuralScope& hir_scope)
-      : module_(&module),
+      : owner_(&unit_lowerer),
         parent_(parent),
         name_(std::move(name)),
         hir_scope_(&hir_scope) {
@@ -101,8 +101,8 @@ class StructuralScopeLowerer {
   [[nodiscard]] auto LowerLhsExpr(const hir::Expr& expr, WalkFrame frame) const
       -> diag::Result<mir::Expr>;
 
-  [[nodiscard]] auto Module() const -> ModuleLowerer& {
-    return *module_;
+  [[nodiscard]] auto Owner() const -> UnitLowerer& {
+    return *owner_;
   }
 
   [[nodiscard]] auto Parent() const -> const StructuralScopeLowerer* {
@@ -163,7 +163,7 @@ class StructuralScopeLowerer {
   [[nodiscard]] auto EnclosingClassShapeAtHops(hir::StructuralHops hops) const
       -> const mir::ClassShape& {
     if (hops.value == 0) {
-      return module_->GetClassShape(class_id_);
+      return owner_->GetClassShape(class_id_);
     }
     if (parent_ == nullptr) {
       throw InternalError(
@@ -385,7 +385,7 @@ class StructuralScopeLowerer {
         hir::StructuralHops{hops.value - 1}, hir_id);
   }
 
-  ModuleLowerer* module_;
+  UnitLowerer* owner_;
   const StructuralScopeLowerer* parent_;
   std::string name_;
   const hir::StructuralScope* hir_scope_;

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -10,7 +10,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_manager.hpp"
-#include "lyra/hir/module_unit.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
@@ -21,7 +21,7 @@ namespace lyra::lowering::hir_to_mir {
 
 // Per-unit lowerer for the HIR-to-MIR pass.
 //
-// Fact: a reference to the input `hir::ModuleUnit`.
+// Fact: a reference to the input `hir::CompilationUnit`.
 // Registry: the HIR-TypeId to MIR-TypeId translation map, populated by `Run`
 // as it walks the input's type list.
 // Root output: the in-progress `mir::CompilationUnit`. Constructed in the
@@ -29,10 +29,11 @@ namespace lyra::lowering::hir_to_mir {
 // the class holds no IR pointer. Handlers reach the unit's append-only API
 // through the mutable `Unit()` overload; downstream consumers post-`Run` use
 // the const overload, which is the same shape they hold post-move.
-class ModuleLowerer {
+class UnitLowerer {
  public:
-  ModuleLowerer(
-      const hir::ModuleUnit& hir, const diag::SourceManager& source_manager)
+  UnitLowerer(
+      const hir::CompilationUnit& hir,
+      const diag::SourceManager& source_manager)
       : hir_(&hir), source_manager_(&source_manager) {
   }
 
@@ -50,7 +51,7 @@ class ModuleLowerer {
     return unit_;
   }
 
-  [[nodiscard]] auto Hir() const -> const hir::ModuleUnit& {
+  [[nodiscard]] auto Hir() const -> const hir::CompilationUnit& {
     return *hir_;
   }
 
@@ -63,7 +64,7 @@ class ModuleLowerer {
 
   [[nodiscard]] auto TranslateType(hir::TypeId hir_id) const -> mir::TypeId {
     if (hir_id.value >= type_map_.size()) {
-      throw InternalError("ModuleLowerer::TranslateType: unmapped HIR type");
+      throw InternalError("UnitLowerer::TranslateType: unmapped HIR type");
     }
     return type_map_[hir_id.value];
   }
@@ -71,7 +72,7 @@ class ModuleLowerer {
   void MapType(hir::TypeId hir_id, mir::TypeId mir_id) {
     if (hir_id.value != type_map_.size()) {
       throw InternalError(
-          "ModuleLowerer::MapType: HIR types must be mapped in HIR id order");
+          "UnitLowerer::MapType: HIR types must be mapped in HIR id order");
     }
     type_map_.emplace_back(mir_id);
   }
@@ -84,7 +85,7 @@ class ModuleLowerer {
       hir::ClassId hir_id, mir::ClassId mir_id, mir::TypeId object_type) {
     if (hir_id.value != class_map_.size()) {
       throw InternalError(
-          "ModuleLowerer::MapClass: HIR classes must be mapped in HIR id "
+          "UnitLowerer::MapClass: HIR classes must be mapped in HIR id "
           "order");
     }
     class_map_.emplace_back(mir_id);
@@ -93,14 +94,14 @@ class ModuleLowerer {
 
   [[nodiscard]] auto TranslateClass(hir::ClassId hir_id) const -> mir::ClassId {
     if (hir_id.value >= class_map_.size()) {
-      throw InternalError("ModuleLowerer::TranslateClass: unmapped HIR class");
+      throw InternalError("UnitLowerer::TranslateClass: unmapped HIR class");
     }
     return class_map_[hir_id.value];
   }
 
   [[nodiscard]] auto ClassObjectType(hir::ClassId hir_id) const -> mir::TypeId {
     if (hir_id.value >= class_object_type_map_.size()) {
-      throw InternalError("ModuleLowerer::ClassObjectType: unmapped HIR class");
+      throw InternalError("UnitLowerer::ClassObjectType: unmapped HIR class");
     }
     return class_object_type_map_[hir_id.value];
   }
@@ -135,7 +136,7 @@ class ModuleLowerer {
     auto& slot = class_shapes_[id.value];
     if (slot.has_value()) {
       throw InternalError(
-          "ModuleLowerer::DefineClassShape: shape for this id is already "
+          "UnitLowerer::DefineClassShape: shape for this id is already "
           "defined");
     }
     slot = std::move(shape);
@@ -146,7 +147,7 @@ class ModuleLowerer {
     if (id.value >= class_shapes_.size() ||
         !class_shapes_[id.value].has_value()) {
       throw InternalError(
-          "ModuleLowerer::GetClassShape: shape for this id is not defined");
+          "UnitLowerer::GetClassShape: shape for this id is not defined");
     }
     return *class_shapes_[id.value];
   }
@@ -155,7 +156,7 @@ class ModuleLowerer {
   [[nodiscard]] auto TranslateTypeData(const hir::TypeData& data) const
       -> mir::TypeData;
 
-  const hir::ModuleUnit* hir_;
+  const hir::CompilationUnit* hir_;
   const diag::SourceManager* source_manager_;
   mir::CompilationUnit unit_;
   std::vector<mir::TypeId> type_map_;

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -7,12 +7,12 @@
 #include "lyra/compiler/unit_metadata.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/frontend/load.hpp"
-#include "lyra/hir/module_unit.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lir/verify.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/mir_to_lir/lower.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -38,8 +38,8 @@ auto BuildUnitMetadata(const mir::CompilationUnit& unit)
 // design through the same owned-child construction any parent uses for a
 // submodule, so no code path is special-cased for the top level.
 auto BuildRootHirUnit(const std::vector<std::string>& top_names)
-    -> hir::ModuleUnit {
-  hir::ModuleUnit root{std::string{kDesignRootUnitName}};
+    -> hir::CompilationUnit {
+  hir::CompilationUnit root{std::string{kDesignRootUnitName}};
   for (const auto& name : top_names) {
     root.root_scope.instance_members.Add(
         hir::InstanceMemberDecl{
@@ -89,16 +89,26 @@ auto Compile(
     sink.Report(std::move(ok.error()));
     return result;
   }
+  const auto packages = lowering::ast_to_hir::CollectPackages(facts);
   const auto bodies = lowering::ast_to_hir::CollectUnitBodies(facts);
 
-  std::vector<hir::ModuleUnit> hir_units;
+  std::vector<hir::CompilationUnit> hir_units;
   std::vector<mir::CompilationUnit> mir_units;
   std::vector<lir::CompilationUnit> lir_units;
   std::vector<ElaboratedUnitMetadata> unit_metadata;
-  hir_units.reserve(bodies.size());
+  hir_units.reserve(packages.size() + bodies.size());
   mir_units.reserve(bodies.size());
   lir_units.reserve(bodies.size());
   unit_metadata.reserve(bodies.size());
+
+  for (const auto* package : packages) {
+    auto hir_or = lowering::ast_to_hir::LowerPackageUnit(facts, *package);
+    if (!hir_or) {
+      sink.Report(std::move(hir_or.error()));
+      return result;
+    }
+    hir_units.push_back(*std::move(hir_or));
+  }
 
   for (const auto* body : bodies) {
     auto hir_or = lowering::ast_to_hir::LowerUnit(facts, *body);
@@ -111,9 +121,9 @@ auto Compile(
       continue;
     }
 
-    lowering::hir_to_mir::ModuleLowerer module(
+    lowering::hir_to_mir::UnitLowerer lowerer(
         hir_units.back(), result.artifacts.parse->diag_sources);
-    auto mir_or = module.Run();
+    auto mir_or = lowerer.Run();
     if (!mir_or) {
       sink.Report(std::move(mir_or.error()));
       return result;
@@ -143,11 +153,11 @@ auto Compile(
   std::optional<lir::CompilationUnit> root_lir_unit;
   std::optional<ElaboratedUnitMetadata> root_metadata;
   if (want_mir) {
-    const hir::ModuleUnit root_hir =
+    const hir::CompilationUnit root_hir =
         BuildRootHirUnit(result.artifacts.top_unit_names);
-    lowering::hir_to_mir::ModuleLowerer root_module(
+    lowering::hir_to_mir::UnitLowerer root_lowerer(
         root_hir, result.artifacts.parse->diag_sources);
-    auto root_mir = root_module.Run();
+    auto root_mir = root_lowerer.Run();
     if (!root_mir) {
       sink.Report(std::move(root_mir.error()));
       return result;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -12,9 +12,9 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/process.hpp"
@@ -47,7 +47,7 @@ auto ForkJoinModeLabel(JoinMode mode) -> std::string_view {
 
 class HirDumper {
  public:
-  auto Dump(const std::vector<ModuleUnit>& units) -> std::string {
+  auto Dump(const std::vector<CompilationUnit>& units) -> std::string {
     for (const auto& u : units) {
       DumpUnit(u);
     }
@@ -802,9 +802,9 @@ class HirDumper {
     return FormatExpr(s.exprs.Get(id));
   }
 
-  void DumpUnit(const ModuleUnit& u) {
+  void DumpUnit(const CompilationUnit& u) {
     unit_ = &u;
-    Line(std::format("ModuleUnit \"{}\"", u.name));
+    Line(std::format("CompilationUnit \"{}\"", u.name));
     Indent();
 
     Line("Types:");
@@ -1515,12 +1515,12 @@ class HirDumper {
   std::string out_;
   int indent_ = 0;
   std::vector<const StructuralScope*> scope_stack_;
-  const ModuleUnit* unit_ = nullptr;
+  const CompilationUnit* unit_ = nullptr;
 };
 
 }  // namespace
 
-auto DumpHir(const std::vector<ModuleUnit>& units) -> std::string {
+auto DumpHir(const std::vector<CompilationUnit>& units) -> std::string {
   HirDumper dumper;
   return dumper.Dump(units);
 }

--- a/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
@@ -11,10 +11,10 @@
 
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/hir/module_unit.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/specialization_name.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -73,11 +73,26 @@ auto CollectUnitBodies(const LowerCompilationFacts& facts)
 auto LowerUnit(
     const LowerCompilationFacts& facts,
     const slang::ast::InstanceBodySymbol& body)
-    -> diag::Result<hir::ModuleUnit> {
+    -> diag::Result<hir::CompilationUnit> {
   const LoweringFacts unit_facts(
       facts.SourceMapper(), facts.Sensitivity(), facts.DisableAssertions());
-  ModuleLowerer module(unit_facts, body);
-  return module.Run();
+  UnitLowerer lowerer(unit_facts, body, SpecializationName(body));
+  return lowerer.Run();
+}
+
+auto CollectPackages(const LowerCompilationFacts& facts)
+    -> std::vector<const slang::ast::PackageSymbol*> {
+  return facts.Compilation().getPackages();
+}
+
+auto LowerPackageUnit(
+    const LowerCompilationFacts& facts,
+    const slang::ast::PackageSymbol& package)
+    -> diag::Result<hir::CompilationUnit> {
+  const LoweringFacts unit_facts(
+      facts.SourceMapper(), facts.Sensitivity(), facts.DisableAssertions());
+  UnitLowerer lowerer(unit_facts, package, std::string{package.name});
+  return lowerer.Run();
 }
 
 auto TopLevelUnitNames(slang::ast::Compilation& compilation)

--- a/src/lyra/lowering/ast_to_hir/constant_value.cpp
+++ b/src/lyra/lowering/ast_to_hir/constant_value.cpp
@@ -24,7 +24,7 @@ namespace {
 // in an expression context; the value itself is folded once, at the sole
 // boundary that reads slang's constant representation.
 auto MaterializeConstantExpr(
-    const hir::ModuleUnit& unit, WalkFrame frame,
+    const hir::CompilationUnit& unit, WalkFrame frame,
     const hir::ConstantValue& value, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   return std::visit(
@@ -112,7 +112,7 @@ auto MakeConstantValue(const slang::ConstantValue& cv, diag::SourceSpan span)
 }
 
 auto MakeConstantValueExpr(
-    const hir::ModuleUnit& unit, WalkFrame frame,
+    const hir::CompilationUnit& unit, WalkFrame frame,
     const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   auto value = MakeConstantValue(cv, span);

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -10,9 +10,9 @@
 
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -23,7 +23,7 @@ namespace {
 // sensitivity list is always `TranslateSensitivityReads(reads)`, the single
 // place a read set is mapped to its runtime projection.
 auto BuildContinuousAssign(
-    ModuleLowerer& module, WalkFrame frame, diag::SourceSpan span,
+    UnitLowerer& unit_lowerer, WalkFrame frame, diag::SourceSpan span,
     hir::Expr lhs, hir::Expr rhs, const std::vector<SensitivityRead>& reads)
     -> hir::ContinuousAssign {
   const hir::ExprId lhs_id = frame.Exprs().Add(std::move(lhs));
@@ -32,7 +32,7 @@ auto BuildContinuousAssign(
       .span = span,
       .lhs = lhs_id,
       .rhs = rhs_id,
-      .sensitivity_list = module.TranslateSensitivityReads(reads, frame),
+      .sensitivity_list = unit_lowerer.TranslateSensitivityReads(reads, frame),
   };
 }
 
@@ -41,7 +41,7 @@ auto BuildContinuousAssign(
 auto StructuralScopeLowerer::LowerContinuousAssign(
     const slang::ast::ContinuousAssignSymbol& sym, WalkFrame frame)
     -> diag::Result<hir::ContinuousAssign> {
-  const auto& mapper = module_->SourceMapper();
+  const auto& mapper = owner_->SourceMapper();
   const auto span = mapper.PointSpanOf(sym.location);
 
   if (sym.getDelay() != nullptr) {
@@ -81,10 +81,10 @@ auto StructuralScopeLowerer::LowerContinuousAssign(
   // LRM 10.3.2: continuous assignment sensitivity is the read set of the
   // RHS expression. slang treats the ContinuousAssignSymbol as the
   // procedural scope for analysis purposes.
-  const auto& reads = module_->Sensitivity().AnalyzeReads(assignment_expr, sym);
+  const auto& reads = owner_->Sensitivity().AnalyzeReads(assignment_expr, sym);
 
   return BuildContinuousAssign(
-      *module_, frame, span, *std::move(lhs_or), *std::move(rhs_or), reads);
+      *owner_, frame, span, *std::move(lhs_or), *std::move(rhs_or), reads);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -15,9 +15,9 @@
 
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/type.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -26,10 +26,10 @@ auto LowerConcatExpr(
     Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConcatenationExpression& cc, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto& module = lowerer.Module();
-  auto type_id = module.InternType(*cc.type, span);
+  auto& unit_lowerer = lowerer.Owner();
+  auto type_id = unit_lowerer.InternType(*cc.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
-  const auto kind = module.Unit().types.Get(*type_id).Kind();
+  const auto kind = unit_lowerer.Unit().types.Get(*type_id).Kind();
   if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kScalarBit &&
       kind != hir::TypeKind::kPackedArray && kind != hir::TypeKind::kQueue) {
     return diag::Fail(
@@ -65,10 +65,10 @@ auto LowerReplicationExpr(
     Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ReplicationExpression& rp, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto& module = lowerer.Module();
-  auto type_id = module.InternType(*rp.type, span);
+  auto& unit_lowerer = lowerer.Owner();
+  auto type_id = unit_lowerer.InternType(*rp.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
-  const auto kind = module.Unit().types.Get(*type_id).Kind();
+  const auto kind = unit_lowerer.Unit().types.Get(*type_id).Kind();
   if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kScalarBit &&
       kind != hir::TypeKind::kPackedArray) {
     return diag::Fail(
@@ -94,7 +94,7 @@ auto LowerAssignmentPatternFromElements(
     Lowerer& lowerer, WalkFrame frame,
     const slang::ast::AssignmentPatternExpressionBase& ap,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = lowerer.Module().InternType(*ap.type, span);
+  auto type_id = lowerer.Owner().InternType(*ap.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   std::vector<hir::ExprId> element_ids;
   element_ids.reserve(ap.elements().size());
@@ -115,7 +115,7 @@ auto LowerAssociativeAssignmentPattern(
     Lowerer& lowerer, WalkFrame frame,
     const slang::ast::StructuredAssignmentPatternExpression& ap,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = lowerer.Module().InternType(*ap.type, span);
+  auto type_id = lowerer.Owner().InternType(*ap.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   std::vector<hir::AssociativeAssignmentPatternExpr::Entry> entries;
   entries.reserve(ap.indexSetters.size());
@@ -150,7 +150,7 @@ auto LowerReplicatedAssignmentPatternExpr(
     Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ReplicatedAssignmentPatternExpression& rp,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = lowerer.Module().InternType(*rp.type, span);
+  auto type_id = lowerer.Owner().InternType(*rp.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   auto count_or = lowerer.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
@@ -181,7 +181,7 @@ auto LowerNewArrayExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::NewArrayExpression& na, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto type_id = proc.Module().InternType(*na.type, span);
+  auto type_id = proc.Owner().InternType(*na.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   auto size_or = proc.LowerExpr(na.sizeExpr(), frame);
   if (!size_or) return std::unexpected(std::move(size_or.error()));
@@ -207,7 +207,7 @@ template <ExprLowerer Lowerer>
 auto LowerNewClassExpr(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::NewClassExpression& nc,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   if (nc.isSuperClass) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedClassFeature,
@@ -224,9 +224,9 @@ auto LowerNewClassExpr(
     }
   }
   const auto& cls = nc.type->getCanonicalType().as<slang::ast::ClassType>();
-  auto class_id = module.InternClass(cls, span);
+  auto class_id = unit_lowerer.InternClass(cls, span);
   if (!class_id) return std::unexpected(std::move(class_id.error()));
-  auto type_id = module.InternType(*nc.type, span);
+  auto type_id = unit_lowerer.InternType(*nc.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,

--- a/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
@@ -27,15 +27,15 @@ auto LowerAssignmentExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::AssignmentExpression& as, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto& module = proc.Module();
-  auto validate = ValidateAssignableImpl(module, true, as.left());
+  auto& unit_lowerer = proc.Owner();
+  auto validate = ValidateAssignableImpl(unit_lowerer, true, as.left());
   if (!validate) return std::unexpected(std::move(validate.error()));
 
   auto lhs_or = proc.LowerExpr(as.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
 
-  auto type_id = module.InternType(*as.type, span);
+  auto type_id = unit_lowerer.InternType(*as.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
 
   const auto kind = as.isNonBlocking() ? hir::AssignKind::kNonBlocking
@@ -94,15 +94,15 @@ auto LowerIncDecExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::UnaryExpression& un, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto& module = proc.Module();
-  auto validate = ValidateAssignableImpl(module, true, un.operand());
+  auto& unit_lowerer = proc.Owner();
+  auto validate = ValidateAssignableImpl(unit_lowerer, true, un.operand());
   if (!validate) return std::unexpected(std::move(validate.error()));
 
   auto target_or = proc.LowerExpr(un.operand(), frame);
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   const hir::ExprId target_id = frame.Exprs().Add(*std::move(target_or));
 
-  auto type_id = module.InternType(*un.type, span);
+  auto type_id = unit_lowerer.InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
 
   return hir::Expr{
@@ -114,10 +114,10 @@ auto LowerIncDecExprProc(
 }
 
 auto ValidateAssignableImpl(
-    ModuleLowerer& module, bool procedural_context,
+    UnitLowerer& unit_lowerer, bool procedural_context,
     const slang::ast::Expression& expr) -> diag::Result<void> {
   using EK = slang::ast::ExpressionKind;
-  const auto& mapper = module.SourceMapper();
+  const auto& mapper = unit_lowerer.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
   auto reject = [&](std::string_view why) -> diag::Result<void> {
     return diag::Fail(
@@ -140,7 +140,7 @@ auto ValidateAssignableImpl(
         if (procedural_context) {
           return reject("a net is not a legal procedural assignment target");
         }
-        if (!module
+        if (!unit_lowerer
                  .LookupStructuralDataObjectBinding(
                      sym.as<slang::ast::ValueSymbol>())
                  .has_value()) {
@@ -156,7 +156,7 @@ auto ValidateAssignableImpl(
       const auto& var = sym.as<slang::ast::VariableSymbol>();
       if (!procedural_context) {
         // LRM 10.3: continuous-assign target must resolve to a structural var.
-        if (!module.LookupStructuralDataObjectBinding(var).has_value()) {
+        if (!unit_lowerer.LookupStructuralDataObjectBinding(var).has_value()) {
           return reject(
               "continuous-assignment target must be a structural variable");
         }
@@ -165,11 +165,11 @@ auto ValidateAssignableImpl(
     }
     case EK::ElementSelect:
       return ValidateAssignableImpl(
-          module, procedural_context,
+          unit_lowerer, procedural_context,
           expr.as<slang::ast::ElementSelectExpression>().value());
     case EK::RangeSelect:
       return ValidateAssignableImpl(
-          module, procedural_context,
+          unit_lowerer, procedural_context,
           expr.as<slang::ast::RangeSelectExpression>().value());
     case EK::MemberAccess: {
       const auto& ma = expr.as<slang::ast::MemberAccessExpression>();
@@ -179,7 +179,8 @@ auto ValidateAssignableImpl(
             "member access target is not a struct field or class "
             "property");
       }
-      return ValidateAssignableImpl(module, procedural_context, ma.value());
+      return ValidateAssignableImpl(
+          unit_lowerer, procedural_context, ma.value());
     }
     case EK::HierarchicalValue: {
       const auto& hv = expr.as<slang::ast::HierarchicalValueExpression>();
@@ -202,7 +203,8 @@ auto ValidateAssignableImpl(
               "replication is not allowed inside a destructuring "
               "assignment target (LRM 11.4.12.1)");
         }
-        auto sub = ValidateAssignableImpl(module, procedural_context, *op);
+        auto sub =
+            ValidateAssignableImpl(unit_lowerer, procedural_context, *op);
         if (!sub) return sub;
       }
       return {};

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -28,9 +28,9 @@
 #include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/expression/query.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -82,7 +82,7 @@ template <ExprLowerer Lowerer>
 auto LowerCallExpr(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
 
   // The LRM 20.6 / 20.7 queries are resolved before the argument loop: their
   // operand is never evaluated and may be a data type, which has no value form
@@ -129,14 +129,14 @@ auto LowerCallExpr(
     const std::string_view name = info.subroutine->name;
 
     if (receiver_type.has_value() &&
-        module.Unit().types.Get(*receiver_type).IsEnum()) {
+        unit_lowerer.Unit().types.Get(*receiver_type).IsEnum()) {
       if (auto kind = LowerEnumMethodName(name); kind.has_value()) {
         // `next` / `prev` have an optional `int unsigned step = 1` (LRM
         // 6.19.5.3/4). When the user omits the step, the lowering hands the
         // backend a single-argument call and lets the backend's intrinsic
         // mechanism supply the default (C++ default-argument; LLVM constant
         // 1; etc.). No synthesized literal is injected at the HIR boundary.
-        auto type_id = module.InternType(*call.type, span);
+        auto type_id = unit_lowerer.InternType(*call.type, span);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
         return hir::Expr{
             .type = *type_id,
@@ -151,13 +151,13 @@ auto LowerCallExpr(
     }
 
     if (receiver_type.has_value() &&
-        module.Unit().types.Get(*receiver_type).Kind() ==
+        unit_lowerer.Unit().types.Get(*receiver_type).Kind() ==
             hir::TypeKind::kString) {
       if (auto kind = LowerStringMethodName(name); kind.has_value()) {
         // LRM 6.16.1 through 6.16.15 -- string intrinsic methods. The
         // receiver is arguments[0]; remaining arguments are the SV method
         // parameters (e.g. substr's `i, j`).
-        auto type_id = module.InternType(*call.type, span);
+        auto type_id = unit_lowerer.InternType(*call.type, span);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
         return hir::Expr{
             .type = *type_id,
@@ -173,13 +173,13 @@ auto LowerCallExpr(
 
     if (receiver_type.has_value() &&
         std::holds_alternative<hir::EventType>(
-            module.Unit().types.Get(*receiver_type).data) &&
+            unit_lowerer.Unit().types.Get(*receiver_type).data) &&
         name == "triggered") {
       // LRM 15.5.3: `e.triggered` returns true for the duration of the time
       // slot in which the event was last triggered. Result type is bit (1'b0
       // / 1'b1) -- slang already typed the expression; we just route the
       // call through the named-event method.
-      auto type_id = module.InternType(*call.type, span);
+      auto type_id = unit_lowerer.InternType(*call.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
@@ -197,14 +197,14 @@ auto LowerCallExpr(
 
     if (receiver_type.has_value() &&
         std::holds_alternative<hir::QueueType>(
-            module.Unit().types.Get(*receiver_type).data)) {
+            unit_lowerer.Unit().types.Get(*receiver_type).data)) {
       // LRM 7.10.2 queue-native methods. The receiver is arguments[0]; any
       // method parameters (insert's index and item, push's item) follow as the
       // remaining arguments. These methods take no `with` clause and are tried
       // before the array-manipulation family so `size` / `delete` resolve to
       // the queue-native form rather than the LRM 7.12 one.
       if (auto kind = LowerQueueMethodName(name); kind.has_value()) {
-        auto type_id = module.InternType(*call.type, span);
+        auto type_id = unit_lowerer.InternType(*call.type, span);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
         return hir::Expr{
             .type = *type_id,
@@ -232,15 +232,15 @@ auto LowerCallExpr(
     // `WithClause`, which HIR -> MIR turns into a closure argument.
     if (receiver_type.has_value() &&
         (std::holds_alternative<hir::UnpackedArrayType>(
-             module.Unit().types.Get(*receiver_type).data) ||
+             unit_lowerer.Unit().types.Get(*receiver_type).data) ||
          std::holds_alternative<hir::DynamicArrayType>(
-             module.Unit().types.Get(*receiver_type).data) ||
+             unit_lowerer.Unit().types.Get(*receiver_type).data) ||
          std::holds_alternative<hir::QueueType>(
-             module.Unit().types.Get(*receiver_type).data) ||
+             unit_lowerer.Unit().types.Get(*receiver_type).data) ||
          std::holds_alternative<hir::AssociativeArrayType>(
-             module.Unit().types.Get(*receiver_type).data))) {
+             unit_lowerer.Unit().types.Get(*receiver_type).data))) {
       if (auto kind = LowerArrayMethodName(name); kind.has_value()) {
-        auto type_id = module.InternType(*call.type, span);
+        auto type_id = unit_lowerer.InternType(*call.type, span);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
         std::optional<hir::WithClause> with_clause;
         if (std::holds_alternative<
@@ -255,7 +255,7 @@ auto LowerCallExpr(
           // distinguishes it from a foreach loop variable (also a slang
           // Iterator symbol) and lets a clause nested in the body name this
           // outer one.
-          const hir::WithClauseId clause_id = module.NextWithClauseId();
+          const hir::WithClauseId clause_id = unit_lowerer.NextWithClauseId();
           auto body_or = lowerer.LowerExpr(
               *iter_info.iterExpr,
               frame.WithIterationClause(iter_var, clause_id));
@@ -281,12 +281,12 @@ auto LowerCallExpr(
 
     if (receiver_type.has_value() &&
         std::holds_alternative<hir::AssociativeArrayType>(
-            module.Unit().types.Get(*receiver_type).data)) {
+            unit_lowerer.Unit().types.Get(*receiver_type).data)) {
       if (auto kind = LowerAssociativeMethodName(name); kind.has_value()) {
         // LRM 7.9 associative-array methods. The receiver is arguments[0]; the
         // key (exists / delete-by-index) follows as the next argument. The
         // no-argument `delete` clears the array.
-        auto type_id = module.InternType(*call.type, span);
+        auto type_id = unit_lowerer.InternType(*call.type, span);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
         return hir::Expr{
             .type = *type_id,
@@ -307,7 +307,7 @@ auto LowerCallExpr(
     if (info.subroutine != nullptr &&
         info.subroutine->knownNameId ==
             slang::parsing::KnownSystemName::IsUnknown) {
-      auto type_id = module.InternType(*call.type, span);
+      auto type_id = unit_lowerer.InternType(*call.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
@@ -329,7 +329,7 @@ auto LowerCallExpr(
     if (info.subroutine != nullptr &&
         info.subroutine->knownNameId ==
             slang::parsing::KnownSystemName::Clog2) {
-      auto type_id = module.InternType(*call.type, span);
+      auto type_id = unit_lowerer.InternType(*call.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
@@ -364,7 +364,7 @@ auto LowerCallExpr(
         throw InternalError(
             "item.index receiver is not an active with-clause iterator");
       }
-      auto type_id = module.InternType(*call.type, span);
+      auto type_id = unit_lowerer.InternType(*call.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
@@ -386,7 +386,7 @@ auto LowerCallExpr(
              slang::parsing::KnownSystemName::Signed ||
          info.subroutine->knownNameId ==
              slang::parsing::KnownSystemName::Unsigned)) {
-      auto type_id = module.InternType(*call.type, span);
+      auto type_id = unit_lowerer.InternType(*call.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
@@ -420,8 +420,8 @@ auto LowerCallExpr(
           std::string{name} + "'");
     }
 
-    const auto result_type =
-        MakeReturnConventionType(module.Unit().builtins, desc->result_conv);
+    const auto result_type = MakeReturnConventionType(
+        unit_lowerer.Unit().builtins, desc->result_conv);
     return hir::Expr{
         .type = result_type,
         .data =
@@ -462,9 +462,9 @@ auto LowerCallExpr(
     // when the field is inherited.
     const auto& declaring_class =
         sym->getParentScope()->asSymbol().as<slang::ast::ClassType>();
-    auto class_id = module.InternClass(declaring_class, span);
+    auto class_id = unit_lowerer.InternClass(declaring_class, span);
     if (!class_id) return std::unexpected(std::move(class_id.error()));
-    auto method_result_type = module.InternType(*call.type, span);
+    auto method_result_type = unit_lowerer.InternType(*call.type, span);
     if (!method_result_type) {
       return std::unexpected(std::move(method_result_type.error()));
     }
@@ -487,14 +487,15 @@ auto LowerCallExpr(
   // from body-bearing subroutines. Resolve it to a ForeignImportRef; its ABI
   // and foreign name were classified once at declaration and are not re-derived
   // here.
-  if (const auto import_binding = module.LookupForeignImportBinding(*sym)) {
+  if (const auto import_binding =
+          unit_lowerer.LookupForeignImportBinding(*sym)) {
     const auto import_hops = frame.HopsTo(import_binding->owner_frame);
     if (!import_hops.has_value()) {
       throw InternalError(
           "AST->HIR call: DPI import owner frame is not on the current scope "
           "stack");
     }
-    auto import_result_type = module.InternType(*call.type, span);
+    auto import_result_type = unit_lowerer.InternType(*call.type, span);
     if (!import_result_type) {
       return std::unexpected(std::move(import_result_type.error()));
     }
@@ -511,7 +512,7 @@ auto LowerCallExpr(
     };
   }
 
-  const auto binding = module.LookupSubroutineBinding(*sym);
+  const auto binding = unit_lowerer.LookupSubroutineBinding(*sym);
   if (!binding.has_value()) {
     throw InternalError(
         "AST->HIR call: resolved user subroutine has no registered HIR "
@@ -523,7 +524,7 @@ auto LowerCallExpr(
         "AST->HIR call: user subroutine owner frame is not on the current "
         "scope stack");
   }
-  auto result_type = module.InternType(*call.type, span);
+  auto result_type = unit_lowerer.InternType(*call.type, span);
   if (!result_type) return std::unexpected(std::move(result_type.error()));
   return hir::Expr{
       .type = *result_type,

--- a/src/lyra/lowering/ast_to_hir/expression/inside.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/inside.cpp
@@ -8,9 +8,9 @@
 #include <slang/ast/expressions/OperatorExpressions.h>
 
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -30,7 +30,7 @@ auto LowerInsideExpr(
     items.push_back(*std::move(item_or));
   }
 
-  auto type_id = lowerer.Module().InternType(*in.type, span);
+  auto type_id = lowerer.Owner().InternType(*in.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -43,12 +43,12 @@ template <ExprLowerer Lowerer>
 auto LowerInsideItemImpl(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::Expression& item_expr)
     -> diag::Result<hir::InsideItem> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   if (item_expr.kind == slang::ast::ExpressionKind::ValueRange) {
     const auto& vr = item_expr.as<slang::ast::ValueRangeExpression>();
     if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
       return diag::Fail(
-          module.SourceMapper().SpanOf(vr.sourceRange),
+          unit_lowerer.SourceMapper().SpanOf(vr.sourceRange),
           diag::DiagCode::kUnsupportedExpressionForm,
           "tolerance-range form in inside operator is not yet supported");
     }

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -29,9 +29,9 @@
 #include "lyra/lowering/ast_to_hir/expression/selects.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -129,20 +129,20 @@ template <ExprLowerer Lowerer>
 auto LowerExprImpl(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::Expression& expr)
     -> diag::Result<hir::Expr> {
-  auto& module = lowerer.Module();
-  const auto span = module.SourceMapper().SpanOf(expr.sourceRange);
+  auto& unit_lowerer = lowerer.Owner();
+  const auto span = unit_lowerer.SourceMapper().SpanOf(expr.sourceRange);
   constexpr bool kProcedural = std::same_as<Lowerer, ProcessLowerer>;
 
   switch (expr.kind) {
     case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto type_id = module.InternType(*expr.type, span);
+      auto type_id = unit_lowerer.InternType(*expr.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeIntegerLiteralExpr(
           expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
     }
 
     case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
-      auto type_id = module.InternType(*expr.type, span);
+      auto type_id = unit_lowerer.InternType(*expr.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeUnbasedUnsizedLiteralExpr(
           expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
@@ -150,14 +150,14 @@ auto LowerExprImpl(
 
     case slang::ast::ExpressionKind::StringLiteral: {
       const auto& sl = expr.as<slang::ast::StringLiteral>();
-      auto type_id = module.InternType(*expr.type, span);
+      auto type_id = unit_lowerer.InternType(*expr.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeStringLiteralExpr(std::string{sl.getValue()}, *type_id, span);
     }
 
     case slang::ast::ExpressionKind::TimeLiteral: {
       const auto& tl = expr.as<slang::ast::TimeLiteral>();
-      auto type_id = module.InternType(*expr.type, span);
+      auto type_id = unit_lowerer.InternType(*expr.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeTimeLiteralExpr(
           tl.getValue(), LowerTimeUnit(tl.getScale().base.unit), *type_id,
@@ -166,13 +166,13 @@ auto LowerExprImpl(
 
     case slang::ast::ExpressionKind::RealLiteral: {
       const auto& rl = expr.as<slang::ast::RealLiteral>();
-      auto type_id = module.InternType(*expr.type, span);
+      auto type_id = unit_lowerer.InternType(*expr.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeRealLiteralExpr(rl.getValue(), *type_id, span);
     }
 
     case slang::ast::ExpressionKind::NullLiteral: {
-      auto type_id = module.InternType(*expr.type, span);
+      auto type_id = unit_lowerer.InternType(*expr.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeNullLiteralExpr(*type_id, span);
     }
@@ -183,12 +183,13 @@ auto LowerExprImpl(
             lowerer, frame, expr.as<slang::ast::NamedValueExpression>());
       } else {
         return LowerNamedValueStructural(
-            module, frame, expr.as<slang::ast::NamedValueExpression>());
+            unit_lowerer, frame, expr.as<slang::ast::NamedValueExpression>());
       }
 
     case slang::ast::ExpressionKind::HierarchicalValue:
       return LowerHierarchicalValue(
-          module, frame, expr.as<slang::ast::HierarchicalValueExpression>());
+          unit_lowerer, frame,
+          expr.as<slang::ast::HierarchicalValueExpression>());
 
     case slang::ast::ExpressionKind::LValueReference:
       throw InternalError(
@@ -360,7 +361,7 @@ auto ProcessLowerer::LowerInsideItem(
 
 auto ProcessLowerer::ValidateAssignableProcedural(
     const slang::ast::Expression& expr) -> diag::Result<void> {
-  return ValidateAssignableImpl(*module_, true, expr);
+  return ValidateAssignableImpl(*owner_, true, expr);
 }
 
 auto StructuralScopeLowerer::LowerExpr(
@@ -371,7 +372,7 @@ auto StructuralScopeLowerer::LowerExpr(
 
 auto StructuralScopeLowerer::ValidateAssignableStructural(
     const slang::ast::Expression& expr) -> diag::Result<void> {
-  return ValidateAssignableImpl(*module_, false, expr);
+  return ValidateAssignableImpl(*owner_, false, expr);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -83,7 +83,7 @@ auto LowerConversionExpr(
   auto operand_or = lowerer.LowerExpr(conv.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
-  auto type_id = lowerer.Module().InternType(*conv.type, span);
+  auto type_id = lowerer.Owner().InternType(*conv.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -104,7 +104,7 @@ auto LowerUnaryExpr(
   auto operand_or = lowerer.LowerExpr(un.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
-  auto type_id = lowerer.Module().InternType(*un.type, span);
+  auto type_id = lowerer.Owner().InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -126,7 +126,7 @@ auto LowerBinaryExpr(
   auto rhs_or = lowerer.LowerExpr(bin.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
-  auto type_id = lowerer.Module().InternType(*bin.type, span);
+  auto type_id = lowerer.Owner().InternType(*bin.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -165,7 +165,7 @@ auto LowerConditionalExpr(
   auto else_or = lowerer.LowerExpr(cond.right(), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
   const hir::ExprId else_id = frame.Exprs().Add(*std::move(else_or));
-  auto type_id = lowerer.Module().InternType(*cond.type, span);
+  auto type_id = lowerer.Owner().InternType(*cond.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,

--- a/src/lyra/lowering/ast_to_hir/expression/query.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/query.cpp
@@ -147,12 +147,12 @@ auto DimensionCount(const slang::ast::Type& operand, bool unpacked_only)
 // simulation knows -- legal, but then the query is not an elaboration-time
 // constant.
 auto ConstantDimensionIndex(
-    const ModuleLowerer& module, const slang::ast::CallExpression& call)
+    const UnitLowerer& unit_lowerer, const slang::ast::CallExpression& call)
     -> std::optional<std::int64_t> {
   if (call.arguments().size() < 2) {
     return 1;
   }
-  slang::ast::EvalContext eval_context(module.Body());
+  slang::ast::EvalContext eval_context(unit_lowerer.SourceScope().asSymbol());
   const slang::ConstantValue index = call.arguments()[1]->eval(eval_context);
   if (!index || !index.isInteger()) {
     return std::nullopt;
@@ -164,23 +164,24 @@ auto ConstantDimensionIndex(
 // state domain: LRM 20.7 types a dimension function's result as `integer`, a
 // 4-state type, and LRM 20.6.1 types `$typename`'s as `string`.
 auto MakeQueryConstant(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::CallExpression& call, const slang::ConstantValue& value,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = module.InternType(*call.type, span);
+  auto type_id = unit_lowerer.InternType(*call.type, span);
   if (!type_id) {
     return std::unexpected(std::move(type_id.error()));
   }
   return MakeConstantValueExpr(
-      module.Unit(), frame, call.type->coerceValue(value), *type_id, span);
+      unit_lowerer.Unit(), frame, call.type->coerceValue(value), *type_id,
+      span);
 }
 
 auto MakeQueryInt(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::CallExpression& call, std::int64_t value,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   return MakeQueryConstant(
-      module, frame, call,
+      unit_lowerer, frame, call,
       slang::ConstantValue{
           slang::SVInt(32, static_cast<std::uint64_t>(value), true)},
       span);
@@ -194,22 +195,23 @@ template <ExprLowerer Lowerer>
 auto BuildElementCountExpr(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   auto operand_or = lowerer.LowerExpr(*call.arguments()[0], frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
-  const bool is_string = module.Unit().types.Get(operand_or->type).Kind() ==
-                         hir::TypeKind::kString;
+  const bool is_string =
+      unit_lowerer.Unit().types.Get(operand_or->type).Kind() ==
+      hir::TypeKind::kString;
   const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
 
-  auto result_type = module.InternType(*call.type, span);
+  auto result_type = unit_lowerer.InternType(*call.type, span);
   if (!result_type) {
     return std::unexpected(std::move(result_type.error()));
   }
   const hir::ExprId count_id = frame.Exprs().Add(
       hir::Expr{
-          .type = module.Unit().builtins.int_type,
+          .type = unit_lowerer.Unit().builtins.int_type,
           .data =
               hir::CallExpr{
                   .callee =
@@ -248,13 +250,13 @@ template <ExprLowerer Lowerer>
 auto LowerOrderedDynamicDimensionQuery(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     QueryKind query, diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   switch (query) {
     case QueryKind::kLeft:
     case QueryKind::kLow:
-      return MakeQueryInt(module, frame, call, 0, span);
+      return MakeQueryInt(unit_lowerer, frame, call, 0, span);
     case QueryKind::kIncrement:
-      return MakeQueryInt(module, frame, call, -1, span);
+      return MakeQueryInt(unit_lowerer, frame, call, -1, span);
     case QueryKind::kSize:
       return BuildElementCountExpr(lowerer, frame, call, span);
     case QueryKind::kRight:
@@ -265,7 +267,7 @@ auto LowerOrderedDynamicDimensionQuery(
       if (!count_or) {
         return std::unexpected(std::move(count_or.error()));
       }
-      auto one_or = MakeQueryInt(module, frame, call, 1, span);
+      auto one_or = MakeQueryInt(unit_lowerer, frame, call, 1, span);
       if (!one_or) {
         return std::unexpected(std::move(one_or.error()));
       }
@@ -302,15 +304,15 @@ auto LowerAssociativeDimensionQuery(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     const slang::ast::Type& dimension, QueryKind query, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   switch (query) {
     case QueryKind::kLeft:
-      return MakeQueryInt(module, frame, call, 0, span);
+      return MakeQueryInt(unit_lowerer, frame, call, 0, span);
     case QueryKind::kIncrement:
-      return MakeQueryInt(module, frame, call, -1, span);
+      return MakeQueryInt(unit_lowerer, frame, call, -1, span);
     case QueryKind::kRight:
       return MakeQueryConstant(
-          module, frame, call,
+          unit_lowerer, frame, call,
           slang::ConstantValue{
               HighestIndexValue(*dimension.getAssociativeIndexType())},
           span);
@@ -322,7 +324,7 @@ auto LowerAssociativeDimensionQuery(
       if (!operand_or) {
         return std::unexpected(std::move(operand_or.error()));
       }
-      auto result_type = module.InternType(*call.type, span);
+      auto result_type = unit_lowerer.InternType(*call.type, span);
       if (!result_type) {
         return std::unexpected(std::move(result_type.error()));
       }
@@ -354,18 +356,18 @@ template <ExprLowerer Lowerer>
 auto LowerDynamicBitsQuery(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   auto operand_or = lowerer.LowerExpr(*call.arguments()[0], frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
-  auto result_type = module.InternType(*call.type, span);
+  auto result_type = unit_lowerer.InternType(*call.type, span);
   if (!result_type) {
     return std::unexpected(std::move(result_type.error()));
   }
   const hir::ExprId width_id = frame.Exprs().Add(
       hir::Expr{
-          .type = module.Unit().builtins.int_type,
+          .type = unit_lowerer.Unit().builtins.int_type,
           .data =
               hir::CallExpr{
                   .callee =
@@ -393,7 +395,7 @@ auto LowerBitsQuery(
     return LowerDynamicBitsQuery(lowerer, frame, call, span);
   }
   return MakeQueryConstant(
-      lowerer.Module(), frame, call,
+      lowerer.Owner(), frame, call,
       slang::ConstantValue{
           slang::SVInt(32, operand_type.getBitstreamWidth(), true)},
       span);
@@ -404,21 +406,22 @@ auto LowerBitsQuery(
 // default signing dropped, a user-defined name qualified by its declaring scope
 // -- are the frontend type printer's.
 auto LowerTypenameQuery(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::CallExpression& call, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   slang::ast::TypePrinter printer;
   printer.append(*call.arguments()[0]->type);
   return MakeQueryConstant(
-      module, frame, call, slang::ConstantValue{printer.toString()}, span);
+      unit_lowerer, frame, call, slang::ConstantValue{printer.toString()},
+      span);
 }
 
 auto LowerDimensionCountQuery(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::CallExpression& call, bool unpacked_only,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   return MakeQueryInt(
-      module, frame, call,
+      unit_lowerer, frame, call,
       static_cast<std::int64_t>(
           DimensionCount(*call.arguments()[0]->type, unpacked_only)),
       span);
@@ -435,10 +438,10 @@ auto LowerDimensionResult(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     const slang::ast::Type& dimension, QueryKind query, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   if (dimension.hasFixedRange() && !dimension.isScalar()) {
     return MakeQueryInt(
-        module, frame, call,
+        unit_lowerer, frame, call,
         FixedDimensionValue(query, dimension.getFixedRange()), span);
   }
   if (dimension.isAssociativeArray()) {
@@ -461,7 +464,7 @@ template <ExprLowerer Lowerer>
 auto LowerComposedDimensionQuery(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     QueryKind query, diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   const slang::ast::Type& operand_type = *call.arguments()[0]->type;
   const auto dimension_count =
       static_cast<std::int64_t>(DimensionCount(operand_type, false));
@@ -493,11 +496,11 @@ auto LowerComposedDimensionQuery(
     rows.push_back(frame.Exprs().Add(*std::move(row_or)));
   }
 
-  auto element_type = module.InternType(*call.type, span);
+  auto element_type = unit_lowerer.InternType(*call.type, span);
   if (!element_type) {
     return std::unexpected(std::move(element_type.error()));
   }
-  const hir::TypeId table_type = module.AddComposedType(
+  const hir::TypeId table_type = unit_lowerer.AddComposedType(
       hir::UnpackedArrayType{
           .element_type = *element_type,
           .dim = hir::UnpackedRange{.left = 1, .right = dimension_count}});
@@ -523,9 +526,9 @@ template <ExprLowerer Lowerer>
 auto LowerDimensionQuery(
     Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
     QueryKind query, diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   const std::optional<std::int64_t> index =
-      ConstantDimensionIndex(module, call);
+      ConstantDimensionIndex(unit_lowerer, call);
   if (!index.has_value()) {
     return LowerComposedDimensionQuery(lowerer, frame, call, query, span);
   }
@@ -561,17 +564,17 @@ auto LowerQueryExpr(
     return std::optional<hir::Expr>{};
   }
 
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   diag::Result<hir::Expr> result = [&] {
     switch (*query) {
       case QueryKind::kBits:
         return LowerBitsQuery(lowerer, frame, call, span);
       case QueryKind::kTypename:
-        return LowerTypenameQuery(module, frame, call, span);
+        return LowerTypenameQuery(unit_lowerer, frame, call, span);
       case QueryKind::kDimensions:
-        return LowerDimensionCountQuery(module, frame, call, false, span);
+        return LowerDimensionCountQuery(unit_lowerer, frame, call, false, span);
       case QueryKind::kUnpackedDimensions:
-        return LowerDimensionCountQuery(module, frame, call, true, span);
+        return LowerDimensionCountQuery(unit_lowerer, frame, call, true, span);
       default:
         return LowerDimensionQuery(lowerer, frame, call, *query, span);
     }

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -176,21 +176,21 @@ auto MakeEnumValueExpr(
 }
 
 auto MakeParameterConstantExpr(
-    ModuleLowerer& module, WalkFrame frame, const slang::ast::Symbol& sym,
+    UnitLowerer& unit_lowerer, WalkFrame frame, const slang::ast::Symbol& sym,
     const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto type_id = module.InternType(type, span);
+  auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return MakeConstantValueExpr(
-      module.Unit(), frame, sym.as<slang::ast::ParameterSymbol>().getValue(),
-      *type_id, span);
+      unit_lowerer.Unit(), frame,
+      sym.as<slang::ast::ParameterSymbol>().getValue(), *type_id, span);
 }
 
 auto MakeEnumConstantExpr(
-    ModuleLowerer& module, const slang::ast::Symbol& sym,
+    UnitLowerer& unit_lowerer, const slang::ast::Symbol& sym,
     const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto type_id = module.InternType(type, span);
+  auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return MakeEnumValueExpr(
       sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
@@ -202,10 +202,10 @@ auto MakeEnumConstantExpr(
 // iteration parameters, not a variable of the enclosing scope, so neither pass
 // class's variable storage is consulted.
 auto MakeIterationElementRefExpr(
-    ModuleLowerer& module, const slang::ast::NamedValueExpression& named,
+    UnitLowerer& unit_lowerer, const slang::ast::NamedValueExpression& named,
     hir::WithClauseId clause, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto type_id = module.InternType(*named.type, span);
+  auto type_id = unit_lowerer.InternType(*named.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return MakeRefExpr(
       hir::IterationBindingRef{
@@ -214,10 +214,10 @@ auto MakeIterationElementRefExpr(
 }
 
 auto MakeClassPropertyRefExpr(
-    ModuleLowerer& module, const slang::ast::Symbol& sym,
+    UnitLowerer& unit_lowerer, const slang::ast::Symbol& sym,
     const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto type_id = module.InternType(type, span);
+  auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::MakeRefExpr(
       hir::ClassPropertyRef{
@@ -245,12 +245,12 @@ auto RouteRefExpr(
 // its context admits. A simple name is always lexically enclosing, so the route
 // is always available and its absence is a compiler-bug invariant.
 auto LowerStructuralSignalRef(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::ValueSymbol& value, const slang::ast::Type& type,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = module.InternType(type, span);
+  auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
-  auto route = module.TranslateReferenceRoute(frame, value);
+  auto route = unit_lowerer.TranslateReferenceRoute(frame, value);
   if (!route) {
     throw InternalError(
         "LowerStructuralSignalRef: structural signal has no reader-relative "
@@ -264,25 +264,26 @@ auto LowerStructuralSignalRef(
 auto LowerNamedValueProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::NamedValueExpression& named) -> diag::Result<hir::Expr> {
-  auto& module = proc.Module();
-  const auto& mapper = module.SourceMapper();
+  auto& unit_lowerer = proc.Owner();
+  const auto& mapper = unit_lowerer.SourceMapper();
   const auto span = mapper.SpanOf(named.sourceRange);
   const auto& sym = named.symbol;
 
   if (auto clause = frame.FindIterationClause(sym)) {
-    return MakeIterationElementRefExpr(module, named, *clause, span);
+    return MakeIterationElementRefExpr(unit_lowerer, named, *clause, span);
   }
 
   switch (ClassifyReferent(sym)) {
     case Referent::kParameterConstant:
-      return MakeParameterConstantExpr(module, frame, sym, *named.type, span);
+      return MakeParameterConstantExpr(
+          unit_lowerer, frame, sym, *named.type, span);
     case Referent::kEnumConstant:
-      return MakeEnumConstantExpr(module, sym, *named.type, span);
+      return MakeEnumConstantExpr(unit_lowerer, sym, *named.type, span);
     // Inside an instance method, a class property named without an explicit
     // handle (LRM 8.4) reaches the invoking object through the method's
     // receiver, so it lowers to a receiver-relative property reference.
     case Referent::kClassProperty:
-      return MakeClassPropertyRefExpr(module, sym, *named.type, span);
+      return MakeClassPropertyRefExpr(unit_lowerer, sym, *named.type, span);
     // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
     // variable-family symbols; each binds to procedural-var storage when the
     // enclosing process declares it, otherwise to the structural signal of the
@@ -296,12 +297,14 @@ auto LowerNamedValueProc(
             hir::ProceduralVarRef{.var = *local}, type, span);
       }
       return LowerStructuralSignalRef(
-          module, frame, sym.as<slang::ast::ValueSymbol>(), *named.type, span);
+          unit_lowerer, frame, sym.as<slang::ast::ValueSymbol>(), *named.type,
+          span);
     }
     // A net (LRM 6.5) is always a structural signal, never a procedural local.
     case Referent::kNetStorage:
       return LowerStructuralSignalRef(
-          module, frame, sym.as<slang::ast::ValueSymbol>(), *named.type, span);
+          unit_lowerer, frame, sym.as<slang::ast::ValueSymbol>(), *named.type,
+          span);
     case Referent::kUnsupported:
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
@@ -315,10 +318,10 @@ auto LowerNamedValueProc(
 // the reader's elaborated position and the target symbol. slang's resolved
 // `ref.path` is provenance, not a routing authority, so it is not consulted.
 auto LowerHierarchicalValue(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::HierarchicalValueExpression& hve)
     -> diag::Result<hir::Expr> {
-  const auto span = module.SourceMapper().SpanOf(hve.sourceRange);
+  const auto span = unit_lowerer.SourceMapper().SpanOf(hve.sourceRange);
 
   if (hve.ref.isViaIfacePort()) {
     return diag::Fail(
@@ -331,9 +334,10 @@ auto LowerHierarchicalValue(
     // A hierarchically reached constant folds to its value; the path is not
     // navigated because the value is fixed at elaboration.
     case Referent::kParameterConstant:
-      return MakeParameterConstantExpr(module, frame, target, *hve.type, span);
+      return MakeParameterConstantExpr(
+          unit_lowerer, frame, target, *hve.type, span);
     case Referent::kEnumConstant:
-      return MakeEnumConstantExpr(module, target, *hve.type, span);
+      return MakeEnumConstantExpr(unit_lowerer, target, *hve.type, span);
     case Referent::kClassProperty:
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
@@ -345,9 +349,9 @@ auto LowerHierarchicalValue(
           "supported");
     case Referent::kVariableStorage:
     case Referent::kNetStorage: {
-      auto type_id = module.InternType(*hve.type, span);
+      auto type_id = unit_lowerer.InternType(*hve.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
-      auto route = module.TranslateReferenceRoute(
+      auto route = unit_lowerer.TranslateReferenceRoute(
           frame, target.as<slang::ast::ValueSymbol>());
       if (!route) {
         return diag::Fail(
@@ -361,23 +365,25 @@ auto LowerHierarchicalValue(
 }
 
 auto LowerNamedValueStructural(
-    ModuleLowerer& module, WalkFrame frame,
+    UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::NamedValueExpression& named) -> diag::Result<hir::Expr> {
-  const auto& mapper = module.SourceMapper();
+  const auto& mapper = unit_lowerer.SourceMapper();
   const auto span = mapper.SpanOf(named.sourceRange);
   const auto& sym = named.symbol;
   if (auto clause = frame.FindIterationClause(sym)) {
-    return MakeIterationElementRefExpr(module, named, *clause, span);
+    return MakeIterationElementRefExpr(unit_lowerer, named, *clause, span);
   }
   switch (ClassifyReferent(sym)) {
     case Referent::kParameterConstant:
-      return MakeParameterConstantExpr(module, frame, sym, *named.type, span);
+      return MakeParameterConstantExpr(
+          unit_lowerer, frame, sym, *named.type, span);
     case Referent::kEnumConstant:
-      return MakeEnumConstantExpr(module, sym, *named.type, span);
+      return MakeEnumConstantExpr(unit_lowerer, sym, *named.type, span);
     case Referent::kVariableStorage:
     case Referent::kNetStorage:
       return LowerStructuralSignalRef(
-          module, frame, sym.as<slang::ast::ValueSymbol>(), *named.type, span);
+          unit_lowerer, frame, sym.as<slang::ast::ValueSymbol>(), *named.type,
+          span);
     // A class property has no structural (non-procedural) meaning: it is only
     // reachable through a method receiver, so outside a method it is rejected
     // alongside the genuinely unsupported kinds.

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -15,9 +15,9 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/expr_builders.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -32,7 +32,7 @@ auto LowerUnboundedLiteralProc(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "`$` is only supported as a queue index or slice bound (LRM 7.10)");
   }
-  const hir::TypeId int_type = proc.Module().Unit().builtins.int_type;
+  const hir::TypeId int_type = proc.Owner().Unit().builtins.int_type;
   const hir::ExprId size_id = frame.Exprs().Add(
       hir::Expr{
           .type = int_type,
@@ -79,7 +79,7 @@ auto LowerElementSelectExpr(
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const hir::ExprId idx_id = frame.Exprs().Add(*std::move(idx_or));
 
-  auto type_id = lowerer.Module().InternType(*sel.type, span);
+  auto type_id = lowerer.Owner().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -150,7 +150,7 @@ auto LowerRangeSelectExpr(
         "LowerRangeSelectExpr: unknown slang RangeSelectionKind");
   }();
 
-  auto type_id = lowerer.Module().InternType(*sel.type, span);
+  auto type_id = lowerer.Owner().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -185,7 +185,7 @@ auto LowerMemberAccessExpr(
   auto base_or = lowerer.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
-  auto type_id = lowerer.Module().InternType(*sel.type, span);
+  auto type_id = lowerer.Owner().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   if (sel.member.kind == slang::ast::SymbolKind::Field) {
     return hir::Expr{
@@ -203,7 +203,7 @@ auto LowerMemberAccessExpr(
     const auto& prop = sel.member.as<slang::ast::ClassPropertySymbol>();
     const auto& declaring_class =
         prop.getParentScope()->asSymbol().as<slang::ast::ClassType>();
-    auto owner_id = lowerer.Module().InternClass(declaring_class, span);
+    auto owner_id = lowerer.Owner().InternClass(declaring_class, span);
     if (!owner_id) return std::unexpected(std::move(owner_id.error()));
     return hir::Expr{
         .type = *type_id,

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -10,8 +10,8 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/structural_scope.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -31,10 +31,10 @@ auto AddChildStructuralScope(hir::Generate& gen, hir::StructuralScope scope)
 // variable is bound, so a genvar reference in the body folds to this block's
 // concrete value.
 auto LowerGenerateScope(
-    ModuleLowerer& module, const slang::ast::GenerateBlockSymbol& block,
+    UnitLowerer& unit_lowerer, const slang::ast::GenerateBlockSymbol& block,
     std::string_view source_name, WalkFrame frame)
     -> diag::Result<hir::StructuralScope> {
-  StructuralScopeLowerer child(module, block);
+  StructuralScopeLowerer child(unit_lowerer, block);
   auto scope_or = child.Run(frame);
   if (!scope_or) return std::unexpected(std::move(scope_or.error()));
   scope_or->source_name = std::string{source_name};
@@ -50,7 +50,7 @@ auto StructuralScopeLowerer::BuildResolvedGenerateFromArray(
   std::vector<hir::ResolvedGenerateItem> items;
   items.reserve(array.entries.size());
   for (const auto* entry : array.entries) {
-    auto scope_or = LowerGenerateScope(*module_, *entry, array.name, frame);
+    auto scope_or = LowerGenerateScope(*owner_, *entry, array.name, frame);
     if (!scope_or) return std::unexpected(std::move(scope_or.error()));
     const hir::StructuralScopeId scope_id =
         AddChildStructuralScope(gen, *std::move(scope_or));
@@ -74,7 +74,7 @@ auto StructuralScopeLowerer::BuildResolvedGenerateFromBlock(
     const slang::ast::GenerateBlockSymbol& block, WalkFrame frame)
     -> diag::Result<hir::Generate> {
   hir::Generate gen{};
-  auto scope_or = LowerGenerateScope(*module_, block, block.name, frame);
+  auto scope_or = LowerGenerateScope(*owner_, block, block.name, frame);
   if (!scope_or) return std::unexpected(std::move(scope_or.error()));
   const hir::StructuralScopeId scope_id =
       AddChildStructuralScope(gen, *std::move(scope_or));

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -21,9 +21,9 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -44,12 +44,12 @@ auto PortConnectionUnsupported(diag::SourceSpan span, std::string message)
 // connection verbatim with its direction; HIR-to-MIR realizes it
 // (LRM 23.3.3).
 auto ConnectElementPorts(
-    StructuralScopeLowerer& scope, ModuleLowerer& module,
+    StructuralScopeLowerer& scope, UnitLowerer& unit_lowerer,
     const slang::ast::InstanceSymbol& inst, hir::DownwardHead head,
     ScopeFrameId home_frame, std::vector<std::uint32_t> element_indices,
     WalkFrame frame) -> diag::Result<void> {
   head.head_indices = std::move(element_indices);
-  const auto span = module.SourceMapper().PointSpanOf(inst.location);
+  const auto span = unit_lowerer.SourceMapper().PointSpanOf(inst.location);
 
   for (const auto* conn : inst.getPortConnections()) {
     if (conn->port.kind != slang::ast::SymbolKind::Port) {
@@ -71,9 +71,9 @@ auto ConnectElementPorts(
           span,
           "port not bound to a connectable variable is not yet supported");
     }
-    auto type_id = module.InternType(port.getType(), span);
+    auto type_id = unit_lowerer.InternType(port.getType(), span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
-    if (!module.Unit().types.Get(*type_id).IsValueChangeObservable()) {
+    if (!unit_lowerer.Unit().types.Get(*type_id).IsValueChangeObservable()) {
       return PortConnectionUnsupported(
           span,
           "port connection of a handle / event type is not yet supported");
@@ -121,7 +121,7 @@ auto ConnectElementPorts(
     // phase, so it keeps only the by-name reach.
     const auto cell_endpoint = [&]() -> hir::PortEndpoint {
       return hir::PortCellEndpoint{
-          .cell = frame.Exprs().Add(module.MakeRoutedMemberRef(
+          .cell = frame.Exprs().Add(unit_lowerer.MakeRoutedMemberRef(
               *internal, home_frame, head, path, *type_id, span))};
     };
 
@@ -146,15 +146,15 @@ auto ConnectElementPorts(
                 "ConnectElementPorts: port default did not fold to a constant");
           }
           auto peer_or = MakeConstantValueExpr(
-              module.Unit(), frame, *constant, *type_id, span);
+              unit_lowerer.Unit(), frame, *constant, *type_id, span);
           if (!peer_or) return std::unexpected(std::move(peer_or.error()));
           peer = frame.Exprs().Add(*std::move(peer_or));
         } else {
           auto peer_or = scope.LowerExpr(*expr, frame);
           if (!peer_or) return std::unexpected(std::move(peer_or.error()));
           peer = frame.Exprs().Add(*std::move(peer_or));
-          sensitivity = module.TranslateSensitivityReads(
-              module.Sensitivity().AnalyzeReads(*expr, inst), frame);
+          sensitivity = unit_lowerer.TranslateSensitivityReads(
+              unit_lowerer.Sensitivity().AnalyzeReads(*expr, inst), frame);
         }
         break;
       }
@@ -175,7 +175,7 @@ auto ConnectElementPorts(
             expr->as<slang::ast::AssignmentExpression>().left(), frame);
         if (!peer_or) return std::unexpected(std::move(peer_or.error()));
         peer = frame.Exprs().Add(*std::move(peer_or));
-        sensitivity = module.TranslateSensitivityReads(
+        sensitivity = unit_lowerer.TranslateSensitivityReads(
             {SensitivityRead{.symbol = internal, .footprint = std::nullopt}},
             frame);
         break;
@@ -211,7 +211,7 @@ auto ConnectElementPorts(
 // carries its own already index-matched connection expressions; this only
 // routes each to the right cell.
 auto ConnectArrayElements(
-    StructuralScopeLowerer& scope, ModuleLowerer& module,
+    StructuralScopeLowerer& scope, UnitLowerer& unit_lowerer,
     const slang::ast::InstanceArraySymbol& array, hir::DownwardHead head,
     ScopeFrameId home_frame, const std::vector<std::uint32_t>& index_prefix,
     WalkFrame frame) -> diag::Result<void> {
@@ -221,13 +221,13 @@ auto ConnectArrayElements(
     const auto* element = array.elements[i];
     if (element->kind == slang::ast::SymbolKind::InstanceArray) {
       auto r = ConnectArrayElements(
-          scope, module, element->as<slang::ast::InstanceArraySymbol>(), head,
-          home_frame, element_prefix, frame);
+          scope, unit_lowerer, element->as<slang::ast::InstanceArraySymbol>(),
+          head, home_frame, element_prefix, frame);
       if (!r) return std::unexpected(std::move(r.error()));
       continue;
     }
     auto r = ConnectElementPorts(
-        scope, module, element->as<slang::ast::InstanceSymbol>(), head,
+        scope, unit_lowerer, element->as<slang::ast::InstanceSymbol>(), head,
         home_frame, std::move(element_prefix), frame);
     if (!r) return std::unexpected(std::move(r.error()));
   }
@@ -243,24 +243,24 @@ auto StructuralScopeLowerer::PopulatePortConnections(
     if (member.kind == slang::ast::SymbolKind::Instance) {
       // The instance member is bound in the pre-pass; a downward port reach
       // cannot miss it, so absence is a compiler-bug invariant.
-      const auto binding = module_->LookupOwnedChildBinding(member);
+      const auto binding = owner_->LookupOwnedChildBinding(member);
       if (!binding.has_value()) {
         throw InternalError(
             "PopulatePortConnections: instance member has no binding");
       }
       auto r = ConnectElementPorts(
-          *this, *module_, member.as<slang::ast::InstanceSymbol>(),
+          *this, *owner_, member.as<slang::ast::InstanceSymbol>(),
           binding->head, binding->home_frame, {}, frame);
       if (!r) return std::unexpected(std::move(r.error()));
     } else if (member.kind == slang::ast::SymbolKind::InstanceArray) {
       // A zero-element array (`Child c[0]`, LRM 23.3.2) constructs no element
       // and binds no member, so there is nothing to connect.
-      const auto binding = module_->LookupOwnedChildBinding(member);
+      const auto binding = owner_->LookupOwnedChildBinding(member);
       if (!binding.has_value()) {
         continue;
       }
       auto r = ConnectArrayElements(
-          *this, *module_, member.as<slang::ast::InstanceArraySymbol>(),
+          *this, *owner_, member.as<slang::ast::InstanceArraySymbol>(),
           binding->head, binding->home_frame, {}, frame);
       if (!r) return std::unexpected(std::move(r.error()));
     }

--- a/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
@@ -18,8 +18,8 @@
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/ast_to_hir/lifetime_extension.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -54,8 +54,8 @@ void ProcessLowerer::AnalyzeLifetimeExtended(
 }
 
 ProcessLowerer::ProcessLowerer(
-    ModuleLowerer& module, const slang::ast::Symbol& containing_symbol)
-    : module_(&module), containing_symbol_(&containing_symbol) {
+    UnitLowerer& unit_lowerer, const slang::ast::Symbol& containing_symbol)
+    : owner_(&unit_lowerer), containing_symbol_(&containing_symbol) {
 }
 
 auto ProcessLowerer::Run(
@@ -87,7 +87,7 @@ auto ProcessLowerer::Run(
                 .direct_child_scopes = std::move(root_children)});
   }
 
-  const auto& mapper = module_->SourceMapper();
+  const auto& mapper = owner_->SourceMapper();
   const auto span = mapper.PointSpanOf(proc.location);
   const auto kind = FromSlangProceduralBlockKind(proc.procedureKind);
 
@@ -102,8 +102,8 @@ auto ProcessLowerer::Run(
     // of its whole procedure, including reads inside any function it calls --
     // the procedure-level sensitivity, not the raw read set of the body node,
     // which reflects only call arguments across a function boundary.
-    out.implicit_sensitivity_list = module_->TranslateSensitivityReads(
-        module_->Sensitivity().AnalyzeProcedureSensitivity(proc), frame);
+    out.implicit_sensitivity_list = owner_->TranslateSensitivityReads(
+        owner_->Sensitivity().AnalyzeProcedureSensitivity(proc), frame);
   }
   return out;
 }

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -19,8 +19,8 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/value_ref.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -160,7 +160,7 @@ auto BuildAssociativeLevel(
     hir::ExprId array, hir::TypeId int_type, diag::SourceSpan span,
     std::vector<hir::StmtId>& setup) -> diag::Result<LevelLoop> {
   auto& body = *frame.current_procedural_body;
-  auto key_type_or = proc.Module().InternType(dim.loopVar->getType(), span);
+  auto key_type_or = proc.Owner().InternType(dim.loopVar->getType(), span);
   if (!key_type_or) return std::unexpected(std::move(key_type_or.error()));
   const hir::TypeId key_type = *key_type_or;
 
@@ -286,7 +286,7 @@ auto BuildForeachNest(
   const slang::ast::Type* inner_array_type = nullptr;
   if (array.has_value() && level + 1 < levels.size()) {
     inner_array_type = array_type->getCanonicalType().getArrayElementType();
-    auto inner_hir_type = proc.Module().InternType(*inner_array_type, span);
+    auto inner_hir_type = proc.Owner().InternType(*inner_array_type, span);
     if (!inner_hir_type) {
       return std::unexpected(std::move(inner_hir_type.error()));
     }
@@ -340,11 +340,11 @@ auto ProcessLowerer::LowerForeachStmt(
     const slang::ast::ForeachLoopStatement& fs, WalkFrame frame)
     -> diag::Result<hir::Stmt> {
   auto& proc = *this;
-  auto& module = proc.Module();
+  auto& unit_lowerer = proc.Owner();
   auto& body = *frame.current_procedural_body;
-  const auto span = module.SourceMapper().SpanOf(fs.sourceRange);
+  const auto span = unit_lowerer.SourceMapper().SpanOf(fs.sourceRange);
 
-  const hir::TypeId int_type = module.Unit().builtins.int_type;
+  const hir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
 
   // Collect the iterated (non-skipped) dimensions in cardinal order. A
   // dimension with no constant range reads the array value at run time -- a

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -10,12 +10,12 @@
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/statement/blocks.hpp"
 #include "lyra/lowering/ast_to_hir/statement/branches.hpp"
 #include "lyra/lowering/ast_to_hir/statement/loops.hpp"
 #include "lyra/lowering/ast_to_hir/statement/timing.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -54,10 +54,10 @@ auto LowerVariableDeclStmt(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::VariableDeclStatement& vd, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
-  const auto& mapper = proc.Module().SourceMapper();
+  const auto& mapper = proc.Owner().SourceMapper();
   const auto& sym = vd.symbol;
   auto type_id_or =
-      proc.Module().InternType(sym.getType(), mapper.PointSpanOf(sym.location));
+      proc.Owner().InternType(sym.getType(), mapper.PointSpanOf(sym.location));
   if (!type_id_or) return std::unexpected(std::move(type_id_or.error()));
   const auto local_id = proc.AddProceduralVar(
       frame, *frame.current_procedural_body, sym, *type_id_or);
@@ -108,7 +108,7 @@ auto LowerReturnStmt(
 auto LowerStatement(
     ProcessLowerer& proc, WalkFrame frame, const slang::ast::Statement& stmt)
     -> diag::Result<hir::Stmt> {
-  const auto& mapper = proc.Module().SourceMapper();
+  const auto& mapper = proc.Owner().SourceMapper();
   const auto span = mapper.SpanOf(stmt.sourceRange);
   switch (stmt.kind) {
     case slang::ast::StatementKind::Empty:
@@ -197,7 +197,7 @@ auto LowerStatement(
       // An assertion embedded in surrounding behavior contributes no statement
       // when disabled; the rest of the process runs. Without the policy it is a
       // rejected construct, not silently ignored.
-      if (proc.Module().DisableAssertions()) {
+      if (proc.Owner().DisableAssertions()) {
         return LowerEmptyStmt(span);
       }
       return diag::Fail(

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -13,7 +13,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/value_ref.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -46,7 +46,7 @@ auto LowerSignalEventTrigger(
   auto expr_or = proc.LowerExpr(sig.expr, frame);
   if (!expr_or) return std::unexpected(std::move(expr_or.error()));
 
-  const auto& expr_type = proc.Module().Unit().types.Get(expr_or->type);
+  const auto& expr_type = proc.Owner().Unit().types.Get(expr_or->type);
   if (sig.edge != slang::ast::EdgeKind::None) {
     // The runtime classifies an edge only on a packed bit-vector cell (LRM
     // 9.4.2 Table 9-2); slang already restricts an edge to an integral operand.
@@ -65,9 +65,9 @@ auto LowerSignalEventTrigger(
 
   const auto edge_kind = LowerEventEdge(sig.edge);
 
-  const auto& reads = proc.Module().Sensitivity().AnalyzeReads(
+  const auto& reads = proc.Owner().Sensitivity().AnalyzeReads(
       sig.expr, proc.ContainingSymbol());
-  auto sensitivity_list = proc.Module().TranslateSensitivityReads(reads, frame);
+  auto sensitivity_list = proc.Owner().TranslateSensitivityReads(reads, frame);
   // Faithful record of SV: every leaf carries the trigger's edge identifier.
   // Whether the runtime can act on it directly (single leaf, LSB-reduce) or
   // needs a snapshot + re-eval wrapper (compound) is a HIR -> MIR decision.
@@ -189,10 +189,9 @@ auto LowerTimedStmt(
   // the body lowers so a read's cross-unit reference is already resolved when
   // its subscription is built.
   if (auto* ie = std::get_if<hir::ImplicitEventControl>(&*timing)) {
-    const auto& reads = proc.Module().Sensitivity().AnalyzeReads(
+    const auto& reads = proc.Owner().Sensitivity().AnalyzeReads(
         ts.stmt, proc.ContainingSymbol());
-    ie->sensitivity_list =
-        proc.Module().TranslateSensitivityReads(reads, frame);
+    ie->sensitivity_list = proc.Owner().TranslateSensitivityReads(reads, frame);
   }
   return hir::Stmt{
       .label = std::nullopt,
@@ -250,8 +249,8 @@ auto LowerWaitStmt(
   const hir::StmtId body_id =
       frame.current_procedural_body->stmts.Add(*std::move(body_or));
   const auto& reads =
-      proc.Module().Sensitivity().AnalyzeReads(w.cond, proc.ContainingSymbol());
-  auto sensitivity = proc.Module().TranslateSensitivityReads(reads, frame);
+      proc.Owner().Sensitivity().AnalyzeReads(w.cond, proc.ContainingSymbol());
+  auto sensitivity = proc.Owner().TranslateSensitivityReads(reads, frame);
   return hir::Stmt{
       .label = std::nullopt,
       .data =

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -29,20 +29,20 @@
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/ast_to_hir/instance_array_shape.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
 #include "lyra/lowering/ast_to_hir/time_resolution.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
 StructuralScopeLowerer::StructuralScopeLowerer(
-    ModuleLowerer& module, const slang::ast::Scope& slang_scope)
-    : module_(&module),
+    UnitLowerer& unit_lowerer, const slang::ast::Scope& slang_scope)
+    : owner_(&unit_lowerer),
       slang_scope_(&slang_scope),
-      frame_(module.LookupScopeFrame(slang_scope)) {
+      frame_(unit_lowerer.LookupScopeFrame(slang_scope)) {
   // A `ref` / `const ref` port's internal variable aliases the connected
   // variable rather than owning storage (LRM 23.3.3.2); record which of this
   // body's variables those are so their members lower to a reference type. Only
@@ -97,10 +97,10 @@ auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
     if (member.kind != slang::ast::SymbolKind::Subroutine) continue;
     const auto& sub = member.as<slang::ast::SubroutineSymbol>();
     if (sub.flags.has(slang::ast::MethodFlags::DPIImport)) {
-      module_->MapForeignImportBinding(
+      owner_->MapForeignImportBinding(
           sub, frame_, hir::ForeignImportId{reserved_foreign_import_id++});
     } else {
-      module_->MapSubroutineBinding(
+      owner_->MapSubroutineBinding(
           sub, frame_, hir::StructuralSubroutineId{reserved_subroutine_id++});
     }
   }
@@ -153,7 +153,7 @@ auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
   auto pc = PopulatePortConnections(*slang_scope_, frame);
   if (!pc) return std::unexpected(std::move(pc.error()));
 
-  for (auto& ref : module_->TakeRoutedRefsForFrame(frame_)) {
+  for (auto& ref : owner_->TakeRoutedRefsForFrame(frame_)) {
     scope.routed_refs.Add(std::move(ref));
   }
   return scope;
@@ -197,8 +197,8 @@ auto StructuralScopeLowerer::PopulateMember(
 auto StructuralScopeLowerer::PopulateTypeAliasMember(
     const slang::ast::TypeAliasType& alias, WalkFrame frame)
     -> diag::Result<void> {
-  const auto& mapper = module_->SourceMapper();
-  auto target_or = module_->InternType(
+  const auto& mapper = owner_->SourceMapper();
+  auto target_or = owner_->InternType(
       alias.targetType.getType(), mapper.PointSpanOf(alias.location));
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   frame.current_structural_scope->AddTypeAlias(
@@ -210,7 +210,7 @@ auto StructuralScopeLowerer::PopulateTypeAliasMember(
 auto StructuralScopeLowerer::PopulateVariableMember(
     const slang::ast::VariableSymbol& var, WalkFrame frame)
     -> diag::Result<void> {
-  const auto& mapper = module_->SourceMapper();
+  const auto& mapper = owner_->SourceMapper();
   if (var.lifetime != slang::ast::VariableLifetime::Static) {
     return diag::Fail(
         mapper.PointSpanOf(var.location),
@@ -218,13 +218,13 @@ auto StructuralScopeLowerer::PopulateVariableMember(
         "only static variables are supported");
   }
   auto type_id_or =
-      module_->InternType(var.getType(), mapper.PointSpanOf(var.location));
+      owner_->InternType(var.getType(), mapper.PointSpanOf(var.location));
   if (!type_id_or) return std::unexpected(std::move(type_id_or.error()));
   // Slang rejects `void` in any variable-declaration position before
   // elaboration, so a void-typed VariableSymbol can only reach this path
   // via a slang/Lyra integration bug.
   if (std::holds_alternative<hir::VoidType>(
-          module_->Unit().types.Get(*type_id_or).data)) {
+          owner_->Unit().types.Get(*type_id_or).data)) {
     throw InternalError(
         "StructuralScopeLowerer::PopulateVariableMember: variable declaration "
         "produced "
@@ -244,15 +244,15 @@ auto StructuralScopeLowerer::PopulateVariableMember(
               .kind = hir::StructuralVariableDecl{
                   .initializer = initializer_id,
                   .reference = ReferenceBindingFor(var)}});
-  module_->MapStructuralDataObjectBinding(var, frame_, local, *type_id_or);
+  owner_->MapStructuralDataObjectBinding(var, frame_, local, *type_id_or);
   return {};
 }
 
 auto StructuralScopeLowerer::PopulateNetMember(
     const slang::ast::NetSymbol& net, WalkFrame frame) -> diag::Result<void> {
-  const auto& mapper = module_->SourceMapper();
+  const auto& mapper = owner_->SourceMapper();
   const auto span = mapper.PointSpanOf(net.location);
-  auto type_id_or = module_->InternType(net.getType(), span);
+  auto type_id_or = owner_->InternType(net.getType(), span);
   if (!type_id_or) return std::unexpected(std::move(type_id_or.error()));
   hir::NetType net_type{};
   switch (net.netType.netKind) {
@@ -273,7 +273,7 @@ auto StructuralScopeLowerer::PopulateNetMember(
               .name = std::string{net.name},
               .type = *type_id_or,
               .kind = hir::StructuralNetDecl{.net_type = net_type}});
-  module_->MapStructuralDataObjectBinding(net, frame_, local, *type_id_or);
+  owner_->MapStructuralDataObjectBinding(net, frame_, local, *type_id_or);
 
   // A net-declaration assignment (`wire w = expr;`, LRM 6.5) is a single
   // continuous driver of the net. slang carries it as the net's initializer
@@ -288,14 +288,14 @@ auto StructuralScopeLowerer::PopulateNetMember(
         hir::MakeRefExpr(
             hir::DirectMemberRef{.var = local}, *type_id_or, span));
     const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
-    const auto& reads = module_->Sensitivity().AnalyzeReads(*init, net);
+    const auto& reads = owner_->Sensitivity().AnalyzeReads(*init, net);
     frame.current_structural_scope->continuous_assigns.Add(
         hir::ContinuousAssign{
             .span = span,
             .lhs = lhs_id,
             .rhs = rhs_id,
             .sensitivity_list =
-                module_->TranslateSensitivityReads(reads, frame)});
+                owner_->TranslateSensitivityReads(reads, frame)});
   }
   return {};
 }
@@ -303,10 +303,10 @@ auto StructuralScopeLowerer::PopulateNetMember(
 auto StructuralScopeLowerer::PopulateSubroutineMember(
     const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
     -> diag::Result<void> {
-  auto decl_or = LowerSubroutineDecl(*module_, sym, frame);
+  auto decl_or = LowerSubroutineDecl(*owner_, sym, frame);
   if (!decl_or) return std::unexpected(std::move(decl_or.error()));
 
-  const auto binding = module_->LookupSubroutineBinding(sym);
+  const auto binding = owner_->LookupSubroutineBinding(sym);
   if (!binding.has_value() ||
       binding->subroutine_id.value !=
           static_cast<std::uint32_t>(
@@ -325,10 +325,10 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
 auto StructuralScopeLowerer::PopulateForeignImportMember(
     const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
     -> diag::Result<void> {
-  auto decl_or = LowerForeignImport(*module_, sym);
+  auto decl_or = LowerForeignImport(*owner_, sym);
   if (!decl_or) return std::unexpected(std::move(decl_or.error()));
 
-  const auto binding = module_->LookupForeignImportBinding(sym);
+  const auto binding = owner_->LookupForeignImportBinding(sym);
   if (!binding.has_value() ||
       binding->import_id.value !=
           static_cast<std::uint32_t>(
@@ -350,10 +350,10 @@ auto StructuralScopeLowerer::PopulateProceduralBlockMember(
   // contributes no behavior, so it is dropped at the source rather than emptied
   // -- an always block with no body and no timing control would be a zero-delay
   // infinite loop.
-  if (module_->DisableAssertions() && proc.isFromAssertion) {
+  if (owner_->DisableAssertions() && proc.isFromAssertion) {
     return {};
   }
-  ProcessLowerer proc_lowerer(*module_, proc);
+  ProcessLowerer proc_lowerer(*owner_, proc);
   auto p = proc_lowerer.Run(proc, frame);
   if (!p) return std::unexpected(std::move(p.error()));
   frame.current_structural_scope->processes.Add(*std::move(p));

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -18,8 +18,8 @@
 #include "lyra/hir/foreign_import.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/subroutine.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/support/dpi_abi.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -187,18 +187,18 @@ auto ResolveImportCName(const slang::ast::SubroutineSymbol& sym)
 }  // namespace
 
 auto LowerSubroutineDecl(
-    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym,
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
     WalkFrame frame) -> diag::Result<hir::SubroutineDecl> {
-  const auto& mapper = module.SourceMapper();
+  const auto& mapper = unit_lowerer.SourceMapper();
 
-  auto return_type_or =
-      module.InternType(sym.getReturnType(), mapper.PointSpanOf(sym.location));
+  auto return_type_or = unit_lowerer.InternType(
+      sym.getReturnType(), mapper.PointSpanOf(sym.location));
   if (!return_type_or) {
     return std::unexpected(std::move(return_type_or.error()));
   }
 
   hir::ProceduralBody body;
-  ProcessLowerer lowerer(module, sym);
+  ProcessLowerer lowerer(unit_lowerer, sym);
   lowerer.AnalyzeLifetimeExtended(sym.getBody());
 
   // Open the root lexical scope accumulators for this subroutine body. The
@@ -215,7 +215,7 @@ auto LowerSubroutineDecl(
   std::vector<hir::SubroutineParam> params;
   params.reserve(sym.getArguments().size());
   for (const auto* formal : sym.getArguments()) {
-    auto formal_type_or = module.InternType(
+    auto formal_type_or = unit_lowerer.InternType(
         formal->getType(), mapper.PointSpanOf(formal->location));
     if (!formal_type_or) {
       return std::unexpected(std::move(formal_type_or.error()));
@@ -265,9 +265,9 @@ auto LowerSubroutineDecl(
 // re-derived downstream. Input-only scalar functions are accepted; the
 // remaining forms are located diagnostics.
 auto LowerForeignImport(
-    ModuleLowerer& module, const slang::ast::SubroutineSymbol& sym)
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
     -> diag::Result<hir::ForeignImportDecl> {
-  const auto& mapper = module.SourceMapper();
+  const auto& mapper = unit_lowerer.SourceMapper();
   const auto loc = mapper.PointSpanOf(sym.location);
   if (sym.subroutineKind == slang::ast::SubroutineKind::Task) {
     return diag::Fail(
@@ -281,7 +281,7 @@ auto LowerForeignImport(
   }
   auto ret_abi = ClassifyDpiScalarResult(sym.getReturnType(), loc);
   if (!ret_abi) return std::unexpected(std::move(ret_abi.error()));
-  auto ret_type = module.InternType(sym.getReturnType(), loc);
+  auto ret_type = unit_lowerer.InternType(sym.getReturnType(), loc);
   if (!ret_type) return std::unexpected(std::move(ret_type.error()));
 
   std::vector<hir::DpiParamAbi> abi_params;
@@ -292,7 +292,7 @@ auto LowerForeignImport(
     if (!direction) return std::unexpected(std::move(direction.error()));
     auto carrier = ClassifyDpiCarrier(formal->getType(), floc);
     if (!carrier) return std::unexpected(std::move(carrier.error()));
-    auto param_type = module.InternType(formal->getType(), floc);
+    auto param_type = unit_lowerer.InternType(formal->getType(), floc);
     if (!param_type) return std::unexpected(std::move(param_type.error()));
     abi_params.push_back(
         hir::DpiParamAbi{

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -28,9 +28,9 @@
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -59,10 +59,10 @@ auto LowerRange(const slang::ConstantRange& r) -> hir::PackedRange {
 // bit (LRM 7.4.1); `form` records the syntactic origin (`int` vs the equivalent
 // `bit signed [31:0]`).
 auto LowerPredefinedInteger(
-    const ModuleLowerer& module, slang::ast::PredefinedIntegerType::Kind k)
+    const UnitLowerer& unit_lowerer, slang::ast::PredefinedIntegerType::Kind k)
     -> hir::PackedArrayType {
   using SK = slang::ast::PredefinedIntegerType::Kind;
-  const auto& builtins = module.Unit().builtins;
+  const auto& builtins = unit_lowerer.Unit().builtins;
   const auto make = [&](hir::TypeId element, std::int64_t msb,
                         hir::Signedness signedness,
                         hir::PackedArrayForm form) -> hir::PackedArrayType {
@@ -107,10 +107,10 @@ auto LowerPredefinedInteger(
 // `TypeId`, so the nest -- and an aggregate element's identity -- is carried by
 // recursion, not flattened here.
 auto LowerExplicitPackedArray(
-    ModuleLowerer& module, const slang::ast::PackedArrayType& array,
+    UnitLowerer& unit_lowerer, const slang::ast::PackedArrayType& array,
     bool outer_signed, diag::SourceSpan span)
     -> diag::Result<hir::PackedArrayType> {
-  auto element = module.InternType(array.elementType, span);
+  auto element = unit_lowerer.InternType(array.elementType, span);
   if (!element) return std::unexpected(std::move(element.error()));
   return hir::PackedArrayType{
       .dim = LowerRange(array.range),
@@ -123,11 +123,11 @@ auto LowerExplicitPackedArray(
 
 auto LowerPackedStruct(
     const slang::ast::PackedStructType& struct_type, diag::SourceSpan decl_span,
-    ModuleLowerer& module) -> diag::Result<hir::PackedStructType> {
+    UnitLowerer& unit_lowerer) -> diag::Result<hir::PackedStructType> {
   std::vector<hir::PackedAggregateField> fields;
   for (const auto& field :
        struct_type.membersOfType<slang::ast::FieldSymbol>()) {
-    auto field_type_or = module.InternType(field.getType(), decl_span);
+    auto field_type_or = unit_lowerer.InternType(field.getType(), decl_span);
     if (!field_type_or) {
       return std::unexpected(std::move(field_type_or.error()));
     }
@@ -151,7 +151,7 @@ auto LowerPackedStruct(
 
 auto LowerPackedUnion(
     const slang::ast::PackedUnionType& union_type, diag::SourceSpan decl_span,
-    ModuleLowerer& module) -> diag::Result<hir::PackedUnionType> {
+    UnitLowerer& unit_lowerer) -> diag::Result<hir::PackedUnionType> {
   if (union_type.isTagged) {
     return diag::Fail(
         decl_span, diag::DiagCode::kUnsupportedTaggedPackedUnion,
@@ -160,7 +160,7 @@ auto LowerPackedUnion(
   std::vector<hir::PackedAggregateField> fields;
   for (const auto& field :
        union_type.membersOfType<slang::ast::FieldSymbol>()) {
-    auto field_type_or = module.InternType(field.getType(), decl_span);
+    auto field_type_or = unit_lowerer.InternType(field.getType(), decl_span);
     if (!field_type_or) {
       return std::unexpected(std::move(field_type_or.error()));
     }
@@ -206,12 +206,12 @@ auto LowerMemberDefault(
 
 auto LowerUnpackedAggregateFields(
     std::span<const slang::ast::FieldSymbol* const> fields,
-    diag::SourceSpan decl_span, ModuleLowerer& module)
+    diag::SourceSpan decl_span, UnitLowerer& unit_lowerer)
     -> diag::Result<std::vector<hir::UnpackedAggregateField>> {
   std::vector<hir::UnpackedAggregateField> out;
   out.reserve(fields.size());
   for (const auto* field : fields) {
-    auto field_type_or = module.InternType(field->getType(), decl_span);
+    auto field_type_or = unit_lowerer.InternType(field->getType(), decl_span);
     if (!field_type_or) {
       return std::unexpected(std::move(field_type_or.error()));
     }
@@ -231,17 +231,17 @@ auto LowerUnpackedAggregateFields(
 
 auto LowerUnpackedStruct(
     const slang::ast::UnpackedStructType& struct_type,
-    diag::SourceSpan decl_span, ModuleLowerer& module)
+    diag::SourceSpan decl_span, UnitLowerer& unit_lowerer)
     -> diag::Result<hir::UnpackedStructType> {
   auto fields_or =
-      LowerUnpackedAggregateFields(struct_type.fields, decl_span, module);
+      LowerUnpackedAggregateFields(struct_type.fields, decl_span, unit_lowerer);
   if (!fields_or) return std::unexpected(std::move(fields_or.error()));
   return hir::UnpackedStructType{.fields = *std::move(fields_or)};
 }
 
 auto LowerUnpackedUnion(
     const slang::ast::UnpackedUnionType& union_type, diag::SourceSpan decl_span,
-    ModuleLowerer& module) -> diag::Result<hir::UnpackedUnionType> {
+    UnitLowerer& unit_lowerer) -> diag::Result<hir::UnpackedUnionType> {
   // A tagged union (LRM 7.3.2) is a type-checked sum type, a separate concept
   // from the untagged overlapping-storage form; reject it here where the
   // declaration span is available, so MIR translation only ever sees untagged
@@ -252,7 +252,7 @@ auto LowerUnpackedUnion(
         "tagged unions are not yet supported");
   }
   auto fields_or =
-      LowerUnpackedAggregateFields(union_type.fields, decl_span, module);
+      LowerUnpackedAggregateFields(union_type.fields, decl_span, unit_lowerer);
   if (!fields_or) return std::unexpected(std::move(fields_or.error()));
   return hir::UnpackedUnionType{
       .fields = *std::move(fields_or),
@@ -262,8 +262,8 @@ auto LowerUnpackedUnion(
 
 auto LowerEnum(
     const slang::ast::EnumType& enum_type, diag::SourceSpan decl_span,
-    ModuleLowerer& module) -> diag::Result<hir::EnumType> {
-  auto base_id_or = module.InternType(enum_type.baseType, decl_span);
+    UnitLowerer& unit_lowerer) -> diag::Result<hir::EnumType> {
+  auto base_id_or = unit_lowerer.InternType(enum_type.baseType, decl_span);
   if (!base_id_or) return std::unexpected(std::move(base_id_or.error()));
   std::vector<hir::EnumMember> members;
   for (const auto& value_sym : enum_type.values()) {
@@ -284,7 +284,7 @@ auto LowerEnum(
 }
 
 auto TranslateTypeData(
-    ModuleLowerer& module, const slang::ast::Type& type,
+    UnitLowerer& unit_lowerer, const slang::ast::Type& type,
     diag::SourceSpan decl_span) -> diag::Result<hir::TypeData> {
   const auto& canonical = type.getCanonicalType();
 
@@ -296,11 +296,12 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::PredefinedIntegerType: {
       const auto& pi = canonical.as<slang::ast::PredefinedIntegerType>();
-      return hir::TypeData{LowerPredefinedInteger(module, pi.integerKind)};
+      return hir::TypeData{
+          LowerPredefinedInteger(unit_lowerer, pi.integerKind)};
     }
     case slang::ast::SymbolKind::PackedArrayType: {
       auto pa = LowerExplicitPackedArray(
-          module, canonical.as<slang::ast::PackedArrayType>(),
+          unit_lowerer, canonical.as<slang::ast::PackedArrayType>(),
           canonical.isSigned(), decl_span);
       if (!pa.has_value()) {
         return std::unexpected(std::move(pa.error()));
@@ -308,8 +309,8 @@ auto TranslateTypeData(
       return hir::TypeData{*std::move(pa)};
     }
     case slang::ast::SymbolKind::EnumType: {
-      auto e =
-          LowerEnum(canonical.as<slang::ast::EnumType>(), decl_span, module);
+      auto e = LowerEnum(
+          canonical.as<slang::ast::EnumType>(), decl_span, unit_lowerer);
       if (!e.has_value()) {
         return std::unexpected(std::move(e.error()));
       }
@@ -336,8 +337,8 @@ auto TranslateTypeData(
     case slang::ast::SymbolKind::NullType:
       return hir::TypeData{hir::NullType{}};
     case slang::ast::SymbolKind::ClassType: {
-      auto class_id_or =
-          module.InternClass(canonical.as<slang::ast::ClassType>(), decl_span);
+      auto class_id_or = unit_lowerer.InternClass(
+          canonical.as<slang::ast::ClassType>(), decl_span);
       if (!class_id_or) {
         return std::unexpected(std::move(class_id_or.error()));
       }
@@ -347,7 +348,8 @@ auto TranslateTypeData(
       return hir::TypeData{hir::VoidType{}};
     case slang::ast::SymbolKind::PackedStructType: {
       auto s = LowerPackedStruct(
-          canonical.as<slang::ast::PackedStructType>(), decl_span, module);
+          canonical.as<slang::ast::PackedStructType>(), decl_span,
+          unit_lowerer);
       if (!s.has_value()) {
         return std::unexpected(std::move(s.error()));
       }
@@ -355,7 +357,7 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::PackedUnionType: {
       auto u = LowerPackedUnion(
-          canonical.as<slang::ast::PackedUnionType>(), decl_span, module);
+          canonical.as<slang::ast::PackedUnionType>(), decl_span, unit_lowerer);
       if (!u.has_value()) {
         return std::unexpected(std::move(u.error()));
       }
@@ -363,7 +365,7 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::FixedSizeUnpackedArrayType: {
       const auto& fa = canonical.as<slang::ast::FixedSizeUnpackedArrayType>();
-      auto elem_id_or = module.InternType(fa.elementType, decl_span);
+      auto elem_id_or = unit_lowerer.InternType(fa.elementType, decl_span);
       if (!elem_id_or) {
         return std::unexpected(std::move(elem_id_or.error()));
       }
@@ -377,7 +379,7 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::DynamicArrayType: {
       const auto& da = canonical.as<slang::ast::DynamicArrayType>();
-      auto elem_id_or = module.InternType(da.elementType, decl_span);
+      auto elem_id_or = unit_lowerer.InternType(da.elementType, decl_span);
       if (!elem_id_or) {
         return std::unexpected(std::move(elem_id_or.error()));
       }
@@ -385,7 +387,7 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::QueueType: {
       const auto& q = canonical.as<slang::ast::QueueType>();
-      auto elem_id_or = module.InternType(q.elementType, decl_span);
+      auto elem_id_or = unit_lowerer.InternType(q.elementType, decl_span);
       if (!elem_id_or) {
         return std::unexpected(std::move(elem_id_or.error()));
       }
@@ -400,7 +402,7 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::AssociativeArrayType: {
       const auto& aa = canonical.as<slang::ast::AssociativeArrayType>();
-      auto elem_id_or = module.InternType(aa.elementType, decl_span);
+      auto elem_id_or = unit_lowerer.InternType(aa.elementType, decl_span);
       if (!elem_id_or) {
         return std::unexpected(std::move(elem_id_or.error()));
       }
@@ -410,7 +412,7 @@ auto TranslateTypeData(
       if (aa.indexType == nullptr) {
         return hir::TypeData{hir::AssociativeArrayType{
             .element_type = *elem_id_or,
-            .key_type = module.Unit().builtins.wildcard_index,
+            .key_type = unit_lowerer.Unit().builtins.wildcard_index,
         }};
       }
       // A declared index covers string (LRM 7.8.2), integral, which includes a
@@ -424,7 +426,7 @@ auto TranslateTypeData(
             "associative arrays are only supported with a string, integral, "
             "chandle, or wildcard index type");
       }
-      auto key_id_or = module.InternType(*aa.indexType, decl_span);
+      auto key_id_or = unit_lowerer.InternType(*aa.indexType, decl_span);
       if (!key_id_or) {
         return std::unexpected(std::move(key_id_or.error()));
       }
@@ -435,13 +437,15 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::UnpackedStructType: {
       auto s = LowerUnpackedStruct(
-          canonical.as<slang::ast::UnpackedStructType>(), decl_span, module);
+          canonical.as<slang::ast::UnpackedStructType>(), decl_span,
+          unit_lowerer);
       if (!s) return std::unexpected(std::move(s.error()));
       return hir::TypeData{*std::move(s)};
     }
     case slang::ast::SymbolKind::UnpackedUnionType: {
       auto u = LowerUnpackedUnion(
-          canonical.as<slang::ast::UnpackedUnionType>(), decl_span, module);
+          canonical.as<slang::ast::UnpackedUnionType>(), decl_span,
+          unit_lowerer);
       if (!u) return std::unexpected(std::move(u.error()));
       return hir::TypeData{*std::move(u)};
     }
@@ -476,7 +480,7 @@ auto SynthesizeDefaultConstructor(hir::TypeId void_type, diag::SourceSpan span)
 
 }  // namespace
 
-auto ModuleLowerer::InternClass(
+auto UnitLowerer::InternClass(
     const slang::ast::ClassType& cls, diag::SourceSpan span)
     -> diag::Result<hir::ClassId> {
   if (const auto it = class_cache_.find(&cls); it != class_cache_.end()) {
@@ -600,11 +604,11 @@ auto ModuleLowerer::InternClass(
   return id;
 }
 
-auto ModuleLowerer::AddComposedType(hir::TypeData data) -> hir::TypeId {
+auto UnitLowerer::AddComposedType(hir::TypeData data) -> hir::TypeId {
   return unit_.types.Add(hir::Type{.data = std::move(data)});
 }
 
-auto ModuleLowerer::InternType(
+auto UnitLowerer::InternType(
     const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<hir::TypeId> {
   const auto* canonical = &type.getCanonicalType();

--- a/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
@@ -1,4 +1,4 @@
-#include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
 #include <algorithm>
 #include <cstdint>
@@ -26,26 +26,26 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
+#include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/instance_array_shape.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
-#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
-ModuleLowerer::ModuleLowerer(
-    const LoweringFacts& facts, const slang::ast::InstanceBodySymbol& body)
-    : facts_(facts), body_(&body), unit_{SpecializationName(body)} {
+UnitLowerer::UnitLowerer(
+    const LoweringFacts& facts, const slang::ast::Scope& scope,
+    std::string name)
+    : facts_(facts), scope_(&scope), unit_{std::move(name)} {
 }
 
-auto ModuleLowerer::Run() -> diag::Result<hir::ModuleUnit> {
+auto UnitLowerer::Run() -> diag::Result<hir::CompilationUnit> {
   WalkFrame frame;
-  DeclareStructuralIdentities(*body_);
-  StructuralScopeLowerer root(*this, *body_);
+  DeclareStructuralIdentities(*scope_);
+  StructuralScopeLowerer root(*this, *scope_);
   auto root_scope_or = root.Run(frame);
   if (!root_scope_or) {
     return std::unexpected(std::move(root_scope_or.error()));
@@ -54,16 +54,15 @@ auto ModuleLowerer::Run() -> diag::Result<hir::ModuleUnit> {
   return std::move(unit_);
 }
 
-auto ModuleLowerer::NextScopeFrameId() -> ScopeFrameId {
+auto UnitLowerer::NextScopeFrameId() -> ScopeFrameId {
   return ScopeFrameId{.value = next_scope_frame_++};
 }
 
-auto ModuleLowerer::NextWithClauseId() -> hir::WithClauseId {
+auto UnitLowerer::NextWithClauseId() -> hir::WithClauseId {
   return hir::WithClauseId{.value = next_with_clause_++};
 }
 
-void ModuleLowerer::DeclareStructuralIdentities(
-    const slang::ast::Scope& scope) {
+void UnitLowerer::DeclareStructuralIdentities(const slang::ast::Scope& scope) {
   const ScopeFrameId frame = NextScopeFrameId();
   scope_frames_.emplace(&scope, frame);
   // A generate or instance owned-child id is the source-order position of that
@@ -126,18 +125,18 @@ void ModuleLowerer::DeclareStructuralIdentities(
   }
 }
 
-auto ModuleLowerer::LookupScopeFrame(const slang::ast::Scope& scope) const
+auto UnitLowerer::LookupScopeFrame(const slang::ast::Scope& scope) const
     -> ScopeFrameId {
   const auto it = scope_frames_.find(&scope);
   if (it == scope_frames_.end()) {
     throw InternalError(
-        "ModuleLowerer::LookupScopeFrame: scope frame was not declared before "
+        "UnitLowerer::LookupScopeFrame: scope frame was not declared before "
         "body lowering");
   }
   return it->second;
 }
 
-void ModuleLowerer::MapStructuralDataObjectBinding(
+void UnitLowerer::MapStructuralDataObjectBinding(
     const slang::ast::ValueSymbol& var, ScopeFrameId home_frame,
     hir::StructuralDataObjectId local, hir::TypeId type) {
   const auto [_, inserted] = structural_data_object_bindings_.emplace(
@@ -145,12 +144,12 @@ void ModuleLowerer::MapStructuralDataObjectBinding(
                 .home_frame = home_frame, .var_id = local, .type = type});
   if (!inserted) {
     throw InternalError(
-        "ModuleLowerer::MapStructuralDataObjectBinding: structural data object "
+        "UnitLowerer::MapStructuralDataObjectBinding: structural data object "
         "already mapped");
   }
 }
 
-auto ModuleLowerer::LookupStructuralDataObjectBinding(
+auto UnitLowerer::LookupStructuralDataObjectBinding(
     const slang::ast::ValueSymbol& var) const
     -> std::optional<StructuralDataObjectBinding> {
   const auto it = structural_data_object_bindings_.find(&var);
@@ -160,7 +159,7 @@ auto ModuleLowerer::LookupStructuralDataObjectBinding(
   return it->second;
 }
 
-void ModuleLowerer::MapSubroutineBinding(
+void UnitLowerer::MapSubroutineBinding(
     const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
     hir::StructuralSubroutineId local) {
   const auto [_, inserted] = subroutine_bindings_.emplace(
@@ -168,12 +167,12 @@ void ModuleLowerer::MapSubroutineBinding(
       SubroutineBinding{.owner_frame = owner_frame, .subroutine_id = local});
   if (!inserted) {
     throw InternalError(
-        "ModuleLowerer::MapSubroutineBinding: subroutine symbol already "
+        "UnitLowerer::MapSubroutineBinding: subroutine symbol already "
         "mapped");
   }
 }
 
-auto ModuleLowerer::LookupSubroutineBinding(
+auto UnitLowerer::LookupSubroutineBinding(
     const slang::ast::SubroutineSymbol& sym) const
     -> std::optional<SubroutineBinding> {
   const auto it = subroutine_bindings_.find(&sym);
@@ -183,7 +182,7 @@ auto ModuleLowerer::LookupSubroutineBinding(
   return it->second;
 }
 
-void ModuleLowerer::MapForeignImportBinding(
+void UnitLowerer::MapForeignImportBinding(
     const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
     hir::ForeignImportId import_id) {
   const auto [_, inserted] = foreign_import_bindings_.emplace(
@@ -191,12 +190,12 @@ void ModuleLowerer::MapForeignImportBinding(
       ForeignImportBinding{.owner_frame = owner_frame, .import_id = import_id});
   if (!inserted) {
     throw InternalError(
-        "ModuleLowerer::MapForeignImportBinding: DPI import symbol already "
+        "UnitLowerer::MapForeignImportBinding: DPI import symbol already "
         "mapped");
   }
 }
 
-auto ModuleLowerer::LookupForeignImportBinding(
+auto UnitLowerer::LookupForeignImportBinding(
     const slang::ast::SubroutineSymbol& sym) const
     -> std::optional<ForeignImportBinding> {
   const auto it = foreign_import_bindings_.find(&sym);
@@ -206,7 +205,7 @@ auto ModuleLowerer::LookupForeignImportBinding(
   return it->second;
 }
 
-void ModuleLowerer::MapOwnedChildBinding(
+void UnitLowerer::MapOwnedChildBinding(
     const slang::ast::Symbol& child, ScopeFrameId home_frame,
     hir::DownwardHead head) {
   const auto [_, inserted] = owned_child_bindings_.emplace(
@@ -214,12 +213,12 @@ void ModuleLowerer::MapOwnedChildBinding(
       OwnedChildBinding{.home_frame = home_frame, .head = std::move(head)});
   if (!inserted) {
     throw InternalError(
-        "ModuleLowerer::MapOwnedChildBinding: owned child already mapped");
+        "UnitLowerer::MapOwnedChildBinding: owned child already mapped");
   }
 }
 
-auto ModuleLowerer::LookupOwnedChildBinding(
-    const slang::ast::Symbol& child) const -> std::optional<OwnedChildBinding> {
+auto UnitLowerer::LookupOwnedChildBinding(const slang::ast::Symbol& child) const
+    -> std::optional<OwnedChildBinding> {
   const auto it = owned_child_bindings_.find(&child);
   if (it == owned_child_bindings_.end()) {
     return std::nullopt;
@@ -254,7 +253,7 @@ auto TargetNetType(const slang::ast::ValueSymbol& target)
 
 }  // namespace
 
-auto ModuleLowerer::MapOrGetRoutedRef(
+auto UnitLowerer::MapOrGetRoutedRef(
     const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
     hir::RoutedRefHead head, std::vector<hir::PathSegment> path,
     hir::TypeId type) -> hir::RoutedRefId {
@@ -273,7 +272,7 @@ auto ModuleLowerer::MapOrGetRoutedRef(
   return id;
 }
 
-auto ModuleLowerer::TakeRoutedRefsForFrame(ScopeFrameId slot_owner_frame)
+auto UnitLowerer::TakeRoutedRefsForFrame(ScopeFrameId slot_owner_frame)
     -> std::vector<hir::RoutedRefDecl> {
   const auto it = routed_refs_by_frame_.find(slot_owner_frame);
   if (it == routed_refs_by_frame_.end()) {
@@ -284,7 +283,7 @@ auto ModuleLowerer::TakeRoutedRefsForFrame(ScopeFrameId slot_owner_frame)
   return out;
 }
 
-auto ModuleLowerer::MakeRoutedMemberRef(
+auto UnitLowerer::MakeRoutedMemberRef(
     const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
     hir::RoutedRefHead head, std::vector<hir::PathSegment> path,
     hir::TypeId type, diag::SourceSpan span) -> hir::Expr {
@@ -297,7 +296,7 @@ auto ModuleLowerer::MakeRoutedMemberRef(
   };
 }
 
-auto ModuleLowerer::TranslateReferenceRoute(
+auto UnitLowerer::TranslateReferenceRoute(
     const WalkFrame& frame, const slang::ast::ValueSymbol& value)
     -> std::optional<hir::ReferenceRoute> {
   // Only a variable or a net is an addressable, observable signal. A genvar or
@@ -446,7 +445,7 @@ auto ModuleLowerer::TranslateReferenceRoute(
   return std::nullopt;
 }
 
-auto ModuleLowerer::TranslateSensitivityReads(
+auto UnitLowerer::TranslateSensitivityReads(
     const std::vector<SensitivityRead>& reads, const WalkFrame& frame)
     -> std::vector<hir::SensitivityEntry> {
   std::vector<hir::SensitivityEntry> out;

--- a/src/lyra/lowering/hir_to_mir/case_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/case_cascade.cpp
@@ -8,12 +8,12 @@
 namespace lyra::lowering::hir_to_mir {
 
 auto AppendCaseSnapshot(
-    const ModuleLowerer& module, WalkFrame frame, mir::ExprId cond_expr_id)
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::ExprId cond_expr_id)
     -> CaseSnapshotRefs {
   auto& wrapper = *frame.current_block;
   const mir::TypeId sel_type = wrapper.exprs.Get(cond_expr_id).type;
   const mir::LocalId sel_var = SnapshotExprToLocal(
-      module, frame, wrapper, "_lyra_case_sel", sel_type, cond_expr_id);
+      unit_lowerer, frame, wrapper, "_lyra_case_sel", sel_type, cond_expr_id);
   return CaseSnapshotRefs{.sel_var = sel_var, .sel_type = sel_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -31,10 +31,10 @@
 namespace lyra::lowering::hir_to_mir {
 
 auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
-  ModuleLowerer& module = *module_;
+  UnitLowerer& unit_lowerer = *owner_;
   const hir::ClassDecl& hir_class = *hir_class_;
 
-  const mir::TypeId self_pointer_type = module.Unit().types.PointerTo(
+  const mir::TypeId self_pointer_type = unit_lowerer.Unit().types.PointerTo(
       object_type_, mir::PointerOwnership::kBorrowed);
 
   // An SV class extends another SV class of this unit; the base identity is
@@ -42,7 +42,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   std::optional<mir::ClassRef> base_ref;
   if (hir_class.base.has_value()) {
     base_ref = mir::ClassRef{mir::IntraUnitClassRef{
-        .class_id = module.TranslateClass(*hir_class.base)}};
+        .class_id = unit_lowerer.TranslateClass(*hir_class.base)}};
   }
 
   mir::Class mir_class{
@@ -66,7 +66,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   // declaration-ordered SV method -- each SV method keeps its natural
   // declaration index.
   mir::CallableCode ctor_code;
-  CallableBindings ctor_bindings(module.Unit(), ctor_code);
+  CallableBindings ctor_bindings(unit_lowerer.Unit(), ctor_code);
   const mir::LocalId self_id = ctor_bindings.Declare(
       BindingOriginId::Receiver(),
       mir::LocalDecl{.name = "self", .type = self_pointer_type});
@@ -86,7 +86,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   field_ids.reserve(hir_class.fields.size());
   field_types.reserve(hir_class.fields.size());
   for (const auto& field : hir_class.fields) {
-    const mir::TypeId field_type = module.TranslateType(field.type);
+    const mir::TypeId field_type = unit_lowerer.TranslateType(field.type);
     field_ids.push_back(mir_class.fields.Add(
         mir::FieldDecl{.name = field.name, .type = field_type}));
     field_types.push_back(field_type);
@@ -117,7 +117,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
       }
       const std::string mangled =
           std::format("{}__{}_{}", callable_name, v.name, j);
-      const mir::TypeId type = module.TranslateType(v.type);
+      const mir::TypeId type = unit_lowerer.TranslateType(v.type);
       const mir::FieldId mid =
           mir_class.fields.Add(mir::FieldDecl{.name = mangled, .type = type});
       placements[j] = StaticStoragePlacement{
@@ -137,7 +137,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   const CallableStoragePlan ctor_plan(
       class_scopes, plan_static_storage("<ctor>", ctor.body));
   ProcessLowerer ctor_lowerer(
-      module, nullptr, mir_class.time_resolution, ctor.body, "<ctor>",
+      unit_lowerer, nullptr, mir_class.time_resolution, ctor.body, "<ctor>",
       mir::MethodVisibility::kInternal, frame, ctor_plan);
 
   // Initialize each property in declaration order before the constructor body
@@ -156,7 +156,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
       value_id = ctor_block.exprs.Add(*std::move(value_or));
     } else {
       value_id = ctor_block.exprs.Add(
-          BuildDefaultValueFromHir(module, frame, field.type));
+          BuildDefaultValueFromHir(unit_lowerer, frame, field.type));
     }
     const mir::ExprId self_ref =
         ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_pointer_type));
@@ -183,8 +183,9 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
     const WalkFrame method_owner_frame =
         WalkFrame{}.WithClass(&mir_class, class_id_, method_link);
     ProcessLowerer method_lowerer(
-        module, nullptr, mir_class.time_resolution, method.body, method.name,
-        mir::MethodVisibility::kPublic, method_owner_frame, method_plans[i]);
+        unit_lowerer, nullptr, mir_class.time_resolution, method.body,
+        method.name, mir::MethodVisibility::kPublic, method_owner_frame,
+        method_plans[i]);
     auto method_or = method_lowerer.Run(method);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     mir_class.methods.Add(*std::move(method_or));
@@ -212,7 +213,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   }
 
   ctor_code.params = std::move(ctor_params);
-  ctor_code.result_type = module.Unit().builtins.void_type;
+  ctor_code.result_type = unit_lowerer.Unit().builtins.void_type;
   const mir::MethodId ctor_method_id = mir_class.methods.Add(
       mir::MethodDecl{
           .name = "<ctor>",

--- a/src/lyra/lowering/hir_to_mir/completion_payload.cpp
+++ b/src/lyra/lowering/hir_to_mir/completion_payload.cpp
@@ -8,17 +8,17 @@
 namespace lyra::lowering::hir_to_mir {
 
 auto CompletionComponentTypes(
-    const ModuleLowerer& module, const hir::SubroutineDecl& decl)
+    const UnitLowerer& unit_lowerer, const hir::SubroutineDecl& decl)
     -> std::vector<mir::TypeId> {
   std::vector<mir::TypeId> components;
   if (decl.result_var.has_value()) {
-    components.push_back(module.TranslateType(decl.result_type));
+    components.push_back(unit_lowerer.TranslateType(decl.result_type));
   }
   for (const auto& param : decl.params) {
     if (param.direction == hir::ParamDirection::kOutput ||
         param.direction == hir::ParamDirection::kInOut) {
-      components.push_back(
-          module.TranslateType(decl.body.procedural_vars.Get(param.var).type));
+      components.push_back(unit_lowerer.TranslateType(
+          decl.body.procedural_vars.Get(param.var).type));
     }
   }
   return components;

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -49,7 +49,7 @@ struct ResolvedNetLhs {
 auto ClassifyLhsAsResolvedNet(
     const StructuralScopeLowerer& lowerer, const WalkFrame& frame,
     hir::ExprId lhs_id) -> std::optional<ResolvedNetLhs> {
-  const mir::CompilationUnit& unit = lowerer.Module().Unit();
+  const mir::CompilationUnit& unit = lowerer.Owner().Unit();
   const auto* prim =
       std::get_if<hir::PrimaryExpr>(&lowerer.HirScope().exprs.Get(lhs_id).data);
   if (prim == nullptr) return std::nullopt;
@@ -93,7 +93,7 @@ auto AttachDriver(
     mir::TypeId value_type, const std::string& driver_name, hir::ExprId source,
     const WalkFrame& resolve_frame, const WalkFrame& init_frame)
     -> diag::Result<AttachedDriver> {
-  mir::CompilationUnit& unit = lowerer.Module().Unit();
+  mir::CompilationUnit& unit = lowerer.Owner().Unit();
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   mir::Class& mir_class = *resolve_frame.current_class;
   const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
@@ -167,7 +167,7 @@ auto LowerContinuousAssign(
     const WalkFrame& resolve_frame, const WalkFrame& init_frame,
     std::string name, const hir::ContinuousAssign& src,
     ContinuousAssignDrivenNets& driven_nets) -> diag::Result<mir::MethodDecl> {
-  mir::CompilationUnit& unit = lowerer.Module().Unit();
+  mir::CompilationUnit& unit = lowerer.Owner().Unit();
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   const mir::TypeId self_ptr_type = ctor_frame.current_class->self_pointer_type;
 

--- a/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
+++ b/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
@@ -31,7 +31,7 @@ auto BuildOutputArgSlot(
   auto target_or = proc.LowerLhsExpr(hir_body.exprs.Get(actual_hir), frame);
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   const mir::TypeId actual_type =
-      proc.Module().TranslateType(hir_body.exprs.Get(actual_hir).type);
+      proc.Owner().TranslateType(hir_body.exprs.Get(actual_hir).type);
   const mir::ExprId actual_id = wrapper.exprs.Add(*std::move(target_or));
   auto value_or = proc.LowerExpr(hir_body.exprs.Get(actual_hir), frame);
   if (!value_or) return std::unexpected(std::move(value_or.error()));

--- a/src/lyra/lowering/hir_to_mir/declaration_initializer.cpp
+++ b/src/lyra/lowering/hir_to_mir/declaration_initializer.cpp
@@ -18,7 +18,7 @@ auto IntegratePendingStaticInitializer(
     const WalkFrame& init_frame, const PendingStaticInitializer& pending)
     -> diag::Result<void> {
   auto& init_block = *init_frame.current_block;
-  const mir::CompilationUnit& unit = process.Module().Unit();
+  const mir::CompilationUnit& unit = process.Owner().Unit();
   const mir::TypeId self_ptr_type = init_frame.current_class->self_pointer_type;
 
   const mir::ExprId target = init_block.exprs.Add(
@@ -33,7 +33,7 @@ auto IntegratePendingStaticInitializer(
   // and needs no Set.
   if (target_is_observable_cell) {
     const mir::ExprId prototype = init_block.exprs.Add(BuildDefaultValueFromHir(
-        process.Module(), init_frame, pending.hir_type));
+        process.Owner(), init_frame, pending.hir_type));
     init_block.AppendStmt(
         mir::ExprStmt{
             .expr = init_block.exprs.Add(
@@ -52,7 +52,7 @@ auto IntegratePendingStaticInitializer(
     init_value = init_block.exprs.Add(*std::move(init_or));
   } else {
     init_value = init_block.exprs.Add(BuildDefaultValueFromHir(
-        process.Module(), init_frame, pending.hir_type));
+        process.Owner(), init_frame, pending.hir_type));
   }
 
   const mir::ExprId services_self_read =

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -55,12 +55,12 @@ namespace {
 // default prototype (honoring its own member inits) plus the element list.
 // Shared by the type-default array path and the explicit-constant array path.
 auto BuildUnpackedArrayValue(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
     hir::TypeId element_type, std::vector<mir::ExprId> element_ids)
     -> mir::Expr {
   auto& block = *frame.current_block;
-  const mir::ExprId element_default =
-      block.exprs.Add(BuildDefaultValueFromHir(module, frame, element_type));
+  const mir::ExprId element_default = block.exprs.Add(
+      BuildDefaultValueFromHir(unit_lowerer, frame, element_type));
   const mir::ExprId list_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(element_ids)},
@@ -79,10 +79,10 @@ auto BuildUnpackedArrayValue(
 // construction (array) over the recursively materialized components, with the
 // type disambiguating a component list as struct members or array elements.
 auto MaterializeConstant(
-    const ModuleLowerer& module, WalkFrame frame, hir::TypeId hir_type,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, hir::TypeId hir_type,
     const hir::ConstantValue& value) -> mir::Expr {
   auto& block = *frame.current_block;
-  const mir::TypeId mir_type = module.TranslateType(hir_type);
+  const mir::TypeId mir_type = unit_lowerer.TranslateType(hir_type);
   return std::visit(
       Overloaded{
           [&](const hir::IntegralConstant& c) -> mir::Expr {
@@ -107,14 +107,14 @@ auto MaterializeConstant(
                 .type = mir_type};
           },
           [&](const std::vector<hir::ConstantValue>& components) -> mir::Expr {
-            const auto& hir_ty = module.Hir().types.Get(hir_type);
+            const auto& hir_ty = unit_lowerer.Hir().types.Get(hir_type);
             if (const auto* st =
                     std::get_if<hir::UnpackedStructType>(&hir_ty.data)) {
               std::vector<mir::ExprId> component_ids;
               component_ids.reserve(components.size());
               for (std::size_t i = 0; i < components.size(); ++i) {
                 component_ids.push_back(block.exprs.Add(MaterializeConstant(
-                    module, frame, st->fields[i].type, components[i])));
+                    unit_lowerer, frame, st->fields[i].type, components[i])));
               }
               return mir::Expr{
                   .data =
@@ -127,10 +127,10 @@ auto MaterializeConstant(
               element_ids.reserve(components.size());
               for (const auto& component : components) {
                 element_ids.push_back(block.exprs.Add(MaterializeConstant(
-                    module, frame, ua->element_type, component)));
+                    unit_lowerer, frame, ua->element_type, component)));
               }
               return BuildUnpackedArrayValue(
-                  module, frame, mir_type, ua->element_type,
+                  unit_lowerer, frame, mir_type, ua->element_type,
                   std::move(element_ids));
             }
             throw InternalError(
@@ -144,10 +144,10 @@ auto MaterializeConstant(
 }  // namespace
 
 auto BuildDefaultValueExpr(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId type)
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId type)
     -> mir::Expr {
   auto& block = *frame.current_block;
-  const auto& ty = module.Unit().types.Get(type);
+  const auto& ty = unit_lowerer.Unit().types.Get(type);
   return std::visit(
       Overloaded{
           [&](const mir::PackedArrayType& pa) -> mir::Expr {
@@ -193,10 +193,10 @@ auto BuildDefaultValueExpr(
             elements.reserve(ua.Size());
             for (std::uint64_t i = 0; i < ua.Size(); ++i) {
               elements.push_back(block.exprs.Add(
-                  BuildDefaultValueExpr(module, frame, ua.element_type)));
+                  BuildDefaultValueExpr(unit_lowerer, frame, ua.element_type)));
             }
             return BuildArrayConstructionCall(
-                module, frame, type, std::move(elements));
+                unit_lowerer, frame, type, std::move(elements));
           },
           // LRM Table 7-1: an unpacked struct defaults member-wise -- each
           // component takes its own type's default, recursively. Synthesized as
@@ -207,8 +207,8 @@ auto BuildDefaultValueExpr(
             std::vector<mir::ExprId> components;
             components.reserve(t.elements.size());
             for (const mir::TypeId elem : t.elements) {
-              components.push_back(
-                  block.exprs.Add(BuildDefaultValueExpr(module, frame, elem)));
+              components.push_back(block.exprs.Add(
+                  BuildDefaultValueExpr(unit_lowerer, frame, elem)));
             }
             return mir::Expr{
                 .data = mir::TupleExpr{.components = std::move(components)},
@@ -220,7 +220,7 @@ auto BuildDefaultValueExpr(
           // struct's member-wise default).
           [&](const mir::UnionType& u) -> mir::Expr {
             const mir::ExprId member_default = block.exprs.Add(
-                BuildDefaultValueExpr(module, frame, u.elements.front()));
+                BuildDefaultValueExpr(unit_lowerer, frame, u.elements.front()));
             return mir::Expr{
                 .data = mir::UnionExpr{.index = 0, .value = member_default},
                 .type = type};
@@ -233,7 +233,7 @@ auto BuildDefaultValueExpr(
           // `data_` empty.
           [&](const mir::DynamicArrayType& da) -> mir::Expr {
             const mir::ExprId element_default = block.exprs.Add(
-                BuildDefaultValueExpr(module, frame, da.element_type));
+                BuildDefaultValueExpr(unit_lowerer, frame, da.element_type));
             return mir::Expr{
                 .data =
                     mir::CallExpr{
@@ -246,14 +246,14 @@ auto BuildDefaultValueExpr(
           // wrapper's shield slot while storage starts empty.
           [&](const mir::QueueType& q) -> mir::Expr {
             const mir::ExprId element_default = block.exprs.Add(
-                BuildDefaultValueExpr(module, frame, q.element_type));
+                BuildDefaultValueExpr(unit_lowerer, frame, q.element_type));
             std::vector<mir::ExprId> args = {element_default};
             // LRM 7.10.5: a bounded queue `int q[$:N]` carries its max index N
             // as a second construction argument so the runtime can enforce it.
             if (q.max_bound.has_value()) {
               args.push_back(block.exprs.Add(
                   mir::MakeIntLiteral(
-                      module.Unit().builtins.int_type,
+                      unit_lowerer.Unit().builtins.int_type,
                       static_cast<std::int64_t>(*q.max_bound))));
             }
             return mir::Expr{
@@ -268,7 +268,7 @@ auto BuildDefaultValueExpr(
           // entry reads, LRM 7.8.6) while storage starts empty.
           [&](const mir::AssociativeArrayType& a) -> mir::Expr {
             const mir::ExprId element_default = block.exprs.Add(
-                BuildDefaultValueExpr(module, frame, a.element_type));
+                BuildDefaultValueExpr(unit_lowerer, frame, a.element_type));
             return mir::Expr{
                 .data =
                     mir::CallExpr{
@@ -328,11 +328,11 @@ auto BuildDefaultValueExpr(
 // element type's source default. Every other type carries no source-level
 // initializer, so its default is the canonical type default.
 auto BuildDefaultValueFromHir(
-    const ModuleLowerer& module, WalkFrame frame, hir::TypeId hir_type)
+    const UnitLowerer& unit_lowerer, WalkFrame frame, hir::TypeId hir_type)
     -> mir::Expr {
   auto& block = *frame.current_block;
-  const auto& hir_ty = module.Hir().types.Get(hir_type);
-  const mir::TypeId mir_type = module.TranslateType(hir_type);
+  const auto& hir_ty = unit_lowerer.Hir().types.Get(hir_type);
+  const mir::TypeId mir_type = unit_lowerer.TranslateType(hir_type);
 
   if (const auto* st = std::get_if<hir::UnpackedStructType>(&hir_ty.data)) {
     std::vector<mir::ExprId> components;
@@ -341,9 +341,9 @@ auto BuildDefaultValueFromHir(
       const mir::ExprId component =
           field.default_init.has_value()
               ? block.exprs.Add(MaterializeConstant(
-                    module, frame, field.type, *field.default_init))
+                    unit_lowerer, frame, field.type, *field.default_init))
               : block.exprs.Add(
-                    BuildDefaultValueFromHir(module, frame, field.type));
+                    BuildDefaultValueFromHir(unit_lowerer, frame, field.type));
       components.push_back(component);
     }
     return mir::Expr{
@@ -360,20 +360,20 @@ auto BuildDefaultValueFromHir(
     elements.reserve(size);
     for (std::uint64_t i = 0; i < size; ++i) {
       elements.push_back(block.exprs.Add(
-          BuildDefaultValueFromHir(module, frame, ua->element_type)));
+          BuildDefaultValueFromHir(unit_lowerer, frame, ua->element_type)));
     }
     return BuildUnpackedArrayValue(
-        module, frame, mir_type, ua->element_type, std::move(elements));
+        unit_lowerer, frame, mir_type, ua->element_type, std::move(elements));
   }
 
-  return BuildDefaultValueExpr(module, frame, mir_type);
+  return BuildDefaultValueExpr(unit_lowerer, frame, mir_type);
 }
 
 auto BuildArrayConstructionCall(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
     std::vector<mir::ExprId> elements) -> mir::Expr {
   auto& block = *frame.current_block;
-  const auto& ty = module.Unit().types.Get(array_type);
+  const auto& ty = unit_lowerer.Unit().types.Get(array_type);
   const mir::TypeId element_type = std::visit(
       [](const auto& t) -> mir::TypeId {
         using TyT = std::decay_t<decltype(t)>;
@@ -390,7 +390,7 @@ auto BuildArrayConstructionCall(
       },
       ty.data);
   const mir::ExprId element_default =
-      block.exprs.Add(BuildDefaultValueExpr(module, frame, element_type));
+      block.exprs.Add(BuildDefaultValueExpr(unit_lowerer, frame, element_type));
   const mir::ExprId list_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
@@ -403,7 +403,7 @@ auto BuildArrayConstructionCall(
       q != nullptr && q->max_bound.has_value()) {
     args.push_back(block.exprs.Add(
         mir::MakeIntLiteral(
-            module.Unit().builtins.int_type,
+            unit_lowerer.Unit().builtins.int_type,
             static_cast<std::int64_t>(*q->max_bound))));
   }
   return mir::Expr{
@@ -414,12 +414,12 @@ auto BuildArrayConstructionCall(
 }
 
 auto BuildAssociativeConstructionCall(
-    ModuleLowerer& module, WalkFrame frame, mir::TypeId assoc_type,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId assoc_type,
     std::vector<std::pair<mir::ExprId, mir::ExprId>> entries,
     std::optional<mir::ExprId> user_default) -> mir::Expr {
   auto& block = *frame.current_block;
   const auto* assoc = std::get_if<mir::AssociativeArrayType>(
-      &module.Unit().types.Get(assoc_type).data);
+      &unit_lowerer.Unit().types.Get(assoc_type).data);
   if (assoc == nullptr) {
     throw InternalError(
         "BuildAssociativeConstructionCall: result type is not "
@@ -428,7 +428,7 @@ auto BuildAssociativeConstructionCall(
   const mir::TypeId key_type = assoc->key_type;
   const mir::TypeId element_type = assoc->element_type;
 
-  const mir::TypeId tuple_type = module.Unit().types.Intern(
+  const mir::TypeId tuple_type = unit_lowerer.Unit().types.Intern(
       mir::TupleType{.elements = {key_type, element_type}});
   std::vector<mir::ExprId> tuple_ids;
   tuple_ids.reserve(entries.size());
@@ -438,7 +438,7 @@ auto BuildAssociativeConstructionCall(
             .data = mir::TupleExpr{.components = {key_id, value_id}},
             .type = tuple_type}));
   }
-  const mir::TypeId entries_type = module.Unit().types.Intern(
+  const mir::TypeId entries_type = unit_lowerer.Unit().types.Intern(
       mir::UnpackedArrayType{
           .element_type = tuple_type,
           .dim = mir::UnpackedRange::ZeroBased(tuple_ids.size())});
@@ -448,7 +448,7 @@ auto BuildAssociativeConstructionCall(
           .type = entries_type});
 
   const mir::ExprId element_default =
-      block.exprs.Add(BuildDefaultValueExpr(module, frame, element_type));
+      block.exprs.Add(BuildDefaultValueExpr(unit_lowerer, frame, element_type));
   std::vector<mir::ExprId> args;
   args.reserve(user_default.has_value() ? 3U : 2U);
   args.push_back(element_default);

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -107,13 +107,13 @@ struct SnapshotBinding {
 };
 
 auto SnapshotPredicate(
-    ModuleLowerer& module, WalkFrame frame, mir::Block& wrapper,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::Block& wrapper,
     std::size_t index, mir::TypeId predicate_type,
     mir::ExprId predicate_expr_id) -> SnapshotBinding {
   const BindingOriginId origin =
-      BindingOriginId::Synthesized(module.NextSynthesizedSite(), 0);
+      BindingOriginId::Synthesized(unit_lowerer.NextSynthesizedSite(), 0);
   const mir::LocalId local = SnapshotExprToLocal(
-      module, frame, wrapper, std::format("_lyra_unique_cond_{}", index),
+      unit_lowerer, frame, wrapper, std::format("_lyra_unique_cond_{}", index),
       predicate_type, predicate_expr_id, origin);
   return {.local = local, .origin = origin};
 }
@@ -187,15 +187,15 @@ auto BuildDiagnosticThenScope(
 }
 
 auto BuildUniqueCheckClosure(
-    ModuleLowerer& module, const WalkFrame& wrapper_frame,
+    UnitLowerer& unit_lowerer, const WalkFrame& wrapper_frame,
     hir::UniquePriorityCheck check,
     const std::vector<SnapshotBinding>& snapshot_vars, std::string origin)
     -> mir::Expr {
-  ClosureBuilder closure(module.Unit(), wrapper_frame);
+  ClosureBuilder closure(unit_lowerer.Unit(), wrapper_frame);
   mir::Block& body = closure.Body();
 
-  const mir::TypeId int_type = module.Unit().builtins.int_type;
-  const mir::TypeId bit1_type = module.Unit().builtins.bit1;
+  const mir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
+  const mir::TypeId bit1_type = unit_lowerer.Unit().builtins.bit1;
   const BodyBindingRef self_ref =
       closure.Bindings().EnsureCarrier(BindingOriginId::Receiver());
 
@@ -264,7 +264,7 @@ auto BuildUniqueCheckClosure(
           .type = int_type});
 
   mir::Block diag_block = BuildDiagnosticThenScope(
-      module.Unit(), closure.Bindings(), self_ref, count_var, verdict,
+      unit_lowerer.Unit(), closure.Bindings(), self_ref, count_var, verdict,
       std::move(origin));
 
   const mir::BlockId diag_scope_id =
@@ -282,14 +282,14 @@ auto BuildUniqueCheckClosure(
 }  // namespace
 
 auto BuildDeferredCheckCascade(
-    ModuleLowerer& module, WalkFrame frame, mir::Block wrapper,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::Block wrapper,
     std::vector<DeferredCheckBranch> branches,
     std::optional<mir::Block> tail_else, hir::UniquePriorityCheck check,
     std::optional<std::string> outer_label, diag::SourceSpan span)
     -> mir::Stmt {
-  const mir::TypeId void_type = module.Unit().builtins.void_type;
-  const mir::TypeId int_type = module.Unit().builtins.int_type;
-  const mir::TypeId bit1_type = module.Unit().builtins.bit1;
+  const mir::TypeId void_type = unit_lowerer.Unit().builtins.void_type;
+  const mir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
+  const mir::TypeId bit1_type = unit_lowerer.Unit().builtins.bit1;
 
   // SnapshotPredicate / BuildDefaultValueExpr append to wrapper, so route
   // through a wrapper-local frame; the cascade levels each derive their own
@@ -303,17 +303,17 @@ auto BuildDeferredCheckCascade(
     const mir::TypeId predicate_type =
         wrapper.exprs.Get(branches[i].predicate).type;
     snapshot_vars.push_back(SnapshotPredicate(
-        module, wrapper_frame, wrapper, i, predicate_type,
+        unit_lowerer, wrapper_frame, wrapper, i, predicate_type,
         branches[i].predicate));
   }
 
   mir::Expr closure = BuildUniqueCheckClosure(
-      module, wrapper_frame, check, snapshot_vars,
-      FormatRuntimeOriginString(span, module.SourceManager()));
+      unit_lowerer, wrapper_frame, check, snapshot_vars,
+      FormatRuntimeOriginString(span, unit_lowerer.SourceManager()));
   const mir::ExprId closure_expr_id = wrapper.exprs.Add(std::move(closure));
 
   const mir::DeferredCheckSiteId site_id =
-      module.Unit().AllocateDeferredCheckSiteId();
+      unit_lowerer.Unit().AllocateDeferredCheckSiteId();
   const mir::ExprId self_id = wrapper.exprs.Add(MakeSelfRefExpr(
       wrapper_frame, wrapper_frame.current_class->self_pointer_type));
   const mir::ExprId site_id_expr = wrapper.exprs.Add(
@@ -419,7 +419,7 @@ auto LowerUniqueIfStmt(
   }
 
   return BuildDeferredCheckCascade(
-      process.Module(), frame, std::move(wrapper), std::move(branches),
+      process.Owner(), frame, std::move(wrapper), std::move(branches),
       std::move(tail_scope), *root.check, std::move(label), span);
 }
 

--- a/src/lyra/lowering/hir_to_mir/endpoint.cpp
+++ b/src/lyra/lowering/hir_to_mir/endpoint.cpp
@@ -13,7 +13,7 @@ namespace lyra::lowering::hir_to_mir {
 auto BindEndpoint(
     const StructuralScopeLowerer& lowerer, const WalkFrame& frame,
     const hir::ReferenceRoute& route) -> BoundEndpoint {
-  const mir::CompilationUnit& unit = lowerer.Module().Unit();
+  const mir::CompilationUnit& unit = lowerer.Owner().Unit();
   return std::visit(
       Overloaded{
           [&](const hir::DirectMemberRef& m) -> BoundEndpoint {

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -13,9 +13,9 @@
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -47,7 +47,7 @@ auto ExtractHirLiteralUint64(const hir::Expr& expr) -> std::uint64_t {
 }
 
 auto BuildArrayReplicationFlatList(
-    const ModuleLowerer& module, WalkFrame frame,
+    const UnitLowerer& unit_lowerer, WalkFrame frame,
     std::span<const mir::ExprId> items_ids, std::uint64_t count,
     mir::TypeId result_type) -> mir::Expr {
   std::vector<mir::ExprId> flat;
@@ -56,7 +56,7 @@ auto BuildArrayReplicationFlatList(
     flat.insert(flat.end(), items_ids.begin(), items_ids.end());
   }
   return BuildArrayConstructionCall(
-      module, frame, result_type, std::move(flat));
+      unit_lowerer, frame, result_type, std::move(flat));
 }
 
 // A packed assignment pattern folds its members into one flat bit plane (LRM
@@ -103,18 +103,18 @@ auto LowerHirConcatExpr(
   // supply one) and its LRM 7.10.5 bound, built here as ordinary arguments
   // ahead of the parts. A packed or string concatenation joins its operands
   // directly and stays a value-build primitive.
-  const auto& result_ty = lowerer.Module().Unit().types.Get(result_type);
+  const auto& result_ty = lowerer.Owner().Unit().types.Get(result_type);
   if (const auto* q = std::get_if<mir::QueueType>(&result_ty.data)) {
     const mir::TypeId element_type = q->element_type;
     const std::int64_t bound = q->max_bound.has_value()
                                    ? static_cast<std::int64_t>(*q->max_bound)
                                    : -1;
     const mir::TypeId machine_int =
-        lowerer.Module().Unit().builtins.machine_int64;
+        lowerer.Owner().Unit().builtins.machine_int64;
     std::vector<mir::ExprId> args;
     args.reserve(operand_ids.size() + 2);
     args.push_back(block.exprs.Add(
-        BuildDefaultValueExpr(lowerer.Module(), frame, element_type)));
+        BuildDefaultValueExpr(lowerer.Owner(), frame, element_type)));
     args.push_back(block.exprs.Add(
         mir::Expr{
             .data = mir::MachineIntLiteral{.value = bound},
@@ -170,17 +170,17 @@ auto LowerHirAssignmentPatternExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  const auto& result_ty = lowerer.Module().Unit().types.Get(result_type);
+  const auto& result_ty = lowerer.Owner().Unit().types.Get(result_type);
   if (IsArrayContainerType(result_ty)) {
     return BuildArrayConstructionCall(
-        lowerer.Module(), frame, result_type, std::move(element_ids));
+        lowerer.Owner(), frame, result_type, std::move(element_ids));
   }
   if (std::holds_alternative<mir::TupleType>(result_ty.data)) {
     return mir::Expr{
         .data = mir::TupleExpr{.components = std::move(element_ids)},
         .type = result_type};
   }
-  mir::CompilationUnit& unit = lowerer.Module().Unit();
+  mir::CompilationUnit& unit = lowerer.Owner().Unit();
   const auto& result_pa = result_ty.AsIntegralPacked();
   const mir::ExprId concat_id = block.exprs.Add(
       mir::Expr{
@@ -203,12 +203,12 @@ auto LowerHirAssignmentPatternReplicationExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  const auto& result_ty = lowerer.Module().Unit().types.Get(result_type);
+  const auto& result_ty = lowerer.Owner().Unit().types.Get(result_type);
   if (IsArrayContainerType(result_ty)) {
     const std::uint64_t count =
         ExtractHirLiteralUint64(lowerer.HirExprs().Get(a.count));
     return BuildArrayReplicationFlatList(
-        lowerer.Module(), frame, item_ids, count, result_type);
+        lowerer.Owner(), frame, item_ids, count, result_type);
   }
   if (std::holds_alternative<mir::TupleType>(result_ty.data)) {
     const std::uint64_t count =
@@ -222,7 +222,7 @@ auto LowerHirAssignmentPatternReplicationExpr(
         .data = mir::TupleExpr{.components = std::move(components)},
         .type = result_type};
   }
-  mir::CompilationUnit& unit = lowerer.Module().Unit();
+  mir::CompilationUnit& unit = lowerer.Owner().Unit();
   const auto& result_pa = result_ty.AsIntegralPacked();
   const std::uint64_t count =
       ExtractHirLiteralUint64(lowerer.HirExprs().Get(a.count));
@@ -261,14 +261,14 @@ auto LowerHirDynamicArrayNewExprProc(
   if (!size_or) return std::unexpected(std::move(size_or.error()));
   const mir::ExprId size_id = block.exprs.Add(*std::move(size_or));
 
-  const auto& hir_result_ty = process.Module().Hir().types.Get(hir_result_type);
+  const auto& hir_result_ty = process.Owner().Hir().types.Get(hir_result_type);
   const auto* hir_da = std::get_if<hir::DynamicArrayType>(&hir_result_ty.data);
   if (hir_da == nullptr) {
     throw InternalError(
         "LowerHirDynamicArrayNewExprProc: result type is not DynamicArrayType");
   }
   const mir::ExprId prototype_id = block.exprs.Add(
-      BuildDefaultValueFromHir(process.Module(), frame, hir_da->element_type));
+      BuildDefaultValueFromHir(process.Owner(), frame, hir_da->element_type));
 
   std::vector<mir::ExprId> args;
   args.reserve(n.initializer.has_value() ? 3U : 2U);
@@ -317,7 +317,7 @@ auto LowerHirAssociativeAssignmentPatternExpr(
     user_default = block.exprs.Add(*std::move(default_or));
   }
   return BuildAssociativeConstructionCall(
-      lowerer.Module(), frame, result_type, std::move(entries), user_default);
+      lowerer.Owner(), frame, result_type, std::move(entries), user_default);
 }
 
 // One concrete instantiation per pass class. The handler templates are defined

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -18,11 +18,11 @@
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/snapshot_local.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -85,7 +85,7 @@ auto IsExprRootedAtStructuralDataObject(
 // the cell, which is the captured reference rather than a re-navigation from a
 // receiver.
 auto CloneLhsSelectorChainOntoRef(
-    ModuleLowerer& module, const WalkFrame& outer_frame,
+    UnitLowerer& unit_lowerer, const WalkFrame& outer_frame,
     ClosureBuilder& closure, mir::ExprId outer_id, mir::ExprId root_id,
     mir::ExprId captured_root) -> mir::ExprId {
   if (outer_id == root_id) {
@@ -114,11 +114,12 @@ auto CloneLhsSelectorChainOntoRef(
             std::vector<mir::ExprId> body_args;
             body_args.reserve(src_args.size());
             body_args.push_back(CloneLhsSelectorChainOntoRef(
-                module, outer_frame, closure, src_args.front(), root_id,
+                unit_lowerer, outer_frame, closure, src_args.front(), root_id,
                 captured_root));
             for (std::size_t i = 1; i < src_args.size(); ++i) {
               body_args.push_back(SnapshotIntoClosure(
-                  module, outer_frame, closure, src_args[i], "_lyra_nba_arg"));
+                  unit_lowerer, outer_frame, closure, src_args[i],
+                  "_lyra_nba_arg"));
             }
             return body.exprs.Add(
                 mir::Expr{
@@ -132,7 +133,8 @@ auto CloneLhsSelectorChainOntoRef(
             const auto index = g.index;
             const mir::TypeId type = outer_expr.type;
             const mir::ExprId base = CloneLhsSelectorChainOntoRef(
-                module, outer_frame, closure, g.tuple, root_id, captured_root);
+                unit_lowerer, outer_frame, closure, g.tuple, root_id,
+                captured_root);
             return body.exprs.Add(
                 mir::Expr{
                     .data = mir::TupleGetExpr{.tuple = base, .index = index},
@@ -142,7 +144,7 @@ auto CloneLhsSelectorChainOntoRef(
             const auto index = g.index;
             const mir::TypeId type = outer_expr.type;
             const mir::ExprId base = CloneLhsSelectorChainOntoRef(
-                module, outer_frame, closure, g.union_value, root_id,
+                unit_lowerer, outer_frame, closure, g.union_value, root_id,
                 captured_root);
             return body.exprs.Add(
                 mir::Expr{
@@ -171,10 +173,10 @@ auto CloneLhsSelectorChainOntoRef(
 // call it would build for a blocking write, only in the closure body.
 template <typename EffectFn>
 auto BuildDeferredAssignClosure(
-    ModuleLowerer& module, WalkFrame frame, mir::ExprId target_in_outer,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::ExprId target_in_outer,
     std::span<const mir::ExprId> operands_in_outer, EffectFn effect_fn)
     -> mir::Expr {
-  mir::CompilationUnit& unit = module.Unit();
+  mir::CompilationUnit& unit = unit_lowerer.Unit();
   mir::Block& outer_block = *frame.current_block;
 
   ClosureBuilder closure(unit, frame);
@@ -190,17 +192,18 @@ auto BuildDeferredAssignClosure(
   const mir::ExprId place_ref = BuildReferenceArg(
       unit, outer_block, root_in_outer,
       outer_block.exprs.Get(root_in_outer).type);
-  const mir::ExprId captured_root =
-      SnapshotIntoClosure(module, frame, closure, place_ref, "_lyra_nba_place");
+  const mir::ExprId captured_root = SnapshotIntoClosure(
+      unit_lowerer, frame, closure, place_ref, "_lyra_nba_place");
 
   const mir::ExprId body_target = CloneLhsSelectorChainOntoRef(
-      module, frame, closure, target_in_outer, root_in_outer, captured_root);
+      unit_lowerer, frame, closure, target_in_outer, root_in_outer,
+      captured_root);
 
   std::vector<mir::ExprId> body_operands;
   body_operands.reserve(operands_in_outer.size());
   for (const mir::ExprId op : operands_in_outer) {
     body_operands.push_back(
-        SnapshotIntoClosure(module, frame, closure, op, "_lyra_nba_arg"));
+        SnapshotIntoClosure(unit_lowerer, frame, closure, op, "_lyra_nba_arg"));
   }
 
   const mir::ExprId effect_id = body.exprs.Add(effect_fn(
@@ -223,7 +226,7 @@ auto ApplyAssignEffect(
   auto& block = *frame.current_block;
   if (kind == hir::AssignKind::kBlocking) {
     const mir::ExprId services_id =
-        block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+        block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
     return effect_fn(block, target_in_outer, operands_in_outer, services_id);
   }
   if (!IsExprRootedAtStructuralDataObject(block, target_in_outer)) {
@@ -232,16 +235,16 @@ auto ApplyAssignEffect(
         "non-blocking assignment to procedural local is not supported yet");
   }
   mir::Expr closure = BuildDeferredAssignClosure(
-      process.Module(), frame, target_in_outer, operands_in_outer, effect_fn);
+      process.Owner(), frame, target_in_outer, operands_in_outer, effect_fn);
   const mir::ExprId closure_id = block.exprs.Add(std::move(closure));
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   return mir::Expr{
       .data =
           mir::CallExpr{
               .callee = mir::Direct{.target = support::BuiltinFn::kSubmitNba},
               .arguments = {services_id, closure_id}},
-      .type = process.Module().Unit().builtins.void_type};
+      .type = process.Owner().Unit().builtins.void_type};
 }
 
 // Axis A for an observable / local target: a whole-cell `Set`, a selector-chain
@@ -264,14 +267,14 @@ auto LowerObservableAssign(
   const std::optional<mir::BinaryOp> compound_op =
       a.compound_op.has_value() ? std::optional{LowerBinaryOp(*a.compound_op)}
                                 : std::nullopt;
-  const mir::TypeId void_type = process.Module().Unit().builtins.void_type;
+  const mir::TypeId void_type = process.Owner().Unit().builtins.void_type;
   const std::array<mir::ExprId, 1> operands{rhs_id};
   return ApplyAssignEffect(
       process, frame, a.kind, span, lhs_id, operands,
       [&](mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
           mir::ExprId services) -> mir::Expr {
         return BuildObservableAssignExpr(
-            process.Module().Unit(), blk, services, target, ops[0], compound_op,
+            process.Owner().Unit(), blk, services, target, ops[0], compound_op,
             result_type, void_type);
       });
 }
@@ -302,16 +305,16 @@ auto LowerHirAssignExprProc(
 // destructuring submits per part inside its own block, so this exposes just
 // the closure-building half over the observable write effect.
 auto BuildNbaSubmitClosureExpr(
-    ModuleLowerer& module, WalkFrame frame, mir::ExprId lhs_in_outer,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::ExprId lhs_in_outer,
     mir::ExprId rhs_id_in_outer, mir::TypeId rhs_type) -> mir::Expr {
   const std::array<mir::ExprId, 1> operands{rhs_id_in_outer};
   return BuildDeferredAssignClosure(
-      module, frame, lhs_in_outer, operands,
+      unit_lowerer, frame, lhs_in_outer, operands,
       [&](mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
           mir::ExprId services) -> mir::Expr {
         return BuildObservableAssignExpr(
-            module.Unit(), blk, services, target, ops[0], std::nullopt,
-            rhs_type, module.Unit().builtins.void_type);
+            unit_lowerer.Unit(), blk, services, target, ops[0], std::nullopt,
+            rhs_type, unit_lowerer.Unit().builtins.void_type);
       });
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -58,14 +58,14 @@ auto MaybeWrapObservableLhsWithMutate(
     Lowerer& lowerer, WalkFrame frame, mir::Block& block, mir::ExprId lhs_id)
     -> mir::ExprId {
   const mir::ExprId root_id =
-      FindLhsRootId(lowerer.Module().Unit(), block, lhs_id);
+      FindLhsRootId(lowerer.Owner().Unit(), block, lhs_id);
   const bool root_is_cell = mir::IsObservableCellType(
-      lowerer.Module().Unit().types.Get(block.exprs.Get(root_id).type));
+      lowerer.Owner().Unit().types.Get(block.exprs.Get(root_id).type));
   if (!root_is_cell) return lhs_id;
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(lowerer.Owner(), frame));
   return RewriteLhsRootWithMutate(
-      lowerer.Module().Unit(), block, lhs_id, services_id);
+      lowerer.Owner().Unit(), block, lhs_id, services_id);
 }
 
 // LRM 7.9.4 -- 7.9.7 associative traversal (`m.first(idx)` / `last` / `next` /
@@ -84,15 +84,15 @@ auto LowerAssociativeTraversal(
     throw InternalError(
         "LowerAssociativeTraversal: index argument unexpectedly elided");
   }
-  const auto& module = lowerer.Module();
+  const auto& unit_lowerer = lowerer.Owner();
   const auto& hir_exprs = lowerer.HirExprs();
   const auto recv_hir = *c.arguments[0];
   const auto idx_hir = *c.arguments[1];
   const mir::TypeId key_type =
-      module.TranslateType(hir_exprs.Get(idx_hir).type);
-  const mir::TypeId void_t = module.Unit().builtins.void_type;
+      unit_lowerer.TranslateType(hir_exprs.Get(idx_hir).type);
+  const mir::TypeId void_t = unit_lowerer.Unit().builtins.void_type;
 
-  ClosureBuilder closure(lowerer.Module().Unit(), frame);
+  ClosureBuilder closure(lowerer.Owner().Unit(), frame);
   mir::Block& body = closure.Body();
   const WalkFrame& closure_frame = closure.Frame();
 
@@ -130,16 +130,16 @@ auto LowerAssociativeTraversal(
   const mir::ExprId probe_writeback_id =
       body.exprs.Add(mir::MakeLocalRefExpr(probe_var, key_type));
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(lowerer.Module(), closure_frame));
+      body.exprs.Add(BuildServicesCallExpr(lowerer.Owner(), closure_frame));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
-      module.Unit(), body, services_id, idx_lhs_id, probe_writeback_id,
+      unit_lowerer.Unit(), body, services_id, idx_lhs_id, probe_writeback_id,
       std::nullopt, key_type, void_t);
   body.AppendStmt(mir::ExprStmt{.expr = body.exprs.Add(assign_expr)});
 
   const mir::ExprId found_id =
       body.exprs.Add(mir::MakeLocalRefExpr(found_var, result_type));
   return BuildClosureCallExpr(
-      lowerer.Module().Unit(), *frame.current_block, closure.Build(found_id));
+      lowerer.Owner().Unit(), *frame.current_block, closure.Build(found_id));
 }
 
 // Translates a HIR builtin-method ref to its MIR `Callee`. The identifier
@@ -147,13 +147,13 @@ auto LowerAssociativeTraversal(
 // id names a type-namespace-qualified static call (e.g. `MyEnum::first()`)
 // or an instance call.
 auto MakeBuiltinMirCallee(
-    const ModuleLowerer& module, const hir::BuiltinMethodRef& b,
+    const UnitLowerer& unit_lowerer, const hir::BuiltinMethodRef& b,
     hir::TypeId hir_dispatch_type) -> mir::Callee {
   if (support::IsStaticBuiltinFn(b.method)) {
     return mir::Direct{
         .target = b.method,
         .qualification = mir::TypeQualifier{
-            .type = module.TranslateType(hir_dispatch_type)}};
+            .type = unit_lowerer.TranslateType(hir_dispatch_type)}};
   }
   return mir::Direct{.target = b.method};
 }
@@ -181,8 +181,8 @@ auto ArrayMethodReceiverElementType(const hir::Type& ty)
 // The canonical-default prototype type for an entry whose result shape the
 // receiver does not determine: a container result contributes its element type
 // as the prototype; a scalar result is its own prototype.
-auto ResultPrototypeType(const ModuleLowerer& module, mir::TypeId result_type)
-    -> mir::TypeId {
+auto ResultPrototypeType(
+    const UnitLowerer& unit_lowerer, mir::TypeId result_type) -> mir::TypeId {
   return std::visit(
       Overloaded{
           [](const mir::UnpackedArrayType& t) { return t.element_type; },
@@ -191,7 +191,7 @@ auto ResultPrototypeType(const ModuleLowerer& module, mir::TypeId result_type)
           [](const mir::AssociativeArrayType& t) { return t.element_type; },
           [result_type](const auto&) { return result_type; },
       },
-      module.Unit().types.Get(result_type).data);
+      unit_lowerer.Unit().types.Get(result_type).data);
 }
 
 // LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The element and
@@ -206,27 +206,27 @@ template <ExprLowerer Lowerer>
 auto BuildArrayMethodClosure(
     Lowerer& lowerer, WalkFrame frame, hir::TypeId hir_receiver_type,
     const hir::WithClause* with_clause) -> diag::Result<mir::Expr> {
-  const auto& module = lowerer.Module();
+  const auto& unit_lowerer = lowerer.Owner();
   const auto& hir_exprs = lowerer.HirExprs();
-  const auto& hir_recv_ty = module.Hir().types.Get(hir_receiver_type);
+  const auto& hir_recv_ty = unit_lowerer.Hir().types.Get(hir_receiver_type);
   const auto element_type = ArrayMethodReceiverElementType(hir_recv_ty);
   if (!element_type.has_value()) {
     throw InternalError(
         "BuildArrayMethodClosure: receiver is not an unpacked-array type");
   }
-  const mir::TypeId item_type = module.TranslateType(*element_type);
+  const mir::TypeId item_type = unit_lowerer.TranslateType(*element_type);
   // LRM 7.12.4 `item.index`: the ordinal position for a sequence container, the
   // key for an associative receiver.
-  mir::TypeId index_type = module.Unit().builtins.int_type;
+  mir::TypeId index_type = unit_lowerer.Unit().builtins.int_type;
   if (const auto* assoc =
           std::get_if<hir::AssociativeArrayType>(&hir_recv_ty.data);
       assoc != nullptr) {
-    index_type = module.TranslateType(assoc->key_type);
+    index_type = unit_lowerer.TranslateType(assoc->key_type);
   }
   const std::string iterator_name =
       with_clause != nullptr ? with_clause->element_name : std::string{"item"};
 
-  ClosureBuilder closure(lowerer.Module().Unit(), frame);
+  ClosureBuilder closure(lowerer.Owner().Unit(), frame);
   mir::Block& body = closure.Body();
 
   mir::ExprId body_return_value{};
@@ -355,7 +355,7 @@ auto LowerStructuralSubroutineCall(
   // through `Parent()`. The same receiver path a structural member access
   // takes, so the callee's class is named by this receiver's type.
   args.push_back(BuildEnclosingScopeReceiver(
-      frame, lowerer.Module().Unit(),
+      frame, lowerer.Owner().Unit(),
       mir::EnclosingHops{.value = usr.hops.value}));
   for (std::size_t i = 0; i < c.arguments.size(); ++i) {
     if (!c.arguments[i].has_value()) {
@@ -377,13 +377,13 @@ auto LowerStructuralSubroutineCall(
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
       actual_id = block.exprs.Add(*std::move(arg_or));
       const mir::ExprId root_id =
-          FindLhsRootId(lowerer.Module().Unit(), block, actual_id);
+          FindLhsRootId(lowerer.Owner().Unit(), block, actual_id);
       if (root_id != actual_id) {
         actual_id =
             MaybeWrapObservableLhsWithMutate(lowerer, frame, block, actual_id);
       }
       args.push_back(BuildReferenceArg(
-          lowerer.Module().Unit(), block, actual_id,
+          lowerer.Owner().Unit(), block, actual_id,
           block.exprs.Get(actual_id).type));
     } else {
       auto arg_or = lowerer.LowerExpr(hir_exprs.Get(*c.arguments[i]), frame);
@@ -426,7 +426,7 @@ auto LowerBuiltinMethodCall(
   if (support::IsAssociativeTraversalFn(b.method)) {
     return LowerAssociativeTraversal(lowerer, frame, c, b.method, result_type);
   }
-  const auto& module = lowerer.Module();
+  const auto& unit_lowerer = lowerer.Owner();
   const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const hir::TypeId hir_dispatch_type =
@@ -437,7 +437,7 @@ auto LowerBuiltinMethodCall(
   // Translate the callee up front so the same trait (`mir::IsMutatingCallee`)
   // drives both lowering and backend rendering.
   const mir::Callee mir_callee =
-      MakeBuiltinMirCallee(module, b, hir_dispatch_type);
+      MakeBuiltinMirCallee(unit_lowerer, b, hir_dispatch_type);
 
   // A static call has no value receiver -- `args[0]` is the discardable
   // type-bearer, the type-namespace qualifier rides on the callee. An
@@ -502,9 +502,10 @@ auto LowerBuiltinMethodCall(
   // map's chosen element, an empty reduction's zero, or the index an empty
   // associative dimension reports (LRM 20.7).
   if (support::BuiltinFnTakesResultPrototype(b.method)) {
-    const mir::TypeId proto_type = ResultPrototypeType(module, result_type);
-    args.push_back(
-        block.exprs.Add(BuildDefaultValueExpr(module, frame, proto_type)));
+    const mir::TypeId proto_type =
+        ResultPrototypeType(unit_lowerer, result_type);
+    args.push_back(block.exprs.Add(
+        BuildDefaultValueExpr(unit_lowerer, frame, proto_type)));
   }
 
   // LRM 15.5.3: `e.triggered` reads the triggered flag out of
@@ -514,7 +515,7 @@ auto LowerBuiltinMethodCall(
   // the event-trigger stmt path; `await` takes no services.)
   if (b.method == support::BuiltinFn::kTriggered) {
     args.push_back(
-        block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame)));
+        block.exprs.Add(BuildServicesCallExpr(lowerer.Owner(), frame)));
   }
 
   return mir::Expr{
@@ -542,13 +543,13 @@ auto LowerMethodCall(
   auto receiver_or =
       lowerer.LowerExpr(lowerer.HirExprs().Get(m.receiver), frame);
   if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
-  auto& types = lowerer.Module().Unit().types;
+  auto& types = lowerer.Owner().Unit().types;
   const mir::TypeId object_type =
       std::get<mir::ManagedRefType>(types.Get(receiver_or->type).data).pointee;
   // The method's declaring class is stated on the HIR node; the receiver's
   // runtime class is only used to type the self parameter (which pairs with
   // the target's own arena entry through C++ member lookup).
-  const mir::ClassId owner_class = lowerer.Module().TranslateClass(m.class_id);
+  const mir::ClassId owner_class = lowerer.Owner().TranslateClass(m.class_id);
   const mir::ExprId handle_id = block.exprs.Add(*std::move(receiver_or));
   const mir::ExprId object_id = block.exprs.Add(
       mir::Expr{
@@ -715,7 +716,7 @@ auto MarshalSvToCarrier(
 // constructs the SV value directly. Feeds both a function's marshaled return
 // and the copy-back of an output / inout argument into its actual.
 auto MarshalCarrierToSv(
-    ModuleLowerer& module, WalkFrame frame, mir::ExprId call_id,
+    UnitLowerer& unit_lowerer, WalkFrame frame, mir::ExprId call_id,
     const support::DpiCarrier& carrier_desc, mir::TypeId result_type)
     -> mir::Expr {
   const auto* scalar = std::get_if<support::ScalarCarrier>(&carrier_desc);
@@ -737,9 +738,9 @@ auto MarshalCarrierToSv(
       const mir::ExprId machine_int = block.exprs.Add(
           mir::Expr{
               .data = mir::IntCastExpr{.operand = call_id},
-              .type = module.Unit().builtins.machine_int64});
-      const mir::ExprId prototype =
-          block.exprs.Add(BuildDefaultValueExpr(module, frame, result_type));
+              .type = unit_lowerer.Unit().builtins.machine_int64});
+      const mir::ExprId prototype = block.exprs.Add(
+          BuildDefaultValueExpr(unit_lowerer, frame, result_type));
       return mir::Expr{
           .data =
               mir::CallExpr{
@@ -759,8 +760,8 @@ auto MarshalCarrierToSv(
               mir::CallExpr{.callee = mir::Construct{}, .arguments = {call_id}},
           .type = result_type};
     case support::DpiScalarAbi::kLogicScalar: {
-      const mir::ExprId prototype =
-          block.exprs.Add(BuildDefaultValueExpr(module, frame, result_type));
+      const mir::ExprId prototype = block.exprs.Add(
+          BuildDefaultValueExpr(unit_lowerer, frame, result_type));
       return mir::Expr{
           .data =
               mir::CallExpr{
@@ -820,8 +821,8 @@ auto LowerForeignImportInputsOnly(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
-  auto& unit = module.Unit();
+  auto& unit_lowerer = lowerer.Owner();
+  auto& unit = unit_lowerer.Unit();
   auto& block = *frame.current_block;
   const auto& hir_exprs = lowerer.HirExprs();
 
@@ -853,7 +854,7 @@ auto LowerForeignImportInputsOnly(
   }
   const mir::ExprId call_id = block.exprs.Add(std::move(foreign_call));
   return MarshalCarrierToSv(
-      module, frame, call_id, support::ScalarCarrier{decl.ret_abi},
+      unit_lowerer, frame, call_id, support::ScalarCarrier{decl.ret_abi},
       result_type);
 }
 
@@ -870,8 +871,8 @@ auto LowerForeignImportSequenced(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
-  auto& unit = module.Unit();
+  auto& unit_lowerer = lowerer.Owner();
+  auto& unit = unit_lowerer.Unit();
   const auto& hir_exprs = lowerer.HirExprs();
   const mir::TypeId void_t = unit.builtins.void_type;
 
@@ -1008,8 +1009,8 @@ auto LowerForeignImportSequenced(
     if (const auto* vector = std::get_if<support::VectorCarrier>(&wb.carrier)) {
       const mir::ExprId data =
           BuildBufferDataCall(unit, body, temp_ref, wb.carrier_type);
-      const mir::ExprId prototype =
-          body.exprs.Add(BuildDefaultValueExpr(module, cframe, wb.sv_type));
+      const mir::ExprId prototype = body.exprs.Add(
+          BuildDefaultValueExpr(unit_lowerer, cframe, wb.sv_type));
       rhs_id = body.exprs.Add(
           mir::Expr{
               .data =
@@ -1019,11 +1020,11 @@ auto LowerForeignImportSequenced(
                       .arguments = {data, prototype}},
               .type = wb.sv_type});
     } else {
-      rhs_id = body.exprs.Add(
-          MarshalCarrierToSv(module, cframe, temp_ref, wb.carrier, wb.sv_type));
+      rhs_id = body.exprs.Add(MarshalCarrierToSv(
+          unit_lowerer, cframe, temp_ref, wb.carrier, wb.sv_type));
     }
     const mir::ExprId services_id =
-        body.exprs.Add(BuildServicesCallExpr(module, cframe));
+        body.exprs.Add(BuildServicesCallExpr(unit_lowerer, cframe));
     const mir::Expr assign = BuildObservableAssignExpr(
         unit, body, services_id, lhs_id, rhs_id, std::nullopt, wb.sv_type,
         void_t);
@@ -1037,7 +1038,7 @@ auto LowerForeignImportSequenced(
   const mir::ExprId ret_ref =
       body.exprs.Add(mir::MakeLocalRefExpr(*ret_temp, call_type));
   const mir::ExprId result_id = body.exprs.Add(MarshalCarrierToSv(
-      module, cframe, ret_ref, support::ScalarCarrier{decl.ret_abi},
+      unit_lowerer, cframe, ret_ref, support::ScalarCarrier{decl.ret_abi},
       result_type));
   return BuildClosureCallExpr(
       unit, *frame.current_block, closure.Build(result_id));
@@ -1073,7 +1074,7 @@ auto LowerForeignImportCall(
   // lookup distance, resolved here and then gone; the callable has no body and
   // no receiver, so nothing is reached at run time and the call names its owner
   // directly.
-  const mir::CompilationUnit& unit = lowerer.Module().Unit();
+  const mir::CompilationUnit& unit = lowerer.Owner().Unit();
   const mir::EnclosingHops hops{.value = ref.hops.value};
   const mir::StaticCallableTarget target{
       .owner = EnclosingClassIdAtHops(frame, unit, hops),

--- a/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
@@ -39,7 +39,7 @@ template <ExprLowerer L>
 auto LowerExprImpl(L& lowerer, const hir::Expr& expr, WalkFrame frame)
     -> diag::Result<mir::Expr> {
   constexpr bool kProcedural = std::same_as<L, ProcessLowerer>;
-  const mir::TypeId result_type = lowerer.Module().TranslateType(expr.type);
+  const mir::TypeId result_type = lowerer.Owner().TranslateType(expr.type);
   auto raw_or = std::visit(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
@@ -159,7 +159,7 @@ auto LowerExprImpl(L& lowerer, const hir::Expr& expr, WalkFrame frame)
       expr.data);
   if (!raw_or) return raw_or;
   if (mir::IsObservableCellType(
-          lowerer.Module().Unit().types.Get(raw_or->type))) {
+          lowerer.Owner().Unit().types.Get(raw_or->type))) {
     const mir::ExprId cell_id =
         frame.current_block->exprs.Add(*std::move(raw_or));
     return mir::MakeObservableGetCallExpr(cell_id, result_type);
@@ -176,7 +176,7 @@ template <ExprLowerer L>
 auto LowerLhsExprImpl(L& lowerer, const hir::Expr& expr, WalkFrame frame)
     -> diag::Result<mir::Expr> {
   constexpr bool kProcedural = std::same_as<L, ProcessLowerer>;
-  const mir::TypeId result_type = lowerer.Module().TranslateType(expr.type);
+  const mir::TypeId result_type = lowerer.Owner().TranslateType(expr.type);
   return std::visit(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -429,7 +429,7 @@ auto LowerHirUnaryExpr(
   }
   const mir::ExprId operand_id = block.exprs.Add(*std::move(operand_or));
   return BuildMirUnaryExpr(
-      lowerer.Module().Unit(), block, LowerUnaryOp(u.op), operand_id,
+      lowerer.Owner().Unit(), block, LowerUnaryOp(u.op), operand_id,
       result_type);
 }
 
@@ -445,7 +445,7 @@ auto LowerHirBinaryExpr(
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::ExprId rhs_id = block.exprs.Add(*std::move(rhs_or));
   return BuildMirBinaryExpr(
-      lowerer.Module().Unit(), block, LowerBinaryOp(b.op), lhs_id, rhs_id,
+      lowerer.Owner().Unit(), block, LowerBinaryOp(b.op), lhs_id, rhs_id,
       result_type);
 }
 
@@ -458,7 +458,7 @@ auto LowerHirConditionalExpr(
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const mir::ExprId cond_id = ReduceToCondition(
       block, block.exprs.Add(*std::move(cond_or)),
-      lowerer.Module().Unit().builtins.bit1);
+      lowerer.Owner().Unit().builtins.bit1);
   auto then_or = lowerer.LowerExpr(lowerer.HirExprs().Get(c.then_value), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const mir::ExprId then_id = block.exprs.Add(*std::move(then_or));
@@ -488,13 +488,13 @@ auto LowerHirIncDecExprProc(
   // If the LHS reaches an observable storage cell, the mutation runs inside
   // a `ScopedMutation` snapshot so subscribers fire once on destructor commit.
   const mir::ExprId root_id =
-      FindLhsRootId(process.Module().Unit(), block, target_id);
+      FindLhsRootId(process.Owner().Unit(), block, target_id);
   if (mir::IsObservableCellType(
-          process.Module().Unit().types.Get(block.exprs.Get(root_id).type))) {
+          process.Owner().Unit().types.Get(block.exprs.Get(root_id).type))) {
     const mir::ExprId services_id =
-        block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+        block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
     target_id = RewriteLhsRootWithMutate(
-        process.Module().Unit(), block, target_id, services_id);
+        process.Owner().Unit(), block, target_id, services_id);
   }
 
   return mir::Expr{
@@ -514,7 +514,7 @@ auto LowerHirConversionExpr(
   const mir::ExprId operand_id =
       frame.current_block->exprs.Add(*std::move(operand_or));
   return BuildValueConversion(
-      lowerer.Module().Unit(), *frame.current_block, operand_id, result_type);
+      lowerer.Owner().Unit(), *frame.current_block, operand_id, result_type);
 }
 
 // One concrete instantiation per pass class. The handler templates are defined

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -12,10 +12,10 @@
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/callable_bindings.hpp"
 #include "lyra/lowering/hir_to_mir/endpoint.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -99,9 +99,9 @@ auto StringBytesToConstant(
 // string parameter's value) instead builds a `value::String` via the
 // constructor.
 auto LowerHirStringLiteral(
-    const ModuleLowerer& module, const WalkFrame& frame,
+    const UnitLowerer& unit_lowerer, const WalkFrame& frame,
     const hir::StringLiteral& s, mir::TypeId type) -> mir::Expr {
-  const auto& ty = module.Unit().types.Get(type);
+  const auto& ty = unit_lowerer.Unit().types.Get(type);
   if (ty.IsIntegralPacked()) {
     return mir::Expr{
         .data =
@@ -120,12 +120,12 @@ auto LowerHirStringLiteral(
       .type = type};
 }
 
-auto LowerHirTimeLiteral(const ModuleLowerer& module, const hir::TimeLiteral& t)
-    -> mir::Expr {
+auto LowerHirTimeLiteral(
+    const UnitLowerer& unit_lowerer, const hir::TimeLiteral& t) -> mir::Expr {
   return mir::Expr{
       .data =
           mir::TimeLiteral{.value = t.value, .scale = LowerTimeScale(t.scale)},
-      .type = module.Unit().builtins.realtime};
+      .type = unit_lowerer.Unit().builtins.realtime};
 }
 
 auto LowerHirNullLiteral(mir::TypeId type) -> mir::Expr {
@@ -145,7 +145,7 @@ auto LowerReferenceRouteExpr(
     const StructuralScopeLowerer& lowerer, const WalkFrame& frame,
     const hir::ReferenceRoute& route) -> mir::Expr {
   return EndpointCellExpr(
-      frame, lowerer.Module().Unit(), BindEndpoint(lowerer, frame, route));
+      frame, lowerer.Owner().Unit(), BindEndpoint(lowerer, frame, route));
 }
 
 auto LowerProceduralVarRefExpr(
@@ -229,10 +229,10 @@ auto LowerHirPrimaryExprProc(
           },
           [&](const hir::StringLiteral& s) -> mir::Expr {
             return LowerHirStringLiteral(
-                process.Module(), frame, s, result_type);
+                process.Owner(), frame, s, result_type);
           },
           [&](const hir::TimeLiteral& t) -> mir::Expr {
-            return LowerHirTimeLiteral(process.Module(), t);
+            return LowerHirTimeLiteral(process.Owner(), t);
           },
           [&](const hir::RealLiteral& r) -> mir::Expr {
             return LowerHirRealLiteral(r, result_type);
@@ -280,10 +280,10 @@ auto LowerHirPrimaryExprStructural(
           },
           [&](const hir::StringLiteral& s) -> mir::Expr {
             return LowerHirStringLiteral(
-                lowerer.Module(), frame, s, result_type);
+                lowerer.Owner(), frame, s, result_type);
           },
           [&](const hir::TimeLiteral& t) -> mir::Expr {
-            return LowerHirTimeLiteral(lowerer.Module(), t);
+            return LowerHirTimeLiteral(lowerer.Owner(), t);
           },
           [&](const hir::RealLiteral& r) -> mir::Expr {
             return LowerHirRealLiteral(r, result_type);

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -11,9 +11,9 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -125,14 +125,14 @@ auto WrapSliceToDeclaredType(
 // representation) and a dynamic array is zero-based, so neither contributes an
 // operand.
 auto AppendReceiverRange(
-    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
     std::vector<mir::ExprId>& args) -> void {
   // The declared range is a fact of the receiver's value type. On the write
   // path the base is a place -- an observable cell or a reference -- so unwrap
   // those single-level indirections to reach the underlying value type.
   mir::TypeId base_type = block.exprs.Get(base_id).type;
   for (;;) {
-    const auto& ty = module.Unit().types.Get(base_type);
+    const auto& ty = unit_lowerer.Unit().types.Get(base_type);
     if (const auto* obs = std::get_if<mir::ObservableType>(&ty.data)) {
       base_type = obs->value;
     } else if (const auto* ref = std::get_if<mir::RefType>(&ty.data)) {
@@ -143,9 +143,9 @@ auto AppendReceiverRange(
       break;
     }
   }
-  const auto& base_ty = module.Unit().types.Get(base_type);
+  const auto& base_ty = unit_lowerer.Unit().types.Get(base_type);
   if (const auto* ua = std::get_if<mir::UnpackedArrayType>(&base_ty.data)) {
-    const mir::TypeId int_type = module.Unit().builtins.int_type;
+    const mir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
     args.push_back(
         block.exprs.Add(mir::MakeIntLiteral(int_type, ua->dim.left)));
     args.push_back(
@@ -159,10 +159,10 @@ auto AppendReceiverRange(
 // through, plus the receiver's declared range for the unpacked family; every
 // selectable value resolves the coordinate against that range.
 auto BuildElementAccessCallExpr(
-    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
     mir::ExprId idx_id, AccessSide side, mir::TypeId result_type) -> mir::Expr {
   std::vector<mir::ExprId> args = {base_id, idx_id};
-  AppendReceiverRange(module, block, base_id, args);
+  AppendReceiverRange(unit_lowerer, block, base_id, args);
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -180,9 +180,10 @@ auto BuildElementAccessCallExpr(
 // declared range.
 template <typename LowerOne>
 auto BuildRangeSliceCallExpr(
-    ModuleLowerer& module, mir::Block& block, const hir::RangeBounds& bounds,
-    mir::ExprId base_id, mir::TypeId result_type, AccessSide side,
-    LowerOne lower_one) -> diag::Result<mir::Expr> {
+    UnitLowerer& unit_lowerer, mir::Block& block,
+    const hir::RangeBounds& bounds, mir::ExprId base_id,
+    mir::TypeId result_type, AccessSide side, LowerOne lower_one)
+    -> diag::Result<mir::Expr> {
   struct RawSelector {
     mir::ExprId a;
     mir::ExprId b;
@@ -215,11 +216,11 @@ auto BuildRangeSliceCallExpr(
       },
       bounds);
   if (!raw_or) return std::unexpected(std::move(raw_or.error()));
-  const mir::TypeId int_type = module.Unit().builtins.int_type;
+  const mir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
   const auto form_id =
       block.exprs.Add(mir::MakeIntLiteral(int_type, raw_or->form));
   std::vector<mir::ExprId> args = {base_id, raw_or->a, raw_or->b, form_id};
-  AppendReceiverRange(module, block, base_id, args);
+  AppendReceiverRange(unit_lowerer, block, base_id, args);
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -237,10 +238,10 @@ auto BuildRangeSliceCallExpr(
 // range-select emits, so the runtime sees one slice form regardless of
 // whether the source was `s.field` or `s[hi:lo]`.
 auto BuildFieldSliceCallExpr(
-    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
     std::uint32_t bit_offset, std::uint32_t bit_width, mir::TypeId result_type,
     AccessSide side) -> mir::Expr {
-  const mir::TypeId int_type = module.Unit().builtins.int_type;
+  const mir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
   const auto offset_id = block.exprs.Add(
       mir::MakeIntLiteral(int_type, static_cast<std::int64_t>(bit_offset)));
   const auto width_id = block.exprs.Add(
@@ -266,27 +267,28 @@ auto BuildFieldSliceCallExpr(
 // intact for `operator=` to consume.
 
 auto LowerElementSelectInner(
-    ModuleLowerer& module, mir::Block& block, mir::ExprId base_id,
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
     mir::ExprId idx_id, AccessSide side, mir::TypeId result_type,
     bool wrap_packed_as_owned) -> mir::Expr {
   mir::Expr access_call = BuildElementAccessCallExpr(
-      module, block, base_id, idx_id, side, result_type);
+      unit_lowerer, block, base_id, idx_id, side, result_type);
   if (!wrap_packed_as_owned) return access_call;
   return WrapPackedAsOwned(
-      module.Unit(), block, std::move(access_call), result_type);
+      unit_lowerer.Unit(), block, std::move(access_call), result_type);
 }
 
 template <typename LowerOne>
 auto LowerRangeSelectInner(
-    ModuleLowerer& module, mir::Block& block, const hir::RangeBounds& bounds,
-    mir::ExprId base_id, mir::TypeId result_type, LowerOne lower_one,
-    AccessSide side) -> diag::Result<mir::Expr> {
+    UnitLowerer& unit_lowerer, mir::Block& block,
+    const hir::RangeBounds& bounds, mir::ExprId base_id,
+    mir::TypeId result_type, LowerOne lower_one, AccessSide side)
+    -> diag::Result<mir::Expr> {
   auto slice_or = BuildRangeSliceCallExpr(
-      module, block, bounds, base_id, result_type, side, lower_one);
+      unit_lowerer, block, bounds, base_id, result_type, side, lower_one);
   if (!slice_or) return std::unexpected(std::move(slice_or.error()));
   if (side == AccessSide::kLhs) return *std::move(slice_or);
   return WrapPackedAsOwned(
-      module.Unit(), block, *std::move(slice_or), result_type);
+      unit_lowerer.Unit(), block, *std::move(slice_or), result_type);
 }
 
 // Packed-struct / union field access (LRM 7.2.1: a field "can be selected as if
@@ -296,24 +298,24 @@ auto LowerRangeSelectInner(
 // the field's declared type; the aggregate's storage reconciles the field's
 // representation when the assignment lands.
 auto LowerMemberAccessInner(
-    ModuleLowerer& module, mir::Block& block,
+    UnitLowerer& unit_lowerer, mir::Block& block,
     const hir::PackedAggregateField& field, mir::ExprId base_id,
     mir::TypeId result_type, AccessSide side) -> mir::Expr {
   if (side == AccessSide::kLhs) {
     return BuildFieldSliceCallExpr(
-        module, block, base_id, field.bit_offset, field.bit_width, result_type,
-        side);
+        unit_lowerer, block, base_id, field.bit_offset, field.bit_width,
+        result_type, side);
   }
   const mir::TypeId source_type = block.exprs.Get(base_id).type;
   const mir::TypeId slice_type =
-      PartSelectNaturalType(module.Unit(), source_type, result_type);
+      PartSelectNaturalType(unit_lowerer.Unit(), source_type, result_type);
   mir::Expr slice_call = BuildFieldSliceCallExpr(
-      module, block, base_id, field.bit_offset, field.bit_width, slice_type,
-      side);
+      unit_lowerer, block, base_id, field.bit_offset, field.bit_width,
+      slice_type, side);
   mir::Expr owned = WrapPackedAsOwned(
-      module.Unit(), block, std::move(slice_call), slice_type);
+      unit_lowerer.Unit(), block, std::move(slice_call), slice_type);
   return WrapSliceToDeclaredType(
-      module.Unit(), block, std::move(owned), result_type);
+      unit_lowerer.Unit(), block, std::move(owned), result_type);
 }
 
 }  // namespace
@@ -322,7 +324,7 @@ template <ExprLowerer Lowerer>
 auto LowerHirElementSelectExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const bool is_write = frame.is_lvalue_target;
@@ -338,7 +340,7 @@ auto LowerHirElementSelectExpr(
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
-  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
+  const auto& hir_base_ty = unit_lowerer.Hir().types.Get(hir_base.type);
   // LRM 6.16: indexed character read `s[i]` is the element-value access, the
   // read-side dual of the element-reference write. It joins the generic
   // element-access path (the explicit `getc` / `putc` methods are a separate
@@ -362,14 +364,14 @@ auto LowerHirElementSelectExpr(
           ? AccessSide::kLhs
           : AccessSide::kRead;
   return LowerElementSelectInner(
-      module, block, base_id, idx_id, side, result_type, true);
+      unit_lowerer, block, base_id, idx_id, side, result_type, true);
 }
 
 template <ExprLowerer Lowerer>
 auto LowerHirRangeSelectExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
@@ -384,7 +386,7 @@ auto LowerHirRangeSelectExpr(
     return block.exprs.Add(*std::move(lowered));
   };
   return LowerRangeSelectInner(
-      module, block, sel.bounds, base_id, result_type, lower_one,
+      unit_lowerer, block, sel.bounds, base_id, result_type, lower_one,
       AccessSide::kRead);
 }
 
@@ -397,11 +399,11 @@ template <ExprLowerer Lowerer>
 auto LowerHirMemberAccessExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const auto& base_hir_expr = exprs.Get(sel.base_value);
-  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+  if (unit_lowerer.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedStruct) {
     auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -410,7 +412,7 @@ auto LowerHirMemberAccessExpr(
         .data = mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index},
         .type = result_type};
   }
-  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+  if (unit_lowerer.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedUnion) {
     auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -421,7 +423,7 @@ auto LowerHirMemberAccessExpr(
         .type = result_type};
   }
   const auto& fields =
-      GetAggregateFields(module.Hir().types.Get(base_hir_expr.type));
+      GetAggregateFields(unit_lowerer.Hir().types.Get(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
     throw InternalError("LowerHirMemberAccessExpr: field_index out of range");
   }
@@ -429,7 +431,7 @@ auto LowerHirMemberAccessExpr(
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
-      module, block, fields[sel.field_index], base_id, result_type,
+      unit_lowerer, block, fields[sel.field_index], base_id, result_type,
       AccessSide::kRead);
 }
 
@@ -442,7 +444,7 @@ template <ExprLowerer Lowerer>
 auto LowerHirClassPropertyAccessExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::ClassPropertyAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   auto& block = *frame.current_block;
   const auto& base_hir_expr = lowerer.HirExprs().Get(sel.base_value);
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
@@ -451,7 +453,7 @@ auto LowerHirClassPropertyAccessExpr(
   return mir::MakeFieldAccessExpr(
       base_id,
       mir::FieldTarget{
-          .owner = module.TranslateClass(sel.owner),
+          .owner = unit_lowerer.TranslateClass(sel.owner),
           .slot = mir::FieldId{sel.field_index}},
       result_type);
 }
@@ -460,7 +462,7 @@ template <ExprLowerer Lowerer>
 auto LowerHirElementSelectExprLhs(
     Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
@@ -474,7 +476,7 @@ auto LowerHirElementSelectExprLhs(
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
-  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
+  const auto& hir_base_ty = unit_lowerer.Hir().types.Get(hir_base.type);
   // LRM 6.16: indexed character write `s[i] = ...` is the element-reference
   // access, the write-side dual of the element-value read. It joins the generic
   // element-access path so the place flows through the observable mutate route
@@ -488,14 +490,15 @@ auto LowerHirElementSelectExprLhs(
         .type = result_type};
   }
   return LowerElementSelectInner(
-      module, block, base_id, idx_id, AccessSide::kLhs, result_type, false);
+      unit_lowerer, block, base_id, idx_id, AccessSide::kLhs, result_type,
+      false);
 }
 
 template <ExprLowerer Lowerer>
 auto LowerHirRangeSelectExprLhs(
     Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
@@ -510,7 +513,7 @@ auto LowerHirRangeSelectExprLhs(
     return block.exprs.Add(*std::move(lowered));
   };
   return LowerRangeSelectInner(
-      module, block, sel.bounds, base_id, result_type, lower_one,
+      unit_lowerer, block, sel.bounds, base_id, result_type, lower_one,
       AccessSide::kLhs);
 }
 
@@ -518,14 +521,14 @@ template <ExprLowerer Lowerer>
 auto LowerHirMemberAccessExprLhs(
     Lowerer& lowerer, WalkFrame frame, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const auto& base_hir_expr = exprs.Get(sel.base_value);
   // LRM 7.2: an unpacked-struct member write is a positional projection by
   // index over the base place. The observable root's write routes through the
   // cell's mutate path later, so the place is just the projection here.
-  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+  if (unit_lowerer.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedStruct) {
     auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -538,7 +541,7 @@ auto LowerHirMemberAccessExprLhs(
   // `UnionGetRefExpr` over the union place (the by-reference counterpart of
   // the `UnionGetExpr` read). The observable root routes through the cell's
   // mutate path later; the place is just the projection here.
-  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+  if (unit_lowerer.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedUnion) {
     auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -550,7 +553,7 @@ auto LowerHirMemberAccessExprLhs(
         .type = result_type};
   }
   const auto& fields =
-      GetAggregateFields(module.Hir().types.Get(base_hir_expr.type));
+      GetAggregateFields(unit_lowerer.Hir().types.Get(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
     throw InternalError(
         "LowerHirMemberAccessExprLhs: field_index out of range");
@@ -559,7 +562,7 @@ auto LowerHirMemberAccessExprLhs(
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
-      module, block, fields[sel.field_index], base_id, result_type,
+      unit_lowerer, block, fields[sel.field_index], base_id, result_type,
       AccessSide::kLhs);
 }
 
@@ -572,7 +575,7 @@ template <ExprLowerer Lowerer>
 auto LowerHirClassPropertyAccessExprLhs(
     Lowerer& lowerer, WalkFrame frame, const hir::ClassPropertyAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = lowerer.Module();
+  auto& unit_lowerer = lowerer.Owner();
   auto& block = *frame.current_block;
   const auto& base_hir_expr = lowerer.HirExprs().Get(sel.base_value);
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
@@ -581,7 +584,7 @@ auto LowerHirClassPropertyAccessExprLhs(
   return mir::MakeFieldAccessExpr(
       base_id,
       mir::FieldTarget{
-          .owner = module.TranslateClass(sel.owner),
+          .owner = unit_lowerer.TranslateClass(sel.owner),
           .slot = mir::FieldId{sel.field_index}},
       result_type);
 }

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -66,9 +66,9 @@ auto LowerFinishSystemSubroutineCall(
     }
     level = static_cast<int>(*literal);
   }
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = process.Owner().Unit().builtins;
   const mir::ExprId services_id = frame.current_block->exprs.Add(
-      BuildServicesCallExpr(process.Module(), frame));
+      BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId level_id = frame.current_block->exprs.Add(
       mir::MakeIntLiteral(builtins.int_type, static_cast<std::int64_t>(level)));
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
@@ -102,7 +102,7 @@ auto LowerDiagnosticSystemSubroutineCall(
       process, frame, call, support::PrintRadix::kDecimal, items_offset);
   if (!items_or) return std::unexpected(std::move(items_or.error()));
 
-  auto& unit = process.Module().Unit();
+  auto& unit = process.Owner().Unit();
   auto& block = *frame.current_block;
   const auto time_unit_power =
       static_cast<std::int64_t>(process.Resolution().unit_power);
@@ -110,14 +110,14 @@ auto LowerDiagnosticSystemSubroutineCall(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId text_id = block.exprs.Add(
       BuildFormatCallExpr(unit, block, services_id, items_array));
   const mir::ExprId diagnostic_id =
-      block.exprs.Add(BuildDiagnosticCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildDiagnosticCallExpr(process.Owner(), frame));
   const mir::ExprId origin_id = BuildOriginStringExpr(
       unit, block,
-      FormatRuntimeOriginString(span, process.Module().SourceManager()));
+      FormatRuntimeOriginString(span, process.Owner().SourceManager()));
 
   mir::Expr emit_call{
       .data =
@@ -136,7 +136,7 @@ auto LowerDiagnosticSystemSubroutineCall(
   block.AppendStmt(mir::ExprStmt{.expr = emit_call_id});
 
   const mir::ExprId finish_services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId level_id = block.exprs.Add(
       mir::MakeIntLiteral(
           unit.builtins.int_type, static_cast<std::int64_t>(finish_level)));

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -39,7 +39,7 @@ auto BuildFileIoCall(
   auto& block = *frame.current_block;
   std::vector<mir::ExprId> args;
   args.reserve(operands.size() + 1);
-  args.push_back(block.exprs.Add(BuildFilesCallExpr(process.Module(), frame)));
+  args.push_back(block.exprs.Add(BuildFilesCallExpr(process.Owner(), frame)));
   for (const mir::ExprId operand : operands) {
     args.push_back(operand);
   }
@@ -90,7 +90,7 @@ auto LowerFileOpenCall(
   }
   return BuildFileIoCall(
       process, frame, support::BuiltinFn::kFileOpen, std::move(operands),
-      process.Module().Unit().builtins.int_type);
+      process.Owner().Unit().builtins.int_type);
 }
 
 // LRM 21.3.6: the no-argument flush-all form and the addressed form select
@@ -106,7 +106,7 @@ auto LowerFileFlushCall(
   }
   return BuildFileIoCall(
       process, frame, support::BuiltinFn::kFileFlush, std::move(operands),
-      process.Module().Unit().builtins.void_type);
+      process.Owner().Unit().builtins.void_type);
 }
 
 // LRM 13.5: $fgets / $fread / $ferror write into an actual lvalue argument
@@ -131,7 +131,7 @@ auto LowerFileIOSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
     std::string_view name, const support::FileIOSystemSubroutineInfo& info,
     diag::SourceSpan span) -> diag::Result<mir::Expr> {
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = process.Owner().Unit().builtins;
   switch (info.builtin_fn) {
     case support::BuiltinFn::kFileOpen:
       return LowerFileOpenCall(process, frame, call);
@@ -182,7 +182,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
         "LowerFileIOSystemSubroutineCallStmt: BuiltinFn has no output arg");
   }
 
-  const auto& module = process.Module();
+  const auto& unit_lowerer = process.Owner();
   const auto& hir_proc = process.HirBody();
 
   mir::Block wrapper;
@@ -206,7 +206,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
           mir::MakeLocalRefExpr(slots[0].temp, slots[0].type));
       call_expr = BuildFileIoCall(
           process, wrapper_frame, info.builtin_fn, {temp_ref, fd_id},
-          process.Module().Unit().builtins.int_type);
+          process.Owner().Unit().builtins.int_type);
       break;
     }
     case support::BuiltinFn::kFileRead: {
@@ -216,8 +216,8 @@ auto LowerFileIOSystemSubroutineCallStmt(
       // generic CallExpr whose operands are the temp, the descriptor, and --
       // for the memory form -- the declared bounds plus start / count.
       const auto& dest_hir = hir_proc.exprs.Get(*call.arguments[0]);
-      const auto& dest_hir_ty = module.Hir().types.Get(dest_hir.type);
-      const auto& builtins = process.Module().Unit().builtins;
+      const auto& dest_hir_ty = unit_lowerer.Hir().types.Get(dest_hir.type);
+      const auto& builtins = process.Owner().Unit().builtins;
       const auto* unpacked =
           std::get_if<hir::UnpackedArrayType>(&dest_hir_ty.data);
 
@@ -236,7 +236,8 @@ auto LowerFileIOSystemSubroutineCallStmt(
         // Memory form. Only 1D unpacked of integral packed elements is in
         // scope; struct / union / multi-dim / dynamic-array element types
         // are deferred.
-        const auto& elem_ty = module.Hir().types.Get(unpacked->element_type);
+        const auto& elem_ty =
+            unit_lowerer.Hir().types.Get(unpacked->element_type);
         if (!elem_ty.IsBitVector()) {
           return diag::Fail(
               diag::DiagCode::kUnsupportedSubroutineArgument,
@@ -303,7 +304,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
           mir::MakeLocalRefExpr(slots[0].temp, slots[0].type));
       call_expr = BuildFileIoCall(
           process, wrapper_frame, info.builtin_fn, {fd_id, temp_ref},
-          process.Module().Unit().builtins.int_type);
+          process.Owner().Unit().builtins.int_type);
       break;
     }
     default:
@@ -320,9 +321,9 @@ auto LowerFileIOSystemSubroutineCallStmt(
   }
 
   const mir::ExprId services_id =
-      wrapper.exprs.Add(BuildServicesCallExpr(process.Module(), wrapper_frame));
+      wrapper.exprs.Add(BuildServicesCallExpr(process.Owner(), wrapper_frame));
   return BuildCopyOutBlock(
-      process.Module().Unit(), services_id, frame, std::move(wrapper),
+      process.Owner().Unit(), services_id, frame, std::move(wrapper),
       std::move(label), result_type, std::move(call_expr), false,
       assign_target_id, slots);
 }

--- a/src/lyra/lowering/hir_to_mir/expression/system/plusargs.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/plusargs.cpp
@@ -29,7 +29,7 @@ auto LowerTestPlusargs(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
   const auto& hir_proc = process.HirBody();
-  auto& unit = process.Module().Unit();
+  auto& unit = process.Owner().Unit();
   auto& body = *frame.current_block;
 
   auto user_or =
@@ -42,7 +42,7 @@ auto LowerTestPlusargs(
   const mir::ExprId user_id =
       ConvertToType(unit, body, raw_user_id, unit.builtins.string);
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      body.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -56,14 +56,14 @@ auto LowerValuePlusargs(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
   const auto& hir_proc = process.HirBody();
-  auto& module = process.Module();
-  auto& unit = module.Unit();
+  auto& unit_lowerer = process.Owner();
+  auto& unit = unit_lowerer.Unit();
   const mir::TypeId int_type = unit.builtins.int_type;
   const mir::TypeId bit_t = unit.builtins.bit1;
   const mir::TypeId void_t = unit.builtins.void_type;
 
   const auto& hir_target = hir_proc.exprs.Get(*call.arguments[1]);
-  const mir::TypeId target_type = module.TranslateType(hir_target.type);
+  const mir::TypeId target_type = unit_lowerer.TranslateType(hir_target.type);
 
   // A match writes the parsed remainder into the caller's lvalue and returns
   // 1; a no-match leaves the lvalue untouched and returns 0. Both effects
@@ -82,14 +82,14 @@ auto LowerValuePlusargs(
   const mir::ExprId user_id =
       ConvertToType(unit, body, raw_user_id, unit.builtins.string);
 
-  const mir::ExprId temp_init =
-      body.exprs.Add(BuildDefaultValueExpr(module, closure_frame, target_type));
+  const mir::ExprId temp_init = body.exprs.Add(
+      BuildDefaultValueExpr(unit_lowerer, closure_frame, target_type));
   const mir::LocalId temp_var = closure.Bindings().DeclareAnonymous(
       mir::LocalDecl{.name = "_lyra_plusargs_out", .type = target_type});
   body.AppendStmt(mir::LocalDeclStmt{.target = temp_var, .init = temp_init});
 
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(module, closure_frame));
+      body.exprs.Add(BuildServicesCallExpr(unit_lowerer, closure_frame));
   const mir::ExprId temp_ref =
       body.exprs.Add(mir::MakeLocalRefExpr(temp_var, target_type));
   const mir::ExprId hit_call = body.exprs.Add(
@@ -126,7 +126,7 @@ auto LowerValuePlusargs(
   const mir::ExprId temp_read_then =
       then_body.exprs.Add(mir::MakeLocalRefExpr(temp_var, target_type));
   const mir::ExprId services_id_then =
-      then_body.exprs.Add(BuildServicesCallExpr(module, then_frame));
+      then_body.exprs.Add(BuildServicesCallExpr(unit_lowerer, then_frame));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
       unit, then_body, services_id_then, lvalue_id, temp_read_then,
       std::nullopt, target_type, void_t);

--- a/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
@@ -57,13 +57,13 @@ auto EmitFormatThenWrite(
     ProcessLowerer& process, const WalkFrame& frame, mir::Block& block,
     mir::ExprId items_array, mir::ExprId fd, bool append_newline)
     -> mir::ExprId {
-  auto& unit = process.Module().Unit();
+  auto& unit = process.Owner().Unit();
   const mir::ExprId services =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId text =
       block.exprs.Add(BuildFormatCallExpr(unit, block, services, items_array));
   const mir::ExprId files =
-      block.exprs.Add(BuildFilesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildFilesCallExpr(process.Owner(), frame));
   return block.exprs.Add(
       mir::Expr{
           .data =
@@ -83,7 +83,7 @@ auto LowerStrobeCall(
     const support::PrintSystemSubroutineInfo& print)
     -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
-  auto& unit = process.Module().Unit();
+  auto& unit = process.Owner().Unit();
   const mir::TypeId void_type = unit.builtins.void_type;
   const mir::TypeId int_type = unit.builtins.int_type;
   const std::int64_t time_unit_power =
@@ -97,7 +97,7 @@ auto LowerStrobeCall(
     if (!desc_or) return std::unexpected(std::move(desc_or.error()));
     outer_user_descriptor = block.exprs.Add(*std::move(desc_or));
     const mir::ExprId outer_files =
-        block.exprs.Add(BuildFilesCallExpr(process.Module(), frame));
+        block.exprs.Add(BuildFilesCallExpr(process.Owner(), frame));
     outer_cancellation = block.exprs.Add(
         mir::Expr{
             .data =
@@ -116,11 +116,11 @@ auto LowerStrobeCall(
   std::optional<mir::ExprId> body_user_descriptor;
   if (outer_user_descriptor.has_value()) {
     body_user_descriptor = SnapshotIntoClosure(
-        process.Module(), frame, closure, *outer_user_descriptor, "descriptor");
+        process.Owner(), frame, closure, *outer_user_descriptor, "descriptor");
   }
   if (outer_cancellation.has_value()) {
     const mir::ExprId cancellation = SnapshotIntoClosure(
-        process.Module(), frame, closure, *outer_cancellation, "cancellation");
+        process.Owner(), frame, closure, *outer_cancellation, "cancellation");
     const mir::ExprId is_cancelled = body.exprs.Add(
         mir::Expr{
             .data =
@@ -159,7 +159,7 @@ auto LowerStrobeCall(
 
   const mir::ExprId closure_id = block.exprs.Add(closure.BuildVoid());
   const mir::ExprId services =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -180,7 +180,7 @@ auto LowerPrintSystemSubroutineCall(
   }
 
   auto& block = *frame.current_block;
-  auto& unit = process.Module().Unit();
+  auto& unit = process.Owner().Unit();
   const mir::TypeId int_type = unit.builtins.int_type;
   const bool is_file_sink = print.sink_kind == support::PrintSinkKind::kFile;
 

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -36,15 +36,15 @@ namespace {
 // the `$sscanf` source; the latter two are lifted to string here so the
 // parser only has to handle one shape.
 auto LiftStringSource(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId source_type,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId source_type,
     mir::ExprId source_id) -> mir::ExprId {
-  const mir::TypeKind kind = module.Unit().types.Get(source_type).Kind();
+  const mir::TypeKind kind = unit_lowerer.Unit().types.Get(source_type).Kind();
   if (kind == mir::TypeKind::kString) return source_id;
 
   if (kind == mir::TypeKind::kUnpackedArray) {
     const auto& ua = std::get<mir::UnpackedArrayType>(
-        module.Unit().types.Get(source_type).data);
-    const auto& elem = module.Unit().types.Get(ua.element_type);
+        unit_lowerer.Unit().types.Get(source_type).data);
+    const auto& elem = unit_lowerer.Unit().types.Get(ua.element_type);
     if (!elem.IsIntegralPacked() || elem.AsIntegralPacked().BitWidth() != 8U) {
       throw InternalError(
           "LiftStringSource: $sscanf unpacked-array source must have an "
@@ -57,16 +57,16 @@ auto LiftStringSource(
   }
 
   return frame.current_block->exprs.Add(BuildValueConversion(
-      module.Unit(), *frame.current_block, source_id,
-      module.Unit().builtins.string));
+      unit_lowerer.Unit(), *frame.current_block, source_id,
+      unit_lowerer.Unit().builtins.string));
 }
 
 // LRM 21.3.4.3 permits string or integral as the format argument; the
 // integral form is lifted to string.
 auto LiftStringFormat(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId format_type,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId format_type,
     mir::ExprId format_id) -> mir::ExprId {
-  const auto& t = module.Unit().types.Get(format_type);
+  const auto& t = unit_lowerer.Unit().types.Get(format_type);
   if (t.Kind() == mir::TypeKind::kString) return format_id;
   if (!t.IsIntegralPacked()) {
     throw InternalError(
@@ -74,15 +74,15 @@ auto LiftStringFormat(
         "21.3.4.3)");
   }
   return frame.current_block->exprs.Add(BuildValueConversion(
-      module.Unit(), *frame.current_block, format_id,
-      module.Unit().builtins.string));
+      unit_lowerer.Unit(), *frame.current_block, format_id,
+      unit_lowerer.Unit().builtins.string));
 }
 
 // LRM 21.3.4.3: a source or format string that contains x or z makes
 // the call return -1 before any conversion. Emit the guard before the
 // lift to string, because the lift silently drops the unknown bits.
 auto EmitIsUnknownGuard(
-    const ModuleLowerer& module, WalkFrame frame, mir::TypeId bit_t,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId bit_t,
     mir::ExprId operand_id) -> void {
   auto& body = *frame.current_block;
   const mir::ExprId guard_id = body.exprs.Add(
@@ -97,7 +97,7 @@ auto EmitIsUnknownGuard(
   mir::Block then_body;
   const mir::ExprId minus_one = then_body.exprs.Add(
       mir::MakeIntegerLiteral(
-          module.Unit().builtins.integer, static_cast<std::int64_t>(-1)));
+          unit_lowerer.Unit().builtins.integer, static_cast<std::int64_t>(-1)));
   then_body.AppendStmt(mir::ReturnStmt{.value = minus_one});
 
   body.AppendIfThen(
@@ -137,8 +137,8 @@ auto LowerScanSystemSubroutineCall(
   }
 
   const auto& hir_proc = process.HirBody();
-  auto& module = process.Module();
-  auto& unit = module.Unit();
+  auto& unit_lowerer = process.Owner();
+  auto& unit = unit_lowerer.Unit();
   const mir::TypeId integer_t = unit.builtins.integer;
   const mir::TypeId int_type = unit.builtins.int_type;
   const mir::TypeId string_t = unit.builtins.string;
@@ -153,7 +153,7 @@ auto LowerScanSystemSubroutineCall(
       throw InternalError("LowerScanSystemSubroutineCall: output arg elided");
     }
     const auto& hir_arg = hir_proc.exprs.Get(*call.arguments[i]);
-    const mir::TypeId mir_type = module.TranslateType(hir_arg.type);
+    const mir::TypeId mir_type = unit_lowerer.TranslateType(hir_arg.type);
     auto valid_or = ValidateTargetType(unit, mir_type, info.source, span);
     if (!valid_or) return std::unexpected(std::move(valid_or.error()));
     target_types.push_back(mir_type);
@@ -184,7 +184,7 @@ auto LowerScanSystemSubroutineCall(
     }
     fd_id = raw_source_id;
     const mir::ExprId services_id =
-        body.exprs.Add(BuildServicesCallExpr(process.Module(), closure_frame));
+        body.exprs.Add(BuildServicesCallExpr(process.Owner(), closure_frame));
     const mir::ExprId files_id = body.exprs.Add(
         mir::Expr{
             .data =
@@ -202,9 +202,9 @@ auto LowerScanSystemSubroutineCall(
                     .arguments = {files_id, fd_id}},
             .type = string_t});
   } else {
-    EmitIsUnknownGuard(module, closure_frame, bit_t, raw_source_id);
-    source_id =
-        LiftStringSource(module, closure_frame, raw_source_type, raw_source_id);
+    EmitIsUnknownGuard(unit_lowerer, closure_frame, bit_t, raw_source_id);
+    source_id = LiftStringSource(
+        unit_lowerer, closure_frame, raw_source_type, raw_source_id);
   }
 
   auto format_or =
@@ -212,8 +212,9 @@ auto LowerScanSystemSubroutineCall(
   if (!format_or) return std::unexpected(std::move(format_or.error()));
   const mir::TypeId format_type = format_or->type;
   mir::ExprId format_id = body.exprs.Add(*std::move(format_or));
-  EmitIsUnknownGuard(module, closure_frame, bit_t, format_id);
-  format_id = LiftStringFormat(module, closure_frame, format_type, format_id);
+  EmitIsUnknownGuard(unit_lowerer, closure_frame, bit_t, format_id);
+  format_id =
+      LiftStringFormat(unit_lowerer, closure_frame, format_type, format_id);
 
   // LRM 21.3.4.3 "the offending input character is left unread in the
   // input stream": the parse returns the byte-count it consumed so the
@@ -229,7 +230,7 @@ auto LowerScanSystemSubroutineCall(
   temp_ids.reserve(target_types.size());
   for (std::size_t k = 0; k < target_types.size(); ++k) {
     const mir::ExprId init_id = body.exprs.Add(
-        BuildDefaultValueExpr(module, closure_frame, target_types[k]));
+        BuildDefaultValueExpr(unit_lowerer, closure_frame, target_types[k]));
     const mir::LocalId temp_var = closure.Bindings().DeclareAnonymous(
         mir::LocalDecl{
             .name = std::format("_lyra_scan_temp_{}", k),
@@ -263,7 +264,7 @@ auto LowerScanSystemSubroutineCall(
 
   if (is_file) {
     const mir::ExprId services_after =
-        body.exprs.Add(BuildServicesCallExpr(process.Module(), closure_frame));
+        body.exprs.Add(BuildServicesCallExpr(process.Owner(), closure_frame));
     const mir::ExprId files_after = body.exprs.Add(
         mir::Expr{
             .data =
@@ -308,8 +309,8 @@ auto LowerScanSystemSubroutineCall(
     const mir::ExprId lvalue_id = then_body.exprs.Add(*std::move(lvalue_or));
     const mir::ExprId temp_read_id = then_body.exprs.Add(
         mir::MakeLocalRefExpr(temp_ids[k], target_types[k]));
-    const mir::ExprId services_id_then = then_body.exprs.Add(
-        BuildServicesCallExpr(process.Module(), then_frame));
+    const mir::ExprId services_id_then =
+        then_body.exprs.Add(BuildServicesCallExpr(process.Owner(), then_frame));
     const mir::Expr assign_expr = BuildObservableAssignExpr(
         unit, then_body, services_id_then, lvalue_id, temp_read_id,
         std::nullopt, target_types[k], void_t);

--- a/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
@@ -43,7 +43,7 @@ auto BuildSFormatCallExpr(
       process, frame, call, info.radix, arg_offset);
   if (!items_or) return std::unexpected(std::move(items_or.error()));
 
-  auto& unit = process.Module().Unit();
+  auto& unit = process.Owner().Unit();
   auto& block = *frame.current_block;
   const auto time_unit_power =
       static_cast<std::int64_t>(process.Resolution().unit_power);
@@ -51,7 +51,7 @@ auto BuildSFormatCallExpr(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
 
   return BuildFormatCallExpr(unit, block, services_id, items_array);
 }
@@ -101,7 +101,7 @@ auto LowerSFormatSystemSubroutineCallStmt(
   auto out_or =
       process.LowerLhsExpr(hir_proc.exprs.Get(*call.arguments[0]), frame);
   if (!out_or) return std::unexpected(std::move(out_or.error()));
-  const mir::TypeId out_type = process.Module().TranslateType(
+  const mir::TypeId out_type = process.Owner().TranslateType(
       hir_proc.exprs.Get(*call.arguments[0]).type);
   const mir::ExprId out_id = block.exprs.Add(*std::move(out_or));
 
@@ -114,13 +114,13 @@ auto LowerSFormatSystemSubroutineCallStmt(
   // destination conforms the string value to its own representation. A
   // string-typed destination already matches and passes through unchanged.
   const mir::ExprId value_id =
-      ConvertToType(process.Module().Unit(), block, call_id, out_type);
+      ConvertToType(process.Owner().Unit(), block, call_id, out_type);
 
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
-      process.Module().Unit(), block, services_id, out_id, value_id,
-      std::nullopt, out_type, process.Module().Unit().builtins.void_type);
+      process.Owner().Unit(), block, services_id, out_id, value_id,
+      std::nullopt, out_type, process.Owner().Unit().builtins.void_type);
   const mir::ExprId assign_id = block.exprs.Add(assign_expr);
 
   return mir::Stmt{

--- a/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
@@ -38,11 +38,11 @@ auto SelectTimeFn(const mir::BuiltinMirTypes& builtins, support::TimeKind kind)
 auto LowerTimeSystemSubroutineCall(
     const ProcessLowerer& process, const WalkFrame& frame,
     const support::TimeSystemSubroutineInfo& info) -> diag::Result<mir::Expr> {
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = process.Owner().Unit().builtins;
   const TimeFnInfo fn = SelectTimeFn(builtins, info.kind);
   auto& body = *frame.current_block;
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      body.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId unit_power_id = body.exprs.Add(
       mir::MakeIntLiteral(
           builtins.int_type,

--- a/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
@@ -35,7 +35,7 @@ auto LowerTimeFormatSystemSubroutineCall(
 
   std::vector<mir::ExprId> call_args;
   call_args.push_back(
-      body.exprs.Add(BuildServicesCallExpr(process.Module(), frame)));
+      body.exprs.Add(BuildServicesCallExpr(process.Owner(), frame)));
   for (const auto& arg : args) {
     if (!arg.has_value()) {
       throw InternalError(
@@ -54,13 +54,13 @@ auto LowerTimeFormatSystemSubroutineCall(
           mir::CallExpr{
               .callee = mir::Direct{.target = builtin},
               .arguments = std::move(call_args)},
-      .type = process.Module().Unit().builtins.void_type};
+      .type = process.Owner().Unit().builtins.void_type};
 }
 
 auto LowerPrintTimescaleSystemSubroutineCall(
     const ProcessLowerer& process, const WalkFrame& frame)
     -> diag::Result<mir::Expr> {
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = process.Owner().Unit().builtins;
   auto& body = *frame.current_block;
   const auto resolution = process.Resolution();
 
@@ -86,7 +86,7 @@ auto LowerPrintTimescaleSystemSubroutineCall(
   const mir::ExprId fd_id = body.exprs.Add(
       mir::MakeIntLiteral(builtins.int_type, support::kStdoutFd));
   const mir::ExprId files_id =
-      body.exprs.Add(BuildFilesCallExpr(process.Module(), frame));
+      body.exprs.Add(BuildFilesCallExpr(process.Owner(), frame));
   return mir::Expr{
       .data =
           mir::CallExpr{

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -21,7 +21,7 @@ auto BuildHirInsideItemPredicate(
     -> diag::Result<mir::ExprId> {
   const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  auto& unit = lowerer.Module().Unit();
+  auto& unit = lowerer.Owner().Unit();
   auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
     auto lowered = lowerer.LowerExpr(hir_exprs.Get(id), frame);
     if (!lowered) {

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -106,7 +106,7 @@ auto LowerFormatOperand(
   auto lowered_or = process.LowerExpr(hir_expr, frame);
   if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
   mir::Expr lowered = *std::move(lowered_or);
-  if (TypeContainsChandle(process.Module().Unit(), lowered.type)) {
+  if (TypeContainsChandle(process.Owner().Unit(), lowered.type)) {
     return diag::Fail(
         hir_expr.span, diag::DiagCode::kUnsupportedExpressionForm,
         "a chandle is not a legal format argument (LRM 6.14 permits a chandle "
@@ -127,14 +127,14 @@ auto BuildPrintValueItem(
   // each format directly, without building a string value. Only an unpacked
   // byte array is not directly formattable, so it lifts to a string value
   // here.
-  const auto& value_type = process.Module().Unit().types.Get(lowered.type);
+  const auto& value_type = process.Owner().Unit().types.Get(lowered.type);
   if (spec.kind == value::FormatKind::kString &&
       value_type.Kind() != mir::TypeKind::kString &&
       !value_type.IsIntegralPacked()) {
     const mir::ExprId inner = block.exprs.Add(std::move(lowered));
     lowered = BuildValueConversion(
-        process.Module().Unit(), block, inner,
-        process.Module().Unit().builtins.string);
+        process.Owner().Unit(), block, inner,
+        process.Owner().Unit().builtins.string);
   }
 
   const mir::TypeId type = lowered.type;
@@ -160,7 +160,7 @@ auto BuildPrintItemFromDirective(
       // the operand cursor where it found it; its modifiers ride through the
       // string-format spec like an ordinary `%s` argument.
       auto& block = *frame.current_block;
-      const auto& builtins = process.Module().Unit().builtins;
+      const auto& builtins = process.Owner().Unit().builtins;
       const mir::ExprId self_id = block.exprs.Add(
           MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
       const mir::ExprId path_id = block.exprs.Add(
@@ -391,7 +391,7 @@ auto HasLiteralFormatString(
 auto BuildRuntimeFormatCallExpr(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
     std::size_t arg_offset) -> diag::Result<mir::Expr> {
-  auto& unit = process.Module().Unit();
+  auto& unit = process.Owner().Unit();
   auto& block = *frame.current_block;
   const std::vector<hir::ExprId> args = FlattenCallArgs(call);
 
@@ -447,7 +447,7 @@ auto BuildRuntimeFormatCallExpr(
           .type = unit.builtins.string});
 
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId time_format_id = block.exprs.Add(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -104,7 +104,7 @@ auto ProcessLowerer::BuildStaticStorageAccess(
     const WalkFrame& frame, StaticStoragePlacement placement) const
     -> mir::Expr {
   mir::Block& block = *frame.current_block;
-  const mir::CompilationUnit& unit = module_->Unit();
+  const mir::CompilationUnit& unit = owner_->Unit();
 
   // Intra-unit access is a typed segment: descend from the body's `self`
   // through each intervening materialized scope's borrowed companion member,
@@ -134,7 +134,7 @@ auto ProcessLowerer::BuildStaticStorageAccess(
     // member types come from the published shape, not the not-yet-committed
     // mir class.
     const mir::TypeId step_type =
-        module_->GetClassShape(obj->class_id).fields.Get(step).type;
+        owner_->GetClassShape(obj->class_id).fields.Get(step).type;
     receiver = block.exprs.Add(
         mir::MakeFieldAccessExpr(
             receiver, mir::FieldTarget{.owner = obj->class_id, .slot = step},
@@ -152,7 +152,7 @@ auto ProcessLowerer::BuildStaticStorageAccess(
           }},
       placement.owner);
   const mir::TypeId field_type =
-      module_->GetClassShape(owner_class_id).fields.Get(placement.field).type;
+      owner_->GetClassShape(owner_class_id).fields.Get(placement.field).type;
   return mir::MakeFieldAccessExpr(
       receiver,
       mir::FieldTarget{.owner = owner_class_id, .slot = placement.field},
@@ -175,7 +175,7 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
     -> diag::Result<mir::MethodDecl> {
   const WalkFrame& parent = process.OwnerCtorFrame();
   mir::CallableCode code;
-  CallableBindings bindings(process.Module().Unit(), code);
+  CallableBindings bindings(process.Owner().Unit(), code);
   const mir::LocalId self_id = bindings.Declare(
       BindingOriginId::Receiver(),
       mir::LocalDecl{
@@ -189,7 +189,7 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
   // rather than an implicit exit (LRM 9.2). Its coroutine result type is what
   // makes that return a coroutine completion.
   code.body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
-  code.result_type = process.Module().Unit().builtins.coroutine_void;
+  code.result_type = process.Owner().Unit().builtins.coroutine_void;
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
       .code = std::move(code),
@@ -207,7 +207,7 @@ auto LowerForeverProcess(
     -> diag::Result<mir::MethodDecl> {
   const WalkFrame& parent = process.OwnerCtorFrame();
   mir::CallableCode code;
-  CallableBindings bindings(process.Module().Unit(), code);
+  CallableBindings bindings(process.Owner().Unit(), code);
   const mir::LocalId self_id = bindings.Declare(
       BindingOriginId::Receiver(),
       mir::LocalDecl{
@@ -235,7 +235,7 @@ auto LowerForeverProcess(
           .step = {},
           .scope = body_scope_id});
   code.body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
-  code.result_type = process.Module().Unit().builtins.coroutine_void;
+  code.result_type = process.Owner().Unit().builtins.coroutine_void;
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
       .code = std::move(code),
@@ -265,7 +265,7 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
     -> diag::Result<mir::MethodDecl> {
   const WalkFrame& parent = owner_ctor_frame_;
   mir::CallableCode code;
-  CallableBindings bindings(module_->Unit(), code);
+  CallableBindings bindings(owner_->Unit(), code);
   const mir::LocalId self_id = bindings.Declare(
       BindingOriginId::Receiver(),
       mir::LocalDecl{
@@ -285,12 +285,12 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
   std::vector<mir::LocalId> params{self_id};
   for (const auto& param : src.params) {
     const auto& hir_var = src.body.procedural_vars.Get(param.var);
-    const mir::TypeId value_type = module_->TranslateType(hir_var.type);
+    const mir::TypeId value_type = owner_->TranslateType(hir_var.type);
     const hir::ParamDirection dir = param.direction;
 
     if (dir == hir::ParamDirection::kOutput) {
       const mir::ExprId default_init = code.body.exprs.Add(
-          BuildDefaultValueFromHir(*module_, body_frame, hir_var.type));
+          BuildDefaultValueFromHir(*owner_, body_frame, hir_var.type));
       const mir::LocalId local = bindings.Declare(
           BindingOriginId::Procedural(param.var),
           mir::LocalDecl{.name = hir_var.name, .type = value_type});
@@ -308,7 +308,7 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
                               dir == hir::ParamDirection::kConstRef;
     const mir::TypeId type =
         by_reference
-            ? module_->Unit().types.Intern(
+            ? owner_->Unit().types.Intern(
                   mir::RefType{
                       .pointee = value_type,
                       .mutability = dir == hir::ParamDirection::kConstRef
@@ -333,9 +333,9 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
   // `return` carries. void functions and tasks have none.
   std::vector<mir::TypeId> payload_components;
   if (src.result_var.has_value()) {
-    const mir::TypeId ret_type = module_->TranslateType(src.result_type);
+    const mir::TypeId ret_type = owner_->TranslateType(src.result_type);
     const mir::ExprId default_init = code.body.exprs.Add(
-        BuildDefaultValueFromHir(*module_, body_frame, src.result_type));
+        BuildDefaultValueFromHir(*owner_, body_frame, src.result_type));
     const mir::LocalId result_local = bindings.Declare(
         BindingOriginId::Procedural(*src.result_var),
         mir::LocalDecl{.name = "_lyra_result", .type = ret_type});
@@ -354,10 +354,10 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
   // inout value, normalized by count. A task wraps it in the coroutine call
   // protocol (LRM 13.3); a function's result is the payload itself (LRM 13.4).
   completion_payload_type_ =
-      NormalizeCompletionPayload(module_->Unit(), payload_components);
+      NormalizeCompletionPayload(owner_->Unit(), payload_components);
   const mir::TypeId result_type =
       body_is_coroutine
-          ? module_->Unit().types.CoroutineOf(completion_payload_type_)
+          ? owner_->Unit().types.CoroutineOf(completion_payload_type_)
           : completion_payload_type_;
 
   auto lowered = LowerStraightLineBodyInto(*this, body_frame);
@@ -392,7 +392,7 @@ auto ProcessLowerer::LowerConstructorBodyInto(
           "formal reached MIR lowering; AST-to-HIR rejects these");
     }
     const auto& hir_var = ctor.body.procedural_vars.Get(param.var);
-    const mir::TypeId value_type = module_->TranslateType(hir_var.type);
+    const mir::TypeId value_type = owner_->TranslateType(hir_var.type);
     const mir::LocalId mir_var = frame.bindings->Declare(
         BindingOriginId::Procedural(param.var),
         mir::LocalDecl{.name = hir_var.name, .type = value_type});

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -6,9 +6,9 @@
 
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/endpoint.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -61,7 +61,7 @@ auto MakeValueChangeWaitStmt(
     mir::Block& target_block, const WalkFrame& frame,
     const StructuralScopeLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt {
-  auto& unit = lowerer.Module().Unit();
+  auto& unit = lowerer.Owner().Unit();
 
   std::vector<mir::ExprId> triggers;
   triggers.reserve(sensitivity_list.size());
@@ -79,7 +79,7 @@ auto MakeValueChangeWaitStmt(
           .type = triggers_type});
 
   const mir::ExprId services_id =
-      target_block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame));
+      target_block.exprs.Add(BuildServicesCallExpr(lowerer.Owner(), frame));
   const mir::ExprId call_id = target_block.exprs.Add(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/services_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/services_call.cpp
@@ -25,21 +25,21 @@ auto FormatRuntimeOriginString(
       loc.line, loc.col);
 }
 
-auto BuildServicesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
-    -> mir::Expr {
+auto BuildServicesCallExpr(
+    const UnitLowerer& unit_lowerer, const WalkFrame& frame) -> mir::Expr {
   auto& body = *frame.current_block;
-  const auto& builtins = module.Unit().builtins;
+  const auto& builtins = unit_lowerer.Unit().builtins;
   const mir::ExprId self_id = body.exprs.Add(
       MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
   return mir::MakeServicesCallExpr(self_id, builtins.services);
 }
 
-auto BuildFilesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
+auto BuildFilesCallExpr(const UnitLowerer& unit_lowerer, const WalkFrame& frame)
     -> mir::Expr {
   auto& body = *frame.current_block;
-  const auto& builtins = module.Unit().builtins;
+  const auto& builtins = unit_lowerer.Unit().builtins;
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(module, frame));
+      body.exprs.Add(BuildServicesCallExpr(unit_lowerer, frame));
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -49,11 +49,11 @@ auto BuildFilesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
 }
 
 auto BuildDiagnosticCallExpr(
-    const ModuleLowerer& module, const WalkFrame& frame) -> mir::Expr {
+    const UnitLowerer& unit_lowerer, const WalkFrame& frame) -> mir::Expr {
   auto& body = *frame.current_block;
-  const auto& builtins = module.Unit().builtins;
+  const auto& builtins = unit_lowerer.Unit().builtins;
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(module, frame));
+      body.exprs.Add(BuildServicesCallExpr(unit_lowerer, frame));
   return mir::Expr{
       .data =
           mir::CallExpr{

--- a/src/lyra/lowering/hir_to_mir/snapshot_local.cpp
+++ b/src/lyra/lowering/hir_to_mir/snapshot_local.cpp
@@ -14,7 +14,7 @@
 namespace lyra::lowering::hir_to_mir {
 
 auto SnapshotExprToLocal(
-    const ModuleLowerer& module, WalkFrame frame, mir::Block& wrapper,
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::Block& wrapper,
     std::string name, mir::TypeId type, mir::ExprId expr_id,
     std::optional<BindingOriginId> origin) -> mir::LocalId {
   const mir::LocalId snap_var =
@@ -24,7 +24,7 @@ auto SnapshotExprToLocal(
           : frame.bindings->DeclareAnonymous(
                 mir::LocalDecl{.name = std::move(name), .type = type});
   const mir::ExprId default_init =
-      wrapper.exprs.Add(BuildDefaultValueExpr(module, frame, type));
+      wrapper.exprs.Add(BuildDefaultValueExpr(unit_lowerer, frame, type));
   wrapper.AppendStmt(
       mir::LocalDeclStmt{.target = snap_var, .init = default_init});
 
@@ -40,7 +40,7 @@ auto SnapshotExprToLocal(
 }
 
 auto SnapshotIntoClosure(
-    ModuleLowerer& module, const WalkFrame& outer_frame,
+    UnitLowerer& unit_lowerer, const WalkFrame& outer_frame,
     ClosureBuilder& closure, mir::ExprId outer_expr, std::string name)
     -> mir::ExprId {
   mir::Block& outer_block = *outer_frame.current_block;
@@ -51,7 +51,7 @@ auto SnapshotIntoClosure(
   // The temp initializes directly from the snapshotted expression (not a
   // default-then-assign), so a carrier with no default value -- a `Ref<T>` over
   // the target cell -- is materialized correctly.
-  const std::uint32_t site = module.NextSynthesizedSite();
+  const std::uint32_t site = unit_lowerer.NextSynthesizedSite();
   const BindingOriginId origin = BindingOriginId::Synthesized(site, 0);
   const mir::LocalId temp = outer_frame.bindings->Declare(
       origin,

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -56,8 +56,8 @@ auto LowerDestructuringAssign(
   part_widths.reserve(lhs_concat.operands.size());
   bool any_four_state = false;
   std::uint64_t total_width = 0;
-  const auto& hir_types = process.Module().Hir().types;
-  const auto& mir_types = process.Module().Unit().types;
+  const auto& hir_types = process.Owner().Hir().types;
+  const auto& mir_types = process.Owner().Unit().types;
   for (const hir::ExprId op_id : lhs_concat.operands) {
     const hir::Expr& op = hir_proc.exprs.Get(op_id);
     if (!hir_types.Get(op.type).IsBitVector()) {
@@ -67,7 +67,7 @@ auto LowerDestructuringAssign(
     }
     // Width and 4-state-ness are properties of the flat MIR vector; read them
     // off it directly rather than recompute from the structural HIR type.
-    const auto& packed = mir_types.Get(process.Module().TranslateType(op.type))
+    const auto& packed = mir_types.Get(process.Owner().TranslateType(op.type))
                              .AsIntegralPacked();
     const std::uint64_t w = packed.BitWidth();
     part_widths.push_back(w);
@@ -79,7 +79,7 @@ auto LowerDestructuringAssign(
         "LowerDestructuringAssign: destructuring total width must be positive");
   }
 
-  const mir::TypeId temp_type = process.Module().Unit().types.Intern(
+  const mir::TypeId temp_type = process.Owner().Unit().types.Intern(
       mir::PackedArrayType{
           .atom = any_four_state ? mir::BitAtom::kLogic : mir::BitAtom::kBit,
           .signedness = mir::Signedness::kUnsigned,
@@ -88,7 +88,7 @@ auto LowerDestructuringAssign(
           .form = mir::PackedArrayForm::kExplicit});
 
   const mir::ExprId temp_default_init = wrapper.exprs.Add(
-      BuildDefaultValueExpr(process.Module(), wrapper_frame, temp_type));
+      BuildDefaultValueExpr(process.Owner(), wrapper_frame, temp_type));
   const mir::LocalId snapshot_var = wrapper_frame.bindings->DeclareAnonymous(
       mir::LocalDecl{.name = "_lyra_destruct_rhs", .type = temp_type});
   wrapper.AppendStmt(
@@ -102,7 +102,7 @@ auto LowerDestructuringAssign(
   mir::ExprId rhs_id = wrapper.exprs.Add(*std::move(rhs_or));
   if (wrapper.exprs.Get(rhs_id).type != temp_type) {
     rhs_id = wrapper.exprs.Add(BuildValueConversion(
-        process.Module().Unit(), wrapper, rhs_id, temp_type));
+        process.Owner().Unit(), wrapper, rhs_id, temp_type));
   }
 
   const mir::ExprId temp_assign_target =
@@ -126,25 +126,25 @@ auto LowerDestructuringAssign(
     if (!part_lhs_or) {
       return std::unexpected(std::move(part_lhs_or.error()));
     }
-    const mir::TypeId part_mir_type = process.Module().TranslateType(
+    const mir::TypeId part_mir_type = process.Owner().TranslateType(
         hir_proc.exprs.Get(lhs_concat.operands[i]).type);
     const mir::ExprId part_lhs_id = wrapper.exprs.Add(*std::move(part_lhs_or));
 
     const mir::ExprId offset_id = wrapper.exprs.Add(
         mir::MakeIntLiteral(
-            process.Module().Unit().builtins.int_type,
+            process.Owner().Unit().builtins.int_type,
             static_cast<std::int64_t>(offset)));
     const mir::ExprId count_id = wrapper.exprs.Add(
         mir::MakeIntLiteral(
-            process.Module().Unit().builtins.int_type,
+            process.Owner().Unit().builtins.int_type,
             static_cast<std::int64_t>(w)));
     // `temp[offset +: w]`: a raw indexed-up part-select (`value::SliceForm`
     // `kIndexedUp` == 1); the snapshot value resolves the bit window itself.
     const mir::ExprId form_id = wrapper.exprs.Add(
-        mir::MakeIntLiteral(process.Module().Unit().builtins.int_type, 1));
+        mir::MakeIntLiteral(process.Owner().Unit().builtins.int_type, 1));
     const mir::ExprId temp_ref =
         wrapper.exprs.Add(mir::MakeLocalRefExpr(snapshot_var, temp_type));
-    const mir::TypeId slice_type = process.Module().Unit().types.Intern(
+    const mir::TypeId slice_type = process.Owner().Unit().types.Intern(
         mir::PackedArrayType{
             .atom = any_four_state ? mir::BitAtom::kLogic : mir::BitAtom::kBit,
             .signedness = mir::Signedness::kUnsigned,
@@ -169,25 +169,25 @@ auto LowerDestructuringAssign(
     mir::ExprId rhs_for_part = slice_id;
     if (part_mir_type != slice_type) {
       rhs_for_part = wrapper.exprs.Add(BuildValueConversion(
-          process.Module().Unit(), wrapper, slice_id, part_mir_type));
+          process.Owner().Unit(), wrapper, slice_id, part_mir_type));
     }
 
     mir::ExprId per_part_expr_id{};
     if (assign.kind == hir::AssignKind::kBlocking) {
       const mir::ExprId services_id = wrapper.exprs.Add(
-          BuildServicesCallExpr(process.Module(), wrapper_frame));
+          BuildServicesCallExpr(process.Owner(), wrapper_frame));
       const mir::Expr part_assign_expr = BuildObservableAssignExpr(
-          process.Module().Unit(), wrapper, services_id, part_lhs_id,
+          process.Owner().Unit(), wrapper, services_id, part_lhs_id,
           rhs_for_part, std::nullopt, part_mir_type,
-          process.Module().Unit().builtins.void_type);
+          process.Owner().Unit().builtins.void_type);
       per_part_expr_id = wrapper.exprs.Add(part_assign_expr);
     } else {
       mir::Expr closure_expr = BuildNbaSubmitClosureExpr(
-          process.Module(), wrapper_frame, part_lhs_id, rhs_for_part,
+          process.Owner(), wrapper_frame, part_lhs_id, rhs_for_part,
           part_mir_type);
       const mir::ExprId closure_id = wrapper.exprs.Add(std::move(closure_expr));
       const mir::ExprId services_id = wrapper.exprs.Add(
-          BuildServicesCallExpr(process.Module(), wrapper_frame));
+          BuildServicesCallExpr(process.Owner(), wrapper_frame));
       per_part_expr_id = wrapper.exprs.Add(
           mir::Expr{
               .data =
@@ -195,7 +195,7 @@ auto LowerDestructuringAssign(
                       .callee =
                           mir::Direct{.target = support::BuiltinFn::kSubmitNba},
                       .arguments = {services_id, closure_id}},
-              .type = process.Module().Unit().builtins.void_type});
+              .type = process.Owner().Unit().builtins.void_type});
     }
     wrapper.AppendStmt(mir::ExprStmt{.expr = per_part_expr_id});
   }
@@ -256,15 +256,15 @@ auto LowerSubroutineCallWithWritebacks(
         "LowerSubroutineCallWithWritebacks: argument / formal count mismatch");
   }
 
-  ModuleLowerer& module = process.Module();
-  mir::CompilationUnit& unit = module.Unit();
+  UnitLowerer& unit_lowerer = process.Owner();
+  mir::CompilationUnit& unit = unit_lowerer.Unit();
   const hir::ProceduralBody& hir_proc = process.HirBody();
   mir::Block wrapper;
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper);
 
   // The completion layout the callee body and this call site share.
   const std::vector<mir::TypeId> components =
-      CompletionComponentTypes(module, decl);
+      CompletionComponentTypes(unit_lowerer, decl);
   const mir::TypeId payload_type = NormalizeCompletionPayload(unit, components);
   const bool is_task = decl.kind == hir::SubroutineKind::kTask;
   const mir::TypeId call_result_type =
@@ -301,7 +301,7 @@ auto LowerSubroutineCallWithWritebacks(
           "unexpectedly elided");
     }
     const hir::Expr& hir_arg = hir_proc.exprs.Get(*call.arguments[i]);
-    const mir::TypeId formal_type = module.TranslateType(
+    const mir::TypeId formal_type = unit_lowerer.TranslateType(
         decl.body.procedural_vars.Get(decl.params[i].var).type);
 
     // An `output` passes no argument; an `inout` passes its incoming value.
@@ -336,8 +336,8 @@ auto LowerSubroutineCallWithWritebacks(
       const bool root_is_cell = mir::IsObservableCellType(
           unit.types.Get(wrapper.exprs.Get(root_id).type));
       if (root_is_cell && root_id != actual_id) {
-        const mir::ExprId services_id =
-            wrapper.exprs.Add(BuildServicesCallExpr(module, wrapper_frame));
+        const mir::ExprId services_id = wrapper.exprs.Add(
+            BuildServicesCallExpr(unit_lowerer, wrapper_frame));
         actual_id =
             RewriteLhsRootWithMutate(unit, wrapper, actual_id, services_id);
       }
@@ -376,7 +376,7 @@ auto LowerSubroutineCallWithWritebacks(
       mir::LocalDeclStmt{.target = completion, .init = completion_value});
 
   const mir::ExprId services_id =
-      wrapper.exprs.Add(BuildServicesCallExpr(module, wrapper_frame));
+      wrapper.exprs.Add(BuildServicesCallExpr(unit_lowerer, wrapper_frame));
   const mir::TypeId void_type = unit.builtins.void_type;
   for (const CompletionWriteback& wb : writebacks) {
     // A single-component payload is the bare value; otherwise project the
@@ -452,7 +452,7 @@ auto LowerExprStmt(
         if (support::IsFileOutputArgBuiltinFn(file_info->builtin_fn)) {
           return LowerFileIOSystemSubroutineCallStmt(
               process, frame, std::move(label), *call, *file_info, std::nullopt,
-              process.Module().TranslateType(inner.type));
+              process.Owner().TranslateType(inner.type));
         }
       }
       if (const auto* sformat_info = support::GetSFormatInfo(desc)) {
@@ -475,7 +475,7 @@ auto LowerExprStmt(
       const mir::ExprId await_id = block.exprs.Add(
           mir::Expr{
               .data = mir::AwaitExpr{.awaitable = call_id},
-              .type = process.Module().Unit().builtins.void_type});
+              .type = process.Owner().Unit().builtins.void_type});
       return mir::Stmt{
           .label = std::move(label), .data = mir::ExprStmt{.expr = await_id}};
     }
@@ -509,7 +509,7 @@ auto LowerExprStmt(
         if (const auto* sys_ref =
                 std::get_if<hir::SystemSubroutineRef>(&call->callee)) {
           const auto& desc = support::LookupSystemSubroutine(sys_ref->id);
-          const mir::TypeId result_type = process.Module().TranslateType(
+          const mir::TypeId result_type = process.Owner().TranslateType(
               conv_target_type.has_value() ? *conv_target_type
                                            : call_carrier->type);
           if (const auto* file_info = support::GetFileIOInfo(desc)) {

--- a/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
@@ -48,8 +48,8 @@ void OpenActivationScope(
     return;
   }
 
-  ModuleLowerer& module = process.Module();
-  mir::CompilationUnit& unit = module.Unit();
+  UnitLowerer& unit_lowerer = process.Owner();
+  mir::CompilationUnit& unit = unit_lowerer.Unit();
 
   // The escaping scope's locals are promoted into a compiler-generated struct
   // whose identity lives in the unit's struct registry; its emission nesting is
@@ -65,7 +65,7 @@ void OpenActivationScope(
     const hir::ProceduralVarDecl& decl = body.procedural_vars.Get(v);
     fields.push_back(struct_decl.fields.Add(
         mir::FieldDecl{
-            .name = decl.name, .type = module.TranslateType(decl.type)}));
+            .name = decl.name, .type = unit_lowerer.TranslateType(decl.type)}));
   }
   const mir::StructId struct_id = unit.AddStruct(std::move(struct_decl));
   // The struct is nested in the class whose body opens this scope -- its
@@ -95,7 +95,7 @@ void OpenActivationScope(
   // comes from the unit's synthesized-site allocator, the one collision-free id
   // space every synthesized carrier shares.
   const BindingOriginId handle_origin =
-      BindingOriginId::Synthesized(module.NextSynthesizedSite(), 0);
+      BindingOriginId::Synthesized(unit_lowerer.NextSynthesizedSite(), 0);
   const mir::LocalId handle = frame.bindings->Declare(
       handle_origin,
       mir::LocalDecl{.name = struct_name + "_h", .type = handle_type});

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -39,7 +39,7 @@ auto LowerIfStmt(
   }
   const mir::ExprId cond_id = ReduceToCondition(
       block, block.exprs.Add(*std::move(cond_expr_or)),
-      process.Module().Unit().builtins.bit1);
+      process.Owner().Unit().builtins.bit1);
 
   auto then_or = LowerStmtIntoChildScope(process, frame, i.then_stmt);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
@@ -65,7 +65,7 @@ auto LowerCaseStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::CaseStmt& c, diag::SourceSpan span) -> diag::Result<mir::Stmt> {
   const hir::ProceduralBody& hir_proc = process.HirBody();
-  const mir::TypeId bit_type = process.Module().Unit().builtins.bit1;
+  const mir::TypeId bit_type = process.Owner().Unit().builtins.bit1;
   const mir::BinaryOp compare_op = [&] {
     switch (c.condition_kind) {
       case hir::CaseCondition::kNormal:
@@ -89,7 +89,7 @@ auto LowerCaseStmt(
   const mir::ExprId cond_expr_id = wrapper.exprs.Add(*std::move(cond_or));
 
   const CaseSnapshotRefs snapshot =
-      AppendCaseSnapshot(process.Module(), wrapper_frame, cond_expr_id);
+      AppendCaseSnapshot(process.Owner(), wrapper_frame, cond_expr_id);
 
   std::vector<mir::Block> body_scopes;
   body_scopes.reserve(c.items.size());
@@ -127,7 +127,7 @@ auto LowerCaseStmt(
             }
             return label_frame.current_block->exprs.Add(*std::move(lab_or));
           },
-          process.Module().Unit());
+          process.Owner().Unit());
       if (!pred_or) return std::unexpected(std::move(pred_or.error()));
       predicates.push_back(*pred_or);
     }
@@ -140,7 +140,7 @@ auto LowerCaseStmt(
               .predicate = predicates[i], .body = std::move(body_scopes[i])});
     }
     return BuildDeferredCheckCascade(
-        process.Module(), frame, std::move(wrapper), std::move(branches),
+        process.Owner(), frame, std::move(wrapper), std::move(branches),
         std::move(default_scope), *c.check, std::move(label), span);
   }
 
@@ -157,7 +157,7 @@ auto LowerCaseStmt(
           }
           return label_frame.current_block->exprs.Add(*std::move(lab_or));
         },
-        process.Module().Unit());
+        process.Owner().Unit());
   };
 
   return BuildCaseCascade(
@@ -171,7 +171,7 @@ auto LowerCaseInsideStmt(
     const hir::CaseInsideStmt& c, diag::SourceSpan span)
     -> diag::Result<mir::Stmt> {
   const hir::ProceduralBody& hir_proc = process.HirBody();
-  const mir::TypeId bit_type = process.Module().Unit().builtins.bit1;
+  const mir::TypeId bit_type = process.Owner().Unit().builtins.bit1;
 
   mir::Block wrapper;
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper);
@@ -182,7 +182,7 @@ auto LowerCaseInsideStmt(
   const mir::ExprId cond_expr_id = wrapper.exprs.Add(*std::move(cond_or));
 
   const CaseSnapshotRefs snapshot =
-      AppendCaseSnapshot(process.Module(), wrapper_frame, cond_expr_id);
+      AppendCaseSnapshot(process.Owner(), wrapper_frame, cond_expr_id);
 
   std::vector<mir::Block> body_scopes;
   body_scopes.reserve(c.items.size());
@@ -254,7 +254,7 @@ auto LowerCaseInsideStmt(
               .predicate = predicates[i], .body = std::move(body_scopes[i])});
     }
     return BuildDeferredCheckCascade(
-        process.Module(), frame, std::move(wrapper), std::move(branches),
+        process.Owner(), frame, std::move(wrapper), std::move(branches),
         std::move(default_scope), *c.check, std::move(label), span);
   }
 

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -60,9 +60,9 @@ auto LowerAutomaticVarDeclStmt(
     init_value = block.exprs.Add(*std::move(init_or));
   } else {
     init_value = block.exprs.Add(
-        BuildDefaultValueFromHir(process.Module(), frame, hir_local.type));
+        BuildDefaultValueFromHir(process.Owner(), frame, hir_local.type));
   }
-  init_value = ConvertToType(process.Module().Unit(), block, init_value, type);
+  init_value = ConvertToType(process.Owner().Unit(), block, init_value, type);
 
   return mir::Stmt{
       .label = std::move(label),
@@ -93,9 +93,9 @@ auto LowerPromotedVarDeclStmt(
     init_value = block.exprs.Add(*std::move(init_or));
   } else {
     init_value = block.exprs.Add(
-        BuildDefaultValueFromHir(process.Module(), frame, hir_type));
+        BuildDefaultValueFromHir(process.Owner(), frame, hir_type));
   }
-  init_value = ConvertToType(process.Module().Unit(), block, init_value, type);
+  init_value = ConvertToType(process.Owner().Unit(), block, init_value, type);
   const mir::ExprId assign =
       block.exprs.Add(mir::MakeAssignExpr(target, init_value, type));
   return mir::Stmt{
@@ -108,7 +108,7 @@ auto LowerVarDeclStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::VarDeclStmt& v) -> diag::Result<mir::Stmt> {
   const auto& hir_local = process.HirBody().procedural_vars.Get(v.var);
-  const mir::TypeId type = process.Module().TranslateType(hir_local.type);
+  const mir::TypeId type = process.Owner().TranslateType(hir_local.type);
   if (hir_local.lifetime_extended) {
     return LowerPromotedVarDeclStmt(
         process, frame, std::move(label), v, hir_local.type, type);

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -80,9 +80,9 @@ auto LowerForkStmt(
     fork_block.AppendStmt(*std::move(lowered));
   }
 
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = process.Owner().Unit().builtins;
   const mir::ExprId services_id =
-      fork_block.exprs.Add(BuildServicesCallExpr(process.Module(), fork_frame));
+      fork_block.exprs.Add(BuildServicesCallExpr(process.Owner(), fork_frame));
 
   std::vector<mir::ExprId> call_args;
   call_args.reserve(1 + f.branches.size());
@@ -94,7 +94,7 @@ auto LowerForkStmt(
     // returns inside it become `co_return`. The branch policy snapshots the
     // fork's own block-item declarations and aliases deeper enclosing
     // variables (LRM 6.21).
-    ClosureBuilder closure(process.Module().Unit(), fork_frame, branch_policy);
+    ClosureBuilder closure(process.Owner().Unit(), fork_frame, branch_policy);
     auto lowered = process.LowerStmt(branch, closure.Frame());
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
@@ -140,9 +140,9 @@ auto LowerWaitForkStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label)
     -> diag::Result<mir::Stmt> {
   mir::Block& block = *frame.current_block;
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = process.Owner().Unit().builtins;
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId call_id = block.exprs.Add(
       mir::Expr{
           .data =
@@ -168,9 +168,9 @@ auto LowerDisableForkStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label)
     -> diag::Result<mir::Stmt> {
   mir::Block& block = *frame.current_block;
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = process.Owner().Unit().builtins;
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   const mir::ExprId call_id = block.exprs.Add(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/statement/loops.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/loops.cpp
@@ -39,7 +39,7 @@ auto LowerForStmt(
             [&](const hir::ForInitDecl& d) -> diag::Result<mir::ForInit> {
               const auto& hir_local = hir_proc.procedural_vars.Get(d.var);
               const mir::TypeId type =
-                  process.Module().TranslateType(hir_local.type);
+                  process.Owner().TranslateType(hir_local.type);
               const mir::LocalId local_id = frame.bindings->Declare(
                   BindingOriginId::Procedural(d.var),
                   mir::LocalDecl{.name = hir_local.name, .type = type});
@@ -55,7 +55,7 @@ auto LowerForStmt(
                 init_id = block.exprs.Add(*std::move(init_or));
               } else {
                 init_id = block.exprs.Add(BuildDefaultValueFromHir(
-                    process.Module(), frame, hir_local.type));
+                    process.Owner(), frame, hir_local.type));
               }
               return mir::ForInit{
                   mir::ForInitDecl{.induction_var = local_id, .init = init_id}};
@@ -83,7 +83,7 @@ auto LowerForStmt(
     }
     cond_id = ReduceToCondition(
         block, block.exprs.Add(*std::move(cond_or)),
-        process.Module().Unit().builtins.bit1);
+        process.Owner().Unit().builtins.bit1);
   }
 
   std::vector<mir::ExprId> step_ids;
@@ -128,7 +128,7 @@ auto LowerWhileStmt(
   }
   const mir::ExprId cond_id = ReduceToCondition(
       block, block.exprs.Add(*std::move(cond_or)),
-      process.Module().Unit().builtins.bit1);
+      process.Owner().Unit().builtins.bit1);
 
   auto body_or = LowerStmtIntoChildScope(process, frame, w.body);
   if (!body_or) {
@@ -159,7 +159,7 @@ auto LowerDoWhileStmt(
   }
   const mir::ExprId cond_id = ReduceToCondition(
       block, block.exprs.Add(*std::move(cond_or)),
-      process.Module().Unit().builtins.bit1);
+      process.Owner().Unit().builtins.bit1);
 
   const mir::BlockId body_scope_id =
       frame.current_block->child_scopes.Add(std::move(*body_or));
@@ -172,8 +172,8 @@ auto LowerDoWhileStmt(
 auto LowerRepeatStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::RepeatStmt& r) -> diag::Result<mir::Stmt> {
-  const mir::TypeId int_type = process.Module().Unit().builtins.int_type;
-  const mir::TypeId bit_type = process.Module().Unit().builtins.bit1;
+  const mir::TypeId int_type = process.Owner().Unit().builtins.int_type;
+  const mir::TypeId bit_type = process.Owner().Unit().builtins.bit1;
 
   mir::Block wrapper;
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper);
@@ -186,7 +186,7 @@ auto LowerRepeatStmt(
   mir::ExprId count_expr_id = wrapper.exprs.Add(*std::move(count_or));
   if (wrapper.exprs.Get(count_expr_id).type != int_type) {
     count_expr_id = wrapper.exprs.Add(BuildValueConversion(
-        process.Module().Unit(), wrapper, count_expr_id, int_type));
+        process.Owner().Unit(), wrapper, count_expr_id, int_type));
   }
 
   const mir::LocalId count_var = frame.bindings->DeclareAnonymous(
@@ -198,9 +198,9 @@ auto LowerRepeatStmt(
       mir::LocalDecl{.name = "_lyra_repeat_index", .type = int_type});
 
   const mir::ExprId zero_id = wrapper.exprs.Add(
-      mir::MakeIntLiteral(process.Module().Unit().builtins.int_type, 0));
+      mir::MakeIntLiteral(process.Owner().Unit().builtins.int_type, 0));
   const mir::ExprId one_id = wrapper.exprs.Add(
-      mir::MakeIntLiteral(process.Module().Unit().builtins.int_type, 1));
+      mir::MakeIntLiteral(process.Owner().Unit().builtins.int_type, 1));
 
   const mir::ExprId idx_ref_cond =
       wrapper.exprs.Add(mir::MakeLocalRefExpr(idx_var, int_type));

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -125,13 +125,13 @@ auto LowerNamedEventTimedStmt(
                     .callee = mir::Direct{.target = support::BuiltinFn::kAwait},
                     .arguments = {receiver_id},
                 },
-            .type = process.Module().Unit().builtins.void_type};
+            .type = process.Owner().Unit().builtins.void_type};
         const mir::ExprId await_id =
             child_block.exprs.Add(std::move(await_call));
         const mir::ExprId await_expr_id = child_block.exprs.Add(
             mir::Expr{
                 .data = mir::AwaitExpr{.awaitable = await_id},
-                .type = process.Module().Unit().builtins.void_type});
+                .type = process.Owner().Unit().builtins.void_type});
         return mir::Stmt{
             .label = std::nullopt,
             .data = mir::ExprStmt{.expr = await_expr_id}};
@@ -206,9 +206,9 @@ auto LowerDelayTimedStmt(
           WalkFrame child_frame) -> diag::Result<mir::Stmt> {
         auto ticks_or = ResolveDelayTicks(process, d);
         if (!ticks_or) return std::unexpected(std::move(ticks_or.error()));
-        const auto& builtins = process.Module().Unit().builtins;
+        const auto& builtins = process.Owner().Unit().builtins;
         const mir::ExprId services_id = child_block.exprs.Add(
-            BuildServicesCallExpr(process.Module(), child_frame));
+            BuildServicesCallExpr(process.Owner(), child_frame));
         const mir::ExprId duration_id = child_block.exprs.Add(
             mir::MakeIntLiteral(
                 builtins.int_type, static_cast<std::int64_t>(*ticks_or)));
@@ -269,14 +269,14 @@ auto LowerEventTriggerStmt(
   // engine handle is a real trailing argument, threaded the same way every
   // runtime effect threads it.
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Owner(), frame));
   mir::Expr call{
       .data =
           mir::CallExpr{
               .callee = mir::Direct{.target = support::BuiltinFn::kTrigger},
               .arguments = {receiver_id, services_id},
           },
-      .type = process.Module().Unit().builtins.void_type};
+      .type = process.Owner().Unit().builtins.void_type};
   const mir::ExprId call_id = block.exprs.Add(std::move(call));
   return mir::Stmt{
       .label = std::move(label), .data = mir::ExprStmt{.expr = call_id}};
@@ -318,7 +318,7 @@ auto LowerWaitStmt(
   wrapper.AppendStmt(
       mir::WhileStmt{
           .condition = ReduceToCondition(
-              wrapper, not_cond_id, process.Module().Unit().builtins.bit1),
+              wrapper, not_cond_id, process.Owner().Unit().builtins.bit1),
           .scope = inner_scope_id});
 
   const hir::Stmt& body_hir = hir_proc.stmts.Get(w.body);

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -61,8 +61,9 @@ void AttachRuntimeScopeCtorPrefix(
 // data type (LRM 6.5 / 7.x). Handle / wrapper types (pointer / vector / object
 // / external ref / external unit object) and named events (LRM 15 -- carry
 // their own subscribe mechanism) pass through unwrapped.
-auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
-  const auto& data = module.Unit().types.Get(t).data;
+auto MaybeWrapObservable(UnitLowerer& unit_lowerer, mir::TypeId t)
+    -> mir::TypeId {
+  const auto& data = unit_lowerer.Unit().types.Get(t).data;
   const bool wrap = std::holds_alternative<mir::PackedArrayType>(data) ||
                     std::holds_alternative<mir::EnumType>(data) ||
                     std::holds_alternative<mir::StringType>(data) ||
@@ -78,7 +79,7 @@ auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
   if (!wrap) {
     return t;
   }
-  return module.Unit().types.Intern(mir::ObservableType{.value = t});
+  return unit_lowerer.Unit().types.Intern(mir::ObservableType{.value = t});
 }
 
 struct GenerateChildSpec {
@@ -91,7 +92,7 @@ struct GenerateChildSpec {
 // distinguished on the hierarchy only by any index it carries; the genvar is
 // folded into the body, so there is no runtime structural-param binding.
 auto EnumerateGenerateChildSpecs(
-    const hir::Generate& gen, ModuleLowerer& module)
+    const hir::Generate& gen, UnitLowerer& unit_lowerer)
     -> std::vector<GenerateChildSpec> {
   std::vector<GenerateChildSpec> specs;
   specs.reserve(gen.data.items.size());
@@ -100,32 +101,32 @@ auto EnumerateGenerateChildSpecs(
     specs.push_back(
         {.scope_id = item.scope,
          .scope = &item_scope,
-         .scope_name = module.NextGenerateScopeName("gen")});
+         .scope_name = unit_lowerer.NextGenerateScopeName("gen")});
   }
   return specs;
 }
 
-auto MakeUniqueObjectPointer(ModuleLowerer& module, mir::ClassId class_id)
+auto MakeUniqueObjectPointer(UnitLowerer& unit_lowerer, mir::ClassId class_id)
     -> mir::TypeId {
   const mir::TypeId object_type =
-      module.Unit().types.Intern(mir::ObjectType{.class_id = class_id});
-  return module.Unit().types.PointerTo(
+      unit_lowerer.Unit().types.Intern(mir::ObjectType{.class_id = class_id});
+  return unit_lowerer.Unit().types.PointerTo(
       object_type, mir::PointerOwnership::kUnique);
 }
 
-auto MakeUniqueExternalUnitPointer(ModuleLowerer& module, std::string unit_name)
-    -> mir::TypeId {
-  const mir::TypeId object_type = module.Unit().types.Intern(
+auto MakeUniqueExternalUnitPointer(
+    UnitLowerer& unit_lowerer, std::string unit_name) -> mir::TypeId {
+  const mir::TypeId object_type = unit_lowerer.Unit().types.Intern(
       mir::ExternalUnitObjectType{.unit_name = std::move(unit_name)});
-  return module.Unit().types.PointerTo(
+  return unit_lowerer.Unit().types.PointerTo(
       object_type, mir::PointerOwnership::kUnique);
 }
 
 auto MakeBorrowedExternalUnitPointer(
-    ModuleLowerer& module, std::string unit_name) -> mir::TypeId {
-  const mir::TypeId object_type = module.Unit().types.Intern(
+    UnitLowerer& unit_lowerer, std::string unit_name) -> mir::TypeId {
+  const mir::TypeId object_type = unit_lowerer.Unit().types.Intern(
       mir::ExternalUnitObjectType{.unit_name = std::move(unit_name)});
-  return module.Unit().types.PointerTo(
+  return unit_lowerer.Unit().types.PointerTo(
       object_type, mir::PointerOwnership::kBorrowed);
 }
 
@@ -137,12 +138,12 @@ auto MakeBorrowedExternalUnitPointer(
 // dim, appending the index and recursing, so an N-dimensional member unrolls
 // into independent construct-and-own leaves.
 void EmitExternalUnitDimLevel(
-    ModuleLowerer& module, const WalkFrame& frame, mir::ExprId parent_self,
+    UnitLowerer& unit_lowerer, const WalkFrame& frame, mir::ExprId parent_self,
     const std::string& runtime_label, mir::TypeId leaf_pointer_type,
     std::optional<mir::FieldId> companion, std::span<const std::uint32_t> dims,
     std::vector<mir::ExprId>& indices) {
   mir::Block& block = *frame.current_block;
-  const auto& builtins = module.Unit().builtins;
+  const auto& builtins = unit_lowerer.Unit().builtins;
   const auto int_lit = [&](std::int64_t v) -> mir::ExprId {
     return block.exprs.Add(mir::MakeIntLiteral(builtins.int_type, v));
   };
@@ -156,7 +157,7 @@ void EmitExternalUnitDimLevel(
     // The child's structural identity, fixed before its constructor runs.
     // Indices reflect the position this leaf occupies in its enclosing
     // dim chain (empty for a scalar instance).
-    const mir::TypeId indices_type = module.Unit().types.Intern(
+    const mir::TypeId indices_type = unit_lowerer.Unit().types.Intern(
         mir::UnpackedArrayType{
             .element_type = builtins.int_type,
             .dim = mir::UnpackedRange::ZeroBased(indices.size())});
@@ -174,7 +175,7 @@ void EmitExternalUnitDimLevel(
 
     std::vector<mir::ExprId> ctor_args = {
         parent_self, segment_id,
-        block.exprs.Add(BuildServicesCallExpr(module, frame))};
+        block.exprs.Add(BuildServicesCallExpr(unit_lowerer, frame))};
     const mir::ExprId ctor_call_id = block.exprs.Add(
         mir::Expr{
             .data =
@@ -226,8 +227,8 @@ void EmitExternalUnitDimLevel(
   for (std::uint32_t i = 0; i < count; ++i) {
     indices.push_back(int_lit(static_cast<std::int64_t>(i)));
     EmitExternalUnitDimLevel(
-        module, frame, parent_self, runtime_label, leaf_pointer_type, companion,
-        remaining_dims, indices);
+        unit_lowerer, frame, parent_self, runtime_label, leaf_pointer_type,
+        companion, remaining_dims, indices);
     indices.pop_back();
   }
 }
@@ -238,7 +239,7 @@ void EmitExternalUnitDimLevel(
 // unrolls into `dims[0] * dims[1] * ...` independent construct-and-own leaves,
 // each carrying its per-dimension index in its own Segment.
 void AppendExternalUnitConstruction(
-    ModuleLowerer& module, const WalkFrame& frame,
+    UnitLowerer& unit_lowerer, const WalkFrame& frame,
     const std::string& target_unit, const std::string& runtime_label,
     std::optional<mir::FieldId> companion,
     std::span<const std::uint32_t> dims) {
@@ -247,11 +248,11 @@ void AppendExternalUnitConstruction(
   const mir::ExprId parent_self =
       block.exprs.Add(MakeSelfRefExpr(frame, self_ptr_type));
   const mir::TypeId leaf_pointer_type =
-      MakeUniqueExternalUnitPointer(module, target_unit);
+      MakeUniqueExternalUnitPointer(unit_lowerer, target_unit);
   std::vector<mir::ExprId> indices;
   EmitExternalUnitDimLevel(
-      module, frame, parent_self, runtime_label, leaf_pointer_type, companion,
-      dims, indices);
+      unit_lowerer, frame, parent_self, runtime_label, leaf_pointer_type,
+      companion, dims, indices);
 }
 
 // Emits the constructor-body construction call for each instance member. The
@@ -265,7 +266,7 @@ void EmitInstanceMemberConstruction(
   for (const auto& im : hir_scope.instance_members) {
     const hir::InstanceMemberId id{next_instance++};
     AppendExternalUnitConstruction(
-        lowerer.Module(), frame, im.target_unit, im.instance_name,
+        lowerer.Owner(), frame, im.target_unit, im.instance_name,
         lowerer.InstanceCompanion(id), im.array_dims);
   }
 }
@@ -281,7 +282,7 @@ void EmitInstanceMemberConstruction(
 // after the whole object tree exists.
 void DeclareRoutedRefSlots(
     StructuralScopeLowerer& lowerer, mir::ClassShape& shape) {
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   std::uint32_t slot_index = 0;
   for (const auto& cu : hir_scope.routed_refs) {
@@ -296,13 +297,13 @@ void DeclareRoutedRefSlots(
             "yet supported");
       }
     }
-    const mir::TypeId value = module.TranslateType(cu.recipe.type);
-    const mir::TypeId leaf =
-        cu.target_net_type.has_value()
-            ? module.Unit().types.Intern(mir::ResolvedType{.value = value})
-            : MaybeWrapObservable(module, value);
-    const mir::TypeId slot_type =
-        module.Unit().types.PointerTo(leaf, mir::PointerOwnership::kBorrowed);
+    const mir::TypeId value = unit_lowerer.TranslateType(cu.recipe.type);
+    const mir::TypeId leaf = cu.target_net_type.has_value()
+                                 ? unit_lowerer.Unit().types.Intern(
+                                       mir::ResolvedType{.value = value})
+                                 : MaybeWrapObservable(unit_lowerer, value);
+    const mir::TypeId slot_type = unit_lowerer.Unit().types.PointerTo(
+        leaf, mir::PointerOwnership::kBorrowed);
     const mir::FieldId slot = shape.fields.Add(
         mir::FieldDecl{.name = std::move(member_name), .type = slot_type});
     lowerer.AddRoutedRefTarget(slot, slot_type);
@@ -318,9 +319,9 @@ void DeclareRoutedRefSlots(
 // single hop; the runtime SDK's `GetChild` / `ResolveVisibleChild` accept
 // it as a `std::span<PackedArray>`.
 auto BuildIndicesLiteral(
-    ModuleLowerer& module, mir::Block& block,
+    UnitLowerer& unit_lowerer, mir::Block& block,
     std::span<const std::uint32_t> indices) -> mir::ExprId {
-  const auto& builtins = module.Unit().builtins;
+  const auto& builtins = unit_lowerer.Unit().builtins;
   std::vector<mir::ExprId> ids;
   ids.reserve(indices.size());
   for (const std::uint32_t idx : indices) {
@@ -328,7 +329,7 @@ auto BuildIndicesLiteral(
         mir::MakeIntLiteral(
             builtins.int_type, static_cast<std::int64_t>(idx))));
   }
-  const mir::TypeId indices_type = module.Unit().types.Intern(
+  const mir::TypeId indices_type = unit_lowerer.Unit().types.Intern(
       mir::UnpackedArrayType{
           .element_type = builtins.int_type,
           .dim = mir::UnpackedRange::ZeroBased(indices.size())});
@@ -339,12 +340,12 @@ auto BuildIndicesLiteral(
 }
 
 auto BuildStringLiteral(
-    ModuleLowerer& module, mir::Block& block, const std::string& s)
+    UnitLowerer& unit_lowerer, mir::Block& block, const std::string& s)
     -> mir::ExprId {
   return block.exprs.Add(
       mir::Expr{
           .data = mir::StringLiteral{.value = s},
-          .type = module.Unit().builtins.string});
+          .type = unit_lowerer.Unit().builtins.string});
 }
 
 // Finds a class member by its SV-visible name (source_name, or the mangled
@@ -407,10 +408,10 @@ auto ClassBehindOwnedChildMember(
 // the target's typed class pointer via `PointerCastExpr`, so the route stays
 // typed for the following segment.
 auto SdkChildAsTyped(
-    ModuleLowerer& module, mir::Block& block, mir::ExprId receiver,
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId receiver,
     const std::string& name, std::span<const std::uint32_t> indices,
     mir::ClassId target_class_id) -> RouteReceiver {
-  auto& unit = module.Unit();
+  auto& unit = unit_lowerer.Unit();
   const mir::TypeId scope_ptr_type = unit.builtins.scope_ptr;
   const mir::ExprId raw = block.exprs.Add(
       mir::Expr{
@@ -419,10 +420,11 @@ auto SdkChildAsTyped(
                   .callee =
                       mir::Direct{.target = support::BuiltinFn::kGetChild},
                   .arguments =
-                      {receiver, BuildStringLiteral(module, block, name),
-                       BuildIndicesLiteral(module, block, indices)}},
+                      {receiver, BuildStringLiteral(unit_lowerer, block, name),
+                       BuildIndicesLiteral(unit_lowerer, block, indices)}},
           .type = scope_ptr_type});
-  const mir::ClassShape& target_shape = module.GetClassShape(target_class_id);
+  const mir::ClassShape& target_shape =
+      unit_lowerer.GetClassShape(target_class_id);
   const mir::TypeId typed_ptr = unit.types.PointerTo(
       unit.types.Intern(mir::ObjectType{.class_id = target_class_id}),
       mir::PointerOwnership::kBorrowed);
@@ -436,10 +438,10 @@ auto SdkChildAsTyped(
 // Reaches a child by name+indices as an opaque `Scope*` -- the realization of
 // an opaque segment (one crossing into another unit's body).
 auto SdkChildOpaque(
-    ModuleLowerer& module, mir::Block& block, mir::ExprId receiver,
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId receiver,
     const std::string& name, std::span<const std::uint32_t> indices)
     -> RouteReceiver {
-  const mir::TypeId scope_ptr_type = module.Unit().builtins.scope_ptr;
+  const mir::TypeId scope_ptr_type = unit_lowerer.Unit().builtins.scope_ptr;
   const mir::ExprId step = block.exprs.Add(
       mir::Expr{
           .data =
@@ -447,8 +449,8 @@ auto SdkChildOpaque(
                   .callee =
                       mir::Direct{.target = support::BuiltinFn::kGetChild},
                   .arguments =
-                      {receiver, BuildStringLiteral(module, block, name),
-                       BuildIndicesLiteral(module, block, indices)}},
+                      {receiver, BuildStringLiteral(unit_lowerer, block, name),
+                       BuildIndicesLiteral(unit_lowerer, block, indices)}},
           .type = scope_ptr_type});
   return RouteReceiver{
       .expr = step, .shape = nullptr, .class_id = std::nullopt};
@@ -463,8 +465,8 @@ auto SdkChildOpaque(
 auto BuildRouteAnchor(
     StructuralScopeLowerer& lowerer, const WalkFrame& frame,
     const hir::RoutedRefHead& head) -> RouteReceiver {
-  ModuleLowerer& module = lowerer.Module();
-  auto& unit = module.Unit();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
+  auto& unit = unit_lowerer.Unit();
   mir::Block& block = *frame.current_block;
   const mir::TypeId scope_ptr_type = unit.builtins.scope_ptr;
 
@@ -494,11 +496,11 @@ auto BuildRouteAnchor(
     if (!dh->head_indices.empty()) {
       if (anchor.target.has_value()) {
         return SdkChildAsTyped(
-            module, block, enclosing_self, anchor.label, dh->head_indices,
+            unit_lowerer, block, enclosing_self, anchor.label, dh->head_indices,
             *anchor.target);
       }
       return SdkChildOpaque(
-          module, block, enclosing_self, anchor.label, dh->head_indices);
+          unit_lowerer, block, enclosing_self, anchor.label, dh->head_indices);
     }
 
     if (!anchor.companion.has_value()) {
@@ -521,7 +523,7 @@ auto BuildRouteAnchor(
     if (anchor.target.has_value()) {
       return RouteReceiver{
           .expr = head_access,
-          .shape = &module.GetClassShape(*anchor.target),
+          .shape = &unit_lowerer.GetClassShape(*anchor.target),
           .class_id = *anchor.target};
     }
     return RouteReceiver{
@@ -556,8 +558,9 @@ auto BuildRouteAnchor(
                           .target = support::BuiltinFn::kResolveVisibleChild},
                   .arguments =
                       {self_ref,
-                       BuildStringLiteral(module, block, un.head_name),
-                       BuildIndicesLiteral(module, block, un.head_indices)}},
+                       BuildStringLiteral(unit_lowerer, block, un.head_name),
+                       BuildIndicesLiteral(
+                           unit_lowerer, block, un.head_indices)}},
           .type = scope_ptr_type});
   return RouteReceiver{
       .expr = matched, .shape = nullptr, .class_id = std::nullopt};
@@ -571,12 +574,12 @@ auto AppendRouteSegment(
     StructuralScopeLowerer& lowerer, mir::Block& block,
     const RouteReceiver& receiver, const hir::PathSegment& segment)
     -> RouteReceiver {
-  ModuleLowerer& module = lowerer.Module();
-  auto& unit = module.Unit();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
+  auto& unit = unit_lowerer.Unit();
 
   if (receiver.shape == nullptr) {
     return SdkChildOpaque(
-        module, block, receiver.expr, segment.name, segment.indices);
+        unit_lowerer, block, receiver.expr, segment.name, segment.indices);
   }
 
   const auto step_field = FindFieldByName(*receiver.shape, segment.name);
@@ -592,10 +595,11 @@ auto AppendRouteSegment(
         ClassBehindOwnedChildMember(unit, step_type);
     if (target.has_value()) {
       return SdkChildAsTyped(
-          module, block, receiver.expr, segment.name, segment.indices, *target);
+          unit_lowerer, block, receiver.expr, segment.name, segment.indices,
+          *target);
     }
     return SdkChildOpaque(
-        module, block, receiver.expr, segment.name, segment.indices);
+        unit_lowerer, block, receiver.expr, segment.name, segment.indices);
   }
 
   if (!receiver.class_id.has_value()) {
@@ -621,7 +625,7 @@ auto AppendRouteSegment(
   if (const auto* obj = std::get_if<mir::ObjectType>(&pointee_data)) {
     return RouteReceiver{
         .expr = step_access,
-        .shape = &module.GetClassShape(obj->class_id),
+        .shape = &unit_lowerer.GetClassShape(obj->class_id),
         .class_id = obj->class_id};
   }
   return RouteReceiver{
@@ -635,8 +639,8 @@ auto MaterializeLeaf(
     StructuralScopeLowerer& lowerer, mir::Block& block,
     const RouteReceiver& receiver, const hir::PathSegment& leaf,
     mir::TypeId slot_type) -> mir::ExprId {
-  ModuleLowerer& module = lowerer.Module();
-  auto& unit = module.Unit();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
+  auto& unit = unit_lowerer.Unit();
 
   if (!leaf.indices.empty()) {
     throw InternalError(
@@ -681,7 +685,7 @@ auto MaterializeLeaf(
                       mir::Direct{.target = support::BuiltinFn::kGetSignal},
                   .arguments =
                       {receiver.expr,
-                       BuildStringLiteral(module, block, leaf.name)}},
+                       BuildStringLiteral(unit_lowerer, block, leaf.name)}},
           .type = void_ptr_type});
   return block.exprs.Add(
       mir::Expr{
@@ -749,8 +753,8 @@ void InstallRoutedRefs(
 // (`is_final == true`) lifecycle (LRM 9.2). Startup and shutdown are distinct
 // registration callees, not one tagged call.
 void AppendProcessRegistration(
-    ModuleLowerer& module, const WalkFrame& activate_frame, mir::MethodId body,
-    bool is_final) {
+    UnitLowerer& unit_lowerer, const WalkFrame& activate_frame,
+    mir::MethodId body, bool is_final) {
   mir::Block& block = *activate_frame.current_block;
   const mir::TypeId self_ptr_type =
       activate_frame.current_class->self_pointer_type;
@@ -767,7 +771,7 @@ void AppendProcessRegistration(
                                   .owner = activate_frame.current_class_id,
                                   .slot = body}},
                   .arguments = {body_self}},
-          .type = module.Unit().builtins.coroutine_void});
+          .type = unit_lowerer.Unit().builtins.coroutine_void});
   const mir::ExprId reg_self =
       block.exprs.Add(MakeSelfRefExpr(activate_frame, self_ptr_type));
   const mir::ExprId reg_call = block.exprs.Add(
@@ -780,7 +784,7 @@ void AppendProcessRegistration(
                                         ? support::BuiltinFn::kRegisterFinal
                                         : support::BuiltinFn::kRegisterInitial},
                   .arguments = {reg_self, body_call}},
-          .type = module.Unit().builtins.void_type});
+          .type = unit_lowerer.Unit().builtins.void_type});
   block.AppendStmt(mir::ExprStmt{.expr = reg_call});
 }
 
@@ -798,7 +802,7 @@ auto InstallPortConnections(
   mir::Class& mir_class = *frame.current_class;
   mir::Block& resolve_block = *resolve_frame.current_block;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
-  ModuleLowerer& module = lowerer.Module();
+  UnitLowerer& unit_lowerer = lowerer.Owner();
   for (const auto& pc : hir_scope.port_connections) {
     if (pc.direction == hir::PortDirection::kRef) {
       // A `ref` port reaches the child's reference member by the same route
@@ -811,11 +815,11 @@ auto InstallPortConnections(
         throw InternalError(
             "InstallPortConnections: a ref port reaches its child downward");
       }
-      const mir::TypeId value_type = module.TranslateType(recipe.type);
-      const mir::TypeId ref_type = module.Unit().types.Intern(
+      const mir::TypeId value_type = unit_lowerer.TranslateType(recipe.type);
+      const mir::TypeId ref_type = unit_lowerer.Unit().types.Intern(
           mir::RefType{
               .pointee = value_type, .mutability = mir::Mutability::kMutable});
-      const mir::TypeId slot_type = module.Unit().types.PointerTo(
+      const mir::TypeId slot_type = unit_lowerer.Unit().types.PointerTo(
           ref_type, mir::PointerOwnership::kBorrowed);
       const mir::ExprId nav =
           BuildRouteValue(lowerer, resolve_frame, recipe, slot_type);
@@ -828,8 +832,8 @@ auto InstallPortConnections(
       const mir::ExprId peer_cell =
           resolve_block.exprs.Add(*std::move(peer_or));
 
-      const mir::ExprId bind =
-          BindReferenceSlot(module.Unit(), resolve_block, target, peer_cell);
+      const mir::ExprId bind = BindReferenceSlot(
+          unit_lowerer.Unit(), resolve_block, target, peer_cell);
       resolve_block.AppendStmt(mir::ExprStmt{.expr = bind});
       continue;
     }
@@ -856,7 +860,7 @@ auto InstallPortConnections(
         driven_nets);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     const mir::MethodId body = mir_class.methods.Add(std::move(*method_or));
-    AppendProcessRegistration(module, activate_frame, body, false);
+    AppendProcessRegistration(unit_lowerer, activate_frame, body, false);
   }
   return {};
 }
@@ -883,7 +887,7 @@ void ValidateOwnedChildConstruction(
 // where the stmts land and carry the constructor's bindings so a `self` read
 // resolves to the receiver binding.
 void AppendOwnedChildConstruction(
-    ModuleLowerer& module, const WalkFrame& arm_frame,
+    UnitLowerer& unit_lowerer, const WalkFrame& arm_frame,
     const std::string& runtime_label, mir::ClassId child_scope_id,
     std::optional<mir::ExprId> array_index,
     std::optional<mir::FieldId> companion_field) {
@@ -891,10 +895,10 @@ void AppendOwnedChildConstruction(
   const mir::Class& owner_class = *arm_frame.current_class;
   ValidateOwnedChildConstruction(owner_class, child_scope_id);
 
-  const auto& builtins = module.Unit().builtins;
+  const auto& builtins = unit_lowerer.Unit().builtins;
   const mir::TypeId self_ptr_type = owner_class.self_pointer_type;
   const mir::TypeId child_ptr_type =
-      MakeUniqueObjectPointer(module, child_scope_id);
+      MakeUniqueObjectPointer(unit_lowerer, child_scope_id);
 
   const auto string_literal = [&](const std::string& s) -> mir::ExprId {
     return arm_block.exprs.Add(
@@ -915,7 +919,7 @@ void AppendOwnedChildConstruction(
   if (array_index.has_value()) {
     index_elems.push_back(*array_index);
   }
-  const mir::TypeId indices_type = module.Unit().types.Intern(
+  const mir::TypeId indices_type = unit_lowerer.Unit().types.Intern(
       mir::UnpackedArrayType{
           .element_type = builtins.int_type,
           .dim = mir::UnpackedRange::ZeroBased(index_elems.size())});
@@ -936,7 +940,7 @@ void AppendOwnedChildConstruction(
   ctor_call_args.push_back(self_read());
   ctor_call_args.push_back(segment_id);
   ctor_call_args.push_back(
-      arm_block.exprs.Add(BuildServicesCallExpr(module, arm_frame)));
+      arm_block.exprs.Add(BuildServicesCallExpr(unit_lowerer, arm_frame)));
   const mir::ExprId ctor_call_id = arm_block.exprs.Add(
       mir::Expr{
           .data =
@@ -992,7 +996,7 @@ auto LowerResolvedGenerate(
     const GenerateBindings& gen_bindings, const hir::ResolvedGenerate& resolved)
     -> diag::Result<mir::Stmt> {
   mir::Block& block = *frame.current_block;
-  const mir::TypeId int_type = lowerer.Module().Unit().builtins.int_type;
+  const mir::TypeId int_type = lowerer.Owner().Unit().builtins.int_type;
 
   mir::Block body;
   const WalkFrame body_frame = frame.WithBlock(&body);
@@ -1003,7 +1007,7 @@ auto LowerResolvedGenerate(
       index_id = body.exprs.Add(mir::MakeIntLiteral(int_type, *item.index));
     }
     AppendOwnedChildConstruction(
-        lowerer.Module(), body_frame, binding.label, binding.scope_id, index_id,
+        lowerer.Owner(), body_frame, binding.label, binding.scope_id, index_id,
         binding.companion);
   }
   const mir::BlockId body_id = block.child_scopes.Add(std::move(body));
@@ -1020,16 +1024,16 @@ auto LowerGenerateAsStmt(
 }  // namespace
 
 auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
-  ModuleLowerer& module = *module_;
+  UnitLowerer& unit_lowerer = *owner_;
   const hir::StructuralScope& hir_scope = *hir_scope_;
   StructuralScopeLowerer& lowerer = *this;
 
   // The identity is minted before the shape is populated so the class's own
   // `self_pointer_type` can name it.
-  class_id_ = module.Unit().DeclareClass();
+  class_id_ = unit_lowerer.Unit().DeclareClass();
   const mir::TypeId self_object_type =
-      module.Unit().types.Intern(mir::ObjectType{.class_id = class_id_});
-  const mir::TypeId self_pointer_type = module.Unit().types.PointerTo(
+      unit_lowerer.Unit().types.Intern(mir::ObjectType{.class_id = class_id_});
+  const mir::TypeId self_pointer_type = unit_lowerer.Unit().types.PointerTo(
       self_object_type, mir::PointerOwnership::kBorrowed);
 
   mir::ClassShape shape;
@@ -1042,17 +1046,18 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
   shape.self_pointer_type = self_pointer_type;
   shape.time_resolution = hir_scope.time_resolution;
 
-  AttachRuntimeScopeCtorPrefix(module.Unit(), shape);
+  AttachRuntimeScopeCtorPrefix(unit_lowerer.Unit(), shape);
   for (const auto& alias : hir_scope.type_aliases) {
     shape.type_aliases.push_back(
         mir::TypeAliasDecl{
-            .name = alias.name, .target = module.TranslateType(alias.target)});
+            .name = alias.name,
+            .target = unit_lowerer.TranslateType(alias.target)});
   }
 
   for (std::size_t i = 0; i < hir_scope.structural_data_objects.size(); ++i) {
     const hir::StructuralDataObjectId hir_id{static_cast<std::uint32_t>(i)};
     const auto& d = hir_scope.structural_data_objects.Get(hir_id);
-    const mir::TypeId mir_value_type = module.TranslateType(d.type);
+    const mir::TypeId mir_value_type = unit_lowerer.TranslateType(d.type);
     // A net (LRM 6.5) and a variable are peer kinds: a `ref` / `const ref`
     // port (LRM 23.3.3.2) member aliases the connected variable (a reference);
     // a net owns a resolved cell whose value is the resolution of its drivers;
@@ -1062,7 +1067,7 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
     const bool is_reference = var != nullptr && var->reference.has_value();
     const mir::TypeId mir_field_type = [&] {
       if (is_reference) {
-        return module.Unit().types.Intern(
+        return unit_lowerer.Unit().types.Intern(
             mir::RefType{
                 .pointee = mir_value_type,
                 .mutability =
@@ -1071,10 +1076,10 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
                         : mir::Mutability::kMutable});
       }
       if (var == nullptr) {
-        return module.Unit().types.Intern(
+        return unit_lowerer.Unit().types.Intern(
             mir::ResolvedType{.value = mir_value_type});
       }
-      return MaybeWrapObservable(module, mir_value_type);
+      return MaybeWrapObservable(unit_lowerer, mir_value_type);
     }();
     const mir::FieldId mir_id = shape.fields.Add(
         mir::FieldDecl{.name = d.name, .type = mir_field_type});
@@ -1102,11 +1107,11 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
     GenerateBindings gen_bindings;
     gen_bindings.by_scope_id.resize(gen.child_scopes.size());
 
-    auto specs = EnumerateGenerateChildSpecs(gen, module);
+    auto specs = EnumerateGenerateChildSpecs(gen, unit_lowerer);
     for (auto& spec : specs) {
       const std::string child_label = spec.scope->source_name;
       auto child = std::make_unique<StructuralScopeLowerer>(
-          module, &lowerer, std::move(spec.scope_name), *spec.scope);
+          unit_lowerer, &lowerer, std::move(spec.scope_name), *spec.scope);
       auto child_r = child->DeclareShape();
       if (!child_r) return std::unexpected(std::move(child_r.error()));
 
@@ -1125,8 +1130,9 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
       }
       std::optional<mir::FieldId> companion;
       if (is_scalar) {
-        const mir::TypeId companion_type = module.Unit().types.PointerTo(
-            module.Unit().types.Intern(mir::ObjectType{.class_id = child_id}),
+        const mir::TypeId companion_type = unit_lowerer.Unit().types.PointerTo(
+            unit_lowerer.Unit().types.Intern(
+                mir::ObjectType{.class_id = child_id}),
             mir::PointerOwnership::kBorrowed);
         companion = shape.fields.Add(
             mir::FieldDecl{
@@ -1158,7 +1164,7 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
         continue;
       }
       const mir::TypeId companion_type =
-          MakeBorrowedExternalUnitPointer(module, im.target_unit);
+          MakeBorrowedExternalUnitPointer(unit_lowerer, im.target_unit);
       const mir::FieldId companion = shape.fields.Add(
           mir::FieldDecl{
               .name = std::format("{}_companion", im.instance_name),
@@ -1215,7 +1221,7 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
     if (!materializes[i]) continue;
     const auto& decl = hir_scope.procedural_scopes.Get(
         hir::ProceduralScopeId{static_cast<std::uint32_t>(i)});
-    const mir::ClassId class_id = module.Unit().DeclareClass();
+    const mir::ClassId class_id = unit_lowerer.Unit().DeclareClass();
     scope_classes[i] = class_id;
     mir::ClassShape sub_shape;
     sub_shape.name = std::format("{}__{}", name_, *decl.label);
@@ -1224,11 +1230,11 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
     sub_shape.is_scope_tree_node = true;
     sub_shape.is_final = true;
     const mir::TypeId sub_self_object =
-        module.Unit().types.Intern(mir::ObjectType{.class_id = class_id});
-    sub_shape.self_pointer_type = module.Unit().types.PointerTo(
+        unit_lowerer.Unit().types.Intern(mir::ObjectType{.class_id = class_id});
+    sub_shape.self_pointer_type = unit_lowerer.Unit().types.PointerTo(
         sub_self_object, mir::PointerOwnership::kBorrowed);
     sub_shape.time_resolution = hir_scope.time_resolution;
-    AttachRuntimeScopeCtorPrefix(module.Unit(), sub_shape);
+    AttachRuntimeScopeCtorPrefix(unit_lowerer.Unit(), sub_shape);
     // Carry the enclosing structural scope's type aliases (typedefs declared
     // at module / generate level) so the cpp renderer can name those types
     // when emitting a static's slot inside this nested class. C++ enclosing-
@@ -1275,8 +1281,9 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
       // the companion member the intra-unit typed segment navigates through. It
       // is not a source-visible signal (object pointer, no source_name), so the
       // static-signal registration excludes it.
-      const mir::TypeId companion_type = module.Unit().types.PointerTo(
-          module.Unit().types.Intern(mir::ObjectType{.class_id = my_class}),
+      const mir::TypeId companion_type = unit_lowerer.Unit().types.PointerTo(
+          unit_lowerer.Unit().types.Intern(
+              mir::ObjectType{.class_id = my_class}),
           mir::PointerOwnership::kBorrowed);
       const mir::FieldId companion_id = parent_shape.fields.Add(
           mir::FieldDecl{
@@ -1303,8 +1310,8 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
 
       const std::string mangled =
           std::format("{}__{}_{}", callable_name, v.name, var_id.value);
-      const mir::TypeId type = module.TranslateType(v.type);
-      const mir::TypeId field_type = MaybeWrapObservable(module, type);
+      const mir::TypeId type = unit_lowerer.TranslateType(v.type);
+      const mir::TypeId field_type = MaybeWrapObservable(unit_lowerer, type);
       mir::FieldDecl field_decl{.name = mangled, .type = field_type};
       // The source-name registration follows the var's lexical scope, not its
       // physical owner. Only a static in a named block is hierarchically
@@ -1357,10 +1364,10 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
   // builds each class's constructor against the published shape.
   for (std::size_t i = 0; i < hir_scope.procedural_scopes.size(); ++i) {
     if (!materializes[i]) continue;
-    module.DefineClassShape(scope_classes[i], std::move(sub_shapes[i]));
+    unit_lowerer.DefineClassShape(scope_classes[i], std::move(sub_shapes[i]));
   }
 
-  module.DefineClassShape(class_id_, std::move(shape));
+  unit_lowerer.DefineClassShape(class_id_, std::move(shape));
   return class_id_;
 }
 
@@ -1537,11 +1544,11 @@ void FinalizeConstructor(
 
 auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     -> diag::Result<void> {
-  ModuleLowerer& module = *module_;
+  UnitLowerer& unit_lowerer = *owner_;
   const hir::StructuralScope& hir_scope = *hir_scope_;
   StructuralScopeLowerer& lowerer = *this;
 
-  const mir::ClassShape& shape = module.GetClassShape(class_id_);
+  const mir::ClassShape& shape = unit_lowerer.GetClassShape(class_id_);
   mir::Class mir_class;
   mir_class.name = shape.name;
   mir_class.base = shape.base;
@@ -1565,7 +1572,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     for (const hir::DpiParamAbi& p : imp.params) {
       params.push_back(
           mir::ForeignParam{
-              .sv_type = module.TranslateType(p.sv_type),
+              .sv_type = unit_lowerer.TranslateType(p.sv_type),
               .carrier = p.carrier,
               .direction = p.direction});
     }
@@ -1573,13 +1580,13 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
         mir::StaticCallableDecl{
             .name = imp.name,
             .params = std::move(params),
-            .ret_sv_type = module.TranslateType(imp.ret_sv_type),
+            .ret_sv_type = unit_lowerer.TranslateType(imp.ret_sv_type),
             .ret_abi = imp.ret_abi,
             .external = mir::ExternalSymbol{
                 .foreign_name = imp.foreign_name, .is_pure = imp.is_pure}});
   }
 
-  const mir::TypeId void_type = module.Unit().builtins.void_type;
+  const mir::TypeId void_type = unit_lowerer.Unit().builtins.void_type;
   const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
   ScopeChainNode outer_scope_link{};
   const auto seed_self = [&](CallableBindings& bindings) -> mir::LocalId {
@@ -1592,7 +1599,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   // binding seeded into its `locals`, and every nested block's `self` read
   // resolves through that one binding.
   mir::CallableCode ctor_code;
-  CallableBindings ctor_bindings(module.Unit(), ctor_code);
+  CallableBindings ctor_bindings(unit_lowerer.Unit(), ctor_code);
   const mir::LocalId self_id = seed_self(ctor_bindings);
   // Each prefix param the base contract demands lands as an ordinary local
   // after `self`, so a base call reads it as a plain LocalRef and the ctor
@@ -1612,7 +1619,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           .WithBindings(&ctor_bindings);
 
   mir::CallableCode initialize_code;
-  CallableBindings init_bindings(module.Unit(), initialize_code);
+  CallableBindings init_bindings(unit_lowerer.Unit(), initialize_code);
   const mir::LocalId init_self_id = seed_self(init_bindings);
   mir::Block& initialize_block = initialize_code.body;
   const WalkFrame init_frame =
@@ -1621,7 +1628,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           .WithBindings(&init_bindings);
 
   mir::CallableCode resolve_code;
-  CallableBindings resolve_bindings(module.Unit(), resolve_code);
+  CallableBindings resolve_bindings(unit_lowerer.Unit(), resolve_code);
   const mir::LocalId resolve_self_id = seed_self(resolve_bindings);
   mir::Block& resolve_block = resolve_code.body;
   const WalkFrame resolve_frame =
@@ -1630,7 +1637,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           .WithBindings(&resolve_bindings);
 
   mir::CallableCode activate_code;
-  CallableBindings activate_bindings(module.Unit(), activate_code);
+  CallableBindings activate_bindings(unit_lowerer.Unit(), activate_code);
   const mir::LocalId activate_self_id = seed_self(activate_bindings);
   mir::Block& activate_block = activate_code.body;
   const WalkFrame activate_frame =
@@ -1651,12 +1658,12 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     const mir::FieldId mir_id =
         lowerer.TranslateStructuralDataObject(hir::StructuralHops{0}, hir_id);
     const mir::TypeId mir_field_type = mir_class.fields.Get(mir_id).type;
-    const mir::TypeId mir_value_type = module.TranslateType(d.type);
+    const mir::TypeId mir_value_type = unit_lowerer.TranslateType(d.type);
     const auto* var = std::get_if<hir::StructuralVariableDecl>(&d.kind);
     const bool is_net = var == nullptr;
     const bool is_reference = var != nullptr && var->reference.has_value();
     const mir::TypeKind var_kind =
-        module.Unit().types.Get(mir_value_type).Kind();
+        unit_lowerer.Unit().types.Get(mir_value_type).Kind();
     // Owned children (pointer / vector / object), cross-instance reference
     // slots (borrowed pointers filled in the resolve phase), and named events
     // have no "value assignment" -- their declaration shape itself fixes the
@@ -1690,10 +1697,11 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
       const auto emit_value_store = [&](mir::ExprId value_id) {
         const mir::ExprId services_id = initialize_block.exprs.Add(
             mir::MakeServicesCallExpr(
-                init_self_read(), module.Unit().builtins.services));
+                init_self_read(), unit_lowerer.Unit().builtins.services));
         append_stmt(BuildObservableAssignExpr(
-            module.Unit(), initialize_block, services_id, init_target, value_id,
-            std::nullopt, mir_value_type, module.Unit().builtins.void_type));
+            unit_lowerer.Unit(), initialize_block, services_id, init_target,
+            value_id, std::nullopt, mir_value_type,
+            unit_lowerer.Unit().builtins.void_type));
       };
 
       // Every observable value cell installs its declared representation and
@@ -1702,12 +1710,14 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
       // verified against it rather than discovered from whichever store runs
       // first. A non-observable value member carries no cell wrapper, so it
       // installs its representation through an ordinary store of the default.
-      if (mir::IsObservableCellType(module.Unit().types.Get(mir_field_type))) {
+      if (mir::IsObservableCellType(
+              unit_lowerer.Unit().types.Get(mir_field_type))) {
         const mir::ExprId prototype = initialize_block.exprs.Add(
-            BuildDefaultValueFromHir(module, init_frame, d.type));
+            BuildDefaultValueFromHir(unit_lowerer, init_frame, d.type));
         append_stmt(
             mir::MakeObservableInitializeCallExpr(
-                init_target, prototype, module.Unit().builtins.void_type));
+                init_target, prototype,
+                unit_lowerer.Unit().builtins.void_type));
         if (var->initializer.has_value()) {
           auto value_or = lowerer.LowerExpr(
               hir_scope.exprs.Get(*var->initializer), init_frame);
@@ -1723,7 +1733,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           value_id = initialize_block.exprs.Add(*std::move(value_or));
         } else {
           value_id = initialize_block.exprs.Add(
-              BuildDefaultValueFromHir(module, init_frame, d.type));
+              BuildDefaultValueFromHir(unit_lowerer, init_frame, d.type));
         }
         emit_value_store(value_id);
       }
@@ -1741,7 +1751,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
               self_read(), mir::FieldTarget{.owner = class_id_, .slot = mir_id},
               mir_field_type));
       const mir::ExprId prototype = ctor_block.exprs.Add(
-          BuildDefaultValueFromHir(module, ctor_frame, d.type));
+          BuildDefaultValueFromHir(unit_lowerer, ctor_frame, d.type));
       ctor_block.AppendStmt(
           mir::Stmt{
               .label = std::nullopt,
@@ -1764,14 +1774,14 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           mir::MakeFieldAccessExpr(
               self_read(), mir::FieldTarget{.owner = class_id_, .slot = mir_id},
               mir_field_type));
-      const mir::TypeId var_ptr_type = module.Unit().types.PointerTo(
+      const mir::TypeId var_ptr_type = unit_lowerer.Unit().types.PointerTo(
           mir_field_type, mir::PointerOwnership::kBorrowed);
       const mir::ExprId addr_id =
           ctor_block.exprs.Add(mir::MakeAddressOfExpr(var_ref, var_ptr_type));
       const mir::ExprId name_id = ctor_block.exprs.Add(
           mir::Expr{
               .data = mir::StringLiteral{.value = d.name},
-              .type = module.Unit().builtins.string});
+              .type = unit_lowerer.Unit().builtins.string});
       const mir::ExprId call = ctor_block.exprs.Add(
           mir::Expr{
               .data =
@@ -1798,7 +1808,8 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     const hir::ProceduralScopeId scope_id{static_cast<std::uint32_t>(i)};
     const auto& entry = scope_materialization_.Get(scope_id);
     if (!entry.materialized) continue;
-    const mir::ClassShape& sub_shape = module.GetClassShape(entry.class_id);
+    const mir::ClassShape& sub_shape =
+        unit_lowerer.GetClassShape(entry.class_id);
     mir::Class sub_class;
     sub_class.name = sub_shape.name;
     sub_class.base = sub_shape.base;
@@ -1811,7 +1822,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     sub_class.type_aliases = sub_shape.type_aliases;
 
     mir::CallableCode sub_ctor_code;
-    CallableBindings sub_ctor_bindings(module.Unit(), sub_ctor_code);
+    CallableBindings sub_ctor_bindings(unit_lowerer.Unit(), sub_ctor_code);
     const mir::LocalId sub_self_id = sub_ctor_bindings.Declare(
         BindingOriginId::Receiver(),
         mir::LocalDecl{.name = "self", .type = sub_shape.self_pointer_type});
@@ -1836,7 +1847,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           std::get_if<hir::ProceduralScopeId>(&child_entry.runtime_parent);
       if (parent_scope == nullptr || parent_scope->value != i) continue;
       AppendOwnedChildConstruction(
-          module, sub_ctor_frame, child_entry.label, child_entry.class_id,
+          unit_lowerer, sub_ctor_frame, child_entry.label, child_entry.class_id,
           std::nullopt, child_entry.companion_field);
     }
     // Register each static on this procedural-storage scope as a by-name
@@ -1848,7 +1859,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
       const mir::FieldId mid{static_cast<std::uint32_t>(mi)};
       const auto& m = sub_class.fields.Get(mid);
       if (m.source_name.empty()) continue;
-      const mir::TypeKind mk = module.Unit().types.Get(m.type).Kind();
+      const mir::TypeKind mk = unit_lowerer.Unit().types.Get(m.type).Kind();
       if (mk == mir::TypeKind::kPointer || mk == mir::TypeKind::kVector ||
           mk == mir::TypeKind::kObject) {
         continue;
@@ -1859,14 +1870,14 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
           mir::MakeFieldAccessExpr(
               sub_self, mir::FieldTarget{.owner = entry.class_id, .slot = mid},
               m.type));
-      const mir::TypeId addr_type = module.Unit().types.PointerTo(
+      const mir::TypeId addr_type = unit_lowerer.Unit().types.PointerTo(
           m.type, mir::PointerOwnership::kBorrowed);
       const mir::ExprId addr = sub_ctor_block.exprs.Add(
           mir::MakeAddressOfExpr(member_ref, addr_type));
       const mir::ExprId name_lit = sub_ctor_block.exprs.Add(
           mir::Expr{
               .data = mir::StringLiteral{.value = m.source_name},
-              .type = module.Unit().builtins.string});
+              .type = unit_lowerer.Unit().builtins.string});
       const mir::ExprId reg_self = sub_ctor_block.exprs.Add(
           MakeSelfRefExpr(sub_ctor_frame, sub_shape.self_pointer_type));
       const mir::ExprId call = sub_ctor_block.exprs.Add(
@@ -1893,12 +1904,12 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     const bool sub_is_unit = false;
     const std::vector<mir::ExprId> sub_base_trailing_args =
         InstallGeneratedDefinition(
-            module.Unit(), sub_class, entry.class_id, sub_is_unit,
+            unit_lowerer.Unit(), sub_class, entry.class_id, sub_is_unit,
             sub_ctor_code, std::nullopt, std::nullopt, std::nullopt);
     FinalizeConstructor(
-        module.Unit(), sub_class, std::move(sub_ctor_code),
+        unit_lowerer.Unit(), sub_class, std::move(sub_ctor_code),
         sub_ctor_prefix_local_ids, sub_base_trailing_args);
-    module.Unit().DefineClass(entry.class_id, std::move(sub_class));
+    unit_lowerer.Unit().DefineClass(entry.class_id, std::move(sub_class));
   }
 
   // Construct every top-level materialized procedural-storage scope in the
@@ -1911,7 +1922,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     if (!entry.materialized) continue;
     if (!std::holds_alternative<EnclosingClass>(entry.runtime_parent)) continue;
     AppendOwnedChildConstruction(
-        module, ctor_frame, entry.label, entry.class_id, std::nullopt,
+        unit_lowerer, ctor_frame, entry.label, entry.class_id, std::nullopt,
         entry.companion_field);
   }
 
@@ -1919,7 +1930,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     const auto& src = hir_scope.structural_subroutines.Get(
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
     ProcessLowerer subroutine_lowerer(
-        module, &lowerer, hir_scope.time_resolution, src.body, src.name,
+        unit_lowerer, &lowerer, hir_scope.time_resolution, src.body, src.name,
         mir::MethodVisibility::kInternal, ctor_frame,
         subroutine_storage_plans_[i]);
     auto decl_or = subroutine_lowerer.Run(src);
@@ -1943,14 +1954,14 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
         hir_scope.processes.Get(hir::ProcessId{static_cast<std::uint32_t>(i)});
     std::string name = std::format("process_{}", mir_class.methods.size());
     ProcessLowerer process_lowerer(
-        module, &lowerer, hir_scope.time_resolution, p.body, std::move(name),
-        mir::MethodVisibility::kInternal, ctor_frame,
+        unit_lowerer, &lowerer, hir_scope.time_resolution, p.body,
+        std::move(name), mir::MethodVisibility::kInternal, ctor_frame,
         process_storage_plans_[i]);
     auto decl_or = process_lowerer.Run(p);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     const mir::MethodId body = mir_class.methods.Add(*std::move(decl_or));
     AppendProcessRegistration(
-        module, activate_frame, body, p.kind == hir::ProcessKind::kFinal);
+        unit_lowerer, activate_frame, body, p.kind == hir::ProcessKind::kFinal);
     for (const auto& pending :
          process_lowerer.TakePendingStaticInitializers()) {
       auto integ = IntegratePendingStaticInitializer(
@@ -1980,7 +1991,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
         driven_nets);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     const mir::MethodId body = mir_class.methods.Add(std::move(*method_or));
-    AppendProcessRegistration(module, activate_frame, body, false);
+    AppendProcessRegistration(unit_lowerer, activate_frame, body, false);
   }
 
   // Recurse into descendants. Every class's shape is already published, so a
@@ -2017,7 +2028,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   // its body; once complete, it is moved into the class's method storage and
   // referenced by the construction protocol.
 
-  auto& unit = module.Unit();
+  auto& unit = unit_lowerer.Unit();
 
   // The resolve, initialize, and activate phases are ordinary callables run by
   // the runtime after construction (LRM 23.3.3.2 / 6.8 / 9.2), each present

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -5,7 +5,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/type.hpp"
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -55,10 +55,10 @@ auto TranslatePackedArrayForm(hir::PackedArrayForm f) -> mir::PackedArrayForm {
 // single-vector projection) contributes its own flat dimensions, onto which
 // this dimension prepends.
 auto FlattenPackedArray(
-    const ModuleLowerer& module, const hir::PackedArrayType& pa)
+    const UnitLowerer& unit_lowerer, const hir::PackedArrayType& pa)
     -> mir::PackedArrayType {
   const mir::PackedRange dim{.left = pa.dim.left, .right = pa.dim.right};
-  const hir::Type& element = module.Hir().types.Get(pa.element_type);
+  const hir::Type& element = unit_lowerer.Hir().types.Get(pa.element_type);
   if (const auto* scalar = std::get_if<hir::ScalarBitType>(&element.data)) {
     return mir::PackedArrayType{
         .atom = TranslateBitAtom(scalar->atom),
@@ -68,8 +68,8 @@ auto FlattenPackedArray(
     };
   }
   const mir::PackedArrayType& inner =
-      module.Unit()
-          .types.Get(module.TranslateType(pa.element_type))
+      unit_lowerer.Unit()
+          .types.Get(unit_lowerer.TranslateType(pa.element_type))
           .AsIntegralPacked();
   std::vector<mir::PackedRange> dims;
   dims.reserve(inner.dims.size() + 1U);
@@ -100,7 +100,7 @@ auto FlattenPackedAggregate(
 
 }  // namespace
 
-auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
+auto UnitLowerer::TranslateTypeData(const hir::TypeData& data) const
     -> mir::TypeData {
   return std::visit(
       Overloaded{

--- a/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
@@ -1,4 +1,4 @@
-#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -17,7 +17,7 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
+auto UnitLowerer::Run() -> diag::Result<mir::CompilationUnit> {
   WalkFrame root_frame;
 
   // Every class identity is minted before any type is translated, so a class
@@ -64,7 +64,7 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
   return std::move(unit_);
 }
 
-auto ModuleLowerer::NextGenerateScopeName(std::string_view arm_tag)
+auto UnitLowerer::NextGenerateScopeName(std::string_view arm_tag)
     -> std::string {
   return std::format("gen{}_{}", next_generate_scope_name_++, arm_tag);
 }

--- a/tests/cases/cpp/package_compile_time_contents/case.yaml
+++ b/tests/cases/cpp/package_compile_time_contents/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.package_compile_time_contents
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    wide: 165
+    nib: 12
+    col: 1
+    wv: 8
+    masked: 240

--- a/tests/cases/cpp/package_compile_time_contents/main.sv
+++ b/tests/cases/cpp/package_compile_time_contents/main.sv
@@ -1,0 +1,34 @@
+// A package's compile-time contents -- a localparam, a typedef, and an enum --
+// referenced from a separate module. These fold to a value or intern as a type
+// at elaboration in the referencing module, so the package manifests no
+// cross-unit runtime entity. Both reference forms are exercised: explicit
+// `pkg::item` scope resolution and a name brought into scope by `import pkg::*`.
+package pkg;
+  localparam int W = 8;
+  localparam logic [7:0] Mask = 8'hF0;
+  typedef logic [3:0] nibble_t;
+  typedef enum logic [1:0] { Red, Green, Blue } color_t;
+endpackage
+
+module Top;
+  import pkg::*;
+
+  // Package constant as a packed width (explicit scope).
+  logic [pkg::W-1:0] wide;
+  // Package typedef as a variable type (explicit scope).
+  pkg::nibble_t nib;
+  // Package typedef reached by import (bare name).
+  color_t col;
+  // Package constant in value context (explicit scope).
+  int wv;
+  // Package constant reached by import, in value context (bare name).
+  logic [7:0] masked;
+
+  initial begin
+    wide = 8'hA5;
+    nib = 4'hC;
+    col = Green;
+    wv = pkg::W;
+    masked = 8'hFF & Mask;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Makes a SystemVerilog `package` a first-class compilation unit in HIR. Packages are now collected alongside module tops and lowered through the same unit lowerer, so a package's declarations appear as a lowered unit -- the foundation for the packages workstream (`docs/progress/packages.md`). PK1 (a package's compile-time contents -- localparams, typedefs, enums -- referenced from another module by `pkg::item` or `import`) is covered by a new test.

The change also aligns the unit-versus-module naming the package work exposed. The HIR unit type `ModuleUnit` becomes `CompilationUnit`, matching `mir::CompilationUnit` and `lir::CompilationUnit`; the AST-to-HIR and HIR-to-MIR `ModuleLowerer` classes become `UnitLowerer`, matching `mir_to_lir::UnitLowerer`; and the sub-lowerer accessor `Module()` becomes `Owner()`. These are pure renames with no behavior change.

## Testing

`bazel test //...` passes.