### PR TITLE
Complete LRM 9.7 fine-grain process control

### DIFF
--- a/docs/architecture/activation.md
+++ b/docs/architecture/activation.md
@@ -40,7 +40,21 @@ the awaiter consumes, not of the scheduler.
   for as long as any descendant is live.
 - The **registration set**: every external reference to a parked activation (a region queue slot, a
   delay slot, an event waiter entry, a value-change subscription, a join aggregator entry) as a
-  revocable registration owned by the activation.
+  revocable registration owned by the activation. A registration is the activation's _current
+  enrollment_ in a target, not the wait itself.
+- The **activation disposition**: how an activation currently participates in execution --
+  `Executing`, `Runnable`, `Blocked`, `Suspended`, or `Terminal`. This is the activation's
+  authoritative state; the registration set and completion slot are resources constrained by it, not
+  independent facts. `Suspended` carries the disposition the activation held before it was
+  suspended.
+- The **pending wait**: for a `Blocked` (or `Suspended`-from-blocked) activation, the retainable
+  ability to re-establish its wait and to report whether the wait is already satisfied -- distinct
+  from the registration, which only records the current enrollment. It is a uniform capability every
+  suspending construct supplies, never a taxonomy the scheduler branches on.
+- The **active leaf**: the relation from a process to the one activation currently carrying its
+  thread. A process is a single thread (a task or function call runs in the caller's thread, LRM
+  9.5), so when it is not executing exactly one leaf activation -- the innermost frame -- is
+  enrolled or runnable. Process control names the process and acts on its active leaf.
 - The **join state**: the completion aggregator for a fork's branches and its join-mode condition.
 
 ## Does Not Own
@@ -87,9 +101,12 @@ the awaiter consumes, not of the scheduler.
    Destruction is gated on the registration set being empty. A registration is **one record**: the
    activation owns it and the target links it, so the relation is stored once and reached from both
    ends. The activation's set and the target's list are two indexes over that record, never two
-   descriptions of it. _Consequence: an activation can be cancelled and torn down with no dangling
-   token left in any queue, waiter, or subscription -- and revoking is a detach, so neither end ever
-   searches the other, and neither can hold a belief the other has abandoned._
+   descriptions of it. A registration records the activation's _current enrollment_ in a target, not
+   the wait it is serving: revoking a registration detaches the enrollment and forgets nothing the
+   activation still needs, because the ability to re-establish the wait lives in the pending wait
+   (invariant 7), not the registration. _Consequence: an activation can be cancelled and torn down
+   with no dangling token left in any queue, waiter, or subscription -- and revoking is a detach, so
+   neither end ever searches the other, and neither can hold a belief the other has abandoned._
 
 5. **A typed await consumes the typed terminal outcome.** Awaiting an activation yields its outcome:
    `Succeeded(T)` produces `T`, `Faulted` re-raises the exception into the awaiter, `Cancelled`
@@ -105,6 +122,22 @@ the awaiter consumes, not of the scheduler.
    join state. A deferred effect is a closure submitted to a region, not an activation.
    _Consequence: each kind reuses the activation core but binds its own ownership / continuation /
    completion; deferred work never enters the activation/completion model._
+
+7. **An activation's disposition is authoritative, and suspension saves the disposition it
+   replaces.** A non-terminal activation is `Executing`, `Runnable` (entitled to run; the region it
+   sits in is the engine's placement, not part of the disposition), or `Blocked` (waiting on a
+   condition, enrolled by a registration and holding a pending wait). `Suspended` is not another
+   kind of wait: it is process control (LRM 9.7) revoking an activation's scheduler participation
+   while saving the disposition it held -- `Suspended(Runnable)` or `Suspended(Blocked)` -- so
+   resume restores exactly that. A saved `Runnable` resume re-takes an execution entitlement; a
+   saved `Blocked` resume asks its pending wait to re-establish, which either re-enrolls or reports
+   the wait already satisfied. The pending wait is one uniform capability every suspending construct
+   supplies -- re-establish, report-satisfied, discard -- so no scheduler or activation path
+   branches on which construct the wait came from; the construct-specific knowledge stays in the
+   construct's own registration, exactly as a wakeup registration is one per-construct runtime call
+   and the suspend itself is construct-neutral. _Consequence: the disposition is one state machine
+   with one authoritative owner; the registration set, the pending wait, and run-queue membership
+   are resources that must agree with it, never independent truths that drift._
 
 ## Boundary to Adjacent Layers
 
@@ -158,6 +191,31 @@ the awaiter consumes, not of the scheduler.
   or an await edge. These are closures submitted to a region; they neither suspend their submitter
   nor settle an outcome a consumer awaits (invariant 6).
 
+- **A central taxonomy of wait kinds the scheduler or activation core branches on** -- a
+  `variant`/enum of delay / event / join / await blocks switched over on suspend, resume, or wake.
+  The pending wait is a uniform capability; a suspending construct already registers its own wakeup
+  through its own call, so re-establishing it is that same construct's business, dispatched
+  uniformly. A kind switch on the execution path reintroduces the source-language timing concept the
+  engine is forbidden to know (invariant 7, `scheduling.md`).
+
+- **A second authoritative copy of the wait's state** -- a blocked-operation object that duplicates
+  the deadline / observable / target the suspending construct already holds, kept in sync with it.
+  The wait's state has one home (the construct's own retained state); the pending wait is the
+  capability to re-establish from that home, not a mirror of it. Two copies is the registration
+  double-encoding forbidden by invariant 4, one level up.
+
+- **Scheduling placement folded into the disposition** -- a `Runnable(region)` that pins which
+  region or queue a runnable activation must be restored to. `Runnable` is the semantic entitlement
+  to run; the region is the engine's placement, chosen when the activation is scheduled (resume
+  places a runnable-suspended activation into the active region, LRM 9.7). A disposition that
+  carries region lets scheduler placement leak into activation semantics (invariant 7).
+
+- **`Suspended` modeled as a new kind of wait, or the disposition split across independent fields**
+  -- a suspended activation given its own wait target to re-fire, or its state inferred from
+  execution flags plus registration-emptiness plus queue membership plus pending-wait presence, each
+  separately authoritative. Suspension saves the prior disposition; the disposition is one
+  authoritative state its resources must agree with (invariant 7).
+
 - **A fork branch modeled as a task the parent awaits.** A branch has its own process identity, is
   owned by the spawning process's lineage, and reports to a join state under a join-mode condition;
   `join_none` has no parent wait at all. Reusing task-enable ownership for a branch conflates the
@@ -206,7 +264,11 @@ state. That the first two coincide for a branch is not a collapse of the relatio
 The C++ backend realizes an activation as a coroutine frame. Its activation token is the coroutine
 promise's non-templated base (the scheduler holds a pointer to it); its completion slot is the typed
 result the promise carries; a task enable is `co_await` of the activation, with symmetric transfer
-realizing the continuation and `await_resume` consuming the terminal outcome. The promise base, the
-`coroutine_handle`, and symmetric transfer are this realization's mechanics; the activation,
-completion slot, registration set, and join state are the model they realize. A future LIR / LLVM
-backend realizes the same model with coroutine intrinsics and explicit control edges instead.
+realizing the continuation and `await_resume` consuming the terminal outcome. A suspending construct
+realizes a pending wait by the state it retains to re-establish itself -- a delay its absolute
+deadline, an event control its observables and edges -- reached uniformly through the pending-wait
+capability. The promise base, the `coroutine_handle`, and symmetric transfer are this realization's
+mechanics; the activation, completion slot, registration set, disposition, and pending wait are the
+model they realize. A future LIR / LLVM backend realizes the same model with coroutine intrinsics
+and explicit control edges instead, the pending wait re-established by re-issuing the construct's
+own wakeup-registration call rather than re-entering the suspended body.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -34,6 +34,14 @@ the detail lives in the entry itself.
   fixed-size unpacked array.
 - [unpacked-struct-representation](unpacked-struct-representation.md) -- an unpacked struct is the
   generic product type (MIR `TupleType`), positional access, defaults synthesized at lowering.
+- [unpacked-union-representation](unpacked-union-representation.md) -- an untagged unpacked union is
+  overlapping storage realized as an active-member value (MIR `UnionType`).
+- [selector-coordinate-resolution](selector-coordinate-resolution.md) -- a select carries a semantic
+  selection; the selected value owns its declared coordinate system and resolves the source index
+  against its own declared range.
+- [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md) -- for the unpacked /
+  container family the index range is part of the type, not the payload; amends
+  [selector-coordinate-resolution](selector-coordinate-resolution.md) decision 1.
 - [slice-value-semantics](slice-value-semantics.md) -- a slice read materializes an owned value; the
   access model is value, not borrow.
 - [queue-operators](queue-operators.md) -- queue access operators lower to built-in method calls;
@@ -52,6 +60,9 @@ the detail lives in the entry itself.
 - [declarations-before-bodies](declarations-before-bodies.md) -- every structural declaration's
   identity and shape is CU-global and queryable before any executable lowering begins.
 - [foreach-lowering](foreach-lowering.md) -- the lowering shape of `foreach`.
+- [compound-assignment-write-location](compound-assignment-write-location.md) -- `lhs op= rhs`
+  lowers to a high-level assign carrying the operator; each backend realizes "evaluate the target
+  once" rather than desugaring a read-modify-write into MIR.
 - [conversion-folding](conversion-folding.md) -- when type conversions are folded.
 - [variable-initialization](variable-initialization.md) -- LRM 10.5 variable initialization as a
   constructor-scope statement.
@@ -75,6 +86,9 @@ the detail lives in the entry itself.
   `ErasedCallableType<Sig>` level with an explicit erasure.
 - [builtin-call-identity](builtin-call-identity.md) -- built-in method calls carry a flat
   closed-namespace identifier (`support::BuiltinFn`) shared by HIR and MIR.
+- [dpi-foreign-boundary](dpi-foreign-boundary.md) -- DPI-C is a foreign arm of the one callable
+  model, not a parallel IR subsystem; import / export reuse the ordinary call family, with ABI
+  marshaling at the runtime boundary rather than a dedicated MIR node.
 - [address-of-primitive](address-of-primitive.md) -- MIR carries an explicit place-to-pointer
   operator (`AddressOfExpr`), dual to `DerefExpr`; the backend never injects `&`.
 - [event-control-unification](event-control-unification.md) -- unified treatment of event control:

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -34,14 +34,6 @@ the detail lives in the entry itself.
   fixed-size unpacked array.
 - [unpacked-struct-representation](unpacked-struct-representation.md) -- an unpacked struct is the
   generic product type (MIR `TupleType`), positional access, defaults synthesized at lowering.
-- [unpacked-union-representation](unpacked-union-representation.md) -- an untagged unpacked union is
-  overlapping storage realized as an active-member value (MIR `UnionType`).
-- [selector-coordinate-resolution](selector-coordinate-resolution.md) -- a select carries a semantic
-  selection; the selected value owns its declared coordinate system and resolves the source index
-  against its own declared range.
-- [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md) -- for the unpacked /
-  container family the index range is part of the type, not the payload; amends
-  [selector-coordinate-resolution](selector-coordinate-resolution.md) decision 1.
 - [slice-value-semantics](slice-value-semantics.md) -- a slice read materializes an owned value; the
   access model is value, not borrow.
 - [queue-operators](queue-operators.md) -- queue access operators lower to built-in method calls;
@@ -60,9 +52,6 @@ the detail lives in the entry itself.
 - [declarations-before-bodies](declarations-before-bodies.md) -- every structural declaration's
   identity and shape is CU-global and queryable before any executable lowering begins.
 - [foreach-lowering](foreach-lowering.md) -- the lowering shape of `foreach`.
-- [compound-assignment-write-location](compound-assignment-write-location.md) -- `lhs op= rhs`
-  lowers to a high-level assign carrying the operator; each backend realizes "evaluate the target
-  once" rather than desugaring a read-modify-write into MIR.
 - [conversion-folding](conversion-folding.md) -- when type conversions are folded.
 - [variable-initialization](variable-initialization.md) -- LRM 10.5 variable initialization as a
   constructor-scope statement.
@@ -86,9 +75,6 @@ the detail lives in the entry itself.
   `ErasedCallableType<Sig>` level with an explicit erasure.
 - [builtin-call-identity](builtin-call-identity.md) -- built-in method calls carry a flat
   closed-namespace identifier (`support::BuiltinFn`) shared by HIR and MIR.
-- [dpi-foreign-boundary](dpi-foreign-boundary.md) -- DPI-C is a foreign arm of the one callable
-  model, not a parallel IR subsystem; import / export reuse the ordinary call family, with ABI
-  marshaling at the runtime boundary rather than a dedicated MIR node.
 - [address-of-primitive](address-of-primitive.md) -- MIR carries an explicit place-to-pointer
   operator (`AddressOfExpr`), dual to `DerefExpr`; the backend never injects `&`.
 - [event-control-unification](event-control-unification.md) -- unified treatment of event control:
@@ -201,6 +187,11 @@ the detail lives in the entry itself.
   activation owns and the target merely links; the activation-side set and the target-side list are
   two indexes over it, revoking is a detach rather than a search, and the two-authoritative-copies
   shape is rejected.
+- [activation-disposition](activation-disposition.md) -- an activation has one authoritative
+  disposition (Executing / Runnable / Blocked / Suspended(saved) / Terminal); a wait is a retainable
+  pending capability distinct from its registration (enrollment), supplied uniformly by each
+  construct; suspension saves the prior disposition; a central wait-kind taxonomy,
+  `Runnable(region)`, and mirroring the wait's state are rejected.
 
 ### Diagnostics
 

