### PR TITLE
Add the scalar real value domain to the execution backend

### DIFF
--- a/docs/progress/execution-backend.md
+++ b/docs/progress/execution-backend.md
@@ -23,7 +23,7 @@ the stretch that made it.
       handle the generated frame holds. A store copies into it; a load copies out; the store
       decision is made where storage placement belongs and the backend realizes it as an ordinary
       call, so it stays mechanical. Complete for the value domains the backend realizes today
-      (packed and string). Contracts and rationale:
+      (packed, string, and the real family -- real, shortreal, realtime). Contracts and rationale:
       `../decisions/cross-suspension-value-storage.md`,
       `../decisions/activation-frame-and-transient-scope.md`.
 
@@ -39,8 +39,14 @@ yet. Each is another instance of the same lifetime question, so the first to lan
 extends the activation frame or the backend adopts one lifetime discipline (a traced heap,
 ownership, or native in-frame layout) for every value.
 
-- [ ] **The remaining value domains** (reals, enumerations, aggregates, containers) -- not realized
-      on the execution backend at all yet, so no cross-suspension case exists for them.
+- [x] **The scalar real family** (real, shortreal, realtime) -- realized on the execution backend as
+      a value domain alongside packed and string: arithmetic, comparison, the integer/real
+      conversions, and real formatting run, a real signal member is an observable cell, and a real
+      procedural local crosses a suspension as an activation-frame value. It extended the activation
+      frame with another domain rather than forcing a new lifetime discipline, since a real is a
+      non-managed value like a packed one.
+- [ ] **The remaining value domains** (aggregates, containers) -- not realized on the execution
+      backend at all yet, so no cross-suspension case exists for them.
 - [ ] **A managed value (class handle) across a suspension.** A traceable frame and precise
       reclamation, none of which is implemented: the managed reference is realized as a
       reference-counted handle that does not reclaim cycles, and only in the C++ backend. Contract:

