### PR TITLE
Lower SV virtual method dispatch to canonical slots

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -65,10 +65,26 @@ each stage establishes, not how.
       item above. Minimal surface: fields, `new`, direct instance-method call, handle equality
       against another handle and against null.
 
-- [ ] Class inheritance: a single concrete base, `super` and the base-constructor call, and dynamic
-      dispatch through logical method slots -- a method introduces, overrides, or finalizes a slot,
-      and a virtual call names a receiver and a slot rather than a fixed callee. Pure-virtual /
-      abstract classes. The override relation established earlier feeds slot inheritance.
+- [x] Class inheritance's structural relation: a single concrete base is a resolved reference on the
+      derived class's declaration, and each own member (field, method) belongs to the derived's own
+      arena while an inherited member is reached through the base's arena. A cross-class reference
+      to a member is owner-qualified: it names the class arena the member lives in, so an inherited
+      method or property is identified by its declaring class rather than by the receiver's runtime
+      class.
+
+- [x] Dynamic dispatch through logical method slots: a method introduces, overrides, or finalizes a
+      slot as a fact stated on its declaration, and a virtual call site names a receiver and the
+      slot's canonical identity rather than a fixed callee. A backend renders the dispatch from the
+      stated slot; no consumer re-derives which method overrides which by matching names or
+      signatures. A handle whose static type is a base but whose dynamic type is a derived resolves
+      the call to the derived's implementation.
+
+- [ ] `super` reference and the base-constructor call: an override body reaches its base-class
+      implementation by name-independent reference, and a constructor forwards to the base's
+      construction as its first act (LRM 8.7).
+
+- [ ] Pure-virtual and abstract classes (LRM 8.21): a virtual method with no body is a contract the
+      derived must fill, and a class carrying such a slot is not directly constructible.
 
 - [ ] Interface-class conformance: a class may conform to several interfaces, a relation distinct
       from its single concrete base and carrying no second instance storage. Type-associated static

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -4,8 +4,10 @@
 #include <string>
 #include <vector>
 
+#include "lyra/base/arena.hpp"
 #include "lyra/hir/class_id.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/method_id.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type_id.hpp"
 
@@ -43,7 +45,7 @@ struct ClassDecl {
   std::string name;
   std::optional<ClassId> base;
   std::vector<ClassField> fields;
-  std::vector<SubroutineDecl> methods;
+  base::Arena<SubroutineDecl, MethodId> methods;
   SubroutineDecl constructor;
 };
 