--- a/docs/decisions/activation-disposition.md
+++ b/docs/decisions/activation-disposition.md
@@ -1,0 +1,157 @@
+# An activation has one authoritative disposition, and a wait is a pending capability distinct from its enrollment
+
+Date: 2026-07-15. Status: accepted.
+
+## Why this decision matters
+
+Process control (LRM 9.7) `suspend()` / `resume()` is the first operation that must **re-establish a
+wait without re-entering the body that created it**. A running body registers a wait through a
+runtime call (a delay, an event control, a level wait, an `await`) and then suspends; every other
+mechanism -- normal wake, `disable`, `kill` -- either resumes the body past that point or destroys
+it. None needs to reconstruct the wait. `resume()` does: it must re-sensitize a process the body
+cannot re-enter to re-run the registration.
+
+`activation-registration.md` gave the runtime a `Registration` -- the activation's revocable
+membership in a wake target. That is enough to _detach_ a wait (revoke the enrollment) but not to
+_re-establish_ one: a registration records where the activation is presently linked, and a revoke
+forgets it. The wait itself -- the absolute deadline, the observables and edges, the target process
+-- has no retainable home; it survives only because the awaitable temporary holds it inside the
+opaque coroutine frame and the normal wake path re-enters `await_resume`. `suspend`/`resume` breaks
+both assumptions.
+
+## The failure this decision is drawn from
+
+The first design answered this with a `RearmCapability`: an opaque
+`move_only_function<void(RuntimeServices&)>` on the activation's frame core, installed at park,
+invoked at resume. Its API would not settle -- one-shot vs retained, when to clear, `bool` vs enum
+result, a special case for the delay bucket, a capture-ownership rule, a cached current frame. Each
+question looked like closure tuning; together they were the tell of a missing state machine leaking
+into a single slot. The closure was being asked to be, at once:
+
+- the **blocked operation** (how to re-establish the wait),
+- the **saved disposition** (was the activation blocked, or already runnable when suspended),
+- the **wake state** (has the wait fired), and
+- the **scheduling effect** (which region to resume into).
+
+A slot whose surface is that many unrelated responsibilities is the wrong structure -- the same
+reading `activation-registration.md` applied to the two-authoritative-copies registration: when the
+machinery serves reconciliation rather than the relation, the model is missing a concept. Here the
+missing concept is the activation's **disposition** and, under it, a **pending wait** that is
+separate from its **registration**.
+
+## The model
+
+```text
+ActivationDisposition   -- how an activation participates in execution; authoritative
+  Executing
+  Runnable              -- entitled to run; the region is the engine's placement, not carried here
+  Blocked               -- waiting on a condition: one Registration (enrollment) + one PendingWait
+  Suspended(saved)      -- scheduler participation revoked; saves Runnable or Blocked to restore
+  Terminal
+
+Registration  -- the activation's CURRENT enrollment in a wake target's list (unchanged).
+PendingWait   -- a Blocked activation's retainable ability to re-establish its wait and to report
+                 whether the wait is already satisfied. One uniform capability, not a taxonomy.
+```
+
+A `Blocked` activation holds both: the `Registration` is where it is linked now; the `PendingWait`
+is how to link again. Revoking the registration (desensitize) leaves the pending wait intact.
+Re-establishing (`resume`) asks the pending wait to re-enroll or to report the condition already
+met. A normal wake consumes the pending wait and moves the disposition to `Runnable`; termination
+discards it.
+
+The wait's own state -- the deadline, the observables and edges, the target -- stays in the
+construct that registered it (its retained awaiter/registration state); the pending wait is the
+capability to re-establish _from_ that state, reached uniformly, never a second copy of it.
+
+## The decisions
+
+```text
+D1. The disposition is the one authoritative state. The registration set, the pending wait, and
+    run-queue membership are resources constrained to agree with it, never independent truths. Debug
+    invariants tie them: Blocked has a pending wait and a registration; Suspended(Blocked) has a
+    pending wait and no registration; Runnable has a run-queue registration; Terminal has neither.
+
+D2. A registration is the current enrollment; a pending wait is the retainable wait. They are
+    distinct. `suspend` of a blocked activation detaches the registration and keeps the pending wait;
+    `resume` re-establishes through the pending wait.
+
+D3. The pending wait is a UNIFORM capability -- re-establish, report-satisfied, discard -- supplied
+    by each suspending construct. No scheduler or activation path branches on which construct a wait
+    came from. This is the same construct-neutrality `jit-process-suspension.md` fixed for the
+    execution backend, where a wakeup is one per-construct registration call and the suspend is a
+    generic edge; re-establishing a wait is that same per-construct call issued again, dispatched
+    uniformly.
+
+D4. The wait's state has one home: the construct's own retained state. The pending wait re-establishes
+    from it; it does not mirror it into a second authoritative object.
+
+D5. `Suspended` is not another kind of wait. It saves the disposition it replaced --
+    `Suspended(Runnable)` or `Suspended(Blocked)` -- and `resume` restores exactly that: a saved
+    Runnable re-takes an execution entitlement; a saved Blocked re-establishes its pending wait,
+    which re-enrolls or reports satisfied.
+
+D6. `Runnable` carries no region. The region (active / inactive / next-delta / delay bucket) is the
+    engine's placement, chosen when the activation is scheduled. `resume` places a runnable-suspended
+    activation into the active region (LRM 9.7); it does not restore a saved region.
+
+D7. A process has exactly one active leaf activation while not executing (a task/function call runs in
+    the caller's thread, LRM 9.5, so a process is one frame stack with one innermost enrolled or
+    runnable frame). Process control names the process and acts on that leaf. The process -> active
+    leaf relation is a maintained invariant, not an incidental cache.
+```
+
+## Consequences
+
+- The wobble in the rearm-capability API disappears, because each question it could not answer is
+  now owned elsewhere: blocked-vs-runnable is the saved disposition (D5), when-to-clear is "wake
+  consumes the pending wait" (D1), region is the engine's (D6). In particular, the ad-hoc "clear the
+  rearm at the wake verb so the woken-but-not-resumed window re-queues instead of re-waiting" rule
+  is not a rule at all: a wake moves `Blocked -> Runnable`, so a later `suspend` saves `Runnable`
+  and `resume` re-queues -- it falls out of the state machine.
+- The per-construct resume semantics live in one place per construct and read as the LRM rule: an
+  edge re-subscribes (a trigger during suspension is missed), a delay compares its absolute deadline
+  (a delay that transpired during suspension resumes runnable), a monotonic condition (join, wait
+  fork, await) re-checks. None of this is a scheduler branch.
+- The two backends realize the same model: the C++ backend keeps the construct's retained state in
+  the awaiter frame and the pending wait as a constrained capability over it; the execution backend
+  re-issues the construct's wakeup-registration call behind a generic suspend edge
+  (`jit-process-suspension.md`). Neither needs a central wait-kind enum.
+
+## Rejected alternatives
+
+- **A typed taxonomy of blocked operations** --
+  `variant<DelayBlock, ValueChangeBlock, JoinBlock, ...>` visited on suspend / resume / wake. It
+  reads as more inspectable, but a kind switch on the execution path is exactly the source-language
+  timing concept `scheduling.md` and `jit-process-suspension.md` forbid the scheduler to know, and
+  it duplicates the wait state the construct already holds (D4). The construct-specific knowledge
+  belongs in the construct's own registration, reached through a uniform capability, not in a
+  central variant.
+
+- **`Runnable(region)`** -- pinning the region a runnable activation must be restored to. `resume`
+  restores an activation to the active region regardless of where it sat (LRM 9.7); carrying the
+  region folds scheduler placement into activation semantics (D6).
+
+- **A second authoritative copy of the wait's state** -- a blocked-operation object mirroring the
+  deadline / observable / target the construct already holds. This is the two-authoritative-copies
+  shape `activation-registration.md` rejected, one level up (D4).
+
+- **"An opaque re-establish closure cannot map to the execution backend."** Retracted. Lyra's
+  runtime effects are ordinary closures / per-construct calls already
+  (`runtime-effects-as-generic-calls.md`, `jit-process-suspension.md`); the execution backend
+  re-realizes a re-establish as re-issuing the construct's registration call behind a generic
+  control edge, with no need to introspect a kind. The closure is a valid C++ realization of the
+  pending-wait capability; it is not the model, and it is not backend lock-in.
+
+## Cross-references
+
+- `../architecture/activation.md` -- invariant 7 (disposition and pending wait), the refined
+  invariant 4 (registration as enrollment), and the forbidden shapes this entry's D3 / D4 / D6
+  state.
+- `../architecture/scheduling.md` -- the engine as a construct-neutral mechanism; a wait kind is not
+  a distinction the execution path may branch on.
+- [activation-registration](activation-registration.md) -- the registration as one record owned by
+  the activation; this entry separates that enrollment from the retainable wait it serves.
+- [jit-process-suspension](jit-process-suspension.md) -- the execution-backend counterpart: a
+  per-construct wakeup registration behind a generic suspend edge, which re-establishing a pending
+  wait re-issues.

--- a/docs/progress/activation.md
+++ b/docs/progress/activation.md
@@ -19,8 +19,9 @@ or incomplete relative to the contract.
       scheduler-visible execution core carries none of it. The value and the exception now travel
       together in one typed completion slot held off the scheduler-visible core; a consumer reads
       the whole outcome once, which re-raises a fault or yields the value. The execution core the
-      scheduler sees is purely suspend / resume / wait state / identity. The `Cancelled` alternative
-      is not present, and as realized it has no reader -- see the cancellation item below.
+      scheduler sees is purely suspend / resume / wait state / identity. The `Cancelled` slot
+      alternative is not present: as the cancellation item below settles, killed-ness is realized as
+      a persistent fact of the process node, read by `status()` / `await()`, not as a slot value.
 
 - [x] **Registrations are revocable.** Contract invariant 4: every external reference to a parked
       activation -- a region queue slot, a delay slot, an event waiter entry, a value-change
@@ -34,26 +35,48 @@ or incomplete relative to the contract.
       new registration kind may be added that an activation cannot revoke, and adding one means
       giving a target a list, not teaching the scheduler a new way to be searched.
 
-- [ ] **Cancellation covers the dynamic domain only, and settles no outcome.** Contract: the
-      terminal outcome includes `Cancelled`; a cancellation domain -- a relation distinct from
-      ownership and continuation -- decides which activations are cancelled together; disabling
-      settles `Cancelled`, revokes every registration, cancels the owned descendants, then releases
-      the frame. Current shape: cancellation over the dynamic domain is real. `disable fork` (LRM
-      9.6.3) walks the process lineage, which is that domain, and cancels the whole descendant
-      subtree -- including the descendants of subprocesses that have already terminated; releasing
-      each frame revokes its registrations, so nothing is left able to resume it.
+- [x] **Cancellation over the dynamic domain settles a reader.** Contract: a cancellation domain --
+      a relation distinct from ownership and continuation -- decides which activations are cancelled
+      together; disabling revokes every registration, cancels the owned descendants, then releases
+      the frame. Current shape: `disable fork` (LRM 9.6.3) and `kill` (LRM 9.7) both walk the
+      process lineage, which is that domain, and terminate the whole descendant subtree -- including
+      the descendants of subprocesses that have already terminated. Both funnel through one terminal
+      transition: each terminated node is marked KILLED and its frame released, and releasing a
+      frame revokes its registrations, so nothing -- queue, waiter, subscription, or a handle held
+      past the kill -- is left able to resume it.
 
-      Two gaps remain. `disable` of a named block or task (LRM 9.6.2) is not cancellation over the
-      dynamic domain at all: it selects its targets from static, syntactic block identity, and it
-      transfers control in the disabling process (execution resumes after the named block), so it is
-      a control-flow construct layered on this model rather than a use of it.
+      Cancellation now has a reader. `process::status()` reports a killed process as KILLED through a
+      handle that outlives it, and `process::await()` (LRM 9.7) suspends a process until another
+      terminates -- normally or forcibly -- then reads that outcome. KILLED is realized as a
+      persistent fact of the process node, a terminal cause distinguishing a finished process from a
+      killed one, not as a `Cancelled` value in the completion slot: a cancelled activation is
+      released while parked, so its slot is never read. The contract's three-way completion slot
+      (`Succeeded` / `Faulted` / `Cancelled`) should be revised accordingly -- cancellation is a
+      lifetime event observed through status / await, not a third terminal value the consumer reads
+      from the slot.
 
-      And no `Cancelled` value is settled. Cancelling releases the activation, so its completion slot
-      is never read: the disabled subtree is destroyed whole, which leaves no surviving consumer
-      awaiting a cancelled activation. A settled `Cancelled` first acquires a reader with LRM 9.7
-      `process::status()` (a killed process reports `KILLED`), so the outcome is deliberately not
-      materialized ahead of that reader. The contract's three-way completion slot should be revisited
-      against this: as realized, cancellation is a lifetime event, not a third terminal value.
+      One gap: the killed subtree must be off the calling process's own execution stack, because
+      terminating a process releases (destroys) its frame and a running body cannot destroy the frame
+      it executes in. Killing the calling process or one of its ancestors is rejected for now.
+      Supporting it needs a deferred safe-boundary termination -- mark the target, unwind the calling
+      body to the scheduler's resume boundary, and tear the frame down there -- rather than the
+      synchronous release used for an off-stack subtree.
+
+- [x] **Pause and resume settle on the disposition model.** `process::suspend()` / `resume()` (LRM
+      9.7) pause and restart a process. An activation carries an authoritative disposition and a
+      blocked one holds a retainable pending wait, distinct from its registration (enrollment): a
+      suspend detaches the enrollment and saves the disposition, and a resume re-establishes the
+      pending wait -- re-enrolling, or becoming runnable if the condition already holds. Each
+      suspending construct supplies that re-establish uniformly, so its own LRM resume rule reads in
+      one place: an edge or named event re-subscribes (a trigger during suspension is missed), a
+      delay compares its absolute deadline (a transpired delay resumes runnable), a monotonic
+      condition (join, wait fork, await) re-checks. `status()` reports SUSPENDED. See the activation
+      contract and the activation-disposition decision.
+
+- [ ] **Static-block disable remains.** `disable` of a named block or task (LRM 9.6.2) is not
+      cancellation over the dynamic domain at all: it selects its targets from static, syntactic
+      block identity, and transfers control in the disabling process (execution resumes after the
+      named block), so it is a control-flow construct layered on this model rather than a use of it.
 
 - [ ] **Runtime vocabulary trails the model.** The execution code names the activation and its core
       in coroutine-implementation terms; the contract's vocabulary is activation / completion slot /

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -861,25 +861,6 @@ enough to warrant its own focused review.
       touches how a unit definition is published and filled; it warrants its own review rather than
       riding along with a value-domain or storage cut.
 
-- [ ] R59 -- Unify the fixed-name runtime library types. MIR carries a family of type kinds that
-      each mean only "a type the runtime library provides, mapped to a fixed `lyra::runtime::X`
-      name": the object-tree bases (`ScopeType`, `InstanceType`, `GenScopeType`,
-      `ProceduralStorageScopeType`) and the subsystem facades (`ServicesType`, `FilesType`,
-      `DiagnosticType`) are seven nullary type-kind arms, while the inert value payloads already
-      ride one parametric `RuntimeLibraryType{kind}`. The seven nullary arms differ from one another
-      only in their fixed C++ name and their semantic role -- a base a class extends and reasons
-      about for tree-node membership, versus an opaque receiver of an effect-method family -- and
-      neither difference needs its own top-level type kind. Target shape: the fixed-name runtime
-      types share one parametric representation, as the inert payloads already do, with the
-      base-versus-facade role read as a property where it is load-bearing (base-lineage resolution,
-      receiver dispatch) rather than encoded as a per-type-kind axis. `ObjectType`,
-      `ExternalUnitObjectType`, and `ImportedRuntimeObjectType` stay distinct and out of this cut:
-      they are the three legs of the object-identity-by-boundary set
-      (`../architecture/object_model.md` invariant 2 -- intra-unit id, cross-unit name, imported
-      library declaration), an object identity rather than a fixed runtime handle name. **Blocker**:
-      none, but it re-bases base-lineage resolution and receiver dispatch, both load-bearing, so it
-      warrants its own focused review rather than riding a feature cut.
-
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -861,6 +861,25 @@ enough to warrant its own focused review.
       touches how a unit definition is published and filled; it warrants its own review rather than
       riding along with a value-domain or storage cut.
 
+- [ ] R59 -- Unify the fixed-name runtime library types. MIR carries a family of type kinds that
+      each mean only "a type the runtime library provides, mapped to a fixed `lyra::runtime::X`
+      name": the object-tree bases (`ScopeType`, `InstanceType`, `GenScopeType`,
+      `ProceduralStorageScopeType`) and the subsystem facades (`ServicesType`, `FilesType`,
+      `DiagnosticType`) are seven nullary type-kind arms, while the inert value payloads already
+      ride one parametric `RuntimeLibraryType{kind}`. The seven nullary arms differ from one another
+      only in their fixed C++ name and their semantic role -- a base a class extends and reasons
+      about for tree-node membership, versus an opaque receiver of an effect-method family -- and
+      neither difference needs its own top-level type kind. Target shape: the fixed-name runtime
+      types share one parametric representation, as the inert payloads already do, with the
+      base-versus-facade role read as a property where it is load-bearing (base-lineage resolution,
+      receiver dispatch) rather than encoded as a per-type-kind axis. `ObjectType`,
+      `ExternalUnitObjectType`, and `ImportedRuntimeObjectType` stay distinct and out of this cut:
+      they are the three legs of the object-identity-by-boundary set
+      (`../architecture/object_model.md` invariant 2 -- intra-unit id, cross-unit name, imported
+      library declaration), an object identity rather than a fixed runtime handle name. **Blocker**:
+      none, but it re-bases base-lineage resolution and receiver dispatch, both load-bearing, so it
+      warrants its own focused review rather than riding a feature cut.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <variant>
 
 #include "lyra/hir/class_id.hpp"