--- a/include/lyra/backend/llvm/codegen_function.hpp
+++ b/include/lyra/backend/llvm/codegen_function.hpp
@@ -69,6 +69,7 @@ class CodeGenFunction {
   auto ResolvePlaceAddress(const lir::Place& place) -> llvm::Value*;
   auto LowerIntConst(const lir::IntConst& constant) -> llvm::Value*;
   auto LowerStrConst(const lir::StrConst& constant) -> llvm::Value*;
+  auto LowerRealConst(const lir::RealConst& constant) -> llvm::Value*;
   void LowerTerminator(const lir::Terminator& terminator);
 
   auto BuiltinCallee(
@@ -78,6 +79,8 @@ class CodeGenFunction {
       const lir::BuiltinTarget& target, const lir::CallInstr& call,
       lir::TypeId result_type) -> llvm::FunctionCallee;
   auto ConstructCallee(const lir::CallInstr& call) -> llvm::FunctionCallee;
+  auto RealConstructCallee(const lir::CallInstr& call, ValueDomain dst)
+      -> llvm::FunctionCallee;
   auto ForeignCallee(
       const lir::ForeignTarget& target, const lir::CallInstr& call,
       lir::TypeId result_type) -> llvm::FunctionCallee;

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -29,7 +29,7 @@ class CodeGenTypes;
 // -- and a source type with no runtime realization has no domain at all. It
 // grows only when the runtime library gains a value type, never to mirror the
 // source language's type kinds.
-enum class ValueDomain : std::uint8_t { kPacked, kString };
+enum class ValueDomain : std::uint8_t { kPacked, kString, kReal, kShortReal };
 
 auto ValueDomainName(ValueDomain domain) -> std::string_view;
 
@@ -81,6 +81,20 @@ class RuntimeAbi {
   auto MakeString() -> llvm::FunctionCallee;
   auto MakePrintLiteralItem() -> llvm::FunctionCallee;
   auto PackedConst() -> llvm::FunctionCallee;
+
+  // Builds a real-family constant from its host-precision immediate: `double`
+  // for `kReal`, `float` for `kShortReal`. The runtime owns the resulting value
+  // and returns an opaque handle.
+  auto RealConst(ValueDomain domain) -> llvm::FunctionCallee;
+
+  // Builds a real-family value from a machine `int64` -- the outer step of the
+  // integral-to-real conversion, whose inner step already read the operand out
+  // as a host integer.
+  auto RealFromInt(ValueDomain domain) -> llvm::FunctionCallee;
+
+  // Reshapes one real-family precision into another (`shortreal` <-> `real`):
+  // `dst` names the result precision, `src` the operand's.
+  auto RealReshape(ValueDomain dst, ValueDomain src) -> llvm::FunctionCallee;
 
   // Builds a scope's structural identity from its parent-side label and its
   // per-dimension indices; the runtime owns the resulting segment handle.

--- a/include/lyra/lir/function.hpp
+++ b/include/lyra/lir/function.hpp
@@ -67,6 +67,11 @@ struct StrConst {
   TypeId type;
 };
 
+struct RealConst {
+  double value;
+  TypeId type;
+};
+
 // The code address of a method, as a value. A closure is built from a code
 // reference plus its environment, so a method's address is an operand, not a
 // call target.
@@ -78,7 +83,7 @@ struct FuncRef {
 // A constant or code reference is an operand rather than a value of its own
 // because it has no storage and no dataflow origin to name -- it is
 // materialized at the use site.
-using Operand = std::variant<Use, IntConst, StrConst, FuncRef>;
+using Operand = std::variant<Use, IntConst, StrConst, RealConst, FuncRef>;
 
 // A runtime-library entry. A static factory is named by its type namespace as
 // well as its function -- `String::FromPackedArray` and `PackedArray::FromInt`

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -91,6 +91,12 @@ void lyra_rt_cell_packed_set(void* cell, void* services, const void* value);
 auto lyra_rt_cell_string_get(void* cell) -> const void*;
 void lyra_rt_cell_string_initialize(void* cell, const void* prototype);
 void lyra_rt_cell_string_set(void* cell, void* services, const void* value);
+auto lyra_rt_cell_real_get(void* cell) -> const void*;
+void lyra_rt_cell_real_initialize(void* cell, const void* prototype);
+void lyra_rt_cell_real_set(void* cell, void* services, const void* value);
+auto lyra_rt_cell_shortreal_get(void* cell) -> const void*;
+void lyra_rt_cell_shortreal_initialize(void* cell, const void* prototype);
+void lyra_rt_cell_shortreal_set(void* cell, void* services, const void* value);
 
 // A procedural local whose value crosses a suspension (LRM 9.4). The cell lives
 // in the running activation's frame, so the handle a generated frame holds
@@ -190,6 +196,65 @@ auto lyra_rt_string_lt(const void* lhs, const void* rhs) -> void*;
 auto lyra_rt_string_le(const void* lhs, const void* rhs) -> void*;
 auto lyra_rt_string_gt(const void* lhs, const void* rhs) -> void*;
 auto lyra_rt_string_ge(const void* lhs, const void* rhs) -> void*;
+
+// The `real` / `realtime` host-double value domain. A relational or equality
+// entry yields a packed 1-bit; the arithmetic entries yield a real. `const`
+// builds a real from a host-precision immediate, `from_int64` from an integer
+// already read out of a packed value, and `from_shortreal` / `from_real`
+// reshape the other real precision. The activation-frame entries hold a real
+// local across a suspension.
+auto lyra_rt_real_add(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_sub(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_mul(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_div(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_neg(const void* operand) -> void*;
+auto lyra_rt_real_inc(const void* operand) -> void*;
+auto lyra_rt_real_dec(const void* operand) -> void*;
+auto lyra_rt_real_eq(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_ne(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_lt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_le(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_gt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_ge(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_real_to_bool(const void* operand) -> bool;
+auto lyra_rt_real_pow(const void* base, const void* exponent) -> void*;
+auto lyra_rt_real_round(const void* value) -> std::int64_t;
+auto lyra_rt_real_const(double value) -> void*;
+auto lyra_rt_real_from_int64(std::int64_t value) -> void*;
+auto lyra_rt_real_from_shortreal(const void* value) -> void*;
+auto lyra_rt_real_from_real(const void* value) -> void*;
+auto lyra_rt_activation_frame_alloc_real() -> void*;
+void lyra_rt_activation_frame_store_real(void* cell, const void* value);
+auto lyra_rt_activation_frame_load_real(const void* cell) -> void*;
+auto lyra_rt_make_print_value_item_real(const void* value, const void* spec)
+    -> void*;
+
+// The `shortreal` host-float value domain, the single-precision peer of the
+// real domain above.
+auto lyra_rt_shortreal_add(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_sub(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_mul(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_div(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_neg(const void* operand) -> void*;
+auto lyra_rt_shortreal_inc(const void* operand) -> void*;
+auto lyra_rt_shortreal_dec(const void* operand) -> void*;
+auto lyra_rt_shortreal_eq(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_ne(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_lt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_le(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_gt(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_ge(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_shortreal_to_bool(const void* operand) -> bool;
+auto lyra_rt_shortreal_pow(const void* base, const void* exponent) -> void*;
+auto lyra_rt_shortreal_round(const void* value) -> std::int64_t;
+auto lyra_rt_shortreal_const(float value) -> void*;
+auto lyra_rt_shortreal_from_int64(std::int64_t value) -> void*;
+auto lyra_rt_shortreal_from_real(const void* value) -> void*;
+auto lyra_rt_activation_frame_alloc_shortreal() -> void*;
+void lyra_rt_activation_frame_store_shortreal(void* cell, const void* value);
+auto lyra_rt_activation_frame_load_shortreal(const void* cell) -> void*;
+auto lyra_rt_make_print_value_item_shortreal(
+    const void* value, const void* spec) -> void*;
 
 // Builds one conversion's format specification, and the print item that pairs a
 // value with it. Each field arrives as a packed value, as the value model

--- a/include/lyra/runtime/member_storage.hpp
+++ b/include/lyra/runtime/member_storage.hpp
@@ -5,6 +5,7 @@
 #include "lyra/runtime/scope_program.hpp"
 #include "lyra/runtime/var.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/real.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
@@ -27,7 +28,10 @@ class MemberStorage {
   [[nodiscard]] auto Address() -> void*;
 
  private:
-  std::variant<void*, Var<value::PackedArray>, Var<value::String>> object_;
+  std::variant<
+      void*, Var<value::PackedArray>, Var<value::String>, Var<value::Real>,
+      Var<value::ShortReal>>
+      object_;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/scope_program.hpp
+++ b/include/lyra/runtime/scope_program.hpp
@@ -79,7 +79,13 @@ struct ScopeProgram {
 // has no domain at all. It grows when the runtime gains a value type, never to
 // mirror the source language. `kNone` is the domain of storage that carries no
 // value of its own, such as a box holding a borrowed handle.
-enum class ValueDomain : std::uint8_t { kNone, kPacked, kString };
+enum class ValueDomain : std::uint8_t {
+  kNone,
+  kPacked,
+  kString,
+  kReal,
+  kShortReal,
+};
 
 // How a member's storage is realized. A borrowed handle is a box holding a
 // pointer the instance does not own, the storage behind a companion reference

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -255,6 +255,9 @@ auto CodeGenFunction::LowerOperand(const lir::Operand& operand)
           [&](const lir::StrConst& c) -> llvm::Value* {
             return LowerStrConst(c);
           },
+          [&](const lir::RealConst& c) -> llvm::Value* {
+            return LowerRealConst(c);
+          },
           [&](const lir::FuncRef& f) -> llvm::Value* {
             return module_->MethodFunction(f.method.class_id, f.method.index);
           }},
@@ -296,6 +299,20 @@ auto CodeGenFunction::LowerIntConst(const lir::IntConst& constant)
 auto CodeGenFunction::LowerStrConst(const lir::StrConst& constant)
     -> llvm::Value* {
   return builder_.CreateGlobalStringPtr(constant.value);
+}
+
+// A real literal has no native constant form in the opaque value model -- it is
+// a runtime object -- so its constant is a host-precision immediate handed to a
+// runtime constructor, the same shape a packed constant takes.
+auto CodeGenFunction::LowerRealConst(const lir::RealConst& constant)
+    -> llvm::Value* {
+  const ValueDomain domain = DomainOf(constant.type);
+  llvm::Type* host = domain == ValueDomain::kShortReal
+                         ? llvm::Type::getFloatTy(module_->Context())
+                         : llvm::Type::getDoubleTy(module_->Context());
+  return builder_.CreateCall(
+      module_->Runtime().RealConst(domain),
+      {llvm::ConstantFP::get(host, constant.value)});
 }
 
 auto CodeGenFunction::BuiltinCallee(
@@ -430,11 +447,35 @@ auto CodeGenFunction::ConstructCallee(const lir::CallInstr& call)
             throw InternalError(
                 "llvm codegen: pointer construct is not yet lowerable");
           },
+          [&](const lir::RealType&) -> llvm::FunctionCallee {
+            return RealConstructCallee(call, ValueDomain::kReal);
+          },
+          [&](const lir::RealTimeType&) -> llvm::FunctionCallee {
+            return RealConstructCallee(call, ValueDomain::kReal);
+          },
+          [&](const lir::ShortRealType&) -> llvm::FunctionCallee {
+            return RealConstructCallee(call, ValueDomain::kShortReal);
+          },
           [&](const auto&) -> llvm::FunctionCallee {
             throw InternalError(
                 "llvm codegen: construct result type is not yet lowerable");
           }},
       module_->Unit().types.Get(result).data);
+}
+
+// A real-family construct is a conversion into `dst`: from a machine int64 (the
+// integral-to-real bridge, whose inner step already read the operand out as a
+// host integer) or from another real precision (`shortreal` <-> `real`). The
+// single operand's type selects which, since the result type fixes only the
+// destination precision.
+auto CodeGenFunction::RealConstructCallee(
+    const lir::CallInstr& call, ValueDomain dst) -> llvm::FunctionCallee {
+  const lir::TypeId arg_type = OperandType(call.args.at(0));
+  if (std::holds_alternative<lir::MachineIntType>(
+          module_->Unit().types.Get(arg_type).data)) {
+    return module_->Runtime().RealFromInt(dst);
+  }
+  return module_->Runtime().RealReshape(dst, DomainOf(arg_type));
 }
 
 auto CodeGenFunction::ConstructDefinitionArg(lir::TypeId result)

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -24,6 +24,10 @@ auto ValueDomainName(ValueDomain domain) -> std::string_view {
       return "packed";
     case ValueDomain::kString:
       return "string";
+    case ValueDomain::kReal:
+      return "real";
+    case ValueDomain::kShortReal:
+      return "shortreal";
   }
   throw InternalError("llvm codegen: unknown value domain");
 }
@@ -37,6 +41,11 @@ auto ValueDomainOf(const lir::CompilationUnit& unit, lir::TypeId type)
           // which read its declared members, need more than that.
           [](const lir::EnumType&) { return ValueDomain::kPacked; },
           [](const lir::StringType&) { return ValueDomain::kString; },
+          // `real` and `realtime` are one host-precision value (LRM 6.12.1);
+          // `shortreal` is the single-precision one.
+          [](const lir::RealType&) { return ValueDomain::kReal; },
+          [](const lir::RealTimeType&) { return ValueDomain::kReal; },
+          [](const lir::ShortRealType&) { return ValueDomain::kShortReal; },
           [](const auto&) -> ValueDomain {
             throw InternalError(
                 "llvm codegen: value type has no runtime library domain");
@@ -136,6 +145,29 @@ auto RuntimeAbi::PackedConst() -> llvm::FunctionCallee {
       "lyra_rt_packed_const", types_->Ptr(),
       {llvm::Type::getInt64Ty(*ctx_), llvm::Type::getInt32Ty(*ctx_),
        llvm::Type::getInt1Ty(*ctx_), llvm::Type::getInt1Ty(*ctx_)});
+}
+
+auto RuntimeAbi::RealConst(ValueDomain domain) -> llvm::FunctionCallee {
+  llvm::Type* host = domain == ValueDomain::kShortReal
+                         ? llvm::Type::getFloatTy(*ctx_)
+                         : llvm::Type::getDoubleTy(*ctx_);
+  return Get(
+      std::format("lyra_rt_{}_const", ValueDomainName(domain)), types_->Ptr(),
+      {host});
+}
+
+auto RuntimeAbi::RealFromInt(ValueDomain domain) -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_{}_from_int64", ValueDomainName(domain)),
+      types_->Ptr(), {llvm::Type::getInt64Ty(*ctx_)});
+}
+
+auto RuntimeAbi::RealReshape(ValueDomain dst, ValueDomain src)
+    -> llvm::FunctionCallee {
+  return Get(
+      std::format(
+          "lyra_rt_{}_from_{}", ValueDomainName(dst), ValueDomainName(src)),
+      types_->Ptr(), {types_->Ptr()});
 }
 
 auto RuntimeAbi::MakeSegment() -> llvm::FunctionCallee {

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -141,6 +141,12 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_cell_string_get", &lyra_rt_cell_string_get);
   add("lyra_rt_cell_string_initialize", &lyra_rt_cell_string_initialize);
   add("lyra_rt_cell_string_set", &lyra_rt_cell_string_set);
+  add("lyra_rt_cell_real_get", &lyra_rt_cell_real_get);
+  add("lyra_rt_cell_real_initialize", &lyra_rt_cell_real_initialize);
+  add("lyra_rt_cell_real_set", &lyra_rt_cell_real_set);
+  add("lyra_rt_cell_shortreal_get", &lyra_rt_cell_shortreal_get);
+  add("lyra_rt_cell_shortreal_initialize", &lyra_rt_cell_shortreal_initialize);
+  add("lyra_rt_cell_shortreal_set", &lyra_rt_cell_shortreal_set);
   add("lyra_rt_activation_frame_alloc_packed",
       &lyra_rt_activation_frame_alloc_packed);
   add("lyra_rt_activation_frame_alloc_string",
@@ -227,6 +233,61 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
       &lyra_rt_make_print_value_item_packed);
   add("lyra_rt_make_print_value_item_string",
       &lyra_rt_make_print_value_item_string);
+  add("lyra_rt_real_add", &lyra_rt_real_add);
+  add("lyra_rt_real_sub", &lyra_rt_real_sub);
+  add("lyra_rt_real_mul", &lyra_rt_real_mul);
+  add("lyra_rt_real_div", &lyra_rt_real_div);
+  add("lyra_rt_real_neg", &lyra_rt_real_neg);
+  add("lyra_rt_real_inc", &lyra_rt_real_inc);
+  add("lyra_rt_real_dec", &lyra_rt_real_dec);
+  add("lyra_rt_real_eq", &lyra_rt_real_eq);
+  add("lyra_rt_real_ne", &lyra_rt_real_ne);
+  add("lyra_rt_real_lt", &lyra_rt_real_lt);
+  add("lyra_rt_real_le", &lyra_rt_real_le);
+  add("lyra_rt_real_gt", &lyra_rt_real_gt);
+  add("lyra_rt_real_ge", &lyra_rt_real_ge);
+  add("lyra_rt_real_to_bool", &lyra_rt_real_to_bool);
+  add("lyra_rt_real_pow", &lyra_rt_real_pow);
+  add("lyra_rt_real_round", &lyra_rt_real_round);
+  add("lyra_rt_real_const", &lyra_rt_real_const);
+  add("lyra_rt_real_from_int64", &lyra_rt_real_from_int64);
+  add("lyra_rt_real_from_shortreal", &lyra_rt_real_from_shortreal);
+  add("lyra_rt_real_from_real", &lyra_rt_real_from_real);
+  add("lyra_rt_activation_frame_alloc_real",
+      &lyra_rt_activation_frame_alloc_real);
+  add("lyra_rt_activation_frame_store_real",
+      &lyra_rt_activation_frame_store_real);
+  add("lyra_rt_activation_frame_load_real",
+      &lyra_rt_activation_frame_load_real);
+  add("lyra_rt_make_print_value_item_real",
+      &lyra_rt_make_print_value_item_real);
+  add("lyra_rt_shortreal_add", &lyra_rt_shortreal_add);
+  add("lyra_rt_shortreal_sub", &lyra_rt_shortreal_sub);
+  add("lyra_rt_shortreal_mul", &lyra_rt_shortreal_mul);
+  add("lyra_rt_shortreal_div", &lyra_rt_shortreal_div);
+  add("lyra_rt_shortreal_neg", &lyra_rt_shortreal_neg);
+  add("lyra_rt_shortreal_inc", &lyra_rt_shortreal_inc);
+  add("lyra_rt_shortreal_dec", &lyra_rt_shortreal_dec);
+  add("lyra_rt_shortreal_eq", &lyra_rt_shortreal_eq);
+  add("lyra_rt_shortreal_ne", &lyra_rt_shortreal_ne);
+  add("lyra_rt_shortreal_lt", &lyra_rt_shortreal_lt);
+  add("lyra_rt_shortreal_le", &lyra_rt_shortreal_le);
+  add("lyra_rt_shortreal_gt", &lyra_rt_shortreal_gt);
+  add("lyra_rt_shortreal_ge", &lyra_rt_shortreal_ge);
+  add("lyra_rt_shortreal_to_bool", &lyra_rt_shortreal_to_bool);
+  add("lyra_rt_shortreal_pow", &lyra_rt_shortreal_pow);
+  add("lyra_rt_shortreal_round", &lyra_rt_shortreal_round);
+  add("lyra_rt_shortreal_const", &lyra_rt_shortreal_const);
+  add("lyra_rt_shortreal_from_int64", &lyra_rt_shortreal_from_int64);
+  add("lyra_rt_shortreal_from_real", &lyra_rt_shortreal_from_real);
+  add("lyra_rt_activation_frame_alloc_shortreal",
+      &lyra_rt_activation_frame_alloc_shortreal);
+  add("lyra_rt_activation_frame_store_shortreal",
+      &lyra_rt_activation_frame_store_shortreal);
+  add("lyra_rt_activation_frame_load_shortreal",
+      &lyra_rt_activation_frame_load_shortreal);
+  add("lyra_rt_make_print_value_item_shortreal",
+      &lyra_rt_make_print_value_item_shortreal);
   Check(
       jit.getMainJITDylib().define(
           llvm::orc::absoluteSymbols(std::move(symbols))),
@@ -262,6 +323,10 @@ auto AbiDomain(backend::llvm_backend::ValueDomain domain)
       return runtime::ValueDomain::kPacked;
     case backend::llvm_backend::ValueDomain::kString:
       return runtime::ValueDomain::kString;
+    case backend::llvm_backend::ValueDomain::kReal:
+      return runtime::ValueDomain::kReal;
+    case backend::llvm_backend::ValueDomain::kShortReal:
+      return runtime::ValueDomain::kShortReal;
   }
   throw InternalError("jit executor: unknown value domain");
 }

--- a/src/lyra/lir/dump.cpp
+++ b/src/lyra/lir/dump.cpp
@@ -239,6 +239,9 @@ class LirDumper {
             [](const StrConst& c) -> std::string {
               return std::format("str:\"{}\"", c.value);
             },
+            [](const RealConst& c) -> std::string {
+              return std::format("real:{}", c.value);
+            },
             [](const FuncRef& f) -> std::string {
               return std::format(
                   "funcref {}.{}", f.method.class_id.value, f.method.index);

--- a/src/lyra/lir/function.cpp
+++ b/src/lyra/lir/function.cpp
@@ -17,6 +17,7 @@ auto OperandType(const Function& fn, const Operand& operand)
           },
           [](const IntConst& c) -> std::optional<TypeId> { return c.type; },
           [](const StrConst& c) -> std::optional<TypeId> { return c.type; },
+          [](const RealConst& c) -> std::optional<TypeId> { return c.type; },
           [](const FuncRef&) -> std::optional<TypeId> { return std::nullopt; }},
       operand);
 }

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -122,14 +122,18 @@ auto PlacedLocal(const mir::Block& block, mir::ExprId id)
 
 // A value type whose runtime realization is an opaque handle into transient
 // storage the boundary releases at each suspension: a packed value (or the
-// enumeration and packed struct/union projections that share its shape) or a
-// string. A local of such a type that a suspending body reads across a
-// suspension needs activation-stable storage, because its handle cannot outlive
-// the stretch that produced it. A pointer, a reference, an object handle, or a
-// machine scalar is not one of these -- it is stable across a suspension on its
-// own -- so it is unaffected.
+// enumeration and packed struct/union projections that share its shape), a
+// string, or a real-family value (real / shortreal / realtime). A local of such
+// a type that a suspending body reads across a suspension needs
+// activation-stable storage, because its handle cannot outlive the stretch that
+// produced it. A pointer, a reference, an object handle, or a machine scalar is
+// not one of these -- it is stable across a suspension on its own -- so it is
+// unaffected.
 auto IsActivationValueType(const mir::Type& type) -> bool {
-  return type.IsIntegralPacked() || type.Kind() == mir::TypeKind::kString;
+  const mir::TypeKind kind = type.Kind();
+  return type.IsIntegralPacked() || kind == mir::TypeKind::kString ||
+         kind == mir::TypeKind::kReal || kind == mir::TypeKind::kShortReal ||
+         kind == mir::TypeKind::kRealTime;
 }
 
 // Marks every local the canonical lowering needs an address for: one that is
@@ -1017,6 +1021,10 @@ auto FunctionLowerer::LowerExpr(const mir::Block& block, mir::ExprId id)
           },
           [&](const mir::StringLiteral& lit) -> diag::Result<lir::Operand> {
             return lir::Operand{lir::StrConst{
+                .value = lit.value, .type = unit_->TranslateType(type)}};
+          },
+          [&](const mir::RealLiteral& lit) -> diag::Result<lir::Operand> {
+            return lir::Operand{lir::RealConst{
                 .value = lit.value, .type = unit_->TranslateType(type)}};
           },
           [&](const mir::LocalRef& ref) -> diag::Result<lir::Operand> {

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -22,6 +22,7 @@
 #include "lyra/runtime/var.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/real.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
@@ -150,6 +151,8 @@ using lyra::value::PackedArray;
 using lyra::value::PrintItem;
 using lyra::value::PrintLiteralItem;
 using lyra::value::PrintValueItem;
+using lyra::value::Real;
+using lyra::value::ShortReal;
 using lyra::value::String;
 using lyra::value::TimeFormat;
 
@@ -326,6 +329,32 @@ void lyra_rt_cell_string_initialize(void* cell, const void* prototype) {
 void lyra_rt_cell_string_set(void* cell, void* services, const void* value) {
   static_cast<Var<String>*>(cell)->Set(
       *static_cast<RuntimeServices*>(services), Read<String>(value));
+}
+
+auto lyra_rt_cell_real_get(void* cell) -> const void* {
+  return &static_cast<Var<Real>*>(cell)->Get();
+}
+
+void lyra_rt_cell_real_initialize(void* cell, const void* prototype) {
+  static_cast<Var<Real>*>(cell)->Initialize(Read<Real>(prototype));
+}
+
+void lyra_rt_cell_real_set(void* cell, void* services, const void* value) {
+  static_cast<Var<Real>*>(cell)->Set(
+      *static_cast<RuntimeServices*>(services), Read<Real>(value));
+}
+
+auto lyra_rt_cell_shortreal_get(void* cell) -> const void* {
+  return &static_cast<Var<ShortReal>*>(cell)->Get();
+}
+
+void lyra_rt_cell_shortreal_initialize(void* cell, const void* prototype) {
+  static_cast<Var<ShortReal>*>(cell)->Initialize(Read<ShortReal>(prototype));
+}
+
+void lyra_rt_cell_shortreal_set(void* cell, void* services, const void* value) {
+  static_cast<Var<ShortReal>*>(cell)->Set(
+      *static_cast<RuntimeServices*>(services), Read<ShortReal>(value));
 }
 
 // A procedural local whose value crosses a suspension. The cell is allocated in
@@ -662,5 +691,210 @@ auto lyra_rt_make_print_value_item_string(const void* value, const void* spec)
     -> void* {
   return Own(
       PrintItem(PrintValueItem(Read<String>(value), Read<FormatSpec>(spec))));
+}
+
+auto lyra_rt_real_add(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) + Read<Real>(rhs));
+}
+
+auto lyra_rt_real_sub(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) - Read<Real>(rhs));
+}
+
+auto lyra_rt_real_mul(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) * Read<Real>(rhs));
+}
+
+auto lyra_rt_real_div(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) / Read<Real>(rhs));
+}
+
+auto lyra_rt_real_neg(const void* operand) -> void* {
+  return Own(-Read<Real>(operand));
+}
+
+auto lyra_rt_real_inc(const void* operand) -> void* {
+  Real value = Read<Real>(operand);
+  ++value;
+  return Own(std::move(value));
+}
+
+auto lyra_rt_real_dec(const void* operand) -> void* {
+  Real value = Read<Real>(operand);
+  --value;
+  return Own(std::move(value));
+}
+
+auto lyra_rt_real_eq(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) == Read<Real>(rhs));
+}
+
+auto lyra_rt_real_ne(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) != Read<Real>(rhs));
+}
+
+auto lyra_rt_real_lt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) < Read<Real>(rhs));
+}
+
+auto lyra_rt_real_le(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) <= Read<Real>(rhs));
+}
+
+auto lyra_rt_real_gt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) > Read<Real>(rhs));
+}
+
+auto lyra_rt_real_ge(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<Real>(lhs) >= Read<Real>(rhs));
+}
+
+auto lyra_rt_real_to_bool(const void* operand) -> bool {
+  return static_cast<bool>(Read<Real>(operand));
+}
+
+auto lyra_rt_real_pow(const void* base, const void* exponent) -> void* {
+  return Own(Read<Real>(base).Pow(Read<Real>(exponent)));
+}
+
+auto lyra_rt_real_round(const void* value) -> std::int64_t {
+  return Read<Real>(value).Round();
+}
+
+auto lyra_rt_real_const(double value) -> void* {
+  return Own(Real{value});
+}
+
+auto lyra_rt_real_from_int64(std::int64_t value) -> void* {
+  return Own(Real::FromInt64(value));
+}
+
+auto lyra_rt_real_from_shortreal(const void* value) -> void* {
+  return Own(Real{Read<ShortReal>(value)});
+}
+
+auto lyra_rt_real_from_real(const void* value) -> void* {
+  return Own(Read<Real>(value));
+}
+
+auto lyra_rt_activation_frame_alloc_real() -> void* {
+  return GeneratedCallScope::Current()
+      .ActivationFrame()
+      .New<ActivationValueCell<Real>>();
+}
+
+void lyra_rt_activation_frame_store_real(void* cell, const void* value) {
+  static_cast<ActivationValueCell<Real>*>(cell)->Store(Read<Real>(value));
+}
+
+auto lyra_rt_activation_frame_load_real(const void* cell) -> void* {
+  return Own(static_cast<const ActivationValueCell<Real>*>(cell)->Get());
+}
+
+auto lyra_rt_make_print_value_item_real(const void* value, const void* spec)
+    -> void* {
+  return Own(
+      PrintItem(PrintValueItem(Read<Real>(value), Read<FormatSpec>(spec))));
+}
+
+auto lyra_rt_shortreal_add(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) + Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_sub(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) - Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_mul(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) * Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_div(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) / Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_neg(const void* operand) -> void* {
+  return Own(-Read<ShortReal>(operand));
+}
+
+auto lyra_rt_shortreal_inc(const void* operand) -> void* {
+  ShortReal value = Read<ShortReal>(operand);
+  ++value;
+  return Own(std::move(value));
+}
+
+auto lyra_rt_shortreal_dec(const void* operand) -> void* {
+  ShortReal value = Read<ShortReal>(operand);
+  --value;
+  return Own(std::move(value));
+}
+
+auto lyra_rt_shortreal_eq(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) == Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_ne(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) != Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_lt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) < Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_le(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) <= Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_gt(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) > Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_ge(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<ShortReal>(lhs) >= Read<ShortReal>(rhs));
+}
+
+auto lyra_rt_shortreal_to_bool(const void* operand) -> bool {
+  return static_cast<bool>(Read<ShortReal>(operand));
+}
+
+auto lyra_rt_shortreal_pow(const void* base, const void* exponent) -> void* {
+  return Own(Read<ShortReal>(base).Pow(Read<ShortReal>(exponent)));
+}
+
+auto lyra_rt_shortreal_round(const void* value) -> std::int64_t {
+  return Read<ShortReal>(value).Round();
+}
+
+auto lyra_rt_shortreal_const(float value) -> void* {
+  return Own(ShortReal{value});
+}
+
+auto lyra_rt_shortreal_from_int64(std::int64_t value) -> void* {
+  return Own(ShortReal::FromInt64(value));
+}
+
+auto lyra_rt_shortreal_from_real(const void* value) -> void* {
+  return Own(ShortReal{Read<Real>(value)});
+}
+
+auto lyra_rt_activation_frame_alloc_shortreal() -> void* {
+  return GeneratedCallScope::Current()
+      .ActivationFrame()
+      .New<ActivationValueCell<ShortReal>>();
+}
+
+void lyra_rt_activation_frame_store_shortreal(void* cell, const void* value) {
+  static_cast<ActivationValueCell<ShortReal>*>(cell)->Store(
+      Read<ShortReal>(value));
+}
+
+auto lyra_rt_activation_frame_load_shortreal(const void* cell) -> void* {
+  return Own(static_cast<const ActivationValueCell<ShortReal>*>(cell)->Get());
+}
+
+auto lyra_rt_make_print_value_item_shortreal(
+    const void* value, const void* spec) -> void* {
+  return Own(PrintItem(
+      PrintValueItem(Read<ShortReal>(value), Read<FormatSpec>(spec))));
 }
 }