--- a/include/lyra/hir/method_id.hpp
+++ b/include/lyra/hir/method_id.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+struct MethodId {
+  std::uint32_t value;
+
+  auto operator<=>(const MethodId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/method_id.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -43,11 +45,30 @@ struct SubroutineParam {
          direction == ParamDirection::kInOut;
 }
 
+// The declaration identity of a class instance method in HIR: a
+// (class, method) pair naming one entry in the owning class's method arena.
+// A frontend symbol translates to this identity at the AST-to-HIR boundary;
+// downstream consumers hold it as-is and never re-derive it from another
+// enumeration order.
+struct MethodRef {
+  ClassId class_id;
+  MethodId method;
+
+  auto operator==(const MethodRef&) const -> bool = default;
+};
+
 // LRM 13.4.1 implicit result variable: a non-void function implicitly declares
 // a body-local variable of the return type that the body reads and writes
 // through the function name. `result_var` indexes the body's procedural-var
 // arena for that variable; it is absent for void functions and tasks, which
 // yield no value.
+//
+// Two facts on a class method carry its participation in virtual dispatch
+// (LRM 8.20); each is atomic and reflects the source directly. `is_virtual`
+// records the `virtual` keyword. `overrides`, when present, is the frontend-
+// resolved reference to the base method this one overrides -- carried as an
+// already-resolved identity so downstream consumers never repeat the name and
+// signature matching the frontend has done.
 struct SubroutineDecl {
   std::string name;
   SubroutineKind kind;
@@ -55,6 +76,8 @@ struct SubroutineDecl {
   std::vector<SubroutineParam> params;
   std::optional<ProceduralVarId> result_var;
   ProceduralBody body;
+  bool is_virtual = false;
+  std::optional<MethodRef> overrides;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <cstdint>
 #include <variant>
 
 #include "lyra/hir/class_id.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/foreign_import_id.hpp"
+#include "lyra/hir/method_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/subroutine_id.hpp"
 #include "lyra/support/builtin_fn.hpp"
@@ -30,11 +30,12 @@ struct ForeignImportRef {
 
 // Calls an instance method (LRM 8.6) on `receiver`, an expression yielding the
 // class handle the call dispatches through. `class_id` names the declaring
-// class and `method_index` is the method's declaration-order position in it.
+// class and `method` is the method's declaration-order position in that
+// class's HIR method arena.
 struct MethodCallRef {
   ExprId receiver;
   ClassId class_id;
-  std::uint32_t method_index;
+  MethodId method;
 };
 
 // Calls a `$xxx` system subroutine. The id resolves through

--- a/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
@@ -12,11 +12,13 @@
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/Type.h>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/frontend/slang_source_mapper.hpp"
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/method_id.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
@@ -163,6 +165,27 @@ class UnitLowerer {
   auto InternClass(const slang::ast::ClassType& cls, diag::SourceSpan span)
       -> diag::Result<hir::ClassId>;
 
+  // Records a frontend method symbol's HIR arena identity as the class
+  // interning that owns it adds the method. Downstream consumers translate a
+  // frontend symbol into the HIR-side identity through this cache, so the
+  // slang enumeration order is walked once (at class interning) and never
+  // again at a resolution site.
+  void RegisterMethodId(
+      const slang::ast::SubroutineSymbol& method, hir::MethodId id) {
+    method_cache_.emplace(&method, id);
+  }
+
+  [[nodiscard]] auto LookupMethodId(
+      const slang::ast::SubroutineSymbol& method) const -> hir::MethodId {
+    if (const auto it = method_cache_.find(&method);
+        it != method_cache_.end()) {
+      return it->second;
+    }
+    throw InternalError(
+        "UnitLowerer::LookupMethodId: method has no HIR identity; the "
+        "owning class was not interned before this lookup");
+  }
+
   // Facts.
   [[nodiscard]] auto SourceMapper() const
       -> const frontend::SlangSourceMapper& {
@@ -282,6 +305,8 @@ class UnitLowerer {
   // Registries.
   std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;
   std::unordered_map<const slang::ast::ClassType*, hir::ClassId> class_cache_;
+  std::unordered_map<const slang::ast::SubroutineSymbol*, hir::MethodId>
+      method_cache_;
   StructuralDataObjectBindings structural_data_object_bindings_;
   SubroutineBindings subroutine_bindings_;
   ForeignImportBindings foreign_import_bindings_;

--- a/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
+#include <optional>
+#include <vector>
+
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/class_decl.hpp"
+#include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
 #include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
+#include "lyra/mir/field.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -22,6 +27,13 @@ namespace lyra::lowering::hir_to_mir {
 // A class method body names only its receiver and its own locals, so it is
 // lowered inside no structural scope -- its body lowerer carries a null
 // enclosing scope, never an owner that stands in for one.
+//
+// The lowering runs in two stages. `DeclareShape` publishes the class's
+// structural facts -- fields, method signatures, canonical dispatch role --
+// so peers can query them by id while their own bodies lower. `PopulateBodies`
+// then composes the executable `mir::Class`. The stages run independently
+// per class; every class's shape is published before any body lowers, so a
+// body's cross-class reference always resolves against a settled shape.
 class ClassDeclLowerer {
  public:
   ClassDeclLowerer(
@@ -33,16 +45,32 @@ class ClassDeclLowerer {
         hir_class_(&hir_class) {
   }
 
-  // Builds and returns the class object. The caller, which owns the class
-  // registry and holds the pre-declared identity, defines the returned object
-  // into the unit.
-  auto Run() -> diag::Result<mir::Class>;
+  // Publishes this class's `ClassShape` to the module's shape store so peer
+  // body lowering can read every fact it might need -- the base reference,
+  // the field arena, each method's dispatch role -- without waiting for any
+  // sibling class's body to lower.
+  auto DeclareShape() -> diag::Result<void>;
+
+  // Composes the class from the already-published shape plus every body,
+  // and commits it to the compilation unit. Any cross-class query the
+  // bodies make resolves against the shape store, never against another
+  // class's still-in-progress state.
+  auto PopulateBodies() -> diag::Result<void>;
 
  private:
   UnitLowerer* owner_;
   mir::ClassId class_id_;
   mir::TypeId object_type_;
   const hir::ClassDecl* hir_class_;
+
+  // Storage layout the shape stage settles and the body stage reuses: the
+  // property field ids in declaration order, and the per-callable
+  // static-storage plans whose placements name the exact field ids the
+  // published shape declares.
+  std::vector<mir::FieldId> field_ids_;
+  ProceduralScopeMaterializationTable class_scopes_;
+  std::vector<CallableStoragePlan> method_plans_;
+  std::optional<CallableStoragePlan> ctor_plan_;
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/abi_adapter_id.hpp
+++ b/include/lyra/mir/abi_adapter_id.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::mir {
+
+struct AbiAdapterId {
+  std::uint32_t value;
+
+  auto operator<=>(const AbiAdapterId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -6,6 +6,7 @@
 
 #include "lyra/base/arena.hpp"
 #include "lyra/base/time.hpp"
+#include "lyra/mir/abi_adapter_id.hpp"
 #include "lyra/mir/callable_code.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/class_ref.hpp"
@@ -60,10 +61,21 @@ struct ConstructorDecl {
   std::vector<FieldInit> member_inits;
 };
 
-// The structural portion of a class declaration: the fields a peer needs to
+// The declaration-facing view of a method: the facts a peer's body lowering
+// needs to know about this method while its own body is being lowered. The
+// method's body itself is not here; the finished `MethodDecl` on the class
+// carries the body once every body composes. `virtual_dispatch` is here so
+// a peer that calls this method picks between direct and virtual invocation
+// from a stated fact, with no dependency on which class's body lowered
+// first.
+struct MethodSignature {
+  std::optional<VirtualDispatchRole> virtual_dispatch;
+};
+
+// The structural portion of a class declaration: the facts a peer needs to
 // read about a class while its own body is being lowered. Each field has the
 // same semantics as the same-named field on `Class`; the executable parts
-// (`constructor`, `methods`) are not represented here.
+// (`constructor`, method bodies) are not represented here.
 struct ClassShape {
   std::string name;
   std::optional<ClassRef> base;
@@ -71,6 +83,7 @@ struct ClassShape {
   TimeResolution time_resolution;
   base::Arena<ParamDecl, ParamId> ctor_prefix_params;
   base::Arena<FieldDecl, FieldId> fields;
+  base::Arena<MethodSignature, MethodId> method_signatures;
   std::vector<ClassId> contained;
   std::vector<TypeAliasDecl> type_aliases;
   // Whether the class occupies a node of the runtime object tree -- a module
@@ -111,6 +124,12 @@ struct Class {
   // inside this class by iterating this list -- no walk over the body tree.
   std::vector<StructId> structs;
   base::Arena<MethodDecl, MethodId> methods;
+  // The runtime-callback adapters this class owns -- callables whose
+  // identity is a plain function pointer the runtime holds, semantically
+  // distinct from the instance methods above. Referenced from the class's
+  // generated-behavior constant by `FunctionRef`; never called through a
+  // MIR CallExpr. Empty for a class that has no runtime callback surface.
+  base::Arena<AbiAdapter, AbiAdapterId> abi_adapters;
   // The class-level static constants this class owns, emitted as static
   // members. A runtime scope's generated-behavior record is one such constant;
   // the constructor forwards its address to the runtime base through the

--- a/include/lyra/mir/class_ref.hpp
+++ b/include/lyra/mir/class_ref.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
 #include <variant>
 
 #include "lyra/mir/class_id.hpp"
+#include "lyra/mir/method_id.hpp"
 
 namespace lyra::mir {
 
@@ -35,28 +35,39 @@ struct ExternalClassRef {
 // target-language name). A consumer reads each arm directly.
 using ClassRef = std::variant<IntraUnitClassRef, ExternalClassRef>;
 
-// A lifecycle hook the runtime base declares and a derived object may override.
-// `kResolve` / `kInitialize` / `kActivate` are the post-construction phases the
-// engine invokes (binding cross-instance references, running variable
-// initializers, registering processes). Constant properties -- time precision
-// (LRM 3.14.2) and def-name (LRM 23.8) -- are not hooks: they are immutable
-// scope metadata read as data, not generated bodies.
-enum class RuntimeMethod : std::uint8_t {
-  kResolve,
-  kInitialize,
-  kActivate,
+// A method that introduces a new virtual dispatch slot on the class it
+// declares -- LRM 8.20 `virtual function` first appearance in an inheritance
+// chain. The slot's canonical identity is this method's own declaration
+// identity: as long as a dispatch slot carries no state beyond what the
+// introducer's declaration already holds (a name, a signature, participation
+// in dispatch), aliasing "slot identity" to "introducer's (class, method)"
+// is a chosen simplification, not a natural fact. When a slot gains
+// independent metadata -- a pure/abstract requirement, a final marker,
+// interface conformance -- a distinct `SlotId` becomes the right shape.
+struct IntroducesVirtualSlot {
+  auto operator==(const IntroducesVirtualSlot&) const -> bool = default;
 };
 
-// A reference to a runtime-library method.
-struct RuntimeLibraryMethodRef {
-  RuntimeMethod method;
+// A method that overrides a virtual dispatch slot declared by a class of this
+// same compilation unit -- LRM 8.20. The stored (`slot_owner`, `slot_id`) is
+// the slot's canonical identity: the class and method-arena position where
+// the slot was originally introduced, invariant across every override in the
+// chain. A call site names the slot in one read; no consumer walks an
+// override chain to derive it.
+struct OverridesIntraUnitSlot {
+  ClassId slot_owner;
+  MethodId slot_id;
 
-  auto operator==(const RuntimeLibraryMethodRef&) const -> bool = default;
+  auto operator==(const OverridesIntraUnitSlot&) const -> bool = default;
 };
 
-// A reference to the base method an instance method overrides, resolved to a
-// declaration rather than a textual name. A consumer reads the override target
-// through one path; the only base method is a runtime-library virtual.
-using OverriddenMethodRef = std::variant<RuntimeLibraryMethodRef>;
+// A method's participation in the class-object dispatch table (LRM 8.20). A
+// non-participating method (a regular direct-only callable) carries no value
+// of this optional; a participating method carries the arm whose payload
+// names the slot's canonical identity: an introducer names itself, an
+// intra-unit override names the introducing (class, method) pair. A
+// consumer reads the slot's identity in one step.
+using VirtualDispatchRole =
+    std::variant<IntroducesVirtualSlot, OverridesIntraUnitSlot>;
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -6,6 +6,7 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/mir/abi_adapter_id.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/closure.hpp"
@@ -195,6 +196,21 @@ struct Indirect {
   ExprId closure;
 };
 
+// A virtually-dispatched call: the receiver is evaluated once and then the
+// implementation of the named slot on that receiver's dynamic type runs
+// (LRM 8.20). `owner_class` and `slot` name the slot as it appears in the
+// class arena that introduced it -- the canonical logical identity a
+// backend uses to reach the method's name and signature; the receiver's
+// dynamic type is what decides which implementation runs. The receiver
+// rides here, distinct from user-supplied `CallExpr::arguments`, so the
+// call carries exactly the arguments the SV source wrote and the receiver
+// is not conflated with them.
+struct Virtual {
+  ExprId receiver;
+  ClassId owner_class;
+  MethodId slot;
+};
+
 // Constructs a value of the call's result data type from the positional
 // arguments -- the data type's constructor, which is just a call whose
 // callee is the type itself (Python's `T(args)`, Rust's `T::new(args)`).
@@ -206,7 +222,14 @@ struct Indirect {
 // form is `ArrayLiteralExpr`, a value literal, not this.
 struct Construct {};
 
-using Callee = std::variant<Direct, Indirect, Construct>;
+// One call site's invocation semantics. The arm is a property of the call
+// node, independent of the callee's own dispatch-family membership: a
+// super-qualified call to a virtual-family method carries `Direct` because
+// the source demands the base implementation regardless of the receiver's
+// dynamic type, while a plain unqualified call to the same method carries
+// `Virtual`. A backend reads the invocation semantic from the arm and never
+// re-derives it from the callee declaration.
+using Callee = std::variant<Direct, Indirect, Construct, Virtual>;
 
 struct CallExpr {
   Callee callee;
@@ -414,13 +437,12 @@ struct UnionGetRefExpr {
   std::size_t index;
 };
 
-// A value that is a reference to a named callable of this class -- a plain
-// function pointer whose type is the callable's signature. Realized by taking
-// the callable's address (`&Class::name`). Used to install a lifecycle entry or
-// its ABI adapter into a unit's runtime definition as a bare function value,
-// with no wrapper object -- the generic-language "function as a value".
+// Used where a runtime callback surface takes a bare function value with no
+// wrapper object (a lifecycle hook slot in a per-class definition constant).
+// The referent is an `AbiAdapter`, never an instance method: instance
+// methods have no function-pointer-compatible identity.
 struct FunctionRef {
-  MethodId callable;
+  AbiAdapterId adapter;
 };
 
 // A place naming one of this class's static constants (`Class::name`), the data

--- a/include/lyra/mir/method.hpp
+++ b/include/lyra/mir/method.hpp
@@ -17,28 +17,36 @@ namespace lyra::mir {
 // here rather than inferring it from the object's base or the method's role.
 enum class MethodVisibility : std::uint8_t { kPublic, kInternal };
 
-// A named, class-level callable: callable code plus a name. Every SystemVerilog
-// function and task, every process body, and the synthesized lifecycle bodies
-// are this one concept, distinguished only by how a referencing site uses them.
-// The signature -- the parameter list (with `self` at `code.params[0]`) and the
-// result type that carries the call protocol and completion payload -- lives in
-// `code`, so the backend reads task-versus-function and the output pack from
-// `code.result_type`, not a side enum. The body is uniform across every
-// callable: a static function over the explicit receiver `self`. How a
-// referencing site reaches the callable -- a direct call, a constructor-time
-// process registration, an engine-dispatched lifecycle hook -- is the
-// referencing site's concern, realized as separate dispatch plumbing. The
-// declaration records one dispatch fact of its own, the base method it
-// overrides when it overrides one, which leaves the uniform body untouched.
+// A named class instance-method callable (LRM 8.6). Every SystemVerilog
+// function and task, every process body, and the synthesized lifecycle body
+// is one of these -- callables whose receiver is the enclosing object,
+// bound implicitly at the call site. The signature -- the parameter list
+// (with `self` at `code.params[0]`) and the result type carrying the call
+// protocol -- lives in `code`, so a backend reads task-versus-function and
+// the output pack from `code.result_type`, not a side enum. `visibility`
+// states whether the method is part of the object's externally callable
+// surface. `virtual_dispatch`, when present, states this method's role in
+// the class's dispatch table -- either introducing a new slot or filling an
+// ancestor's -- so a backend renders the introduction or override marker
+// off stated structure, never re-deriving virtualness by name matching.
 struct MethodDecl {
   std::string name;
   CallableCode code;
-  // The base method this declaration overrides, resolved to a declaration
-  // reference, or absent for a method that introduces no override. A lifecycle
-  // body overrides the runtime base's matching hook; a backend reads the
-  // override target here rather than re-deriving it from the method name.
-  std::optional<OverriddenMethodRef> overrides;
+  std::optional<VirtualDispatchRole> virtual_dispatch;
   MethodVisibility visibility;
+};
+
+// A named class-owned callable whose identity is a plain function pointer
+// the runtime library holds and calls back through -- the shape a
+// `void (*)(RuntimeScopeBase*)` lifecycle hook requires. Structurally a
+// distinct callable species from `MethodDecl`: its receiver is an explicit
+// parameter (never bound implicitly), it participates in no dispatch table,
+// and it is reached only as a code address, never through a CallExpr. A
+// backend renders it in the target language's function-pointer-compatible
+// form, which is not the form an instance method takes.
+struct AbiAdapter {
+  std::string name;
+  CallableCode code;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/runtime/gc_ref.hpp
+++ b/include/lyra/runtime/gc_ref.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 namespace lyra::runtime {
@@ -10,6 +11,10 @@ namespace lyra::runtime {
 // heap object whose lifetime the simulator owns. Null is a legal value, copies
 // are shallow (two handles refer to the same object), and identity is compared
 // by object address.
+//
+// A handle assigns from a handle to a subclass -- LRM 8.14 permits assigning a
+// derived-class handle to a base-class variable -- so the type carries a
+// converting constructor when the pointee is a compatible-pointer subclass.
 //
 // Realized as a shared owner: the last handle to drop releases the object. A
 // cycle of handles that becomes unreachable is not reclaimed.
@@ -20,6 +25,18 @@ class GcRef {
   GcRef(std::nullptr_t) {  // NOLINT(google-explicit-constructor)
   }
   explicit GcRef(std::shared_ptr<T> ptr) : ptr_(std::move(ptr)) {
+  }
+
+  template <typename U>
+    requires(std::is_convertible_v<U*, T*> && !std::is_same_v<U, T>)
+  GcRef(const GcRef<U>& other)  // NOLINT(google-explicit-constructor)
+      : ptr_(other.ptr_) {
+  }
+
+  template <typename U>
+    requires(std::is_convertible_v<U*, T*> && !std::is_same_v<U, T>)
+  GcRef(GcRef<U>&& other) noexcept  // NOLINT(google-explicit-constructor)
+      : ptr_(std::move(other.ptr_)) {
   }
 
   auto operator->() const -> T* {
@@ -40,6 +57,9 @@ class GcRef {
   }
 
  private:
+  template <typename U>
+  friend class GcRef;
+
   std::shared_ptr<T> ptr_;
 };
 

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -18,6 +18,7 @@
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/mir/class.hpp"
+#include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/field.hpp"
 #include "lyra/mir/type.hpp"
@@ -64,12 +65,36 @@ auto RenderMethodParam(
   return std::format("{} {}", RenderTypeAsCpp(unit, s, param.type), param.name);
 }
 
-// The one renderer for every callable body. A body renders uniformly as a
-// static function over the explicit receiver `self`: the result type (whose
-// `void` and coroutine cases are ordinary types, handled in `RenderTypeAsCpp`),
-// the name, every parameter (`self` is `params[0]`, rendered like any other),
-// and the body (a plain statement render, including any `co_return` that is
-// itself a body statement).
+// The C++ specifier this method's dispatch role prefixes its declaration
+// with: `virtual` when the method introduces a new dispatch slot on this
+// class, empty otherwise; the source of virtualness for an override is the
+// slot the base already declares, which the `override` suffix records
+// separately.
+auto VirtualPrefix(const mir::MethodDecl& m) -> std::string_view {
+  if (!m.virtual_dispatch.has_value()) return "";
+  if (std::holds_alternative<mir::IntroducesVirtualSlot>(*m.virtual_dispatch)) {
+    return "virtual ";
+  }
+  return "";
+}
+
+// The trailing specifier attached after the return type when this method
+// fills an inherited dispatch slot: `override` records that the base's slot
+// resolves through this implementation, so a name-only compilation cannot
+// silently disagree with the intended override target.
+auto OverrideSuffix(const mir::MethodDecl& m) -> std::string_view {
+  if (!m.virtual_dispatch.has_value()) return "";
+  if (std::holds_alternative<mir::IntroducesVirtualSlot>(*m.virtual_dispatch)) {
+    return "";
+  }
+  return " override";
+}
+
+// The renderer for a class instance method: a C++ instance member function.
+// `this` is what MIR calls `self`, seeded through a one-line adapter so the
+// body's expressions resolve receiver-relative references uniformly. The
+// method's dispatch role decorates the declaration with `virtual` or
+// `override` where applicable.
 auto RenderMethod(
     const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::Class& s, const mir::MethodDecl& m, std::size_t indent)
@@ -78,12 +103,44 @@ auto RenderMethod(
                                   ? ScopeView::ForRoot(unit, s, m.code)
                                   : parent_struct_view->WithClass(s, m.code);
 
-  std::string ret = RenderTypeAsCpp(unit, s, m.code.result_type);
+  const std::string ret = RenderTypeAsCpp(unit, s, m.code.result_type);
+  const mir::LocalId self_local = m.code.params[0];
+  const auto& self_decl = m.code.locals.Get(self_local);
+  const std::string self_type = RenderTypeAsCpp(unit, s, self_decl.type);
 
-  std::string sig = std::format("static auto {}(", m.name);
-  for (std::size_t i = 0; i < m.code.params.size(); ++i) {
-    if (i != 0) sig += ", ";
+  std::string sig = std::format("{}auto {}(", VirtualPrefix(m), m.name);
+  for (std::size_t i = 1; i < m.code.params.size(); ++i) {
+    if (i != 1) sig += ", ";
     sig += RenderMethodParam(unit, s, m.code.locals.Get(m.code.params[i]));
+  }
+  sig += std::format(") -> {}{}", ret, OverrideSuffix(m));
+
+  std::string out;
+  out += std::format("{}{} {{\n", Indent(indent), sig);
+  out += std::format(
+      "{}{} {} = this;\n", Indent(indent + 1), self_type, self_decl.name);
+  out += RenderBlockStatements(body_view, indent + 1);
+  out += std::format("{}}}\n", Indent(indent));
+  return out;
+}
+
+// The renderer for a runtime-callback adapter: a static class member so its
+// address decays to a plain function pointer of the shape the runtime
+// callback table requires. The receiver is the callable's first explicit
+// parameter, rendered like any other formal.
+auto RenderAbiAdapter(
+    const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
+    const mir::Class& s, const mir::AbiAdapter& a, std::size_t indent)
+    -> std::string {
+  const ScopeView body_view = (parent_struct_view == nullptr)
+                                  ? ScopeView::ForRoot(unit, s, a.code)
+                                  : parent_struct_view->WithClass(s, a.code);
+
+  const std::string ret = RenderTypeAsCpp(unit, s, a.code.result_type);
+  std::string sig = std::format("static auto {}(", a.name);
+  for (std::size_t i = 0; i < a.code.params.size(); ++i) {
+    if (i != 0) sig += ", ";
+    sig += RenderMethodParam(unit, s, a.code.locals.Get(a.code.params[i]));
   }
   sig += std::format(") -> {}", ret);
 
@@ -295,6 +352,24 @@ auto RenderScopeAsClass(
     }
     out += "\n";
     out += RenderMethod(parent_struct_view, unit, s, sub, indent + 1);
+  }
+
+  // The class's runtime-callback adapters. Each renders as a static member
+  // whose address decays to a plain function pointer for the runtime
+  // callback table; the class never exposes them on its public surface.
+  if (!s.abi_adapters.empty()) {
+    if (open_section != mir::MethodVisibility::kInternal) {
+      open_section = mir::MethodVisibility::kInternal;
+      out += std::format(
+          "\n{} {}:\n", Indent(indent),
+          VisibilityKeyword(mir::MethodVisibility::kInternal));
+    }
+    for (std::size_t i = 0; i < s.abi_adapters.size(); ++i) {
+      const auto& a =
+          s.abi_adapters.Get(mir::AbiAdapterId{static_cast<std::uint32_t>(i)});
+      out += "\n";
+      out += RenderAbiAdapter(parent_struct_view, unit, s, a, indent + 1);
+    }
   }
 
   // The class's static constants (a tree node's generated-behavior record among

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -6,7 +6,6 @@
 #include <string_view>
 #include <variant>
 
-#include "lyra/backend/cpp/formatting.hpp"
 #include "lyra/backend/cpp/render_expr.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/backend/cpp/scope_view.hpp"
@@ -414,13 +413,12 @@ struct CalleeRender {
   std::size_t leading_arg_count;
 };
 
-// Renders a `Direct` callee whose target is a user-declared method. The target
-// states its owning class explicitly, so the emitted qualification names the
-// declaring class arena without deriving it from the receiver's runtime type
-// (which may differ from the declaring class when the method is inherited).
-// The `self` receiver stays an ordinary leading argument. No qualification is
-// allowed today -- cross-class explicit qualification is gated on SV class
-// support.
+// Renders a `Direct` callee whose target is a user-declared method. The method
+// renders as a C++ instance member function, so the emitted callee text is
+// `(receiver)->name` -- the receiver rides as `arguments[0]` in MIR and is
+// consumed here rather than passed as an ordinary argument. No qualification
+// is allowed today -- cross-class explicit qualification is gated on SV
+// class support.
 auto RenderDirectMethodCall(
     const ScopeView& view, const mir::CallExpr& call,
     const mir::MethodTarget& method,
@@ -433,10 +431,12 @@ auto RenderDirectMethodCall(
     throw InternalError("Direct method call expects a receiver argument");
   }
   const auto& cls = view.Unit().GetClass(method.owner);
+  const mir::Expr& receiver = view.Expr(call.arguments[0]);
   return {
       .expr = std::format(
-          "{}::{}", ToCppName(cls.name), cls.methods.Get(method.slot).name),
-      .leading_arg_count = 0};
+          "({})->{}", RenderExpr(view, receiver),
+          cls.methods.Get(method.slot).name),
+      .leading_arg_count = 1};
 }
 
 // Renders a `Direct` callee whose target is a `BuiltinFn`. Picks one of
@@ -518,6 +518,14 @@ auto RenderCalleePart(
             return {
                 .expr =
                     std::format("({})", RenderExpr(view, view.Expr(i.closure))),
+                .leading_arg_count = 0};
+          },
+          [&](const mir::Virtual& v) -> CalleeRender {
+            const auto& cls = view.Unit().GetClass(v.owner_class);
+            return {
+                .expr = std::format(
+                    "({})->{}", RenderExpr(view, view.Expr(v.receiver)),
+                    cls.methods.Get(v.slot).name),
                 .leading_arg_count = 0};
           },
           [&](const mir::Construct&) -> CalleeRender {

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -168,9 +168,8 @@ auto RenderRealLiteralExpr(
 
 auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
     -> std::string {
-  // Every callable body is a static function over the explicit receiver `self`
-  // (its `locals[0]`), so a local reference renders as its own name -- `self`
-  // included, which is just the first parameter's name.
+  // Every local -- including `self` (`locals[0]`), which the method emit
+  // seeds from `this` -- renders as its declared name.
   return view.Local(ref).name;
 }
 
@@ -893,7 +892,7 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
             const mir::Class& cls = view.Class();
             return std::format(
                 "&{}::{}", ToCppName(cls.name),
-                cls.methods.Get(fr.callable).name);
+                cls.abi_adapters.Get(fr.adapter).name);
           },
           [&](const mir::StaticConstantRef& r) -> std::string {
             const mir::Class& cls = view.Class();

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -537,7 +537,7 @@ class HirDumper {
             [](const MethodCallRef& m) -> std::string {
               return std::format(
                   "Method class=Class[{}] index={} recv=Expr[{}]",
-                  m.class_id.value, m.method_index, m.receiver.value);
+                  m.class_id.value, m.method.value, m.receiver.value);
             },
             [](const SystemSubroutineRef& s) -> std::string {
               const auto& desc = support::LookupSystemSubroutine(s.id);
@@ -853,7 +853,8 @@ class HirDumper {
       }
     }
     for (std::size_t i = 0; i < c.methods.size(); ++i) {
-      DumpSubroutine("Method", i, c.methods[i]);
+      DumpSubroutine(
+          "Method", i, c.methods.Get(MethodId{static_cast<std::uint32_t>(i)}));
     }
     DumpSubroutine("Constructor", 0, c.constructor);
     Dedent();

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -1,7 +1,6 @@
 #include "lyra/lowering/ast_to_hir/expression/calls.hpp"
 
 #include <cstddef>
-#include <cstdint>
 #include <expected>
 #include <optional>
 #include <string>
@@ -57,23 +56,6 @@ auto MakeReturnConventionType(
       return builtins.realtime;
   }
   throw InternalError("MakeReturnConventionType: unknown ReturnConvention");
-}
-
-// An instance method's declaration-order index among its class's methods,
-// matching the order the HIR ClassDecl registers them, so the index names the
-// same method when the call is lowered (LRM 8.6).
-auto ClassMethodIndex(const slang::ast::SubroutineSymbol& method)
-    -> std::uint32_t {
-  const auto* scope = method.getParentScope();
-  std::uint32_t index = 0;
-  for (const auto& member :
-       scope->membersOfType<slang::ast::SubroutineSymbol>()) {
-    if (&member == &method) {
-      return index;
-    }
-    ++index;
-  }
-  throw InternalError("ClassMethodIndex: method not found in its class");
 }
 
 }  // namespace
@@ -476,7 +458,7 @@ auto LowerCallExpr(
                     hir::MethodCallRef{
                         .receiver = receiver,
                         .class_id = *class_id,
-                        .method_index = ClassMethodIndex(*sym)},
+                        .method = unit_lowerer.LookupMethodId(*sym)},
                 .arguments = std::move(arg_ids),
             },
         .span = span,

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -255,7 +255,9 @@ auto LowerSubroutineDecl(
       .result_type = *return_type_or,
       .params = std::move(params),
       .result_var = result_var,
-      .body = std::move(body)};
+      .body = std::move(body),
+      .is_virtual = false,
+      .overrides = std::nullopt};
 }
 
 // Lowers a DPI-C import declaration (LRM 35.4) to a bodyless external callable.

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -475,7 +475,9 @@ auto SynthesizeDefaultConstructor(hir::TypeId void_type, diag::SourceSpan span)
       .result_type = void_type,
       .params = {},
       .result_var = std::nullopt,
-      .body = std::move(body)};
+      .body = std::move(body),
+      .is_virtual = false,
+      .overrides = std::nullopt};
 }
 
 }  // namespace
@@ -557,11 +559,10 @@ auto UnitLowerer::InternClass(
           span, diag::DiagCode::kUnsupportedClassFeature,
           "static class methods are not yet supported");
     }
-    if (method.flags.has(
-            slang::ast::MethodFlags::Virtual | slang::ast::MethodFlags::Pure)) {
+    if (method.flags.has(slang::ast::MethodFlags::Pure)) {
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedClassFeature,
-          "virtual class methods are not yet supported");
+          "pure virtual class methods are not yet supported");
     }
     if (method.subroutineKind == slang::ast::SubroutineKind::Task) {
       return diag::Fail(
@@ -570,7 +571,25 @@ auto UnitLowerer::InternClass(
     }
     auto method_decl = LowerSubroutineDecl(*this, method, WalkFrame{});
     if (!method_decl) return std::unexpected(std::move(method_decl.error()));
-    decl.methods.push_back(*std::move(method_decl));
+    method_decl->is_virtual =
+        method.flags.has(slang::ast::MethodFlags::Virtual);
+    // The frontend has already matched signature, direction, return type, and
+    // any other LRM 8.20 override compatibility rule when it resolved this
+    // reference; the HIR consumes it as an already-resolved identity. Its
+    // base's methods were interned earlier by the recursive `InternClass`
+    // above, so their HIR identities are already in the cache the lookup
+    // reads.
+    if (const auto* overridden = method.getOverride(); overridden != nullptr) {
+      const auto& base_class =
+          overridden->getParentScope()->asSymbol().as<slang::ast::ClassType>();
+      auto base_class_id = InternClass(base_class, span);
+      if (!base_class_id)
+        return std::unexpected(std::move(base_class_id.error()));
+      method_decl->overrides = hir::MethodRef{
+          .class_id = *base_class_id, .method = LookupMethodId(*overridden)};
+    }
+    const hir::MethodId method_id = decl.methods.Add(*std::move(method_decl));
+    RegisterMethodId(method, method_id);
   }
 
   hir::SubroutineDecl constructor =

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/base/overloaded.hpp"
+#include "lyra/hir/class_decl.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
@@ -19,47 +21,178 @@
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/callable_code.hpp"
 #include "lyra/mir/class.hpp"
+#include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/field.hpp"
 #include "lyra/mir/local.hpp"
+#include "lyra/mir/method_id.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
-auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
+namespace {
+
+// Walks the HIR override chain starting at `method` and returns its
+// participation in the class's dispatch table (LRM 8.20). Reads HIR only --
+// HIR is complete before any class shape lowers, so this is order-independent
+// with respect to sibling classes. The walk terminates at either an
+// introducer (`overrides == nullopt && is_virtual`) or a non-participating
+// method (both facts absent). Depth is bounded by inheritance depth; the
+// frontend guarantees the chain is acyclic (LRM 8.13).
+auto CanonicalizeVirtualDispatch(
+    const UnitLowerer& unit_lowerer, const hir::SubroutineDecl& method)
+    -> std::optional<mir::VirtualDispatchRole> {
+  if (method.overrides.has_value()) {
+    const hir::MethodRef& base_ref = *method.overrides;
+    const hir::SubroutineDecl& base_method = unit_lowerer.Hir()
+                                                 .classes.Get(base_ref.class_id)
+                                                 .methods.Get(base_ref.method);
+    const auto base_role =
+        CanonicalizeVirtualDispatch(unit_lowerer, base_method);
+    if (!base_role.has_value()) {
+      throw InternalError(
+          "CanonicalizeVirtualDispatch: HIR override references a base "
+          "method the frontend did not classify as virtual");
+    }
+    const mir::ClassId base_mir_class =
+        unit_lowerer.TranslateClass(base_ref.class_id);
+    const mir::MethodId base_mir_slot{base_ref.method.value};
+    return std::visit(
+        Overloaded{
+            [&](const mir::IntroducesVirtualSlot&) -> mir::VirtualDispatchRole {
+              return mir::OverridesIntraUnitSlot{
+                  .slot_owner = base_mir_class, .slot_id = base_mir_slot};
+            },
+            [](const mir::OverridesIntraUnitSlot& s)
+                -> mir::VirtualDispatchRole { return s; }},
+        *base_role);
+  }
+  if (method.is_virtual) {
+    return mir::VirtualDispatchRole{mir::IntroducesVirtualSlot{}};
+  }
+  return std::nullopt;
+}
+
+// Appends a mangled static-lifetime field per static procedural var to
+// `fields`, returning the placements a callable body reads to route each
+// static write to its persistent slot. Static locals of a class body
+// (LRM 13.3.1) live on the enclosing class since a class carries no
+// procedural-scope hierarchy of its own.
+auto PlanStaticStorage(
+    const UnitLowerer& unit_lowerer, std::string_view callable_name,
+    const hir::ProceduralBody& body,
+    base::Arena<mir::FieldDecl, mir::FieldId>& fields)
+    -> std::vector<std::optional<StaticStoragePlacement>> {
+  std::vector<std::optional<StaticStoragePlacement>> placements(
+      body.procedural_vars.size());
+  for (std::size_t j = 0; j < body.procedural_vars.size(); ++j) {
+    const hir::ProceduralVarId var_id{static_cast<std::uint32_t>(j)};
+    const auto& v = body.procedural_vars.Get(var_id);
+    if (v.lifetime != hir::VariableLifetime::kStatic) continue;
+    const std::string mangled =
+        std::format("{}__{}_{}", callable_name, v.name, j);
+    const mir::TypeId type = unit_lowerer.TranslateType(v.type);
+    const mir::FieldId mid =
+        fields.Add(mir::FieldDecl{.name = mangled, .type = type});
+    placements[j] = StaticStoragePlacement{
+        .owner = StorageOwner{EnclosingClass{}}, .field = mid};
+  }
+  return placements;
+}
+
+}  // namespace
+
+auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
   UnitLowerer& unit_lowerer = *owner_;
   const hir::ClassDecl& hir_class = *hir_class_;
 
   const mir::TypeId self_pointer_type = unit_lowerer.Unit().types.PointerTo(
       object_type_, mir::PointerOwnership::kBorrowed);
 
-  // An SV class extends another SV class of this unit; the base identity is
-  // its intra-unit class id, resolved through the unit's class registry.
   std::optional<mir::ClassRef> base_ref;
   if (hir_class.base.has_value()) {
     base_ref = mir::ClassRef{mir::IntraUnitClassRef{
         .class_id = unit_lowerer.TranslateClass(*hir_class.base)}};
   }
 
-  mir::Class mir_class{
+  mir::ClassShape shape{
       .name = hir_class.name,
       .base = base_ref,
-      .is_scope_tree_node = false,
-      .is_final = false,
       .self_pointer_type = self_pointer_type,
       .time_resolution = {},
+      .ctor_prefix_params = {},
       .fields = {},
-      .constructor = {},
+      .method_signatures = {},
       .contained = {},
+      .type_aliases = {},
+      .is_scope_tree_node = false,
+      .is_final = false};
+
+  // Property fields come first in declaration order (LRM 8.4), so an SV
+  // reference to a property by its declaration index reaches the same shape
+  // slot regardless of what static-lifetime storage the class also owns.
+  field_ids_.reserve(hir_class.fields.size());
+  for (const auto& field : hir_class.fields) {
+    const mir::TypeId field_type = unit_lowerer.TranslateType(field.type);
+    field_ids_.push_back(shape.fields.Add(
+        mir::FieldDecl{.name = field.name, .type = field_type}));
+  }
+
+  // Each SV method's static-lifetime locals get their per-instance slot on
+  // this same shape, appended after the properties, so a static write from a
+  // body routes to the exact same field slot the shape declares.
+  method_plans_.reserve(hir_class.methods.size());
+  for (const auto& method : hir_class.methods) {
+    method_plans_.emplace_back(
+        class_scopes_,
+        PlanStaticStorage(
+            unit_lowerer, method.name, method.body, shape.fields));
+  }
+  ctor_plan_.emplace(
+      class_scopes_,
+      PlanStaticStorage(
+          unit_lowerer, "<ctor>", hir_class.constructor.body, shape.fields));
+
+  // Method signatures publish each method's canonical dispatch role. Peer
+  // body lowering that names one of this class's methods reads this to pick
+  // between direct and virtual invocation, with no cross-class MIR read.
+  for (const auto& method : hir_class.methods) {
+    shape.method_signatures.Add(
+        mir::MethodSignature{
+            .virtual_dispatch =
+                CanonicalizeVirtualDispatch(unit_lowerer, method)});
+  }
+
+  unit_lowerer.DefineClassShape(class_id_, std::move(shape));
+  return {};
+}
+
+auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
+  UnitLowerer& unit_lowerer = *owner_;
+  const hir::ClassDecl& hir_class = *hir_class_;
+  const mir::ClassShape& shape = unit_lowerer.GetClassShape(class_id_);
+
+  mir::Class mir_class{
+      .name = shape.name,
+      .base = shape.base,
+      .is_scope_tree_node = shape.is_scope_tree_node,
+      .is_final = shape.is_final,
+      .self_pointer_type = shape.self_pointer_type,
+      .time_resolution = shape.time_resolution,
+      .fields = shape.fields,
+      .constructor = {},
+      .contained = shape.contained,
       .structs = {},
       .methods = {},
+      .abi_adapters = {},
       .static_constants = {},
       .static_callables = {},
-      .type_aliases = {}};
+      .type_aliases = shape.type_aliases};
 
   // The constructor's callable code is built in a local first, then handed
   // to the class's method storage last so its id sits after every
@@ -69,7 +202,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   CallableBindings ctor_bindings(unit_lowerer.Unit(), ctor_code);
   const mir::LocalId self_id = ctor_bindings.Declare(
       BindingOriginId::Receiver(),
-      mir::LocalDecl{.name = "self", .type = self_pointer_type});
+      mir::LocalDecl{.name = "self", .type = shape.self_pointer_type});
   mir::Block& ctor_block = ctor_code.body;
   ScopeChainNode scope_link{};
   const WalkFrame frame = WalkFrame{}
@@ -77,68 +210,10 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
                               .WithBlock(&ctor_block)
                               .WithBindings(&ctor_bindings);
 
-  // Declare each class property (LRM 8.4) as a value-typed member -- a property
-  // owns its storage directly and is not an observable cell. Declaration order
-  // is preserved so a receiver-relative property reference in an initializer or
-  // a method body indexes the same member.
-  std::vector<mir::FieldId> field_ids;
-  std::vector<mir::TypeId> field_types;
-  field_ids.reserve(hir_class.fields.size());
-  field_types.reserve(hir_class.fields.size());
-  for (const auto& field : hir_class.fields) {
-    const mir::TypeId field_type = unit_lowerer.TranslateType(field.type);
-    field_ids.push_back(mir_class.fields.Add(
-        mir::FieldDecl{.name = field.name, .type = field_type}));
-    field_types.push_back(field_type);
-  }
-
-  // Pre-declare a callable's static-lifetime body locals as members on this
-  // class before any body lowers. A static local has per-instance storage that
-  // outlives every activation of its body (LRM 13.3.1); an SV class has no
-  // named-procedural-block hierarchy, so every static lives directly on the
-  // enclosing SV class. The mangled name (`<callable>__<source>_<hir_id>`)
-  // keeps sibling callables that reuse a source identifier from colliding on
-  // the field arena; the `hir_id` suffix distinguishes nested-block reuses too.
-  // These trail the property members, so property indices stay stable.
-  //
-  // The materialization table is empty because there are no procedural-storage
-  // scopes inside class bodies; the per-callable plans still need a reference
-  // for the API.
-  ProceduralScopeMaterializationTable class_scopes;
-  const auto plan_static_storage = [&](std::string_view callable_name,
-                                       const hir::ProceduralBody& body) {
-    std::vector<std::optional<StaticStoragePlacement>> placements(
-        body.procedural_vars.size());
-    for (std::size_t j = 0; j < body.procedural_vars.size(); ++j) {
-      const hir::ProceduralVarId var_id{static_cast<std::uint32_t>(j)};
-      const auto& v = body.procedural_vars.Get(var_id);
-      if (v.lifetime != hir::VariableLifetime::kStatic) {
-        continue;
-      }
-      const std::string mangled =
-          std::format("{}__{}_{}", callable_name, v.name, j);
-      const mir::TypeId type = unit_lowerer.TranslateType(v.type);
-      const mir::FieldId mid =
-          mir_class.fields.Add(mir::FieldDecl{.name = mangled, .type = type});
-      placements[j] = StaticStoragePlacement{
-          .owner = StorageOwner{EnclosingClass{}}, .field = mid};
-    }
-    return placements;
-  };
-
-  std::vector<CallableStoragePlan> method_plans;
-  method_plans.reserve(hir_class.methods.size());
-  for (const auto& method : hir_class.methods) {
-    method_plans.emplace_back(
-        class_scopes, plan_static_storage(method.name, method.body));
-  }
-
   const hir::SubroutineDecl& ctor = hir_class.constructor;
-  const CallableStoragePlan ctor_plan(
-      class_scopes, plan_static_storage("<ctor>", ctor.body));
   ProcessLowerer ctor_lowerer(
       unit_lowerer, nullptr, mir_class.time_resolution, ctor.body, "<ctor>",
-      mir::MethodVisibility::kInternal, frame, ctor_plan);
+      mir::MethodVisibility::kInternal, frame, *ctor_plan_);
 
   // Initialize each property in declaration order before the constructor body
   // runs (LRM 8.7): a property with an explicit initializer takes that value --
@@ -148,6 +223,7 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
   // read an earlier property whose own initialization has already run.
   for (std::size_t i = 0; i < hir_class.fields.size(); ++i) {
     const hir::ClassField& field = hir_class.fields[i];
+    const mir::TypeId field_type = mir_class.fields.Get(field_ids_[i]).type;
     mir::ExprId value_id{};
     if (field.initializer.has_value()) {
       auto value_or = ctor_lowerer.LowerExpr(
@@ -159,35 +235,39 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
           BuildDefaultValueFromHir(unit_lowerer, frame, field.type));
     }
     const mir::ExprId self_ref =
-        ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_pointer_type));
+        ctor_block.exprs.Add(MakeSelfRefExpr(frame, shape.self_pointer_type));
     const mir::ExprId target = ctor_block.exprs.Add(
         mir::MakeFieldAccessExpr(
             self_ref,
-            mir::FieldTarget{.owner = class_id_, .slot = field_ids[i]},
-            field_types[i]));
-    const mir::ExprId assign = ctor_block.exprs.Add(
-        mir::MakeAssignExpr(target, value_id, field_types[i]));
+            mir::FieldTarget{.owner = class_id_, .slot = field_ids_[i]},
+            field_type));
+    const mir::ExprId assign =
+        ctor_block.exprs.Add(mir::MakeAssignExpr(target, value_id, field_type));
     ctor_block.AppendStmt(mir::ExprStmt{.expr = assign});
   }
 
-  // Each instance method (LRM 8.6) is lowered as a callable this class owns: it
-  // resolves the body's `self` to the managed handle, and the method's
+  // Each instance method (LRM 8.6) is lowered as a callable this class owns:
+  // it resolves the body's `self` to the managed handle, and the method's
   // declaration-order position becomes its `MethodId`, so a call site naming
   // the index reaches the same method. SV classes do not have a separate
   // Initialize lifecycle phase, so a method's pending static initializers
   // integrate into this class's constructor block (matching the per-instance
   // storage shape used for class-method statics).
   for (std::size_t i = 0; i < hir_class.methods.size(); ++i) {
-    const auto& method = hir_class.methods[i];
+    const hir::MethodId method_id{static_cast<std::uint32_t>(i)};
+    const auto& method = hir_class.methods.Get(method_id);
     ScopeChainNode method_link{};
     const WalkFrame method_owner_frame =
         WalkFrame{}.WithClass(&mir_class, class_id_, method_link);
     ProcessLowerer method_lowerer(
         unit_lowerer, nullptr, mir_class.time_resolution, method.body,
         method.name, mir::MethodVisibility::kPublic, method_owner_frame,
-        method_plans[i]);
+        method_plans_[i]);
     auto method_or = method_lowerer.Run(method);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
+    method_or->virtual_dispatch =
+        shape.method_signatures.Get(mir::MethodId{method_id.value})
+            .virtual_dispatch;
     mir_class.methods.Add(*std::move(method_or));
     for (const auto& pending : method_lowerer.TakePendingStaticInitializers()) {
       auto integ = IntegratePendingStaticInitializer(
@@ -218,12 +298,13 @@ auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
       mir::MethodDecl{
           .name = "<ctor>",
           .code = std::move(ctor_code),
-          .overrides = std::nullopt,
+          .virtual_dispatch = std::nullopt,
           .visibility = mir::MethodVisibility::kInternal});
   mir_class.constructor = mir::ConstructorDecl{
       .method = ctor_method_id, .base_init = std::nullopt, .member_inits = {}};
 
-  return mir_class;
+  unit_lowerer.Unit().DefineClass(class_id_, std::move(mir_class));
+  return {};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -269,7 +269,7 @@ auto LowerContinuousAssign(
   return mir::MethodDecl{
       .name = std::move(name),
       .code = std::move(code),
-      .overrides = std::nullopt,
+      .virtual_dispatch = std::nullopt,
       .visibility = mir::MethodVisibility::kInternal};
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -523,23 +523,41 @@ auto LowerBuiltinMethodCall(
       .type = result_type};
 }
 
-// An instance-method call (LRM 8.6): the receiver handle is the first argument,
-// followed by the method's value arguments. The callee names the class method
-// directly; the receiver's class layout, not the call site, decides how the
-// backend dispatches.
+// Reads the slot's canonical (owner, id) off a method's stated
+// `virtual_dispatch`. Every participating method already stores this pair --
+// an introducer names itself, an intra-unit override was populated with the
+// canonical id at class lowering -- so this is a one-arm dispatch, never a
+// chain walk.
+auto CanonicalIntraUnitSlot(
+    mir::ClassId self_owner, mir::MethodId self_slot,
+    const mir::VirtualDispatchRole& role)
+    -> std::pair<mir::ClassId, mir::MethodId> {
+  return std::visit(
+      Overloaded{
+          [&](const mir::IntroducesVirtualSlot&)
+              -> std::pair<mir::ClassId, mir::MethodId> {
+            return {self_owner, self_slot};
+          },
+          [](const mir::OverridesIntraUnitSlot& s)
+              -> std::pair<mir::ClassId, mir::MethodId> {
+            return {s.slot_owner, s.slot_id};
+          }},
+      role);
+}
+
+// An instance-method call (LRM 8.6): the receiver evaluates to the managed
+// handle, and the borrowed pointer to the object reaches the method body as
+// its `self`. A direct call passes that pointer as `arguments[0]` and names
+// the concrete method arena entry; a virtual call carries it as
+// `Virtual::receiver` and names the slot's canonical identity so the
+// receiver's dynamic type -- not the call site -- picks the implementation
+// (LRM 8.20).
 template <ExprLowerer Lowerer>
 auto LowerMethodCall(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     const hir::MethodCallRef& m, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
-  std::vector<mir::ExprId> args;
-  args.reserve(c.arguments.size() + 1);
-
-  // The receiver evaluates to the managed handle; the method body operates on
-  // a borrowed pointer to the object (LRM 8.6). Reaching the object from the
-  // handle and taking its address yields that borrowed receiver -- the body
-  // does not own or root the object, the caller's handle does.
   auto receiver_or =
       lowerer.LowerExpr(lowerer.HirExprs().Get(m.receiver), frame);
   if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
@@ -550,24 +568,53 @@ auto LowerMethodCall(
   // runtime class is only used to type the self parameter (which pairs with
   // the target's own arena entry through C++ member lookup).
   const mir::ClassId owner_class = lowerer.Owner().TranslateClass(m.class_id);
+  const mir::MethodId method_slot{m.method.value};
   const mir::ExprId handle_id = block.exprs.Add(*std::move(receiver_or));
   const mir::ExprId object_id = block.exprs.Add(
       mir::Expr{
           .data = mir::DerefExpr{.pointer = handle_id}, .type = object_type});
   const mir::TypeId self_pointer_type =
       types.PointerTo(object_type, mir::PointerOwnership::kBorrowed);
-  args.push_back(
-      block.exprs.Add(mir::MakeAddressOfExpr(object_id, self_pointer_type)));
+  const mir::ExprId receiver_ptr =
+      block.exprs.Add(mir::MakeAddressOfExpr(object_id, self_pointer_type));
 
+  std::vector<mir::ExprId> user_args;
+  user_args.reserve(c.arguments.size());
   for (const auto& arg : c.arguments) {
     if (!arg.has_value()) {
       throw InternalError("LowerMethodCall: method-call argument elided");
     }
     auto arg_or = lowerer.LowerExpr(lowerer.HirExprs().Get(*arg), frame);
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-    args.push_back(block.exprs.Add(*std::move(arg_or)));
+    user_args.push_back(block.exprs.Add(*std::move(arg_or)));
   }
 
+  // Cross-class dispatch role is queried through the shape store, not the
+  // unit's class registry: while any peer body is lowering the registry is
+  // one-way `Define`, so a `Get` there would leak lowering order into the
+  // reading site.
+  const auto& method_sig = lowerer.Owner()
+                               .GetClassShape(owner_class)
+                               .method_signatures.Get(method_slot);
+  if (method_sig.virtual_dispatch.has_value()) {
+    const auto [canonical_owner, canonical_slot] = CanonicalIntraUnitSlot(
+        owner_class, method_slot, *method_sig.virtual_dispatch);
+    return mir::Expr{
+        .data =
+            mir::CallExpr{
+                .callee =
+                    mir::Virtual{
+                        .receiver = receiver_ptr,
+                        .owner_class = canonical_owner,
+                        .slot = canonical_slot},
+                .arguments = std::move(user_args)},
+        .type = result_type};
+  }
+
+  std::vector<mir::ExprId> direct_args;
+  direct_args.reserve(user_args.size() + 1);
+  direct_args.push_back(receiver_ptr);
+  for (const mir::ExprId a : user_args) direct_args.push_back(a);
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -575,10 +622,9 @@ auto LowerMethodCall(
                   mir::Direct{
                       .target =
                           mir::MethodTarget{
-                              .owner = owner_class,
-                              .slot = mir::MethodId{.value = m.method_index}},
+                              .owner = owner_class, .slot = method_slot},
                       .qualification = std::nullopt},
-              .arguments = std::move(args)},
+              .arguments = std::move(direct_args)},
       .type = result_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -193,7 +193,7 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
       .code = std::move(code),
-      .overrides = std::nullopt,
+      .virtual_dispatch = std::nullopt,
       .visibility = process.Visibility()};
 }
 
@@ -239,7 +239,7 @@ auto LowerForeverProcess(
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
       .code = std::move(code),
-      .overrides = std::nullopt,
+      .virtual_dispatch = std::nullopt,
       .visibility = process.Visibility()};
 }
 
@@ -378,7 +378,7 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
   return mir::MethodDecl{
       .name = src.name,
       .code = std::move(code),
-      .overrides = std::nullopt,
+      .virtual_dispatch = std::nullopt,
       .visibility = Visibility()};
 }
 

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -1391,7 +1391,7 @@ auto InstallGeneratedDefinition(
   const mir::TypeId void_type = unit.builtins.void_type;
   const auto make_adapter =
       [&](std::string name,
-          std::optional<mir::MethodId> body) -> mir::MethodId {
+          std::optional<mir::MethodId> body) -> mir::AbiAdapterId {
     mir::CallableCode code;
     const mir::LocalId self =
         code.locals.Add(mir::LocalDecl{.name = "self", .type = scope_ptr});
@@ -1417,17 +1417,14 @@ auto InstallGeneratedDefinition(
               .type = void_type});
       code.body.AppendStmt(mir::ExprStmt{.expr = call});
     }
-    return cls.methods.Add(
-        mir::MethodDecl{
-            .name = std::move(name),
-            .code = std::move(code),
-            .overrides = std::nullopt,
-            .visibility = mir::MethodVisibility::kInternal});
+    return cls.abi_adapters.Add(
+        mir::AbiAdapter{.name = std::move(name), .code = std::move(code)});
   };
-  const mir::MethodId resolve_abi =
+  const mir::AbiAdapterId resolve_abi =
       make_adapter("ResolveStateAbi", resolve_body);
-  const mir::MethodId init_abi = make_adapter("InitializeStateAbi", init_body);
-  const mir::MethodId create_abi =
+  const mir::AbiAdapterId init_abi =
+      make_adapter("InitializeStateAbi", init_body);
+  const mir::AbiAdapterId create_abi =
       make_adapter("CreateProcessesAbi", create_body);
 
   mir::StaticConstantDecl def;
@@ -1451,10 +1448,10 @@ auto InstallGeneratedDefinition(
             .data = mir::MachineIntLiteral{.value = value},
             .type = unit.builtins.machine_int64});
   };
-  const auto func_ref = [&](mir::MethodId m) {
+  const auto func_ref = [&](mir::AbiAdapterId a) {
     return ex.Add(
         mir::Expr{
-            .data = mir::FunctionRef{.callable = m},
+            .data = mir::FunctionRef{.adapter = a},
             .type = intern(mir::RuntimeLibraryKind::kScopeEntry)});
   };
 
@@ -1474,7 +1471,7 @@ auto InstallGeneratedDefinition(
       {metadata, func_ref(resolve_abi), func_ref(init_abi),
        func_ref(create_abi)});
   if (is_unit) {
-    const mir::MethodId construct_abi =
+    const mir::AbiAdapterId construct_abi =
         make_adapter("ConstructAbi", std::nullopt);
     def.value = construct(
         mir::RuntimeLibraryKind::kUnitDefinition,
@@ -1534,7 +1531,7 @@ void FinalizeConstructor(
       mir::MethodDecl{
           .name = "<ctor>",
           .code = std::move(ctor_code),
-          .overrides = std::nullopt,
+          .virtual_dispatch = std::nullopt,
           .visibility = mir::MethodVisibility::kInternal});
   cls.constructor = mir::ConstructorDecl{
       .method = ctor_method_id,
@@ -2048,7 +2045,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
         mir::MethodDecl{
             .name = std::move(name),
             .code = std::move(code),
-            .overrides = std::nullopt,
+            .virtual_dispatch = std::nullopt,
             .visibility = mir::MethodVisibility::kInternal});
   };
   const std::optional<mir::MethodId> resolve_body =

--- a/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/class_decl_lowerer.hpp"
@@ -41,14 +42,26 @@ auto UnitLowerer::Run() -> diag::Result<mir::CompilationUnit> {
     MapType(hir_id, mir_id);
   }
 
+  // Two-stage class lowering. Stage 1 publishes every class's shape so a
+  // peer body reads any cross-class fact from the shape store, not from a
+  // sibling lowerer's in-progress state. Stage 2 composes each class's
+  // executable form and commits it to the unit. Neither stage observes the
+  // other's iteration order.
+  std::vector<ClassDeclLowerer> class_lowerers;
+  class_lowerers.reserve(hir_->classes.size());
   for (std::size_t i = 0; i < hir_->classes.size(); ++i) {
     const hir::ClassId hir_id{static_cast<std::uint32_t>(i)};
-    ClassDeclLowerer class_lowerer(
+    class_lowerers.emplace_back(
         *this, TranslateClass(hir_id), ClassObjectType(hir_id),
         hir_->classes.Get(hir_id));
-    auto class_or = class_lowerer.Run();
-    if (!class_or) return std::unexpected(std::move(class_or.error()));
-    unit_.DefineClass(TranslateClass(hir_id), *std::move(class_or));
+  }
+  for (auto& class_lowerer : class_lowerers) {
+    auto r = class_lowerer.DeclareShape();
+    if (!r) return std::unexpected(std::move(r.error()));
+  }
+  for (auto& class_lowerer : class_lowerers) {
+    auto r = class_lowerer.PopulateBodies();
+    if (!r) return std::unexpected(std::move(r.error()));
   }
 
   // Two-sweep structural lowering: the first sweep mints every class identity

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -205,6 +205,11 @@ auto LowerCallTarget(
             return Unsupported(
                 "mir_to_lir: indirect (closure) call is not yet lowerable to "
                 "LIR");
+          },
+          [](const mir::Virtual&) -> diag::Result<lir::CallTarget> {
+            return Unsupported(
+                "mir_to_lir: virtual method dispatch is not yet lowerable to "
+                "LIR");
           }},
       callee);
 }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -472,6 +472,23 @@ class MirDumper {
     throw InternalError("MirDumper: unknown BinaryOp");
   }
 
+  [[nodiscard]] auto FormatVirtualDispatchRole(
+      const VirtualDispatchRole& role) const -> std::string {
+    return std::visit(
+        Overloaded{
+            [](const IntroducesVirtualSlot&) -> std::string {
+              return "IntroducesSlot";
+            },
+            [this](const OverridesIntraUnitSlot& o) -> std::string {
+              const auto& owner = unit_->GetClass(o.slot_owner);
+              const auto& method = owner.methods.Get(o.slot_id);
+              return std::format(
+                  "OverridesIntraUnitSlot[Class[{}].{}(Method[{}])]",
+                  o.slot_owner.value, method.name, o.slot_id.value);
+            }},
+        role);
+  }
+
   [[nodiscard]] auto FormatDirectTarget(const DirectTarget& target) const
       -> std::string {
     return std::visit(
@@ -522,6 +539,14 @@ class MirDumper {
               return std::format("Indirect[closure=Expr[{}]]", i.closure.value);
             },
             [](const Construct&) -> std::string { return "Construct"; },
+            [this](const Virtual& v) -> std::string {
+              const auto& owner = unit_->GetClass(v.owner_class);
+              const auto& method = owner.methods.Get(v.slot);
+              return std::format(
+                  "Virtual[recv=Expr[{}] slot=Class[{}].{}(Method[{}])]",
+                  v.receiver.value, v.owner_class.value, method.name,
+                  v.slot.value);
+            },
         },
         callee);
   }
@@ -682,7 +707,7 @@ class MirDumper {
             },
             [](const FunctionRef& fr) -> std::string {
               return std::format(
-                  "FunctionRef callable=Method[{}]", fr.callable.value);
+                  "FunctionRef adapter=AbiAdapter[{}]", fr.adapter.value);
             },
             [](const StaticConstantRef& r) -> std::string {
               return std::format(
@@ -793,6 +818,16 @@ class MirDumper {
       DumpMethod(s.methods.Get(mid), i);
     }
     Dedent();
+
+    if (!s.abi_adapters.empty()) {
+      Line("AbiAdapters:");
+      Indent();
+      for (std::size_t i = 0; i < s.abi_adapters.size(); ++i) {
+        DumpAbiAdapter(
+            s.abi_adapters.Get(AbiAdapterId{static_cast<std::uint32_t>(i)}), i);
+      }
+      Dedent();
+    }
 
     if (!s.static_callables.empty()) {
       Line("StaticCallables:");
@@ -914,21 +949,11 @@ class MirDumper {
         std::format(
             "Visibility: {}",
             d.visibility == MethodVisibility::kPublic ? "public" : "internal"));
-    if (d.overrides.has_value()) {
-      const auto& ref = std::get<RuntimeLibraryMethodRef>(*d.overrides);
-      std::string_view target = "Resolve";
-      switch (ref.method) {
-        case RuntimeMethod::kResolve:
-          target = "Resolve";
-          break;
-        case RuntimeMethod::kInitialize:
-          target = "Initialize";
-          break;
-        case RuntimeMethod::kActivate:
-          target = "Activate";
-          break;
-      }
-      Line(std::format("Overrides: {}", target));
+    if (d.virtual_dispatch.has_value()) {
+      Line(
+          std::format(
+              "VirtualDispatch: {}",
+              FormatVirtualDispatchRole(*d.virtual_dispatch)));
     }
     for (std::size_t i = 0; i < d.code.params.size(); ++i) {
       const auto& param = d.code.locals.Get(d.code.params[i]);
@@ -937,6 +962,21 @@ class MirDumper {
               "Param[{}] \"{}\" : Type[{}]", i, param.name, param.type.value));
     }
     DumpCallableBody(d.code);
+    Dedent();
+  }
+
+  void DumpAbiAdapter(const AbiAdapter& a, std::size_t index) {
+    Line(
+        std::format(
+            "[{}] \"{}\" : Type[{}]", index, a.name, a.code.result_type.value));
+    Indent();
+    for (std::size_t i = 0; i < a.code.params.size(); ++i) {
+      const auto& param = a.code.locals.Get(a.code.params[i]);
+      Line(
+          std::format(
+              "Param[{}] \"{}\" : Type[{}]", i, param.name, param.type.value));
+    }
+    DumpCallableBody(a.code);
     Dedent();
   }
 

--- a/tests/cases/cpp/class_virtual_single/case.yaml
+++ b/tests/cases/cpp/class_virtual_single/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_virtual_single
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    base_result: 1
+    derived_result: 2

--- a/tests/cases/cpp/class_virtual_single/main.sv
+++ b/tests/cases/cpp/class_virtual_single/main.sv
@@ -1,0 +1,29 @@
+// LRM 8.20 virtual method: a `virtual function` in the base declares a
+// dispatch slot; a derived class's same-signature function implicitly
+// overrides it. Calling through a derived handle reaches the derived
+// implementation because the slot resolves by the receiver's dynamic type.
+module Top;
+  class Base;
+    virtual function int classify();
+      return 1;
+    endfunction
+  endclass
+
+  class Derived extends Base;
+    function int classify();
+      return 2;
+    endfunction
+  endclass
+
+  int base_result;
+  int derived_result;
+
+  initial begin
+    Base b;
+    Derived d;
+    b = new;
+    d = new;
+    base_result = b.classify();
+    derived_result = d.classify();
+  end
+endmodule

--- a/tests/cases/cpp/class_virtual_two_level/case.yaml
+++ b/tests/cases/cpp/class_virtual_two_level/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.class_virtual_two_level
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    base_rank: 10
+    mid_rank: 20
+    leaf_rank: 30

--- a/tests/cases/cpp/class_virtual_two_level/main.sv
+++ b/tests/cases/cpp/class_virtual_two_level/main.sv
@@ -1,0 +1,39 @@
+// LRM 8.20 virtual method through a two-level override chain: Base
+// introduces the slot, Mid overrides it, Leaf overrides again. Calling
+// through a Leaf handle dispatches to the Leaf implementation; through a
+// Mid handle to Mid's; through a Base handle to Base's.
+module Top;
+  class Base;
+    virtual function int rank();
+      return 10;
+    endfunction
+  endclass
+
+  class Mid extends Base;
+    function int rank();
+      return 20;
+    endfunction
+  endclass
+
+  class Leaf extends Mid;
+    function int rank();
+      return 30;
+    endfunction
+  endclass
+
+  int base_rank;
+  int mid_rank;
+  int leaf_rank;
+
+  initial begin
+    Base b;
+    Mid m;
+    Leaf l;
+    b = new;
+    m = new;
+    l = new;
+    base_rank = b.rank();
+    mid_rank = m.rank();
+    leaf_rank = l.rank();
+  end
+endmodule

--- a/tests/cases/cpp/class_virtual_via_base_handle/case.yaml
+++ b/tests/cases/cpp/class_virtual_via_base_handle/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_virtual_via_base_handle
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    through_base_handle: 200
+    through_derived_handle: 200

--- a/tests/cases/cpp/class_virtual_via_base_handle/main.sv
+++ b/tests/cases/cpp/class_virtual_via_base_handle/main.sv
@@ -1,0 +1,30 @@
+// LRM 8.20 virtual dispatch through a base-typed handle: the static type of
+// the handle is Base but its dynamic type is Derived; a virtual call
+// resolves by the dynamic type, so the Derived implementation runs. This is
+// the shape virtual dispatch is defined to support -- the receiver's static
+// type would resolve the wrong method under any static-scoped rule.
+module Top;
+  class Base;
+    virtual function int tag();
+      return 100;
+    endfunction
+  endclass
+
+  class Derived extends Base;
+    function int tag();
+      return 200;
+    endfunction
+  endclass
+
+  int through_base_handle;
+  int through_derived_handle;
+
+  initial begin
+    Base h;
+    Derived d;
+    d = new;
+    h = d;
+    through_base_handle = h.tag();
+    through_derived_handle = d.tag();
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds SystemVerilog virtual method dispatch (LRM 8.20) end to end: HIR carries the frontend's resolved override reference, MIR states each method's canonical dispatch slot as a first-class fact on its declaration, HIR-to-MIR selects a virtual or direct call at each site off that stated fact, and the C++ backend renders the two shapes as ordinary C++ instance-member calls with the `virtual` and `override` decorations the dispatch role dictates. Base-typed handles that hold a derived instance now resolve their calls through the receiver's dynamic type.

## Design

Class inheritance's structural relation is landed in the object model: a single concrete base is a resolved reference on the derived class's declaration, and every cross-class reference to a member is owner-qualified so an inherited method or property is identified by its declaring class rather than by the receiver's runtime class. The dispatch role sits on `MethodDecl.virtual_dispatch` as an optional variant: absent for direct-only callables, `IntroducesVirtualSlot` for a new-slot introducer, `OverridesIntraUnitSlot` for a filler that names the introducing (class, method) canonically. Canonicalization walks the HIR override chain once at class lowering; every downstream consumer reads the canonical id in one step.

`ClassDeclLowerer` now runs in two stages, matching `StructuralScopeLowerer`. `DeclareShape` publishes each class's `ClassShape` -- fields, method signatures with the canonical dispatch role -- to the module's shape store; `PopulateBodies` composes the executable class against the settled shape and commits it. Cross-class shape queries during body lowering resolve against the shape store, not the compilation unit's class registry, so declaration order is unobserved.

Runtime callback adapters (a runtime lifecycle hook stored as a plain `void (*)(Scope*)` in a per-class definition constant) are a distinct MIR species `AbiAdapter` with its own arena and id, referenced by `FunctionRef`. Instance methods have no function-pointer-compatible identity; the type system enforces the separation.

Boundary translation from a frontend method symbol to its HIR arena identity is a cache on `UnitLowerer`, populated as the owning class is interned. The slang enumeration order is walked once; every later resolution site is a hash lookup.

## Testing

Three cases exercise the three shapes: `class_virtual_single` for a base handle and a derived handle resolving to their own overrides, `class_virtual_two_level` for a three-level override chain (Base -> Mid -> Leaf), `class_virtual_via_base_handle` for the base-typed handle that holds a derived instance resolving through dynamic type -- the shape virtual dispatch is defined to make correct.