@@ -9,6 +11,7 @@
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/subroutine_id.hpp"
 #include "lyra/support/builtin_fn.hpp"
+#include "lyra/support/imported_runtime_class.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::hir {
@@ -52,8 +55,17 @@ struct BuiltinMethodRef {
   support::BuiltinFn method;
 };
 
+// Calls a method the runtime library provides for an imported class (LRM 9.7
+// `process`). A bodyless external callable named by its library identity; the
+// receiver is present for an instance method and absent for a static one.
+struct ImportedMethodRef {
+  support::ImportedRuntimeMethod method =
+      support::ImportedRuntimeMethod::kProcessSelf;
+  std::optional<ExprId> receiver = std::nullopt;
+};
+
 using SubroutineRef = std::variant<
     StructuralSubroutineRef, MethodCallRef, SystemSubroutineRef,
-    BuiltinMethodRef, ForeignImportRef>;
+    BuiltinMethodRef, ForeignImportRef, ImportedMethodRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -10,6 +10,7 @@
 #include "lyra/hir/constant_value.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/type_id.hpp"
+#include "lyra/support/imported_runtime_class.hpp"
 
 namespace lyra::hir {
 
@@ -33,6 +34,7 @@ enum class TypeKind {
   kRealTime,
   kChandle,
   kClassHandle,
+  kImportedClassHandle,
   kNull,
   kVoid,
 };
@@ -211,6 +213,14 @@ struct ClassHandleType {
   ClassId class_id;
 };
 
+// LRM 8.3 class handle whose referenced class is an imported runtime-library
+// class rather than a unit-declared one. Managed and null-legal like
+// ClassHandleType, but the class is named by its library identity, not a unit
+// class id.
+struct ImportedClassHandleType {
+  support::ImportedRuntimeClass klass;
+};
+
 // LRM 8.4: the type slang gives the `null` literal. It is assignment- and
 // comparison-compatible with any class handle; the contextual handle determines
 // the operation, so this type carries no class identity of its own.
@@ -221,7 +231,7 @@ using TypeData = std::variant<
     UnpackedStructType, UnpackedUnionType, UnpackedArrayType, DynamicArrayType,
     QueueType, AssociativeArrayType, WildcardIndexType, StringType, EventType,
     RealType, ShortRealType, RealTimeType, ChandleType, ClassHandleType,
-    NullType, VoidType>;
+    ImportedClassHandleType, NullType, VoidType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -106,6 +106,19 @@ class UnitLowerer {
     return class_object_type_map_[hir_id.value];
   }
 
+  // The pointee object type a managed handle to an imported runtime-library
+  // class names. Each imported class is a fixed library class, so its object
+  // type is a well-known type interned once on the unit.
+  [[nodiscard]] auto ImportedRuntimeObjectType(
+      support::ImportedRuntimeClass klass) const -> mir::TypeId {
+    switch (klass) {
+      case support::ImportedRuntimeClass::kProcess:
+        return unit_.builtins.process_object;
+    }
+    throw InternalError(
+        "UnitLowerer::ImportedRuntimeObjectType: unknown imported class");
+  }
+
   // Mints a collision-free class name for one generate scope, tagged by its
   // arm kind (`loop` / `then` / `else` / ...). The name is only an
   // implementation handle for the emitted type -- a generate scope's runtime

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -42,6 +42,10 @@ struct BuiltinMirTypes {
   TypeId time;
   TypeId services;
   TypeId scope_ptr;
+  // The object type an imported runtime-library class handle (LRM 9.7
+  // `process`) references. A fixed library class named by its qualified name,
+  // exactly as the scope class is.
+  TypeId process_object;
   TypeId files;
   TypeId diagnostic;
   TypeId channel_cancellation;
@@ -116,6 +120,9 @@ struct CompilationUnit {
                     ExternalClassType{
                         .qualified_name = "lyra::runtime::Scope"}),
                 PointerOwnership::kBorrowed),
+            .process_object = types.Intern(
+                ExternalClassType{
+                    .qualified_name = "lyra::runtime::RuntimeProcess"}),
             .files = types.Intern(FilesType{}),
             .diagnostic = types.Intern(DiagnosticType{}),
             .channel_cancellation = types.Intern(

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -20,6 +20,7 @@
 #include "lyra/mir/struct_construct.hpp"
 #include "lyra/mir/unary_op.hpp"
 #include "lyra/support/builtin_fn.hpp"
+#include "lyra/support/imported_runtime_class.hpp"
 
 namespace lyra::mir {
 
@@ -158,18 +159,28 @@ struct MethodTarget {
   auto operator==(const MethodTarget&) const -> bool = default;
 };
 
-// The target of a `Direct` call -- the symbol identity. Three identity
-// spaces: user-declared class methods (`MethodTarget`, an
-// owner-qualified method identity), built-in runtime entries
-// (closed-namespace `BuiltinFn`), and class-level static callables
-// (`StaticCallableTarget`, which names its own owner -- a DPI-C import's
-// external symbol, a receiver-less associated callable). All three are
-// owner-qualified references; none is recovered from the receiver's runtime
-// type. These collapse into one `CallableId` once the method and
-// static-callable declarations share one callable-declaration shape; the
-// owner survives that collapse.
-using DirectTarget =
-    std::variant<MethodTarget, support::BuiltinFn, StaticCallableTarget>;
+// The target of a call to a method the runtime library provides for an imported
+// class (LRM 9.7 `process`). A bodyless external callable whose implementation
+// is a runtime symbol; the identity names the method, and the backend renders
+// the call mechanically to that symbol -- no per-unit declaration and no
+// per-method backend branch. A receiver, if the method has one, is `args[0]`.
+struct ImportedRuntimeCallTarget {
+  support::ImportedRuntimeMethod method;
+
+  auto operator==(const ImportedRuntimeCallTarget&) const -> bool = default;
+};
+
+// The target of a `Direct` call -- the symbol identity. Four identity spaces:
+// user-declared class methods (`MethodTarget`, an owner-qualified method
+// identity), built-in runtime entries (closed-namespace `BuiltinFn`),
+// class-level static callables (`StaticCallableTarget`, which names its own
+// owner -- a DPI-C import's external symbol, a receiver-less associated
+// callable), and methods the runtime library provides for an imported class
+// (`ImportedRuntimeCallTarget`). None is recovered from the receiver's runtime
+// type.
+using DirectTarget = std::variant<
+    MethodTarget, support::BuiltinFn, StaticCallableTarget,
+    ImportedRuntimeCallTarget>;
 
 // A direct call to a named symbol. The single shape for every direct
 // invocation -- user method, built-in instance method, type-qualified

--- a/include/lyra/runtime/coroutine.hpp
+++ b/include/lyra/runtime/coroutine.hpp
@@ -13,6 +13,7 @@
 namespace lyra::runtime {
 
 class RuntimeProcess;
+class PendingWait;
 
 // Non-templated scheduling state shared by every coroutine frame -- a process
 // body, a task body, a fork branch -- regardless of the value the frame
@@ -34,6 +35,13 @@ struct PromiseBase {
   // resume it. A deque because the targets' lists point at these addresses, and
   // appending must not move the ones already linked.
   std::deque<Registration> registrations;
+  // The wait this activation is blocked on, if any: a capability, held by the
+  // awaiter that suspended this frame, to re-establish the wait on resume (LRM
+  // 9.7). Distinct from `registrations`, which is the current enrollment; a
+  // suspend revokes the enrollment but keeps this. Null while runnable,
+  // executing, or terminal. The awaiter is frame-resident, so this points
+  // within the same frame and dies with it.
+  PendingWait* pending_wait = nullptr;
 
   PromiseBase() = default;
   PromiseBase(const PromiseBase&) = delete;

--- a/include/lyra/runtime/delay.hpp
+++ b/include/lyra/runtime/delay.hpp
@@ -4,6 +4,8 @@
 
 #include "lyra/base/time.hpp"
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/pending_wait.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/value/packed_array.hpp"
 
@@ -29,7 +31,7 @@ inline auto ScaleToGlobalTicks(
 // current slot; `#N>0` scales to the engine's global tick and enqueues at that
 // future SimTime. The engine does not know about delays as a category -- it
 // only sees a process arriving in a queue at the right time.
-class DelayAwaitable {
+class DelayAwaitable : public PendingWait {
  public:
   DelayAwaitable(
       RuntimeServices& services, SimDuration duration,
@@ -44,24 +46,46 @@ class DelayAwaitable {
   }
 
   template <class P>
-  void await_suspend(std::coroutine_handle<P> handle) noexcept {
+  void await_suspend(std::coroutine_handle<P> handle) {
     CoroutineHandle token = &handle.promise();
-    if (duration_ == 0) {
-      services_->ScheduleInactive(token);
-    } else {
-      const SimDuration global_ticks = ScaleToGlobalTicks(
-          duration_, precision_power_, services_->GlobalPrecisionPower());
-      services_->ScheduleAtTime(services_->Now() + global_ticks, token);
-    }
+    Arm(token);
+    token->process->BlockLeaf(token, this);
   }
 
   static void await_resume() noexcept {
   }
 
+  // A delay's deadline is absolute (LRM 9.7): on resume, if it has transpired
+  // the process is runnable, otherwise it re-parks for the remaining time.
+  auto Reestablish(RuntimeServices& services, CoroutineHandle activation)
+      -> PendingWaitOutcome override {
+    if (services.Now() >= deadline_) {
+      return PendingWaitOutcome::kRunnable;
+    }
+    services.ScheduleAtTime(deadline_, activation);
+    return PendingWaitOutcome::kReblocked;
+  }
+
  private:
+  // Fixes the absolute deadline and parks: `#0` on the inactive region of this
+  // slot (its deadline is this time, so a resume finds it transpired), `#N` at
+  // the scaled future time.
+  void Arm(CoroutineHandle token) {
+    if (duration_ == 0) {
+      deadline_ = services_->Now();
+      services_->ScheduleInactive(token);
+    } else {
+      const SimDuration global_ticks = ScaleToGlobalTicks(
+          duration_, precision_power_, services_->GlobalPrecisionPower());
+      deadline_ = services_->Now() + global_ticks;
+      services_->ScheduleAtTime(deadline_, token);
+    }
+  }
+
   RuntimeServices* services_;
   SimDuration duration_;
   std::int8_t precision_power_;
+  SimTime deadline_ = 0;
 };
 
 inline auto Delay(

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -159,8 +159,11 @@ class Engine {
   void RegisterProcesses();
   // Runs a suspended frame's owning process against the engine's execution
   // context. Resuming demands that context, so a body always executes with its
-  // own process identity published.
-  auto ResumeProcess(CoroutineHandle handle) -> bool;
+  // own process identity published. On completion the terminal transition
+  // drains the process's `await` waiters into `woken` for the caller to
+  // schedule.
+  auto ResumeProcess(
+      CoroutineHandle handle, std::vector<CoroutineHandle>& woken) -> bool;
   void RunProcess(CoroutineHandle handle);
   void DrainRunnableQueue(RegistrationList& queue);
 

--- a/include/lyra/runtime/fork.hpp
+++ b/include/lyra/runtime/fork.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/pending_wait.hpp"
 #include "lyra/runtime/registration.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
@@ -63,7 +64,7 @@ class ForkGroup {
 // ready iff every needed completion already arrived (which a zero-branch fork
 // or a `join_any` with an immediate finisher can produce); otherwise the parent
 // parks on the group.
-class JoinAwaitable {
+class JoinAwaitable : public PendingWait {
  public:
   explicit JoinAwaitable(std::shared_ptr<ForkGroup> group)
       : group_(std::move(group)) {
@@ -74,11 +75,26 @@ class JoinAwaitable {
   }
 
   template <class P>
-  void await_suspend(std::coroutine_handle<P> parent) noexcept {
-    group_->ParkParent(&parent.promise());
+  void await_suspend(std::coroutine_handle<P> parent) {
+    CoroutineHandle token = &parent.promise();
+    group_->ParkParent(token);
+    token->process->BlockLeaf(token, this);
   }
 
   void await_resume() const noexcept {
+  }
+
+  // A join condition is monotonic (LRM 9.3.2): branch completions accumulate
+  // during suspension. On resume, if the threshold is now met the parent is
+  // runnable; otherwise re-park on the group. No engine services are needed.
+  // NOLINTNEXTLINE(readability-named-parameter)
+  auto Reestablish(RuntimeServices&, CoroutineHandle activation)
+      -> PendingWaitOutcome override {
+    if (!group_->NeedsPark()) {
+      return PendingWaitOutcome::kRunnable;
+    }
+    group_->ParkParent(activation);
+    return PendingWaitOutcome::kReblocked;
   }
 
  private:
@@ -141,7 +157,7 @@ void SpawnAll(RuntimeServices& services, Branches... branches) {
 // process; the frame parked on it is the one that ran `wait fork` (the task
 // frame when `wait fork` sits in a task), so it is armed through the suspending
 // handle rather than the process's own body.
-class WaitForkAwaitable {
+class WaitForkAwaitable : public PendingWait {
  public:
   explicit WaitForkAwaitable(RuntimeServices& services) : services_(&services) {
   }
@@ -151,11 +167,29 @@ class WaitForkAwaitable {
   }
 
   template <class P>
-  void await_suspend(std::coroutine_handle<P> waiter) const {
-    services_->CurrentProcess().ArmWaitFork(&waiter.promise());
+  void await_suspend(std::coroutine_handle<P> waiter) {
+    CoroutineHandle token = &waiter.promise();
+    services_->CurrentProcess().ArmWaitFork(token);
+    token->process->BlockLeaf(token, this);
   }
 
   void await_resume() const noexcept {
+  }
+
+  // `wait fork` waits on the executing process's own immediate children (LRM
+  // 9.6.1), a monotonic condition. On resume, if every immediate child has
+  // terminated the process is runnable; otherwise re-park on its own condition.
+  // The target is the process owning the waiting frame, not the resumer's
+  // current process, so it is read from the activation.
+  // NOLINTNEXTLINE(readability-named-parameter)
+  auto Reestablish(RuntimeServices&, CoroutineHandle activation)
+      -> PendingWaitOutcome override {
+    RuntimeProcess& process = activation->Process();
+    if (process.HasNoLiveChild()) {
+      return PendingWaitOutcome::kRunnable;
+    }
+    process.ArmWaitFork(activation);
+    return PendingWaitOutcome::kReblocked;
   }
 
  private:
@@ -172,7 +206,11 @@ inline auto WaitFork(RuntimeServices& services) -> WaitForkAwaitable {
 // `wait fork`, it reads the executing process (LRM 9.5), so a `disable fork`
 // inside a task reaches the descendants the enclosing process owns.
 inline void DisableFork(RuntimeServices& services) {
-  services.CurrentProcess().DisableDescendants();
+  std::vector<CoroutineHandle> woken;
+  services.CurrentProcess().DisableDescendants(woken);
+  for (CoroutineHandle waiter : woken) {
+    services.ScheduleNextDelta(waiter);
+  }
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/named_event.hpp
+++ b/include/lyra/runtime/named_event.hpp
@@ -4,6 +4,8 @@
 
 #include "lyra/base/time.hpp"
 #include "lyra/runtime/event.hpp"
+#include "lyra/runtime/pending_wait.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/value/packed_array.hpp"
 
@@ -13,7 +15,7 @@ namespace lyra::runtime {
 // "waiting for an event" state -- the coroutine simply suspends, and the
 // producer schedules it again on trigger through the same construct-neutral
 // verb every other wait uses, so the engine has no event-specific code path.
-class EventAwaitable {
+class EventAwaitable : public PendingWait {
  public:
   explicit EventAwaitable(RuntimeEvent& event) : event_(&event) {
   }
@@ -23,11 +25,23 @@ class EventAwaitable {
   }
 
   template <class P>
-  void await_suspend(std::coroutine_handle<P> handle) noexcept {
-    event_->AddWaiter(&handle.promise());
+  void await_suspend(std::coroutine_handle<P> handle) {
+    CoroutineHandle token = &handle.promise();
+    event_->AddWaiter(token);
+    token->process->BlockLeaf(token, this);
   }
 
   static void await_resume() noexcept {
+  }
+
+  // A named-event trigger is instantaneous (LRM 15.5): a trigger during
+  // suspension is missed, so resume re-subscribes for the next one. No engine
+  // services are needed; the capability signature carries them uniformly.
+  // NOLINTNEXTLINE(readability-named-parameter)
+  auto Reestablish(RuntimeServices&, CoroutineHandle activation)
+      -> PendingWaitOutcome override {
+    event_->AddWaiter(activation);
+    return PendingWaitOutcome::kReblocked;
   }
 
  private:

--- a/include/lyra/runtime/pending_wait.hpp
+++ b/include/lyra/runtime/pending_wait.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+
+#include "lyra/runtime/registration.hpp"
+
+namespace lyra::runtime {
+
+class RuntimeServices;
+
+// Whether re-establishing a wait found its condition already satisfied.
+enum class PendingWaitOutcome : std::uint8_t {
+  // Re-enrolled; the activation stays parked until the condition fires.
+  kReblocked,
+  // Already satisfied; the caller schedules the activation to run.
+  kRunnable,
+};
+
+// The retainable, uniform capability a blocked activation holds to re-establish
+// its wait. It is distinct from the `Registration`, which only records the
+// current enrollment: a suspend revokes the registration but keeps the pending
+// wait, and a resume re-establishes through it without re-entering the
+// suspended body (LRM 9.7 process control).
+//
+// Each suspending construct's awaiter implements this; the activation core
+// holds a pointer to the current one and never branches on which construct it
+// came from. The awaiter is the wait's own retained state (deadline,
+// observables, target), so this is a capability over that state, not a second
+// copy of it.
+class PendingWait {
+ public:
+  PendingWait() = default;
+  PendingWait(const PendingWait&) = delete;
+  auto operator=(const PendingWait&) -> PendingWait& = delete;
+  PendingWait(PendingWait&&) = delete;
+  auto operator=(PendingWait&&) -> PendingWait& = delete;
+  virtual ~PendingWait() = default;
+
+  // Re-establish this wait for `activation` on resume (LRM 9.7). The body is
+  // the construct's own resume rule: an edge or named event re-subscribes (a
+  // trigger during suspension is missed), a delay compares its absolute
+  // deadline (a delay that transpired resumes runnable), a monotonic condition
+  // (join, wait fork, await) re-checks and is runnable if met. Returns
+  // kRunnable when the condition already holds -- the caller schedules
+  // `activation` -- or kReblocked when it re-enrolled and stays parked.
+  virtual auto Reestablish(
+      RuntimeServices& services, CoroutineHandle activation)
+      -> PendingWaitOutcome = 0;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/process_control.hpp
+++ b/include/lyra/runtime/process_control.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/gc_ref.hpp"
+#include "lyra/runtime/runtime_process.hpp"
+#include "lyra/runtime/runtime_services.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::runtime {
+
+// LRM 9.7 `process::state`, in declaration order: `status()` reports the
+// process's state as one of these, and the underlying integer is what the
+// SystemVerilog program compares against the enum members.
+enum class ProcessStatusCode : std::int32_t {
+  kFinished = 0,
+  kRunning = 1,
+  kWaiting = 2,
+  kSuspended = 3,
+  kKilled = 4,
+};
+
+// LRM 9.7 `process::self()`: a handle to the process making the call. A task or
+// function runs in its caller's thread (LRM 9.5), so this returns the enclosing
+// executing process, reached through the ambient execution context.
+inline auto ProcessSelf(RuntimeServices& services) -> GcRef<RuntimeProcess> {
+  return GcRef<RuntimeProcess>(services.CurrentProcess().shared_from_this());
+}
+
+// LRM 9.7 `process::status()`: the process's execution state projected onto the
+// LRM `state` enum. The state lives on the persistent process node rather than
+// the coroutine frame, so a process remains observable through a surviving
+// handle after its body terminates.
+inline auto ProcessStatus(const GcRef<RuntimeProcess>& self)
+    -> lyra::value::PackedArray {
+  const ProcessStatusCode code = [&] {
+    switch (self->ExecutionState()) {
+      case ProcessExecutionState::kCreated:
+      case ProcessExecutionState::kRunning:
+        return ProcessStatusCode::kRunning;
+      case ProcessExecutionState::kWaiting:
+        return ProcessStatusCode::kWaiting;
+      case ProcessExecutionState::kTerminated:
+        return ProcessStatusCode::kFinished;
+    }
+    throw InternalError("ProcessStatus: unknown process execution state");
+  }();
+  return lyra::value::PackedArray::Int(static_cast<std::int32_t>(code));
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/process_control.hpp
+++ b/include/lyra/runtime/process_control.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <coroutine>
 #include <cstdint>
+#include <utility>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/gc_ref.hpp"
+#include "lyra/runtime/pending_wait.hpp"
+#include "lyra/runtime/registration.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/value/packed_array.hpp"
@@ -31,7 +36,9 @@ inline auto ProcessSelf(RuntimeServices& services) -> GcRef<RuntimeProcess> {
 // LRM 9.7 `process::status()`: the process's execution state projected onto the
 // LRM `state` enum. The state lives on the persistent process node rather than
 // the coroutine frame, so a process remains observable through a surviving
-// handle after its body terminates.
+// handle after its body terminates. A terminated process reports FINISHED or
+// KILLED by how it terminated -- the completion slot is gone by then, so the
+// distinction is read from the node's persistent terminal cause.
 inline auto ProcessStatus(const GcRef<RuntimeProcess>& self)
     -> lyra::value::PackedArray {
   const ProcessStatusCode code = [&] {
@@ -41,12 +48,156 @@ inline auto ProcessStatus(const GcRef<RuntimeProcess>& self)
         return ProcessStatusCode::kRunning;
       case ProcessExecutionState::kWaiting:
         return ProcessStatusCode::kWaiting;
+      case ProcessExecutionState::kSuspended:
+        return ProcessStatusCode::kSuspended;
       case ProcessExecutionState::kTerminated:
-        return ProcessStatusCode::kFinished;
+        return self->TerminationCause() == ProcessTerminationCause::kKilled
+                   ? ProcessStatusCode::kKilled
+                   : ProcessStatusCode::kFinished;
     }
     throw InternalError("ProcessStatus: unknown process execution state");
   }();
   return lyra::value::PackedArray::Int(static_cast<std::int32_t>(code));
+}
+
+// LRM 9.7 `process::kill()`: forcibly terminate the process and all its
+// descendant subprocesses. Each terminated node is marked KILLED and its frame
+// released, so nothing can resume it, and every process awaiting one is woken.
+//
+// The subtree terminated here must be off the calling process's C++ stack:
+// releasing a frame destroys it, and a running coroutine cannot destroy the
+// frame it is executing in. Killing the calling process or one of its ancestors
+// is therefore rejected. "Request termination now" and "destroy the current
+// frame now" are distinct; supporting self / ancestor kill needs a deferred
+// safe-boundary termination (mark, unwind the calling body to the engine's
+// resume boundary, tear the frame down there) rather than this synchronous
+// destroy, so it is not yet supported.
+inline void ProcessKill(
+    const GcRef<RuntimeProcess>& self, RuntimeServices& services) {
+  RuntimeProcess& target = *self;
+  if (target.IsSelfOrAncestorOf(services.CurrentProcess())) {
+    throw InternalError(
+        "process::kill on the calling process or one of its ancestors is not "
+        "yet supported");
+  }
+  std::vector<CoroutineHandle> woken;
+  target.TerminateSubtreeKilled(woken);
+  // `self` still pins the target, so detaching it from the lineage cannot free
+  // it mid-call. Killing the target may have satisfied a `wait fork` its parent
+  // is parked on (LRM 9.6.1), and may leave a terminated ancestor with no live
+  // descendant left to retain it.
+  RuntimeProcess* parent = target.Parent();
+  target.DetachFromParent();
+  if (parent != nullptr) {
+    if (CoroutineHandle waiter = parent->TakeWaitForkWaiterIfSatisfied()) {
+      woken.push_back(waiter);
+    }
+    RuntimeProcess::ReleaseTerminatedLineage(*parent);
+  }
+  for (CoroutineHandle waiter : woken) {
+    services.ScheduleNextDelta(waiter);
+  }
+}
+
+// LRM 9.7 `process::await()`: suspend the caller until `self` terminates,
+// normally or forcibly. Parks on the target's termination and resumes when it
+// settles; a target that has already terminated does not suspend at all.
+//
+// Correctness rests on the single-engine serialization Lyra's scheduler
+// provides: `await_ready` observing the target non-terminal and `await_suspend`
+// arming the waiter run in the same coroutine resume with no engine re-entry
+// between them, so the target cannot terminate in that gap. A parallel or
+// re-entrant engine would need an atomic arm-or-observe protocol here.
+class ProcessAwaitAwaitable : public PendingWait {
+ public:
+  explicit ProcessAwaitAwaitable(GcRef<RuntimeProcess> target)
+      : target_(std::move(target)) {
+  }
+
+  [[nodiscard]] auto await_ready() const -> bool {
+    return target_->ExecutionState() == ProcessExecutionState::kTerminated;
+  }
+
+  template <class P>
+  void await_suspend(std::coroutine_handle<P> waiter) {
+    CoroutineHandle token = &waiter.promise();
+    target_->ArmTerminatedWaiter(token);
+    token->process->BlockLeaf(token, this);
+  }
+
+  void await_resume() const noexcept {
+  }
+
+  // Termination is monotonic (LRM 9.7): the target terminates once. On resume,
+  // if it has terminated the awaiter is runnable; otherwise re-park on its
+  // termination. No engine services are needed.
+  // NOLINTNEXTLINE(readability-named-parameter)
+  auto Reestablish(RuntimeServices&, CoroutineHandle activation)
+      -> PendingWaitOutcome override {
+    if (target_->ExecutionState() == ProcessExecutionState::kTerminated) {
+      return PendingWaitOutcome::kRunnable;
+    }
+    target_->ArmTerminatedWaiter(activation);
+    return PendingWaitOutcome::kReblocked;
+  }
+
+ private:
+  // Pins the target across the suspension, so a kill that detaches it from the
+  // lineage while the caller is parked cannot free the node before resume.
+  GcRef<RuntimeProcess> target_;
+};
+
+// It is an error to await the calling process (a process cannot wait for its
+// own termination). The check is here at the call, symmetric with `suspend`, so
+// the awaitable itself is pure readiness.
+inline auto ProcessAwait(
+    const GcRef<RuntimeProcess>& self, RuntimeServices& services)
+    -> ProcessAwaitAwaitable {
+  if (self.Get() == &services.CurrentProcess()) {
+    throw InternalError(
+        "process::await on the calling process is not allowed (LRM 9.7)");
+  }
+  return ProcessAwaitAwaitable{self};
+}
+
+// LRM 9.7 `process::suspend()`: pause a process. It is an error to suspend the
+// calling process (a function cannot suspend its own execution). Suspending a
+// process that is already suspended or terminated has no effect. The activation
+// layer does the state transition and the detach; nothing here schedules.
+inline void ProcessSuspend(
+    const GcRef<RuntimeProcess>& self, RuntimeServices& services) {
+  RuntimeProcess& target = *self;
+  if (&target == &services.CurrentProcess()) {
+    throw InternalError(
+        "process::suspend on the calling process is not allowed (LRM 9.7)");
+  }
+  target.Suspend();
+}
+
+// LRM 9.7 `process::resume()`: restart a suspended process. A process that is
+// not suspended is unaffected. A process suspended while blocked re-establishes
+// its wait through the leaf's pending wait -- re-enrolling, or becoming
+// runnable if the condition is already satisfied; a process suspended while
+// runnable is re-queued to run in the current time step.
+inline void ProcessResume(
+    const GcRef<RuntimeProcess>& self, RuntimeServices& services) {
+  RuntimeProcess& target = *self;
+  if (target.ExecutionState() != ProcessExecutionState::kSuspended) {
+    return;
+  }
+  const CoroutineHandle leaf = target.CurrentLeaf();
+  target.MarkResumed();
+  // A leaf suspended while runnable has no pending wait and is simply
+  // re-queued; one suspended while blocked re-establishes its wait, which
+  // either re-enrolls (nothing to schedule) or reports the condition already
+  // satisfied.
+  PendingWait* pending = leaf->pending_wait;
+  const bool runnable =
+      pending == nullptr ||
+      pending->Reestablish(services, leaf) == PendingWaitOutcome::kRunnable;
+  if (runnable) {
+    services.ScheduleNextDelta(leaf);
+  }
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/registration.hpp
+++ b/include/lyra/runtime/registration.hpp
@@ -8,9 +8,12 @@ namespace lyra::runtime {
 
 struct PromiseBase;
 
-// The scheduling token: an activation's payload-neutral execution core, naming
-// it without naming the value it completes with. The scheduler holds this and
-// nothing else.
+// The C++ realization of the payload-neutral activation token: a handle to an
+// activation's execution core, naming it without naming the value it completes
+// with. The scheduler holds this and nothing else. That it is a `PromiseBase*`
+// today is the C++ backend's realization; a future LIR/LLVM backend realizes
+// the same token concept differently, so no layer above the runtime names this
+// type.
 using CoroutineHandle = PromiseBase*;
 
 // One membership: a target -- a value-change observable, a named event, a join

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -32,7 +32,7 @@ enum class ProcessExecutionState : std::uint8_t {
 // task or function it called (LRM 9.6.1): a subroutine call runs in the
 // caller's thread and creates no process of its own. The list therefore
 // accumulates across every fork the process executes.
-class RuntimeProcess {
+class RuntimeProcess : public std::enable_shared_from_this<RuntimeProcess> {
  public:
   RuntimeProcess(ProcessKind kind, Coroutine<void> coroutine);
 
@@ -40,13 +40,22 @@ class RuntimeProcess {
   auto operator=(const RuntimeProcess&) -> RuntimeProcess& = delete;
   // Non-movable: the coroutine promise stores a back-pointer to this
   // RuntimeProcess, and so does every child node, so its address must stay
-  // stable for as long as either can name it. Owners hold processes via
-  // unique_ptr.
+  // stable for as long as either can name it. A node is retained by shared
+  // ownership -- its parent's lineage while a descendant is live, and any
+  // user-visible `process` handle (LRM 9.7) -- so its lifetime is reachability,
+  // not a single owner.
   RuntimeProcess(RuntimeProcess&&) noexcept = delete;
   auto operator=(RuntimeProcess&&) noexcept -> RuntimeProcess& = delete;
   ~RuntimeProcess() = default;
 
   [[nodiscard]] auto Kind() const -> ProcessKind;
+
+  // The process's internal execution state. A `process` handle (LRM 9.7) reads
+  // it through `status()`, which projects it onto the LRM state enum; the state
+  // survives the coroutine frame, so a terminated process is still observable.
+  [[nodiscard]] auto ExecutionState() const -> ProcessExecutionState {
+    return execution_state_;
+  }
 
   // Resumes `handle` -- the specific coroutine frame that suspended (the
   // innermost one when a task enabled by this process is suspended). Symmetric
@@ -70,7 +79,7 @@ class RuntimeProcess {
   // Takes `child` into this process's lineage. A fork's parallel statement is a
   // thread of the process that executed the fork (LRM 9.5), which is the
   // process running when the branch is spawned, not the frame that spawned it.
-  void AdoptChild(std::unique_ptr<RuntimeProcess> child);
+  void AdoptChild(std::shared_ptr<RuntimeProcess> child);
 
   [[nodiscard]] auto Parent() const -> RuntimeProcess*;
 
@@ -117,7 +126,7 @@ class RuntimeProcess {
   Coroutine<void> coroutine_;
   ProcessExecutionState execution_state_ = ProcessExecutionState::kCreated;
   RuntimeProcess* parent_ = nullptr;
-  std::vector<std::unique_ptr<RuntimeProcess>> children_;
+  std::vector<std::shared_ptr<RuntimeProcess>> children_;
   // The `wait fork` condition holds at most one activation: the frame that
   // executed `wait fork`.
   RegistrationList parked_wait_fork_;

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/pending_wait.hpp"
 #include "lyra/runtime/process_kind.hpp"
 #include "lyra/runtime/registration.hpp"
 
@@ -16,7 +17,22 @@ enum class ProcessExecutionState : std::uint8_t {
   kCreated,
   kRunning,
   kWaiting,
+  kSuspended,
   kTerminated,
+};
+
+// Why a process reached its terminal state, a persistent fact of the process
+// node rather than of its completion slot: a killed process is released while
+// parked, so its slot is never read, yet `status()` (LRM 9.7) must still report
+// KILLED through a surviving handle. Every terminal path settles one of these,
+// and the execution state stays outcome-neutral (`kTerminated`).
+enum class ProcessTerminationCause : std::uint8_t {
+  // Ran to the end of its body -- normally or via an unhandled fault. LRM 9.7
+  // reports this as FINISHED.
+  kCompleted,
+  // Forcibly terminated by `kill` (LRM 9.7) or `disable` (LRM 9.6). Reported as
+  // KILLED.
+  kKilled,
 };
 
 // A node of the dynamic process lineage (LRM 9.5) and, while its body runs, the
@@ -57,19 +73,30 @@ class RuntimeProcess : public std::enable_shared_from_this<RuntimeProcess> {
     return execution_state_;
   }
 
+  // Why the process terminated -- meaningful only once `ExecutionState()` is
+  // `kTerminated`. Distinguishes a FINISHED process from a KILLED one for
+  // `status()` (LRM 9.7).
+  [[nodiscard]] auto TerminationCause() const -> ProcessTerminationCause {
+    return termination_cause_;
+  }
+
   // Resumes `handle` -- the specific coroutine frame that suspended (the
   // innermost one when a task enabled by this process is suspended). Symmetric
   // transfer carries control back up the enable chain. Returns true if the
   // whole process ran to completion (judged on the top-level coroutine), false
   // if it suspended again on some awaitable. Captured `handle` may be destroyed
   // by the time this returns, so completion and exceptions are read off the
-  // top-level coroutine, not `handle`. Completing releases the frame; the node
-  // outlives it.
+  // top-level coroutine, not `handle`.
   //
-  // Taking the context is what makes this the only way a body can run: the
-  // resumed body reaches its own process identity through the context, and a
-  // caller cannot resume without supplying one.
-  auto ResumeWith(ExecutionContext& context, CoroutineHandle handle) -> bool;
+  // Completing runs the whole terminal transition atomically -- terminal state,
+  // frame release, and draining this process's own `await` waiters into `woken`
+  // -- so a body can never be left terminated with its waiters unwoken. The
+  // node outlives the frame. Taking the context is what makes this the only way
+  // a body can run: the resumed body reaches its own process identity through
+  // the context, and a caller cannot resume without supplying one.
+  auto ResumeWith(
+      ExecutionContext& context, CoroutineHandle handle,
+      std::vector<CoroutineHandle>& woken) -> bool;
 
   // The top-level coroutine frame. Awaitables register the innermost handle for
   // wakeup; this is what the engine schedules to start the process and what
@@ -89,6 +116,41 @@ class RuntimeProcess : public std::enable_shared_from_this<RuntimeProcess> {
   // activation are deliberately distinct.
   void ArmWaitFork(CoroutineHandle waiter);
 
+  // Parks `waiter` on this process's termination (LRM 9.7 `await`). It is
+  // resumed once this process settles any terminal state -- normal completion
+  // or a kill -- which is when the terminal transition drains the waiter list
+  // into the runnable set. The caller checks the terminal state first, so a
+  // process that is already terminated is never parked here.
+  void ArmTerminatedWaiter(CoroutineHandle waiter);
+
+  // Records that `leaf` is now blocked on `wait`: `leaf` becomes this process's
+  // active leaf and takes the pending wait, set as one step so they never fall
+  // out of step. Each suspending construct calls this from its `await_suspend`
+  // after it enrolls. The active leaf is the one frame carrying the process's
+  // thread -- the top frame before the body runs, the innermost parked frame
+  // once a wait blocks it; process control (LRM 9.7) names the process and acts
+  // on this leaf.
+  void BlockLeaf(CoroutineHandle leaf, PendingWait* wait) {
+    current_leaf_ = leaf;
+    leaf->pending_wait = wait;
+  }
+  [[nodiscard]] auto CurrentLeaf() const -> CoroutineHandle {
+    return current_leaf_;
+  }
+
+  // LRM 9.7 `suspend`: revoke the active leaf's scheduler participation -- a
+  // detach, no scheduler verb -- and record the suspended state. The leaf's
+  // pending wait is kept if it was blocked (resume re-establishes it) and
+  // absent if it was runnable (resume re-queues); either way its registrations
+  // are revoked. A process already suspended or terminated is unaffected.
+  void Suspend();
+
+  // LRM 9.7 `resume`: leave the suspended state onto the waiting axis so the
+  // bridge that holds the engine can re-establish the leaf's pending wait or
+  // re-queue it. This settles the state axis only; scheduling stays with the
+  // bridge.
+  void MarkResumed();
+
   // True when no immediate child is still executing: the whole live set has
   // reached a terminal state, or there were none. Terminated children retained
   // for their own live descendants (LRM 9.6.3) do not count as live. This is
@@ -99,14 +161,48 @@ class RuntimeProcess : public std::enable_shared_from_this<RuntimeProcess> {
   // unlink and return that frame for scheduling; null otherwise.
   [[nodiscard]] auto TakeWaitForkWaiterIfSatisfied() -> CoroutineHandle;
 
-  // Terminates every descendant of this process -- not only its immediate
-  // children, and including the descendants of subprocesses that have already
-  // terminated (LRM 9.6.3). Nothing is retained afterward: the whole subtree
-  // has reached a terminal state, so releasing the lineage releases each
-  // descendant frame, and a released frame revokes every registration it still
-  // holds, so no queue, waiter list, or subscription can name it. This process
-  // itself keeps running.
-  void DisableDescendants();
+  // Bulk subtree termination (`kill` and `disable fork`) is one transactional
+  // mutation: dismantle the whole subtree, collecting each node's local wake
+  // effects into `woken`, while suppressing any intermediate parent-condition
+  // re-evaluation; the caller then stabilizes the surviving lineage boundary
+  // (the one parent whose child set shrank), re-evaluates its `wait fork`
+  // there, and only then publishes `woken` to the scheduler. No node is
+  // scheduled, and no parent predicate is republished, mid-dismantle -- so
+  // nothing runs while the topology is half-mutated. Anything added to the
+  // terminal transition must respect this: local effects collect here, boundary
+  // effects at the caller, publication last.
+  //
+  // Forcibly terminates every descendant of this process -- not only its
+  // immediate children, and including the descendants of subprocesses that have
+  // already terminated (LRM 9.6.3 `disable fork`). This process itself keeps
+  // running. Shares the kill primitive: each newly-terminated descendant is
+  // marked KILLED and its frame released, so no queue, waiter list, or
+  // subscription can name it, and every activation awaiting one is appended to
+  // `woken` for the caller to schedule. A descendant kept alive by a `process`
+  // handle survives as a parent-less terminal node reporting KILLED; the rest
+  // are reclaimed.
+  void DisableDescendants(std::vector<CoroutineHandle>& woken);
+
+  // Forcibly terminates this process and its whole subtree (LRM 9.7 `kill`):
+  // each node not already terminal is marked KILLED and its frame released, its
+  // await waiters are appended to `woken`, and the lineage links inside the
+  // subtree are severed so a handle-held node becomes a parent-less terminal
+  // orphan and the rest are reclaimed. On return this node is severed from its
+  // own children but still linked to its parent; the caller drops that link.
+  void TerminateSubtreeKilled(std::vector<CoroutineHandle>& woken);
+
+  // Whether `other` is this process or a descendant of it -- i.e. whether
+  // terminating this subtree would tear down `other`'s frame. `kill` consults
+  // it against the calling process to reject killing the running frame.
+  [[nodiscard]] auto IsSelfOrAncestorOf(const RuntimeProcess& other) const
+      -> bool;
+
+  // Unlinks this process from its parent's lineage, dropping the parent's
+  // ownership of it (a surviving `process` handle keeps the node alive as a
+  // parent-less orphan). A process with no parent is owned by its scope and is
+  // left in place. The caller must keep its own reference across the call, as
+  // the parent's may have been the last.
+  void DetachFromParent();
 
   // Releases `process`, whose body has just terminated, along with every
   // ancestor the release leaves with no lineage to retain, walking upward from
@@ -116,20 +212,37 @@ class RuntimeProcess : public std::enable_shared_from_this<RuntimeProcess> {
   static void ReleaseTerminatedLineage(RuntimeProcess& process);
 
  private:
-  // The sole writer of the terminal state, so a body can never be marked
-  // terminated while it still owns the frame it ran in.
-  void SettleTerminated();
+  // The one indivisible terminal transition, and the sole writer of the
+  // terminal state: a body can never be marked terminated while it still owns
+  // the frame it ran in, nor terminated without its own `await` waiters being
+  // extracted. Sets terminal state + cause, releases the frame (which revokes
+  // every registration it held), and drains this process's termination waiters
+  // into `woken`. Split-off variants that settle without draining are
+  // deliberately absent -- that separation was the footgun this primitive
+  // removes.
+  void SettleTerminated(
+      ProcessTerminationCause cause, std::vector<CoroutineHandle>& woken);
   [[nodiscard]] auto IsReleasable() const -> bool;
   void EraseChild(RuntimeProcess& child);
 
   ProcessKind kind_;
   Coroutine<void> coroutine_;
+  // The frame the engine will resume next for this process (invariant: a
+  // non-executing process has exactly one active leaf). Starts at the top frame
+  // and follows the innermost parked frame as waits block it.
+  CoroutineHandle current_leaf_ = nullptr;
   ProcessExecutionState execution_state_ = ProcessExecutionState::kCreated;
+  ProcessTerminationCause termination_cause_ =
+      ProcessTerminationCause::kCompleted;
   RuntimeProcess* parent_ = nullptr;
   std::vector<std::shared_ptr<RuntimeProcess>> children_;
   // The `wait fork` condition holds at most one activation: the frame that
   // executed `wait fork`.
   RegistrationList parked_wait_fork_;
+  // The `await` condition (LRM 9.7): every activation waiting for this process
+  // to terminate. Unlike `wait fork` it holds any number of waiters, drained
+  // when this process settles a terminal state.
+  RegistrationList terminated_waiters_;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -220,7 +220,7 @@ class Scope {
   // Filled during construction; scanned only at construction-time
   // resolution, never on the simulation path.
   std::vector<SignalEntry> signals_;
-  std::vector<std::unique_ptr<RuntimeProcess>> processes_;
+  std::vector<std::shared_ptr<RuntimeProcess>> processes_;
   // Empty std::function == clean slot; no parallel dirty bitmap needed.
   std::vector<std::function<void()>> observed_pending_;
 };

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -9,7 +9,9 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/pending_wait.hpp"
 #include "lyra/runtime/registration.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/trigger.hpp"
 #include "lyra/runtime/value_storage_core.hpp"
@@ -231,9 +233,9 @@ inline void SubscribeValueChange(
 // in `await_suspend`, where the frame that must be resumed is in hand: a wait
 // inside an enabled task has to resume the task's frame, not the enabling
 // process's, and only the language knows which frame is awaiting.
-class ValueChangeWaitAwaitable {
+class EventControlAwaitable : public PendingWait {
  public:
-  explicit ValueChangeWaitAwaitable(std::span<const Trigger> triggers)
+  explicit EventControlAwaitable(std::span<const Trigger> triggers)
       : triggers_(triggers.begin(), triggers.end()) {
   }
 
@@ -243,10 +245,23 @@ class ValueChangeWaitAwaitable {
 
   template <class P>
   void await_suspend(std::coroutine_handle<P> handle) {
-    SubscribeValueChange(&handle.promise(), triggers_);
+    CoroutineHandle token = &handle.promise();
+    SubscribeValueChange(token, triggers_);
+    token->process->BlockLeaf(token, this);
   }
 
   static void await_resume() noexcept {
+  }
+
+  // An edge / value-change is not a level: a change during suspension is missed
+  // (LRM 9.7 resensitize), so resume re-subscribes and waits for the next one.
+  // Re-subscribing needs no engine services, but the capability signature
+  // carries them uniformly.
+  // NOLINTNEXTLINE(readability-named-parameter)
+  auto Reestablish(RuntimeServices&, CoroutineHandle activation)
+      -> PendingWaitOutcome override {
+    SubscribeValueChange(activation, triggers_);
+    return PendingWaitOutcome::kReblocked;
   }
 
  private:
@@ -260,8 +275,8 @@ class ValueChangeWaitAwaitable {
 // ask the runtime which process is running.
 inline auto WaitAny(
     RuntimeServices&,  // NOLINT(readability-named-parameter)
-    std::span<const Trigger> triggers) -> ValueChangeWaitAwaitable {
-  return ValueChangeWaitAwaitable{triggers};
+    std::span<const Trigger> triggers) -> EventControlAwaitable {
+  return EventControlAwaitable{triggers};
 }
 
 // Builds the per-leaf classifier that the Observable invokes per waiter.

--- a/include/lyra/support/imported_runtime_class.hpp
+++ b/include/lyra/support/imported_runtime_class.hpp
@@ -23,6 +23,10 @@ auto ImportedRuntimeClassName(ImportedRuntimeClass klass) -> std::string_view;
 enum class ImportedRuntimeMethod : std::uint8_t {
   kProcessSelf,
   kProcessStatus,
+  kProcessKill,
+  kProcessAwait,
+  kProcessSuspend,
+  kProcessResume,
 };
 
 // The runtime-library function name a call to this method lowers to (the symbol
@@ -31,9 +35,17 @@ enum class ImportedRuntimeMethod : std::uint8_t {
 auto ImportedRuntimeMethodSymbol(ImportedRuntimeMethod method)
     -> std::string_view;
 
-// Whether the method is a static function reached without a receiver, so the
-// call threads the engine services handle rather than a receiver as its
-// leading argument (LRM 9.7 `process::self`).
-auto ImportedRuntimeMethodIsStatic(ImportedRuntimeMethod method) -> bool;
+// Whether the runtime symbol takes the engine services handle. Every method
+// needs it except `status`, a pure read of the process node: `self` and
+// `suspend` identify the calling process through it, while `kill`, `await`, and
+// `resume` reach the scheduler to wake, park, or re-schedule. It is threaded as
+// the leading argument for a receiver-less static call (`self`) and after the
+// receiver otherwise.
+auto ImportedRuntimeMethodTakesServices(ImportedRuntimeMethod method) -> bool;
+
+// Whether calling the method suspends the caller until the target settles, so
+// the statement lowering awaits it (LRM 9.7 `process::await` is the one
+// blocking method). The others return without suspending.
+auto ImportedRuntimeMethodSuspends(ImportedRuntimeMethod method) -> bool;
 
 }  // namespace lyra::support

--- a/include/lyra/support/imported_runtime_class.hpp
+++ b/include/lyra/support/imported_runtime_class.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace lyra::support {
+
+// A nominal class the runtime library defines once and every unit imports by
+// reference (LRM 9.7 `process` is the first). The identity names which library
+// class; the members, methods, and handle realization live in the runtime, not
+// in a per-unit declaration. Shared by HIR and MIR, like BuiltinFn.
+enum class ImportedRuntimeClass : std::uint8_t {
+  kProcess,
+};
+
+// The SystemVerilog source name of an imported runtime-library class.
+auto ImportedRuntimeClassName(ImportedRuntimeClass klass) -> std::string_view;
+
+// A method the runtime library provides for an imported class (LRM 9.7). The
+// implementation is a runtime symbol reached by a mechanical call, so the
+// identity is the flat closed namespace here, shared by HIR and MIR like
+// BuiltinFn -- no per-unit method declaration exists to name it.
+enum class ImportedRuntimeMethod : std::uint8_t {
+  kProcessSelf,
+  kProcessStatus,
+};
+
+// The runtime-library function name a call to this method lowers to (the symbol
+// under `lyra::runtime`). Kept in the support layer, not the backend, so the
+// backend renders the call mechanically without a per-method branch.
+auto ImportedRuntimeMethodSymbol(ImportedRuntimeMethod method)
+    -> std::string_view;
+
+// Whether the method is a static function reached without a receiver, so the
+// call threads the engine services handle rather than a receiver as its
+// leading argument (LRM 9.7 `process::self`).
+auto ImportedRuntimeMethodIsStatic(ImportedRuntimeMethod method) -> bool;
+
+}  // namespace lyra::support

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -511,6 +511,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/gc_ref.hpp\"\n";
   out += "#include \"lyra/runtime/named_event.hpp\"\n";
   out += "#include \"lyra/runtime/net.hpp\"\n";
+  out += "#include \"lyra/runtime/process_control.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
   out += "#include \"lyra/runtime/scope.hpp\"\n";
   out += "#include \"lyra/runtime/sim_time.hpp\"\n";

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -492,6 +492,19 @@ auto RenderDirectStaticCallableCall(
   return {.expr = callable.external.foreign_name, .leading_arg_count = 0};
 }
 
+// Renders a call to a method the runtime library provides for an imported class
+// (LRM 9.7 `process`). The callee is the runtime symbol named by the method
+// identity; every argument -- a receiver handle or the services handle -- is
+// passed positionally, so no leading argument is absorbed into the callee text.
+auto RenderDirectImportedRuntimeCall(
+    const mir::ImportedRuntimeCallTarget& target) -> CalleeRender {
+  return {
+      .expr = std::format(
+          "lyra::runtime::{}",
+          support::ImportedRuntimeMethodSymbol(target.method)),
+      .leading_arg_count = 0};
+}
+
 auto RenderCalleePart(
     const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
     -> CalleeRender {
@@ -510,6 +523,9 @@ auto RenderCalleePart(
                     },
                     [&](const mir::StaticCallableTarget& s) {
                       return RenderDirectStaticCallableCall(view, s);
+                    },
+                    [&](const mir::ImportedRuntimeCallTarget& i) {
+                      return RenderDirectImportedRuntimeCall(i);
                     },
                 },
                 d.target);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -228,6 +228,11 @@ class HirDumper {
               return std::format(
                   "ClassHandleType(class=Class[{}])", c.class_id.value);
             },
+            [](const ImportedClassHandleType& c) -> std::string {
+              return std::format(
+                  "ImportedClassHandleType(class={})",
+                  support::ImportedRuntimeClassName(c.klass));
+            },
             [](const NullType&) -> std::string { return "NullType"; },
             [](const VoidType&) -> std::string { return "VoidType"; },
         },
@@ -554,6 +559,14 @@ class HirDumper {
               return std::format(
                   "ForeignImport[{}](hops={}) \"{}\"", f.id.value, f.hops.value,
                   decl.name);
+            },
+            [](const ImportedMethodRef& i) -> std::string {
+              return std::format(
+                  "ImportedMethod \"{}\"{}",
+                  support::ImportedRuntimeMethodSymbol(i.method),
+                  i.receiver.has_value()
+                      ? std::format(" recv=Expr[{}]", i.receiver->value)
+                      : std::string{});
             },
         },
         callee);

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -58,6 +58,9 @@ auto Type::Kind() const -> TypeKind {
           [](const RealTimeType&) { return TypeKind::kRealTime; },
           [](const ChandleType&) { return TypeKind::kChandle; },
           [](const ClassHandleType&) { return TypeKind::kClassHandle; },
+          [](const ImportedClassHandleType&) {
+            return TypeKind::kImportedClassHandle;
+          },
           [](const NullType&) { return TypeKind::kNull; },
           [](const VoidType&) { return TypeKind::kVoid; },
       },
@@ -134,6 +137,7 @@ auto Type::IsValueChangeObservable() const -> bool {
     case TypeKind::kEvent:
     case TypeKind::kChandle:
     case TypeKind::kClassHandle:
+    case TypeKind::kImportedClassHandle:
     case TypeKind::kNull:
     case TypeKind::kVoid:
       return false;

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -9,7 +9,9 @@
 #include <variant>
 #include <vector>
 
+#include <slang/ast/Compilation.h>
 #include <slang/ast/Expression.h>
+#include <slang/ast/Scope.h>
 #include <slang/ast/SystemSubroutine.h>
 #include <slang/ast/expressions/AssignmentExpressions.h>
 #include <slang/ast/expressions/CallExpression.h>
@@ -56,6 +58,37 @@ auto MakeReturnConventionType(
       return builtins.realtime;
   }
   throw InternalError("MakeReturnConventionType: unknown ReturnConvention");
+}
+
+// A method of an imported runtime-library class (LRM 9.7 `process`) is
+// recognized by the declaring class being a member of the built-in `std`
+// package, exactly as the handle type is; the runtime provides the body, so the
+// call routes to the library symbol rather than a lowered user method.
+auto DetectImportedRuntimeMethod(const slang::ast::SubroutineSymbol& method)
+    -> std::optional<support::ImportedRuntimeMethod> {
+  const slang::ast::Scope* scope = method.getParentScope();
+  if (scope == nullptr) {
+    return std::nullopt;
+  }
+  const slang::ast::Symbol& owner = scope->asSymbol();
+  if (owner.kind != slang::ast::SymbolKind::ClassType) {
+    return std::nullopt;
+  }
+  const auto& cls = owner.as<slang::ast::ClassType>();
+  const slang::ast::Scope* class_scope = cls.getParentScope();
+  if (class_scope == nullptr ||
+      class_scope != static_cast<const slang::ast::Scope*>(
+                         &class_scope->getCompilation().getStdPackage()) ||
+      cls.name != "process") {
+    return std::nullopt;
+  }
+  if (method.name == "self") {
+    return support::ImportedRuntimeMethod::kProcessSelf;
+  }
+  if (method.name == "status") {
+    return support::ImportedRuntimeMethod::kProcessStatus;
+  }
+  return std::nullopt;
 }
 
 }  // namespace
@@ -420,6 +453,32 @@ auto LowerCallExpr(
   if (sym == nullptr) {
     throw InternalError(
         "AST->HIR call: user call missing resolved SubroutineSymbol");
+  }
+
+  // A method of an imported runtime-library class routes to the library symbol.
+  // A static method carries no receiver; an instance method lowers its handle,
+  // present in `thisClass`.
+  if (const auto imported = DetectImportedRuntimeMethod(*sym)) {
+    auto result_type = module.InternType(*call.type, span);
+    if (!result_type) return std::unexpected(std::move(result_type.error()));
+    std::optional<hir::ExprId> receiver;
+    if (const slang::ast::Expression* this_class = call.thisClass();
+        this_class != nullptr) {
+      auto receiver_or = lowerer.LowerExpr(*this_class, frame);
+      if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
+      receiver = frame.Exprs().Add(*std::move(receiver_or));
+    }
+    return hir::Expr{
+        .type = *result_type,
+        .data =
+            hir::CallExpr{
+                .callee =
+                    hir::ImportedMethodRef{
+                        .method = *imported, .receiver = receiver},
+                .arguments = std::move(arg_ids),
+            },
+        .span = span,
+    };
   }
 
   // An instance-method call (LRM 8.6) carries the receiver handle in

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -88,6 +88,18 @@ auto DetectImportedRuntimeMethod(const slang::ast::SubroutineSymbol& method)
   if (method.name == "status") {
     return support::ImportedRuntimeMethod::kProcessStatus;
   }
+  if (method.name == "kill") {
+    return support::ImportedRuntimeMethod::kProcessKill;
+  }
+  if (method.name == "await") {
+    return support::ImportedRuntimeMethod::kProcessAwait;
+  }
+  if (method.name == "suspend") {
+    return support::ImportedRuntimeMethod::kProcessSuspend;
+  }
+  if (method.name == "resume") {
+    return support::ImportedRuntimeMethod::kProcessResume;
+  }
   return std::nullopt;
 }
 
@@ -459,7 +471,7 @@ auto LowerCallExpr(
   // A static method carries no receiver; an instance method lowers its handle,
   // present in `thisClass`.
   if (const auto imported = DetectImportedRuntimeMethod(*sym)) {
-    auto result_type = module.InternType(*call.type, span);
+    auto result_type = unit_lowerer.InternType(*call.type, span);
     if (!result_type) return std::unexpected(std::move(result_type.error()));
     std::optional<hir::ExprId> receiver;
     if (const slang::ast::Expression* this_class = call.thisClass();

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -7,10 +7,13 @@
 #include <utility>
 #include <vector>
 
+#include <slang/ast/Compilation.h>
 #include <slang/ast/EvalContext.h>
 #include <slang/ast/Expression.h>
+#include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/ClassSymbols.h>
+#include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -35,6 +38,44 @@
 namespace lyra::lowering::ast_to_hir {
 
 namespace {
+
+// A class the runtime library defines and every unit imports by reference is a
+// direct member of the built-in `std` package (LRM 9.7 `process` is the first
+// Lyra supports). Keying on the declaring package plus the name -- rather than
+// a bare name match anywhere -- is what makes this the library declaration's
+// identity, not a user class that happens to be named `process`.
+auto DetectImportedRuntimeClass(const slang::ast::ClassType& cls)
+    -> std::optional<support::ImportedRuntimeClass> {
+  const slang::ast::Scope* scope = cls.getParentScope();
+  if (scope == nullptr) {
+    return std::nullopt;
+  }
+  const auto& std_package = scope->getCompilation().getStdPackage();
+  if (scope != static_cast<const slang::ast::Scope*>(&std_package)) {
+    return std::nullopt;
+  }
+  if (cls.name == "process") {
+    return support::ImportedRuntimeClass::kProcess;
+  }
+  return std::nullopt;
+}
+
+// An enum nested in an imported runtime class (LRM 9.7 `process::state`) is a
+// value the runtime returns and the program compares, with no unit-emitted enum
+// declaration behind it. It lowers to its underlying integral type.
+auto EnumBelongsToImportedRuntimeClass(const slang::ast::EnumType& enum_type)
+    -> bool {
+  const slang::ast::Scope* scope = enum_type.getParentScope();
+  if (scope == nullptr) {
+    return false;
+  }
+  const slang::ast::Symbol& owner = scope->asSymbol();
+  if (owner.kind != slang::ast::SymbolKind::ClassType) {
+    return false;
+  }
+  return DetectImportedRuntimeClass(owner.as<slang::ast::ClassType>())
+      .has_value();
+}
 
 auto LowerScalarAtom(slang::ast::ScalarType::Kind k) -> hir::BitAtom {
   switch (k) {
@@ -309,8 +350,11 @@ auto TranslateTypeData(
       return hir::TypeData{*std::move(pa)};
     }
     case slang::ast::SymbolKind::EnumType: {
-      auto e = LowerEnum(
-          canonical.as<slang::ast::EnumType>(), decl_span, unit_lowerer);
+      const auto& enum_type = canonical.as<slang::ast::EnumType>();
+      if (EnumBelongsToImportedRuntimeClass(enum_type)) {
+        return TranslateTypeData(unit_lowerer, enum_type.baseType, decl_span);
+      }
+      auto e = LowerEnum(enum_type, decl_span, unit_lowerer);
       if (!e.has_value()) {
         return std::unexpected(std::move(e.error()));
       }
@@ -337,8 +381,11 @@ auto TranslateTypeData(
     case slang::ast::SymbolKind::NullType:
       return hir::TypeData{hir::NullType{}};
     case slang::ast::SymbolKind::ClassType: {
-      auto class_id_or = unit_lowerer.InternClass(
-          canonical.as<slang::ast::ClassType>(), decl_span);
+      const auto& class_type = canonical.as<slang::ast::ClassType>();
+      if (const auto imported = DetectImportedRuntimeClass(class_type)) {
+        return hir::TypeData{hir::ImportedClassHandleType{.klass = *imported}};
+      }
+      auto class_id_or = unit_lowerer.InternClass(class_type, decl_span);
       if (!class_id_or) {
         return std::unexpected(std::move(class_id_or.error()));
       }

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -1144,10 +1144,11 @@ auto LowerForeignImportCall(
 
 // A call to a method the runtime library provides for an imported class (LRM
 // 9.7 `process`) lowers to a direct call on the library symbol. An instance
-// method passes its receiver handle as the leading argument; a static method
-// threads the engine services handle instead. The receiver is passed as the
-// managed handle itself, not a borrowed object pointer -- the runtime reads the
-// process identity from the handle.
+// method passes its receiver handle as the leading argument; whether the
+// engine services handle follows is a per-method fact. The receiver is passed
+// as the managed handle itself, not a borrowed object pointer -- the runtime
+// reads the process identity from the handle. A suspending method (`await`) is
+// wrapped in an await by the statement lowering, the same as a task enable.
 template <ExprLowerer Lowerer>
 auto LowerImportedMethodCall(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
@@ -1162,9 +1163,13 @@ auto LowerImportedMethodCall(
         lowerer.LowerExpr(lowerer.HirExprs().Get(*m.receiver), frame);
     if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
     args.push_back(block.exprs.Add(*std::move(receiver_or)));
-  } else if (support::ImportedRuntimeMethodIsStatic(m.method)) {
+  }
+  // A static method (no receiver) threads the services handle as its leading
+  // argument; an instance method threads it after the receiver when the method
+  // needs the engine -- to schedule, or to identify the calling process.
+  if (support::ImportedRuntimeMethodTakesServices(m.method)) {
     args.push_back(
-        block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame)));
+        block.exprs.Add(BuildServicesCallExpr(lowerer.Owner(), frame)));
   }
 
   for (const auto& arg : c.arguments) {

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -41,6 +41,7 @@
 #include "lyra/mir/foreign_export_wrapper.hpp"
 #include "lyra/mir/type.hpp"
 #include "lyra/support/builtin_fn.hpp"
+#include "lyra/support/imported_runtime_class.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -1141,6 +1142,52 @@ auto LowerForeignImportCall(
 
 }  // namespace
 
+// A call to a method the runtime library provides for an imported class (LRM
+// 9.7 `process`) lowers to a direct call on the library symbol. An instance
+// method passes its receiver handle as the leading argument; a static method
+// threads the engine services handle instead. The receiver is passed as the
+// managed handle itself, not a borrowed object pointer -- the runtime reads the
+// process identity from the handle.
+template <ExprLowerer Lowerer>
+auto LowerImportedMethodCall(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    const hir::ImportedMethodRef& m, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  auto& block = *frame.current_block;
+  std::vector<mir::ExprId> args;
+  args.reserve(c.arguments.size() + 1);
+
+  if (m.receiver.has_value()) {
+    auto receiver_or =
+        lowerer.LowerExpr(lowerer.HirExprs().Get(*m.receiver), frame);
+    if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
+    args.push_back(block.exprs.Add(*std::move(receiver_or)));
+  } else if (support::ImportedRuntimeMethodIsStatic(m.method)) {
+    args.push_back(
+        block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame)));
+  }
+
+  for (const auto& arg : c.arguments) {
+    if (!arg.has_value()) {
+      throw InternalError("LowerImportedMethodCall: argument elided");
+    }
+    auto arg_or = lowerer.LowerExpr(lowerer.HirExprs().Get(*arg), frame);
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    args.push_back(block.exprs.Add(*std::move(arg_or)));
+  }
+
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::Direct{
+                      .target =
+                          mir::ImportedRuntimeCallTarget{.method = m.method},
+                      .qualification = std::nullopt},
+              .arguments = std::move(args)},
+      .type = result_type};
+}
+
 template <ExprLowerer Lowerer>
 auto LowerHirCallExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
@@ -1176,6 +1223,9 @@ auto LowerHirCallExpr(
           },
           [&](const hir::ForeignImportRef& imp) -> diag::Result<mir::Expr> {
             return LowerForeignImportCall(lowerer, frame, c, imp, result_type);
+          },
+          [&](const hir::ImportedMethodRef& im) -> diag::Result<mir::Expr> {
+            return LowerImportedMethodCall(lowerer, frame, c, im, result_type);
           },
       },
       c.callee);

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -32,6 +32,7 @@
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/support/imported_runtime_class.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -467,6 +468,10 @@ auto LowerExprStmt(
           process.EnclosingScopeLowerer()
               .LookupHirSubroutine(struct_ref->hops, struct_ref->subroutine)
               .kind == hir::SubroutineKind::kTask;
+    } else if (
+        const auto* imported =
+            std::get_if<hir::ImportedMethodRef>(&call->callee)) {
+      suspends = support::ImportedRuntimeMethodSuspends(imported->method);
     }
     auto call_or = process.LowerExpr(inner, frame);
     if (!call_or) return std::unexpected(std::move(call_or.error()));

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -242,6 +242,12 @@ auto UnitLowerer::TranslateTypeData(const hir::TypeData& data) const
             return mir::ManagedRefType{
                 .pointee = ClassObjectType(src.class_id)};
           },
+          [&](const hir::ImportedClassHandleType& src) -> mir::TypeData {
+            // A handle to an imported runtime-library class is the same managed
+            // reference, its pointee the runtime-provided object type.
+            return mir::ManagedRefType{
+                .pointee = ImportedRuntimeObjectType(src.klass)};
+          },
           [](const hir::NullType&) -> mir::TypeData {
             // The `null` literal carries no class identity; it renders as a
             // null pointer that any handle absorbs, so MIR types it as the

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -207,6 +207,12 @@ auto LowerCallTarget(
                               s.slot);
                       return lir::CallTarget{lir::ForeignTarget{
                           .symbol = decl.external.foreign_name}};
+                    },
+                    [&](const mir::ImportedRuntimeCallTarget&)
+                        -> diag::Result<lir::CallTarget> {
+                      return Unsupported(
+                          "mir_to_lir: an imported runtime-library method call "
+                          "is not yet lowerable to LIR");
                     }},
                 d.target);
           },

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -511,6 +511,11 @@ class MirDumper {
                   s.owner.value, s.slot.value, callable.name,
                   callable.external.foreign_name);
             },
+            [](const ImportedRuntimeCallTarget& i) -> std::string {
+              return std::format(
+                  "imported_runtime=\"{}\"",
+                  support::ImportedRuntimeMethodSymbol(i.method));
+            },
         },
         target);
   }

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -76,6 +76,8 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
           HashField(seed, t.class_id.value);
         } else if constexpr (std::is_same_v<T, ExternalUnitObjectType>) {
           HashField(seed, t.unit_name);
+        } else if constexpr (std::is_same_v<T, ExternalClassType>) {
+          HashField(seed, t.qualified_name);
         } else if constexpr (std::is_same_v<T, MachineIntType>) {
           HashField(seed, t.bit_width);
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.signedness)));

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -368,7 +368,7 @@ void Engine::ScheduleAtTime(SimTime when, CoroutineHandle handle) {
 }
 
 void Engine::Spawn(Coroutine<void> coroutine) {
-  auto child = std::make_unique<RuntimeProcess>(
+  auto child = std::make_shared<RuntimeProcess>(
       ProcessKind::kSpawned, std::move(coroutine));
   const CoroutineHandle handle = child->TopHandle();
   execution_context_.CurrentProcess().AdoptChild(std::move(child));

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -167,9 +167,11 @@ void Engine::DrainRunnableQueue(RegistrationList& queue) {
   queue.SpliceBackOnto(queues_.draining);
   while (Registration* queued = queues_.draining.PopFront()) {
     CoroutineHandle handle = queued->activation;
-    // The activation is running, not waiting: it holds no membership until its
-    // body parks again.
+    // The activation is running, not waiting: it holds no membership and no
+    // pending wait until its body parks again (the wait that led here is
+    // consumed).
     handle->RevokeRegistrations();
+    handle->pending_wait = nullptr;
     RunProcess(handle);
   }
 }
@@ -231,7 +233,11 @@ void Engine::ExecuteFinalProcesses() {
   while (Registration* queued = queues_.finals.PopFront()) {
     CoroutineHandle handle = queued->activation;
     handle->RevokeRegistrations();
-    const bool completed = ResumeProcess(handle);
+    // A `final` block is never an `await` target (LRM 9.7 restricts targets to
+    // initial / always / fork), so its terminal transition drains no waiters;
+    // the collector stays empty.
+    std::vector<CoroutineHandle> woken;
+    const bool completed = ResumeProcess(handle, woken);
     if (completed) {
       continue;
     }
@@ -292,12 +298,14 @@ auto Engine::IsRunnablePhase() const -> bool {
          phase_ == SchedulerPhase::kReactive;
 }
 
-auto Engine::ResumeProcess(CoroutineHandle handle) -> bool {
+auto Engine::ResumeProcess(
+    CoroutineHandle handle, std::vector<CoroutineHandle>& woken) -> bool {
   // Capture the owning process before resuming, since `handle` may be an
   // enabled task's frame that is destroyed as control returns up the enable
-  // chain.
+  // chain. On completion the terminal transition drains the process's own
+  // `await` waiters into `woken` atomically.
   RuntimeProcess& process = handle->Process();
-  return process.ResumeWith(execution_context_, handle);
+  return process.ResumeWith(execution_context_, handle, woken);
 }
 
 void Engine::RunProcess(CoroutineHandle handle) {
@@ -312,16 +320,22 @@ void Engine::RunProcess(CoroutineHandle handle) {
   // No wait dispatch: each awaitable has already arranged its own wakeup path
   // during await_suspend.
   RuntimeProcess& process = handle->Process();
-  if (!ResumeProcess(handle)) {
+  std::vector<CoroutineHandle> woken;
+  if (!ResumeProcess(handle, woken)) {
     return;
   }
-  // A terminating process is the last live child its parent was waiting on iff
-  // the parent's `wait fork` condition now holds (LRM 9.6.1); wake the parked
-  // waiter before releasing, while the just-terminated node is still linked.
+  // Terminal transition already settled the process and drained its own `await`
+  // waiters into `woken` (LRM 9.7) atomically. Add the surviving-boundary
+  // effect -- the parent's `wait fork` waiter if this was the last live child
+  // (LRM 9.6.1) -- while the node is still linked, then schedule. The
+  // activation layer names who became runnable; the engine schedules.
   if (RuntimeProcess* parent = process.Parent(); parent != nullptr) {
     if (CoroutineHandle waiter = parent->TakeWaitForkWaiterIfSatisfied()) {
-      ScheduleNextDelta(waiter);
+      woken.push_back(waiter);
     }
+  }
+  for (CoroutineHandle waiter : woken) {
+    ScheduleNextDelta(waiter);
   }
   // Releasing destroys `process` and every ancestor the release leaves with no
   // lineage to retain, so no statement may follow it here.
@@ -358,8 +372,11 @@ void Engine::ScheduleNextDelta(CoroutineHandle handle) {
   // Every satisfied wait comes back through this verb, so it is also where the
   // wait ends: the activation is runnable now, and nothing it was parked on --
   // the sibling observables of an `@(a or b)`, the event it waited for -- may
-  // fire it a second time.
+  // fire it a second time. The pending wait is consumed here too, so a suspend
+  // in the woken-but-not-yet-resumed window saves a runnable disposition (a
+  // re-queue on resume), not a blocked one (a re-establish).
   handle->RevokeRegistrations();
+  handle->pending_wait = nullptr;
   handle->Park(queues_.next_delta);
 }
 

--- a/src/lyra/runtime/runtime_process.cpp
+++ b/src/lyra/runtime/runtime_process.cpp
@@ -1,5 +1,6 @@
 #include "lyra/runtime/runtime_process.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <exception>
 #include <memory>
@@ -37,12 +38,9 @@ void RuntimeProcess::ArmWaitFork(CoroutineHandle waiter) {
 }
 
 auto RuntimeProcess::HasNoLiveChild() const -> bool {
-  for (const auto& child : children_) {
-    if (child->execution_state_ != ProcessExecutionState::kTerminated) {
-      return false;
-    }
-  }
-  return true;
+  return std::ranges::all_of(children_, [](const auto& child) {
+    return child->execution_state_ == ProcessExecutionState::kTerminated;
+  });
 }
 
 auto RuntimeProcess::TakeWaitForkWaiterIfSatisfied() -> CoroutineHandle {
@@ -62,14 +60,14 @@ auto RuntimeProcess::IsReleasable() const -> bool {
          children_.empty();
 }
 
-void RuntimeProcess::AdoptChild(std::unique_ptr<RuntimeProcess> child) {
+void RuntimeProcess::AdoptChild(std::shared_ptr<RuntimeProcess> child) {
   child->parent_ = this;
   children_.push_back(std::move(child));
 }
 
 void RuntimeProcess::EraseChild(RuntimeProcess& child) {
   const std::size_t erased = std::erase_if(
-      children_, [&](const std::unique_ptr<RuntimeProcess>& node) {
+      children_, [&](const std::shared_ptr<RuntimeProcess>& node) {
         return node.get() == &child;
       });
   if (erased != 1) {

--- a/src/lyra/runtime/runtime_process.cpp
+++ b/src/lyra/runtime/runtime_process.cpp
@@ -15,7 +15,11 @@
 namespace lyra::runtime {
 
 RuntimeProcess::RuntimeProcess(ProcessKind kind, Coroutine<void> coroutine)
-    : kind_(kind), coroutine_(std::move(coroutine)) {
+    : kind_(kind),
+      coroutine_(std::move(coroutine)),
+      // Before the body runs, the top frame is the active leaf (what the engine
+      // schedules to start the process); a wait moves the leaf inward.
+      current_leaf_(coroutine_.Token()) {
   // Wire the promise's back-pointer so coroutine-side code (awaitables)
   // can recover the RuntimeProcess identity from within await_suspend.
   coroutine_.BindProcess(*this);
@@ -37,6 +41,28 @@ void RuntimeProcess::ArmWaitFork(CoroutineHandle waiter) {
   waiter->Park(parked_wait_fork_);
 }
 
+void RuntimeProcess::ArmTerminatedWaiter(CoroutineHandle waiter) {
+  waiter->Park(terminated_waiters_);
+}
+
+void RuntimeProcess::Suspend() {
+  if (execution_state_ == ProcessExecutionState::kSuspended ||
+      execution_state_ == ProcessExecutionState::kTerminated) {
+    return;
+  }
+  // Detach the leaf from whatever holds it -- a wait target (desensitize) or a
+  // run queue (dequeue). Its pending wait, if any, is a separate member and
+  // stays: it is the saved blocked disposition resume re-establishes.
+  if (current_leaf_ != nullptr) {
+    current_leaf_->RevokeRegistrations();
+  }
+  execution_state_ = ProcessExecutionState::kSuspended;
+}
+
+void RuntimeProcess::MarkResumed() {
+  execution_state_ = ProcessExecutionState::kWaiting;
+}
+
 auto RuntimeProcess::HasNoLiveChild() const -> bool {
   return std::ranges::all_of(children_, [](const auto& child) {
     return child->execution_state_ == ProcessExecutionState::kTerminated;
@@ -51,8 +77,43 @@ auto RuntimeProcess::TakeWaitForkWaiterIfSatisfied() -> CoroutineHandle {
   return waiter != nullptr ? waiter->activation : nullptr;
 }
 
-void RuntimeProcess::DisableDescendants() {
+void RuntimeProcess::DisableDescendants(std::vector<CoroutineHandle>& woken) {
+  for (const std::shared_ptr<RuntimeProcess>& child : children_) {
+    // Sever the upward link before the recursion severs the downward ones, so a
+    // handle-held child left behind by the clear below is a parent-less orphan
+    // rather than a node pointing into freed storage.
+    child->parent_ = nullptr;
+    child->TerminateSubtreeKilled(woken);
+  }
   children_.clear();
+}
+
+void RuntimeProcess::TerminateSubtreeKilled(
+    std::vector<CoroutineHandle>& woken) {
+  DisableDescendants(woken);
+  if (execution_state_ != ProcessExecutionState::kTerminated) {
+    SettleTerminated(ProcessTerminationCause::kKilled, woken);
+  }
+}
+
+auto RuntimeProcess::IsSelfOrAncestorOf(const RuntimeProcess& other) const
+    -> bool {
+  for (const RuntimeProcess* node = &other; node != nullptr;
+       node = node->parent_) {
+    if (node == this) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void RuntimeProcess::DetachFromParent() {
+  if (parent_ == nullptr) {
+    return;
+  }
+  RuntimeProcess* parent = parent_;
+  parent_ = nullptr;
+  parent->EraseChild(*this);
 }
 
 auto RuntimeProcess::IsReleasable() const -> bool {
@@ -84,18 +145,29 @@ void RuntimeProcess::ReleaseTerminatedLineage(RuntimeProcess& process) {
   }
 }
 
-void RuntimeProcess::SettleTerminated() {
+void RuntimeProcess::SettleTerminated(
+    ProcessTerminationCause cause, std::vector<CoroutineHandle>& woken) {
   execution_state_ = ProcessExecutionState::kTerminated;
-  // The frame is parked at its final suspend point and holds the only copies of
-  // this activation's automatic storage, so it is released with the terminal
-  // state rather than pinned for as long as the node lives. A branch this body
-  // spawned may still be running, which is why the node itself stays (LRM
-  // 9.6.3).
+  termination_cause_ = cause;
+  // The frame is parked at its final suspend point (normal completion) or at
+  // some blocking point (a kill), and holds the only copies of this
+  // activation's automatic storage, so it is released with the terminal state
+  // rather than pinned for as long as the node lives. Releasing it destroys the
+  // frame, which revokes every registration it held -- so a killed process,
+  // parked anywhere, is left unable to resume. A branch this body spawned may
+  // still be running, which is why the node itself stays (LRM 9.6.3).
   coroutine_ = Coroutine<void>{};
+  // Settling and draining the `await` waiters are one step: a process reaching
+  // terminal always hands its waiters to `woken` in the same primitive, so no
+  // terminal path can leave an awaiter parked forever (LRM 9.7).
+  while (Registration* waiter = terminated_waiters_.PopFront()) {
+    woken.push_back(waiter->activation);
+  }
 }
 
 auto RuntimeProcess::ResumeWith(
-    ExecutionContext& context, CoroutineHandle handle) -> bool {
+    ExecutionContext& context, CoroutineHandle handle,
+    std::vector<CoroutineHandle>& woken) -> bool {
   if (execution_state_ == ProcessExecutionState::kTerminated) {
     throw InternalError(
         "RuntimeProcess::ResumeWith: cannot resume terminated process");
@@ -117,7 +189,7 @@ auto RuntimeProcess::ResumeWith(
   // the frame so a faulted process reaches its terminal state and frees its
   // frame on the same path a successful one does, then re-raise it.
   std::exception_ptr fault = coroutine_.Handle().promise().TakeFault();
-  SettleTerminated();
+  SettleTerminated(ProcessTerminationCause::kCompleted, woken);
   if (fault) {
     std::rethrow_exception(fault);
   }

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -190,13 +190,13 @@ auto Scope::Services() -> RuntimeServices& {
 
 void Scope::RegisterInitial(Coroutine<void> coroutine) {
   processes_.push_back(
-      std::make_unique<RuntimeProcess>(
+      std::make_shared<RuntimeProcess>(
           ProcessKind::kInitial, std::move(coroutine)));
 }
 
 void Scope::RegisterFinal(Coroutine<void> coroutine) {
   processes_.push_back(
-      std::make_unique<RuntimeProcess>(
+      std::make_shared<RuntimeProcess>(
           ProcessKind::kFinal, std::move(coroutine)));
 }
 

--- a/src/lyra/support/imported_runtime_class.cpp
+++ b/src/lyra/support/imported_runtime_class.cpp
@@ -21,18 +21,44 @@ auto ImportedRuntimeMethodSymbol(ImportedRuntimeMethod method)
       return "ProcessSelf";
     case ImportedRuntimeMethod::kProcessStatus:
       return "ProcessStatus";
+    case ImportedRuntimeMethod::kProcessKill:
+      return "ProcessKill";
+    case ImportedRuntimeMethod::kProcessAwait:
+      return "ProcessAwait";
+    case ImportedRuntimeMethod::kProcessSuspend:
+      return "ProcessSuspend";
+    case ImportedRuntimeMethod::kProcessResume:
+      return "ProcessResume";
   }
   throw InternalError("ImportedRuntimeMethodSymbol: unknown method");
 }
 
-auto ImportedRuntimeMethodIsStatic(ImportedRuntimeMethod method) -> bool {
+auto ImportedRuntimeMethodTakesServices(ImportedRuntimeMethod method) -> bool {
   switch (method) {
     case ImportedRuntimeMethod::kProcessSelf:
+    case ImportedRuntimeMethod::kProcessKill:
+    case ImportedRuntimeMethod::kProcessAwait:
+    case ImportedRuntimeMethod::kProcessSuspend:
+    case ImportedRuntimeMethod::kProcessResume:
       return true;
     case ImportedRuntimeMethod::kProcessStatus:
       return false;
   }
-  throw InternalError("ImportedRuntimeMethodIsStatic: unknown method");
+  throw InternalError("ImportedRuntimeMethodTakesServices: unknown method");
+}
+
+auto ImportedRuntimeMethodSuspends(ImportedRuntimeMethod method) -> bool {
+  switch (method) {
+    case ImportedRuntimeMethod::kProcessAwait:
+      return true;
+    case ImportedRuntimeMethod::kProcessSelf:
+    case ImportedRuntimeMethod::kProcessStatus:
+    case ImportedRuntimeMethod::kProcessKill:
+    case ImportedRuntimeMethod::kProcessSuspend:
+    case ImportedRuntimeMethod::kProcessResume:
+      return false;
+  }
+  throw InternalError("ImportedRuntimeMethodSuspends: unknown method");
 }
 
 }  // namespace lyra::support

--- a/src/lyra/support/imported_runtime_class.cpp
+++ b/src/lyra/support/imported_runtime_class.cpp
@@ -1,0 +1,38 @@
+#include "lyra/support/imported_runtime_class.hpp"
+
+#include <string_view>
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::support {
+
+auto ImportedRuntimeClassName(ImportedRuntimeClass klass) -> std::string_view {
+  switch (klass) {
+    case ImportedRuntimeClass::kProcess:
+      return "process";
+  }
+  throw InternalError("ImportedRuntimeClassName: unknown imported class");
+}
+
+auto ImportedRuntimeMethodSymbol(ImportedRuntimeMethod method)
+    -> std::string_view {
+  switch (method) {
+    case ImportedRuntimeMethod::kProcessSelf:
+      return "ProcessSelf";
+    case ImportedRuntimeMethod::kProcessStatus:
+      return "ProcessStatus";
+  }
+  throw InternalError("ImportedRuntimeMethodSymbol: unknown method");
+}
+
+auto ImportedRuntimeMethodIsStatic(ImportedRuntimeMethod method) -> bool {
+  switch (method) {
+    case ImportedRuntimeMethod::kProcessSelf:
+      return true;
+    case ImportedRuntimeMethod::kProcessStatus:
+      return false;
+  }
+  throw InternalError("ImportedRuntimeMethodIsStatic: unknown method");
+}
+
+}  // namespace lyra::support

--- a/tests/cases/cpp/process_await_killed/case.yaml
+++ b/tests/cases/cpp/process_await_killed/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.process_await_killed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    awaiter_woke: 1
+    killed_seen: 1

--- a/tests/cases/cpp/process_await_killed/main.sv
+++ b/tests/cases/cpp/process_await_killed/main.sv
@@ -1,0 +1,33 @@
+`timescale 1ns / 1ns
+module Test;
+  // LRM 9.7 `await()` observes a forceful termination, not only a normal one:
+  // one process awaits a worker while a third process kills it. The awaiter
+  // resumes when the kill settles and observes the worker as KILLED. This is
+  // the path where cancellation acquires a reader -- a settled terminal state
+  // read through a surviving handle.
+  int awaiter_woke;
+  int killed_seen;
+
+  process worker;
+
+  initial begin
+    fork
+      begin
+        worker = process::self();
+        #100;
+      end
+    join_none
+  end
+
+  initial begin
+    #1;
+    worker.await();
+    awaiter_woke = 1;
+    killed_seen = (worker.status() == process::KILLED);
+  end
+
+  initial begin
+    #2;
+    worker.kill();
+  end
+endmodule

--- a/tests/cases/cpp/process_disable_fork_killed/case.yaml
+++ b/tests/cases/cpp/process_disable_fork_killed/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.process_disable_fork_killed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    killed_seen: 1

--- a/tests/cases/cpp/process_disable_fork_killed/main.sv
+++ b/tests/cases/cpp/process_disable_fork_killed/main.sv
@@ -1,0 +1,24 @@
+`timescale 1ns / 1ns
+module Test;
+  // LRM 9.6.3 `disable fork` and LRM 9.7 `status()` together: a descendant
+  // terminated by `disable fork` reports KILLED through a handle that outlives
+  // it. `disable fork` and `kill` funnel through the same terminal transition,
+  // so the disabled descendant is marked KILLED exactly as a killed one is,
+  // and a surviving handle still reads that state.
+  int killed_seen;
+
+  process child;
+
+  initial begin
+    fork
+      begin
+        child = process::self();
+        #100;
+      end
+    join_none
+
+    #1;
+    disable fork;
+    killed_seen = (child.status() == process::KILLED);
+  end
+endmodule

--- a/tests/cases/cpp/process_kill_await/case.yaml
+++ b/tests/cases/cpp/process_kill_await/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.process_kill_await
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    killed_ok: 1
+    await_ordered: 1
+    finished_ok: 1

--- a/tests/cases/cpp/process_kill_await/main.sv
+++ b/tests/cases/cpp/process_kill_await/main.sv
@@ -1,0 +1,38 @@
+`timescale 1ns / 1ns
+module Test;
+  // LRM 9.7 fine-grain process control: `kill()` forcibly terminates a process
+  // (reported KILLED and removed from every wait it was parked on), and
+  // `await()` suspends the caller until a process terminates normally
+  // (reported FINISHED). One process forks two workers -- a long-lived one it
+  // kills while parked, and a short one it awaits.
+  int killed_ok;
+  int await_ordered;
+  int finished_ok;
+
+  process slow;
+  process quick;
+  int quick_marker;
+
+  initial begin
+    fork
+      begin
+        slow = process::self();
+        #100;
+      end
+      begin
+        quick = process::self();
+        #10;
+        quick_marker = 7;
+      end
+    join_none
+
+    #1;
+
+    slow.kill();
+    killed_ok = (slow.status() == process::KILLED);
+
+    quick.await();
+    await_ordered = (quick_marker == 7);
+    finished_ok = (quick.status() == process::FINISHED);
+  end
+endmodule

--- a/tests/cases/cpp/process_self_status/case.yaml
+++ b/tests/cases/cpp/process_self_status/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.process_self_status
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    running_self: 1
+    same_handle: 1

--- a/tests/cases/cpp/process_self_status/main.sv
+++ b/tests/cases/cpp/process_self_status/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  // LRM 9.7 fine-grain process control, Cut 1: `process::self()` returns a
+  // handle to the calling process, and `status()` reports its state. A process
+  // reading its own status while executing observes RUNNING, and two `self()`
+  // calls from the same process name the same process.
+  process p;
+  bit running_self;
+  bit same_handle;
+  initial begin
+    p = process::self();
+    running_self = (p.status() == process::RUNNING);
+    same_handle = (process::self() == p);
+  end
+endmodule

--- a/tests/cases/cpp/process_suspend_edge_miss/case.yaml
+++ b/tests/cases/cpp/process_suspend_edge_miss/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.process_suspend_edge_miss
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    suspended_seen: 1
+    woke_count: 1

--- a/tests/cases/cpp/process_suspend_edge_miss/main.sv
+++ b/tests/cases/cpp/process_suspend_edge_miss/main.sv
@@ -1,0 +1,36 @@
+`timescale 1ns / 1ns
+module Test;
+  // LRM 9.7 `suspend()` desensitizes a process waiting on an event: an edge that
+  // occurs while it is suspended is missed, and `resume()` re-sensitizes it so
+  // it wakes only on the next edge. The posedge at t=2 (suspended) is missed;
+  // only the posedge at t=4 (after resume) is counted.
+  bit sig;
+  int woke_count;
+  int suspended_seen;
+
+  process worker;
+
+  initial begin
+    sig = 0;
+    fork
+      begin
+        worker = process::self();
+        forever begin
+          @(posedge sig);
+          woke_count = woke_count + 1;
+        end
+      end
+    join_none
+
+    #1;
+    worker.suspend();
+    suspended_seen = (worker.status() == process::SUSPENDED);
+
+    #1 sig = 1;
+    #1 sig = 0;
+    worker.resume();
+
+    #1 sig = 1;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/process_suspend_resume/case.yaml
+++ b/tests/cases/cpp/process_suspend_resume/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.process_suspend_resume
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    suspended_seen: 1
+    not_progressed: 1
+    resumed_ran: 1

--- a/tests/cases/cpp/process_suspend_resume/main.sv
+++ b/tests/cases/cpp/process_suspend_resume/main.sv
@@ -1,0 +1,34 @@
+`timescale 1ns / 1ns
+module Test;
+  // LRM 9.7 `suspend()` / `resume()`: pausing a process desensitizes it to the
+  // delay it is blocked on (it does not advance while suspended), `status()`
+  // reports SUSPENDED, and resuming a process whose absolute delay has already
+  // transpired makes it runnable at once.
+  int suspended_seen;
+  int not_progressed;
+  int resumed_ran;
+
+  process worker;
+  int marker;
+
+  initial begin
+    fork
+      begin
+        worker = process::self();
+        #50;
+        marker = 7;
+      end
+    join_none
+
+    #1;
+    worker.suspend();
+    suspended_seen = (worker.status() == process::SUSPENDED);
+
+    #100;
+    not_progressed = (marker == 0);
+
+    worker.resume();
+    #1;
+    resumed_ran = (marker == 7);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements LRM 9.7 fine-grain process control on the C++ coroutine backend: `process::self`, `status`, `kill`, `await`, `suspend`, and `resume`. `std::process` is recognized as an imported runtime-library class whose handle is a managed reference to a fixed runtime object type, and its methods lower to mechanical runtime-symbol calls. `kill` terminates a process and its descendants, `await` parks the caller until a target settles, and `suspend`/`resume` desensitize and re-sensitize a process so edges arriving during suspension are missed per the resensitize semantics.

## Design

The activation gains a single authoritative disposition (Executing, Runnable, Blocked, Suspended, Terminal) rather than inferring its participation from scattered state. A wait is modeled as a retainable pending capability that is distinct from its registration: the registration is the activation's current enrollment in a target, while the pending wait is the uniform ability to re-establish that wait and report whether it is already satisfied. Every suspending construct supplies this capability the same way, so the scheduler never branches on a wait-kind taxonomy. Suspension saves the disposition the activation held before it was suspended, and resume re-establishes the wait. Termination is unified through a single settle path so `kill` and `disable fork` both converge on the KILLED outcome and drain awaiters atomically. The rationale, along with the rejected alternatives (a central wait-kind taxonomy, a `Runnable(region)` encoding, and mirroring the wait's state), is recorded in `docs/decisions/activation-disposition.md`.

## Testing

`bazel test //...` passes. New cases cover kill/await ordering, awaiting an already-killed process, `disable fork` settling branches as KILLED, suspend/resume round-trips, and edge-miss during suspension.