--- a/src/lyra/runtime/member_storage.cpp
+++ b/src/lyra/runtime/member_storage.cpp
@@ -6,6 +6,7 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/runtime/scope_program.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/real.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
@@ -22,6 +23,12 @@ MemberStorage::MemberStorage(MemberStorageDescriptor descriptor) {
           return;
         case ValueDomain::kString:
           object_.emplace<Var<value::String>>();
+          return;
+        case ValueDomain::kReal:
+          object_.emplace<Var<value::Real>>();
+          return;
+        case ValueDomain::kShortReal:
+          object_.emplace<Var<value::ShortReal>>();
           return;
         case ValueDomain::kNone:
           throw InternalError(

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -211,6 +211,32 @@ auto WriteNestedSuspensionSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+// The real-family value domain end to end: a real and a shortreal constant, a
+// shortreal-to-real reshape, an integer-to-real conversion, a real accumulated
+// across suspensions (so it is an activation-frame value), a real comparison, a
+// real-to-integer round, and real formatting. Exercises the scalar real domain
+// the same way the integral and string domains are exercised elsewhere.
+auto WriteRealFamilySource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  initial begin\n"
+      << "    real r = 0.0;\n"
+      << "    shortreal s = 2.5;\n"
+      << "    int n = 3;\n"
+      << "    real from_int = n;\n"
+      << "    real widened = s;\n"
+      << "    for (int i = 0; i < n; i = i + 1) begin\n"
+      << "      #1;\n"
+      << "      r = r + 1.5;\n"
+      << "    end\n"
+      << "    if (r > 4.0)\n"
+      << "      $display(\"r=%0.2f widened=%0.2f from_int=%0.2f\", r, "
+         "widened, from_int);\n"
+      << "    $display(\"rounded=%0d sum=%0.2f\", int'(r), r + from_int);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -474,6 +500,37 @@ TEST(LyraRun, JitAndCppAgreeOnNestedSuspension) {
       "i=0 inner_sum=12 total=12\n"
       "i=1 inner_sum=12 total=24\n"
       "final total=24\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnRealFamily) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteRealFamilySource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "r=4.50 widened=2.50 from_int=3.00\n"
+      "rounded=5 sum=7.50\n")
       << "stdout: " << jit.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

The execution backend could realize only two runtime value domains, packed and string; every other value threw at classification, so a `real` program could not run on the JIT at all. This adds the scalar real family (`real`, `shortreal`, `realtime`) as a value domain alongside them. A real is an opaque handle into a runtime-owned value object, the same shape packed and string already take, so the change is mostly wiring the domain through the one classifier and hand-writing the per-operation ABI. Real arithmetic, comparison, the integer/real conversions, real formatting, real signal members, and a real procedural local that crosses a suspension all run on the JIT and match the C++ backend byte for byte.

## Design

Classifying `real`/`realtime` and `shortreal` into the domain enum is the whole unlock: the operator, comparison, boolean-reduction, activation-frame, and print entry points are already domain-parameterized, so they resolve to `lyra_rt_real_*` and `lyra_rt_shortreal_*` names with no new branching, and the runtime side is a thin wrapper over the existing `lyra::value::RealValue`. Two pieces sit outside that generic surface. A real literal has no native constant form in the opaque value model, so it becomes a new LIR real-constant operand carrying a host-precision immediate that a runtime constructor turns into a value, mirroring the packed-constant path. Numeric conversion has no dedicated instruction -- it is already a construct or a value builtin -- so an integer-to-real bridge and a shortreal/real reshape are handled by giving the construct callee a real arm that dispatches on the operand type, and the real-to-integer round is one more value builtin. Because a non-`automatic` procedural variable is static-lifetime and therefore a structural member, a real is also realized as an observable cell, and a real local that crosses a suspension is an activation-frame value like a packed one, extending the existing frame with another domain rather than introducing a new lifetime discipline. Containers, aggregates, managed handles, and DPI real marshaling are deliberately out of scope; `chandle` is left for its own change.

## Testing

A JIT-versus-C++ agreement test drives a real and a shortreal constant, a shortreal-to-real reshape, an integer-to-real conversion, a real accumulated across `#` delays, a real comparison, a real-to-integer round, and real formatting in one program; the two backends produce identical output. The full suite passes.
