### PR TITLE
Lower SV super.method() and base-constructor chaining

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -79,9 +79,13 @@ each stage establishes, not how.
       signatures. A handle whose static type is a base but whose dynamic type is a derived resolves
       the call to the derived's implementation.
 
-- [ ] `super` reference and the base-constructor call: an override body reaches its base-class
+- [x] `super` reference and the base-constructor call: an override body reaches its base-class
       implementation by name-independent reference, and a constructor forwards to the base's
-      construction as its first act (LRM 8.7).
+      construction as its first act (LRM 8.7). The super qualifier is stated at the call site as a
+      call-side fact independent of the callee's virtual role; the base-constructor call is stated
+      on the class's construction protocol, present whenever the class extends a base -- explicit
+      when the source wrote `super.new(args)`, an empty-args implicit forward otherwise -- so a
+      backend never resorts to its target language's default-construction convention.
 
 - [ ] Pure-virtual and abstract classes (LRM 8.21): a virtual method with no body is a contract the
       derived must fill, and a class carrying such a slot is not directly constructible.

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -26,6 +26,18 @@ struct ClassField {
   std::optional<ExprId> initializer;
 };
 
+// A construction-protocol fact (LRM 8.7): the arguments to forward to the
+// base class's constructor before this class's own body runs. Its expressions
+// live in the enclosing constructor body's expression arena, so a captured
+// argument that reads a formal parameter reaches the same procedural var the
+// body would. Absent means the source did not write an explicit `super.new`;
+// with a base present, HIR-to-MIR still emits a stated base call (LRM 8.7
+// implicit `super.new()`) so the ordering is never left to a backend
+// convention. Empty (0-arg) means the source wrote `super.new()` explicitly.
+struct BaseCall {
+  std::vector<ExprId> arguments;
+};
+
 // A SystemVerilog class declaration (LRM 8). The class's properties and its
 // instance methods; references to a class name resolve to this declaration's
 // id. A class is reached through a handle, so it carries no structural
@@ -41,12 +53,18 @@ struct ClassField {
 // synthesized empty constructor, matching the implicit `new` the LRM provides
 // when the source omits one. Property initializers are evaluated as part of
 // its execution, so their expressions live in its body's expression arena.
+//
+// `base_call` peers with `constructor` because base-constructor forwarding is
+// a class-level construction fact, not a statement inside the ctor body
+// (LRM 8.7): source-written `super.new(args)` populates it, and any expression
+// referencing the ctor's own formals lives in the same body arena.
 struct ClassDecl {
   std::string name;
   std::optional<ClassId> base;
   std::vector<ClassField> fields;
   base::Arena<SubroutineDecl, MethodId> methods;
   SubroutineDecl constructor;
+  std::optional<BaseCall> base_call;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -31,12 +31,39 @@ struct ForeignImportRef {
   ForeignImportId id;
 };
 
-// Calls an instance method (LRM 8.6) on `receiver`, an expression yielding the
-// class handle the call dispatches through. `class_id` names the declaring
-// class and `method` is the method's declaration-order position in that
-// class's HIR method arena.
+// The receiver form of an instance-method call (LRM 8.6, 8.15). The three
+// SV source spellings each map to one arm; none combines with another.
+//
+// - `HandleReceiver` -- LRM 8.6 qualified `h.foo()`: the source supplied a
+//   class-handle expression the call dispatches through, and the call obeys
+//   the callee's own virtual role.
+// - `ImplicitSelfReceiver` -- LRM 8.6 unqualified `foo()` from inside a
+//   class method: the receiver is the enclosing method's own self, and the
+//   call obeys the callee's virtual role.
+// - `SuperReceiver` -- LRM 8.15 `super.foo()`: the receiver is still the
+//   enclosing method's self, but the source demands the base's
+//   implementation and the call must skip dynamic dispatch regardless of
+//   whether the target is virtual.
+//
+// The three arms are structurally disjoint because "receiver source" and
+// "dispatch qualifier" are not independent axes -- a super-qualified call is
+// never through an explicit handle, so encoding them as a receiver-optional
+// plus a super-flag would admit an invalid state.
+struct HandleReceiver {
+  ExprId expr;
+};
+struct ImplicitSelfReceiver {};
+struct SuperReceiver {};
+
+using MethodReceiver =
+    std::variant<HandleReceiver, ImplicitSelfReceiver, SuperReceiver>;
+
+// Calls an instance method (LRM 8.6). `class_id` names the declaring class
+// and `method` is the method's declaration-order position in that class's HIR
+// method arena. `receiver` states which of the three LRM-defined source
+// forms reached this call site.
 struct MethodCallRef {
-  ExprId receiver;
+  MethodReceiver receiver;
   ClassId class_id;
   MethodId method;
 };

--- a/include/lyra/lowering/ast_to_hir/process_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/process_lowerer.hpp
@@ -24,6 +24,17 @@
 
 namespace lyra::lowering::ast_to_hir {
 
+// A set of slang AST expressions the frontend exposes twice -- once as a
+// class- or scope-level semantic fact (which an enclosing lowering has
+// already consumed) and once as syntactic residue inside a subroutine body's
+// statement list. The body walker elides the residue by matching pointer
+// identity, so the two exposures resolve to one HIR representation without
+// any per-kind knowledge of which SV construct the node names. The single
+// current user is `super.new(...)` (LRM 8.7), lifted from the ctor body
+// onto its class's construction protocol.
+using ConsumedBodyExpressions =
+    std::unordered_set<const slang::ast::Expression*>;
+
 // Per-process-body lowerer: walks a slang procedural block or subroutine body
 // into a hir::ProceduralBody. Constructed once per process / subroutine; runs
 // once via Run for a procedural block, or used as a helper for subroutine
@@ -33,7 +44,8 @@ namespace lyra::lowering::ast_to_hir {
 class ProcessLowerer {
  public:
   ProcessLowerer(
-      UnitLowerer& unit_lowerer, const slang::ast::Symbol& containing_symbol);
+      UnitLowerer& unit_lowerer, const slang::ast::Symbol& containing_symbol,
+      ConsumedBodyExpressions consumed_body_exprs = {});
 
   // Lowers a procedural block to a complete hir::Process (initial / final /
   // always / always_comb / always_latch / always_ff). Stack-allocates the
@@ -74,6 +86,15 @@ class ProcessLowerer {
     return *containing_symbol_;
   }
 
+  // Slang AST expressions the enclosing lowering has already consumed as a
+  // higher-level semantic fact; the body walker elides any statement whose
+  // whole expression matches by pointer identity. Empty for a walk with
+  // no consumed residues.
+  [[nodiscard]] auto ConsumedBodyExprs() const
+      -> const ConsumedBodyExpressions& {
+    return consumed_body_exprs_;
+  }
+
   // Walker entries used by helper passes inside this layer.
   auto LowerExpr(const slang::ast::Expression& expr, WalkFrame frame)
       -> diag::Result<hir::Expr>;
@@ -91,6 +112,7 @@ class ProcessLowerer {
   // Facts.
   UnitLowerer* owner_;
   const slang::ast::Symbol* containing_symbol_;
+  ConsumedBodyExpressions consumed_body_exprs_;
 
   // Registry.
   std::unordered_map<const slang::ast::VariableSymbol*, hir::ProceduralVarId>

--- a/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
+++ b/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
+#include <optional>
 #include <string_view>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/class_decl.hpp"
 #include "lyra/hir/foreign_export.hpp"
 #include "lyra/hir/foreign_import.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
+class Expression;
 class SubroutineSymbol;
 }  // namespace slang::ast
 
@@ -26,6 +29,25 @@ class UnitLowerer;
 auto LowerSubroutineDecl(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
     WalkFrame frame) -> diag::Result<hir::SubroutineDecl>;
+
+// Lowers a class constructor (LRM 8.7) into its callable and its optional
+// base-construction call as one operation. The base-call is here rather than
+// on the caller because its arguments evaluate in the constructor's own
+// binding frame -- a formal parameter reference in `super.new(a)` must resolve
+// to the same procedural var the body would read -- and only the subroutine
+// lowerer holds that frame while the body lowers. `base_call_ast`, when
+// present, is the slang `NewClassExpression` returned by
+// `ClassType::getBaseConstructorCall()`; the caller retrieves it once and
+// hands it in here.
+struct ConstructorAndBaseCall {
+  hir::SubroutineDecl constructor;
+  std::optional<hir::BaseCall> base_call;
+};
+
+auto LowerConstructorDecl(
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
+    WalkFrame frame, const slang::ast::Expression* base_call_ast)
+    -> diag::Result<ConstructorAndBaseCall>;
 
 // Lowers a slang `import "DPI-C"` subroutine (LRM 35.4) into a bodyless
 // hir::ForeignImportDecl: the resolved foreign name, the pure property, and the

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -111,16 +111,20 @@ class ProcessLowerer {
   // initializers are drained the same way as for a process body.
   auto Run(const hir::SubroutineDecl& src) -> diag::Result<mir::MethodDecl>;
 
-  // Lowers a user-written constructor body (LRM 8.7) into an already-open
-  // constructor frame. Registers each input formal as a body local -- appending
-  // its MIR local to `params` after the receiver the caller seeded -- then
-  // walks the body's statements into `frame.current_block`, after the
-  // field-init prologue the caller composed there. A non-input constructor
-  // formal is rejected at AST-to-HIR, so one reaching here is a compiler-bug
-  // invariant.
-  auto LowerConstructorBodyInto(
+  // Registers each of the constructor's input formals as a MIR body local,
+  // appending its `LocalId` to `params`. Split from body-statement lowering
+  // so the caller can evaluate base-constructor arguments -- which LRM 8.7
+  // orders before the body and which may reference the ctor's formals --
+  // in the same procedural-var registry the body will use. A non-input
+  // formal is a compiler-bug invariant.
+  auto RegisterConstructorFormals(
       const hir::SubroutineDecl& ctor, const WalkFrame& frame,
       std::vector<mir::LocalId>& params) -> diag::Result<void>;
+
+  // Walks the constructor's body statements into `frame.current_block`,
+  // assuming the formals have already been registered and any base-call
+  // arguments the caller wants placed before them are already in the block.
+  auto LowerConstructorBodyInto(const WalkFrame& frame) -> diag::Result<void>;
 
   // Central expression dispatcher. One switch over `hir::Expr::data` routing
   // each kind to its per-family handler; handlers recurse through this

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <variant>
 
+#include "lyra/backend/cpp/formatting.hpp"
 #include "lyra/backend/cpp/render_expr.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/backend/cpp/scope_view.hpp"
@@ -413,20 +414,19 @@ struct CalleeRender {
   std::size_t leading_arg_count;
 };
 
-// Renders a `Direct` callee whose target is a user-declared method. The method
-// renders as a C++ instance member function, so the emitted callee text is
-// `(receiver)->name` -- the receiver rides as `arguments[0]` in MIR and is
-// consumed here rather than passed as an ordinary argument. No qualification
-// is allowed today -- cross-class explicit qualification is gated on SV
-// class support.
+// Renders a `Direct` callee whose target is a user-declared method as
+// `(receiver)->Owner::name`, an owner-qualified C++ member call. The owner
+// prefix is a fixed function of the target's `owner`: for a non-virtual
+// method the qualifier is redundant (C++ resolves the same either way);
+// for a virtual method reached through Direct (LRM 8.15 super) the prefix
+// forces C++ to bypass the vtable, which is precisely what the Direct arm
+// names. Emitting it unconditionally keeps render a fixed function of one
+// MIR node -- no branch on `qualification`, no arm-dependent syntactic
+// shape -- while still producing the correct instruction sequence in every
+// case.
 auto RenderDirectMethodCall(
     const ScopeView& view, const mir::CallExpr& call,
-    const mir::MethodTarget& method,
-    const std::optional<mir::ScopeQualifier>& qualification) -> CalleeRender {
-  if (qualification.has_value()) {
-    throw InternalError(
-        "Direct method call: qualification is not yet implemented");
-  }
+    const mir::MethodTarget& method) -> CalleeRender {
   if (call.arguments.empty()) {
     throw InternalError("Direct method call expects a receiver argument");
   }
@@ -434,7 +434,7 @@ auto RenderDirectMethodCall(
   const mir::Expr& receiver = view.Expr(call.arguments[0]);
   return {
       .expr = std::format(
-          "({})->{}", RenderExpr(view, receiver),
+          "({})->{}::{}", RenderExpr(view, receiver), ToCppName(cls.name),
           cls.methods.Get(method.slot).name),
       .leading_arg_count = 1};
 }
@@ -514,8 +514,7 @@ auto RenderCalleePart(
             return std::visit(
                 Overloaded{
                     [&](const mir::MethodTarget& m) {
-                      return RenderDirectMethodCall(
-                          view, call, m, d.qualification);
+                      return RenderDirectMethodCall(view, call, m);
                     },
                     [&](const support::BuiltinFn& id) {
                       return RenderDirectBuiltinCall(

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -540,9 +540,21 @@ class HirDumper {
                   u.subroutine.value, u.hops.value, decl.name);
             },
             [](const MethodCallRef& m) -> std::string {
+              const std::string recv = std::visit(
+                  Overloaded{
+                      [](const HandleReceiver& h) {
+                        return std::format("Expr[{}]", h.expr.value);
+                      },
+                      [](const ImplicitSelfReceiver&) {
+                        return std::string{"<self>"};
+                      },
+                      [](const SuperReceiver&) {
+                        return std::string{"<super>"};
+                      }},
+                  m.receiver);
               return std::format(
-                  "Method class=Class[{}] index={} recv=Expr[{}]",
-                  m.class_id.value, m.method.value, m.receiver.value);
+                  "Method class=Class[{}] index={} recv={}", m.class_id.value,
+                  m.method.value, recv);
             },
             [](const SystemSubroutineRef& s) -> std::string {
               const auto& desc = support::LookupSystemSubroutine(s.id);
@@ -870,6 +882,14 @@ class HirDumper {
           "Method", i, c.methods.Get(MethodId{static_cast<std::uint32_t>(i)}));
     }
     DumpSubroutine("Constructor", 0, c.constructor);
+    if (c.base_call.has_value()) {
+      std::string args;
+      for (std::size_t i = 0; i < c.base_call->arguments.size(); ++i) {
+        if (i != 0) args += ", ";
+        args += std::format("Expr[{}]", c.base_call->arguments[i].value);
+      }
+      Line(std::format("BaseCall: ({})", args));
+    }
     Dedent();
   }
 

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -209,9 +209,14 @@ auto LowerNewClassExpr(
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto& unit_lowerer = lowerer.Owner();
   if (nc.isSuperClass) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedClassFeature,
-        "super.new is not yet supported");
+    // A `super.new(...)` is a construction-protocol fact that AST-to-HIR
+    // lifts onto the enclosing class declaration; the statement wrapping it
+    // in the ctor body lowers as empty. Reaching this expression-position
+    // path means the source placed `super.new` somewhere the LRM forbids
+    // (LRM 8.7 restricts it to the first ctor statement).
+    throw InternalError(
+        "AST->HIR super.new: NewClassExpression outside the first-statement "
+        "position of a derived constructor body");
   }
   std::vector<hir::ExprId> arguments;
   if (const auto* call = nc.constructorCall(); call != nullptr) {

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -21,6 +21,7 @@
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
 #include <slang/numeric/SVInt.h>
+#include <slang/syntax/AllSyntax.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -37,6 +38,68 @@
 namespace lyra::lowering::ast_to_hir {
 
 namespace {
+
+// True when the call's source syntax carries LRM 8.15 super qualification
+// (`super.foo()` or `this.super.foo()`). Slang resolves `super.foo` to the
+// base's callee symbol but records no semantic flag, so the qualifier
+// survives only on the source syntax -- a scoped name for the plain form or
+// a member access for `this.super.foo()`. Two callee syntaxes reach here
+// depending on whether the source used parentheses; both share the same
+// shape: the callee has a `.left` whose kind is `SuperHandle`.
+auto CallReceivesSuper(const slang::ast::CallExpression& call) -> bool {
+  const auto* syn = call.syntax;
+  if (syn == nullptr) return false;
+  const slang::syntax::SyntaxNode* callee = syn;
+  if (syn->kind == slang::syntax::SyntaxKind::InvocationExpression) {
+    callee = syn->as<slang::syntax::InvocationExpressionSyntax>().left;
+  }
+  if (callee == nullptr) return false;
+  const auto is_super =
+      [](const slang::syntax::SyntaxNode& left_of_dot) -> bool {
+    return left_of_dot.kind == slang::syntax::SyntaxKind::SuperHandle;
+  };
+  if (callee->kind == slang::syntax::SyntaxKind::ScopedName) {
+    return is_super(*callee->as<slang::syntax::ScopedNameSyntax>().left);
+  }
+  if (callee->kind == slang::syntax::SyntaxKind::MemberAccessExpression) {
+    return is_super(
+        *callee->as<slang::syntax::MemberAccessExpressionSyntax>().left);
+  }
+  return false;
+}
+
+// True when the call reaches an instance method through its enclosing class
+// -- either the source supplied a handle (`h.foo()`) or slang resolved an
+// unqualified call to a class-scope subroutine, whose enclosing class is
+// the receiver's own type (LRM 8.6 implicit `this`, including LRM 8.15
+// `super.foo()`).
+auto CallReachesInstanceMethod(
+    const slang::ast::CallExpression& call,
+    const slang::ast::SubroutineSymbol& sym) -> bool {
+  if (call.thisClass() != nullptr) return true;
+  const auto* parent = sym.getParentScope();
+  return parent != nullptr &&
+         parent->asSymbol().kind == slang::ast::SymbolKind::ClassType;
+}
+
+// Classifies the three LRM-defined receiver forms of an instance-method
+// call into a MethodReceiver arm. Super takes precedence over an
+// accompanying `thisClass` because `this.super.foo()` synthesizes a
+// `thisClass` for the outer `this` while the super qualifier still applies
+// at the syntactic level.
+template <ExprLowerer Lowerer>
+auto ClassifyMethodReceiver(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call)
+    -> diag::Result<hir::MethodReceiver> {
+  if (CallReceivesSuper(call)) return hir::SuperReceiver{};
+  if (const auto* this_class = call.thisClass(); this_class != nullptr) {
+    auto receiver_or = lowerer.LowerExpr(*this_class, frame);
+    if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
+    return hir::HandleReceiver{
+        .expr = frame.Exprs().Add(*std::move(receiver_or))};
+  }
+  return hir::ImplicitSelfReceiver{};
+}
 
 // Maps a frontend ReturnConvention to the builtin HIR TypeId that represents
 // it. Local to the calls subsystem (system subroutines are the only consumer).
@@ -493,11 +556,13 @@ auto LowerCallExpr(
     };
   }
 
-  // An instance-method call (LRM 8.6) carries the receiver handle in
-  // `thisClass`; the call dispatches through that handle's class rather than
-  // through an enclosing-scope subroutine.
-  if (const slang::ast::Expression* this_class = call.thisClass();
-      this_class != nullptr) {
+  // Instance-method call (LRM 8.6): three source shapes -- `h.foo()`,
+  // implicit-`this` `foo()` from inside a class body, and `super.foo()` --
+  // all lower to one `MethodCallRef` distinguished by which `MethodReceiver`
+  // arm the classifier picks. The declaring class comes from slang's
+  // resolved callee, which already accounts for inheritance and super
+  // resolution.
+  if (CallReachesInstanceMethod(call, *sym)) {
     for (const auto* formal : sym->getArguments()) {
       if (formal->direction != slang::ast::ArgumentDirection::In) {
         return diag::Fail(
@@ -506,13 +571,8 @@ auto LowerCallExpr(
             "supported");
       }
     }
-    auto receiver_or = lowerer.LowerExpr(*this_class, frame);
+    auto receiver_or = ClassifyMethodReceiver(lowerer, frame, call);
     if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
-    const hir::ExprId receiver = frame.Exprs().Add(*std::move(receiver_or));
-    // The method's declaring class owns the method's arena position. An
-    // inherited method belongs to the base class arena, not the receiver's
-    // runtime class arena; using the receiver's type would misname the slot
-    // when the field is inherited.
     const auto& declaring_class =
         sym->getParentScope()->asSymbol().as<slang::ast::ClassType>();
     auto class_id = unit_lowerer.InternClass(declaring_class, span);
@@ -527,7 +587,7 @@ auto LowerCallExpr(
             hir::CallExpr{
                 .callee =
                     hir::MethodCallRef{
-                        .receiver = receiver,
+                        .receiver = *std::move(receiver_or),
                         .class_id = *class_id,
                         .method = unit_lowerer.LookupMethodId(*sym)},
                 .arguments = std::move(arg_ids),

--- a/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
@@ -54,8 +54,11 @@ void ProcessLowerer::AnalyzeLifetimeExtended(
 }
 
 ProcessLowerer::ProcessLowerer(
-    UnitLowerer& unit_lowerer, const slang::ast::Symbol& containing_symbol)
-    : owner_(&unit_lowerer), containing_symbol_(&containing_symbol) {
+    UnitLowerer& unit_lowerer, const slang::ast::Symbol& containing_symbol,
+    ConsumedBodyExpressions consumed_body_exprs)
+    : owner_(&unit_lowerer),
+      containing_symbol_(&containing_symbol),
+      consumed_body_exprs_(std::move(consumed_body_exprs)) {
 }
 
 auto ProcessLowerer::Run(

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -77,6 +77,11 @@ auto LowerExpressionStmt(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::ExpressionStatement& es, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
+  // Expressions the enclosing lowering has already consumed as a higher-
+  // level semantic fact have no additional body-level effect, so the
+  // wrapping statement lowers to empty. Pointer identity keeps this check
+  // free of any per-kind knowledge of the consumed construct.
+  if (proc.ConsumedBodyExprs().contains(&es.expr)) return LowerEmptyStmt(span);
   auto expr = proc.LowerExpr(es.expr, frame);
   if (!expr) return std::unexpected(std::move(expr.error()));
   const hir::ExprId id = frame.Exprs().Add(*std::move(expr));

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -6,7 +6,10 @@
 #include <utility>
 #include <vector>
 
+#include <slang/ast/Expression.h>
 #include <slang/ast/Symbol.h>
+#include <slang/ast/expressions/AssignmentExpressions.h>
+#include <slang/ast/expressions/CallExpression.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -184,11 +187,20 @@ auto ResolveImportCName(const slang::ast::SubroutineSymbol& sym)
   return std::string{sym.name};
 }
 
-}  // namespace
+// The subroutine's callable code lowered against its own binding frame plus
+// the optional base-call args lowered against that same frame. The two
+// halves must share one frame because a base-call arg may reference a formal
+// parameter, and that reference resolves through the same procedural-var
+// registry the body lowering uses.
+struct SubroutineLoweringResult {
+  hir::SubroutineDecl decl;
+  std::optional<hir::BaseCall> base_call;
+};
 
-auto LowerSubroutineDecl(
+auto LowerSubroutineDeclImpl(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
-    WalkFrame frame) -> diag::Result<hir::SubroutineDecl> {
+    WalkFrame frame, const slang::ast::Expression* base_call_ast)
+    -> diag::Result<SubroutineLoweringResult> {
   const auto& mapper = unit_lowerer.SourceMapper();
 
   auto return_type_or = unit_lowerer.InternType(
@@ -198,7 +210,9 @@ auto LowerSubroutineDecl(
   }
 
   hir::ProceduralBody body;
-  ProcessLowerer lowerer(unit_lowerer, sym);
+  ConsumedBodyExpressions consumed_body_exprs;
+  if (base_call_ast != nullptr) consumed_body_exprs.insert(base_call_ast);
+  ProcessLowerer lowerer(unit_lowerer, sym, std::move(consumed_body_exprs));
   lowerer.AnalyzeLifetimeExtended(sym.getBody());
 
   // Open the root lexical scope accumulators for this subroutine body. The
@@ -233,6 +247,30 @@ auto LowerSubroutineDecl(
         body_frame, body, *sym.returnValVar, *return_type_or);
   }
 
+  // Base-call args (LRM 8.7) evaluate in the constructor's own frame and can
+  // reference formals -- for example `super.new(a * 2)` where `a` is the
+  // derived ctor's parameter. Lowering them here, before the body statements
+  // (which the LRM requires super.new to precede), keeps them ahead of any
+  // stateful body computation and ensures they see only the formals -- the
+  // ordering the runtime observes when it invokes the base ctor first.
+  std::optional<hir::BaseCall> base_call;
+  if (base_call_ast != nullptr) {
+    const auto& new_expr = base_call_ast->as<slang::ast::NewClassExpression>();
+    const auto* ctor_call = new_expr.constructorCall();
+    hir::BaseCall lowered;
+    if (ctor_call != nullptr) {
+      const auto& actuals =
+          ctor_call->as<slang::ast::CallExpression>().arguments();
+      lowered.arguments.reserve(actuals.size());
+      for (const auto* actual : actuals) {
+        auto arg_or = lowerer.LowerExpr(*actual, body_frame);
+        if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+        lowered.arguments.push_back(body.exprs.Add(*std::move(arg_or)));
+      }
+    }
+    base_call = std::move(lowered);
+  }
+
   auto body_stmt_or = lowerer.LowerStmt(sym.getBody(), body_frame);
   if (!body_stmt_or) return std::unexpected(std::move(body_stmt_or.error()));
   body.root_stmt = body.stmts.Add(*std::move(body_stmt_or));
@@ -249,15 +287,40 @@ auto LowerSubroutineDecl(
             .direct_child_scopes = std::move(root_children)});
   }
 
-  return hir::SubroutineDecl{
-      .name = std::string{sym.name},
-      .kind = ToHirSubroutineKind(sym.subroutineKind),
-      .result_type = *return_type_or,
-      .params = std::move(params),
-      .result_var = result_var,
-      .body = std::move(body),
-      .is_virtual = false,
-      .overrides = std::nullopt};
+  return SubroutineLoweringResult{
+      .decl =
+          hir::SubroutineDecl{
+              .name = std::string{sym.name},
+              .kind = ToHirSubroutineKind(sym.subroutineKind),
+              .result_type = *return_type_or,
+              .params = std::move(params),
+              .result_var = result_var,
+              .body = std::move(body),
+              .is_virtual = false,
+              .overrides = std::nullopt},
+      .base_call = std::move(base_call)};
+}
+
+}  // namespace
+
+auto LowerSubroutineDecl(
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
+    WalkFrame frame) -> diag::Result<hir::SubroutineDecl> {
+  auto result_or = LowerSubroutineDeclImpl(unit_lowerer, sym, frame, nullptr);
+  if (!result_or) return std::unexpected(std::move(result_or.error()));
+  return std::move(result_or->decl);
+}
+
+auto LowerConstructorDecl(
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
+    WalkFrame frame, const slang::ast::Expression* base_call_ast)
+    -> diag::Result<ConstructorAndBaseCall> {
+  auto result_or =
+      LowerSubroutineDeclImpl(unit_lowerer, sym, frame, base_call_ast);
+  if (!result_or) return std::unexpected(std::move(result_or.error()));
+  return ConstructorAndBaseCall{
+      .constructor = std::move(result_or->decl),
+      .base_call = std::move(result_or->base_call)};
 }
 
 // Lowers a DPI-C import declaration (LRM 35.4) to a bodyless external callable.

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -596,9 +596,17 @@ auto UnitLowerer::InternClass(
               "supported");
         }
       }
-      auto ctor_decl = LowerSubroutineDecl(*this, method, WalkFrame{});
-      if (!ctor_decl) return std::unexpected(std::move(ctor_decl.error()));
-      user_constructor = *std::move(ctor_decl);
+      // `getBaseConstructorCall` returns the `super.new(...)` slang lifted out
+      // of the ctor body: null when the source did not write one (LRM 8.7
+      // implicit forwarding, materialized as an empty stated base_init in
+      // HIR-to-MIR) or when this class has no base.
+      const slang::ast::Expression* base_call_ast =
+          cls.getBaseConstructorCall();
+      auto ctor_or =
+          LowerConstructorDecl(*this, method, WalkFrame{}, base_call_ast);
+      if (!ctor_or) return std::unexpected(std::move(ctor_or.error()));
+      user_constructor = std::move(ctor_or->constructor);
+      decl.base_call = std::move(ctor_or->base_call);
       continue;
     }
     if (method.flags.has(slang::ast::MethodFlags::Static)) {

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -215,6 +215,38 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
       unit_lowerer, nullptr, mir_class.time_resolution, ctor.body, "<ctor>",
       mir::MethodVisibility::kInternal, frame, *ctor_plan_);
 
+  // Register the ctor formals early so a base-constructor arg (LRM 8.7) can
+  // reference them: `super.new(a * 2)` in the derived ctor reads its own `a`
+  // formal, and that lookup resolves through the same procedural-var
+  // registry the ctor body uses. Formals land as MIR locals appended after
+  // the receiver; the base-call arg exprs and every field initializer below
+  // read them through that registry.
+  std::vector<mir::LocalId> ctor_params{self_id};
+  auto formals_or =
+      ctor_lowerer.RegisterConstructorFormals(ctor, frame, ctor_params);
+  if (!formals_or) return std::unexpected(std::move(formals_or.error()));
+
+  // Base construction (LRM 8.7): a derived class always forwards to its base
+  // -- explicit `super.new(args)` when the source wrote one, an implicit
+  // no-arg `super.new()` otherwise. Both cases publish stated args on the
+  // constructor's base-init so the backend never falls back to its target
+  // language's default-construction convention; base-constructor ordering
+  // is a MIR-stated fact, not a backend convention. A class with no base
+  // carries no base-init.
+  std::optional<mir::BaseInit> base_init;
+  if (hir_class.base_call.has_value()) {
+    std::vector<mir::ExprId> lowered;
+    lowered.reserve(hir_class.base_call->arguments.size());
+    for (const hir::ExprId arg : hir_class.base_call->arguments) {
+      auto arg_or = ctor_lowerer.LowerExpr(ctor.body.exprs.Get(arg), frame);
+      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+      lowered.push_back(ctor_block.exprs.Add(*std::move(arg_or)));
+    }
+    base_init = mir::BaseInit{.args = std::move(lowered)};
+  } else if (hir_class.base.has_value()) {
+    base_init = mir::BaseInit{.args = {}};
+  }
+
   // Initialize each property in declaration order before the constructor body
   // runs (LRM 8.7): a property with an explicit initializer takes that value --
   // lowered through the constructor lowerer so a property read resolves against
@@ -276,16 +308,11 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
     }
   }
 
-  // The constructor body (LRM 8.7) runs after each property is initialized, so
-  // its statements follow the field-init prologue already in the constructor
-  // body. Its input formals extend the constructor signature past the receiver;
-  // a synthesized default constructor contributes an empty body and no formals.
-  std::vector<mir::LocalId> ctor_params{self_id};
-  auto ctor_body_or =
-      ctor_lowerer.LowerConstructorBodyInto(ctor, frame, ctor_params);
-  if (!ctor_body_or) {
-    return std::unexpected(std::move(ctor_body_or.error()));
-  }
+  // The constructor body statements (LRM 8.7) run after base construction
+  // and property initialization, so they follow both the field-init prologue
+  // and the base-call arg evaluation already emitted into the ctor block.
+  auto body_or = ctor_lowerer.LowerConstructorBodyInto(frame);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
   for (const auto& pending : ctor_lowerer.TakePendingStaticInitializers()) {
     auto integ = IntegratePendingStaticInitializer(
         ctor_lowerer, ctor.body, frame, pending);
@@ -301,7 +328,9 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
           .virtual_dispatch = std::nullopt,
           .visibility = mir::MethodVisibility::kInternal});
   mir_class.constructor = mir::ConstructorDecl{
-      .method = ctor_method_id, .base_init = std::nullopt, .member_inits = {}};
+      .method = ctor_method_id,
+      .base_init = std::move(base_init),
+      .member_inits = {}};
 
   unit_lowerer.Unit().DefineClass(class_id_, std::move(mir_class));
   return {};

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -561,25 +561,41 @@ auto LowerMethodCall(
     const hir::MethodCallRef& m, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
-  auto receiver_or =
-      lowerer.LowerExpr(lowerer.HirExprs().Get(m.receiver), frame);
-  if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
   auto& types = lowerer.Owner().Unit().types;
-  const mir::TypeId object_type =
-      std::get<mir::ManagedRefType>(types.Get(receiver_or->type).data).pointee;
+
   // The method's declaring class is stated on the HIR node; the receiver's
   // runtime class is only used to type the self parameter (which pairs with
-  // the target's own arena entry through C++ member lookup).
+  // the target's own arena entry through C++ member lookup). For a super
+  // call HIR already sets `class_id` to the base's identity.
   const mir::ClassId owner_class = lowerer.Owner().TranslateClass(m.class_id);
   const mir::MethodId method_slot{m.method.value};
-  const mir::ExprId handle_id = block.exprs.Add(*std::move(receiver_or));
-  const mir::ExprId object_id = block.exprs.Add(
-      mir::Expr{
-          .data = mir::DerefExpr{.pointer = handle_id}, .type = object_type});
-  const mir::TypeId self_pointer_type =
-      types.PointerTo(object_type, mir::PointerOwnership::kBorrowed);
-  const mir::ExprId receiver_ptr =
-      block.exprs.Add(mir::MakeAddressOfExpr(object_id, self_pointer_type));
+
+  // The receiver pointer origin depends only on whether the source supplied
+  // an explicit handle. A `HandleReceiver` evaluates the handle expression
+  // then derefs the managed wrapper to reach the object; both
+  // `ImplicitSelfReceiver` and `SuperReceiver` read the enclosing method's
+  // own self binding, which is already a borrowed pointer to the object.
+  // The super arm shares the self read here because it differs only in
+  // dispatch semantics, decided below.
+  mir::ExprId receiver_ptr{};
+  if (const auto* handle = std::get_if<hir::HandleReceiver>(&m.receiver)) {
+    auto handle_or =
+        lowerer.LowerExpr(lowerer.HirExprs().Get(handle->expr), frame);
+    if (!handle_or) return std::unexpected(std::move(handle_or.error()));
+    const mir::TypeId object_type =
+        std::get<mir::ManagedRefType>(types.Get(handle_or->type).data).pointee;
+    const mir::ExprId handle_id = block.exprs.Add(*std::move(handle_or));
+    const mir::ExprId object_id = block.exprs.Add(
+        mir::Expr{
+            .data = mir::DerefExpr{.pointer = handle_id}, .type = object_type});
+    const mir::TypeId self_pointer_type =
+        types.PointerTo(object_type, mir::PointerOwnership::kBorrowed);
+    receiver_ptr =
+        block.exprs.Add(mir::MakeAddressOfExpr(object_id, self_pointer_type));
+  } else {
+    receiver_ptr = block.exprs.Add(
+        MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
+  }
 
   std::vector<mir::ExprId> user_args;
   user_args.reserve(c.arguments.size());
@@ -592,14 +608,22 @@ auto LowerMethodCall(
     user_args.push_back(block.exprs.Add(*std::move(arg_or)));
   }
 
-  // Cross-class dispatch role is queried through the shape store, not the
-  // unit's class registry: while any peer body is lowering the registry is
-  // one-way `Define`, so a `Get` there would leak lowering order into the
-  // reading site.
+  // A super call (LRM 8.15) is a dispatch fact independent of the callee's
+  // virtual role: the source demands the base's implementation regardless
+  // of the receiver's dynamic type, so it lowers as `Direct` on the base's
+  // method. The backend's uniform owner-qualified render skips dynamic
+  // dispatch mechanically. Every other receiver form defers to the
+  // callee's own dispatch role: `Virtual` when the target participates in
+  // a slot, `Direct` otherwise. Cross-class dispatch role is queried
+  // through the shape store, not the unit's class registry: while any peer
+  // body is lowering the registry is one-way `Define`, so a `Get` there
+  // would leak lowering order into the reading site.
+  const bool through_super =
+      std::holds_alternative<hir::SuperReceiver>(m.receiver);
   const auto& method_sig = lowerer.Owner()
                                .GetClassShape(owner_class)
                                .method_signatures.Get(method_slot);
-  if (method_sig.virtual_dispatch.has_value()) {
+  if (!through_super && method_sig.virtual_dispatch.has_value()) {
     const auto [canonical_owner, canonical_slot] = CanonicalIntraUnitSlot(
         owner_class, method_slot, *method_sig.virtual_dispatch);
     return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -382,14 +382,14 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
       .visibility = Visibility()};
 }
 
-auto ProcessLowerer::LowerConstructorBodyInto(
+auto ProcessLowerer::RegisterConstructorFormals(
     const hir::SubroutineDecl& ctor, const WalkFrame& frame,
     std::vector<mir::LocalId>& params) -> diag::Result<void> {
   for (const auto& param : ctor.params) {
     if (param.direction != hir::ParamDirection::kInput) {
       throw InternalError(
-          "ProcessLowerer::LowerConstructorBodyInto: a non-input constructor "
-          "formal reached MIR lowering; AST-to-HIR rejects these");
+          "ProcessLowerer::RegisterConstructorFormals: a non-input "
+          "constructor formal reached MIR lowering; AST-to-HIR rejects these");
     }
     const auto& hir_var = ctor.body.procedural_vars.Get(param.var);
     const mir::TypeId value_type = owner_->TranslateType(hir_var.type);
@@ -399,6 +399,11 @@ auto ProcessLowerer::LowerConstructorBodyInto(
     MapProceduralVar(param.var, AutomaticVarBinding{.type = value_type});
     params.push_back(mir_var);
   }
+  return {};
+}
+
+auto ProcessLowerer::LowerConstructorBodyInto(const WalkFrame& frame)
+    -> diag::Result<void> {
   return LowerStraightLineBodyInto(*this, frame);
 }
 

--- a/tests/cases/cpp/class_super_method_chain/case.yaml
+++ b/tests/cases/cpp/class_super_method_chain/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_super_method_chain
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    through_leaf: 111
+    through_mid_handle: 11

--- a/tests/cases/cpp/class_super_method_chain/main.sv
+++ b/tests/cases/cpp/class_super_method_chain/main.sv
@@ -1,0 +1,38 @@
+// LRM 8.15 super along a two-level override chain: Leaf's `super.f()`
+// reaches Mid (its immediate base), whose body then invokes `super.f()`
+// again to reach Base. Each level's contribution is composed on the return
+// path. Also asserts that calling the same slot through a Mid handle
+// (whose dynamic type is Mid) picks up only the Base + Mid contribution --
+// virtual dispatch selects by dynamic type, but a `super` inside a body
+// forces the immediate base regardless.
+module Top;
+  class Base;
+    virtual function int f();
+      return 1;
+    endfunction
+  endclass
+
+  class Mid extends Base;
+    virtual function int f();
+      return super.f() + 10;
+    endfunction
+  endclass
+
+  class Leaf extends Mid;
+    virtual function int f();
+      return super.f() + 100;
+    endfunction
+  endclass
+
+  int through_leaf;
+  int through_mid_handle;
+
+  initial begin
+    Leaf l;
+    Mid m;
+    l = new;
+    m = new;
+    through_leaf = l.f();
+    through_mid_handle = m.f();
+  end
+endmodule

--- a/tests/cases/cpp/class_super_method_direct/case.yaml
+++ b/tests/cases/cpp/class_super_method_direct/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.class_super_method_direct
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    derived_via_super: 15

--- a/tests/cases/cpp/class_super_method_direct/main.sv
+++ b/tests/cases/cpp/class_super_method_direct/main.sv
@@ -1,0 +1,27 @@
+// LRM 8.15 super qualifier: `super.method()` from an override body reaches
+// the base's implementation regardless of the receiver's dynamic type. This
+// case exercises a single-level override where the derived overrides a
+// virtual method and its body invokes `super` to compose with the base
+// result. The variables assert the composition: the derived's own call sums
+// the base contribution and the derived's added term.
+module Top;
+  class Base;
+    virtual function int f();
+      return 10;
+    endfunction
+  endclass
+
+  class Derived extends Base;
+    virtual function int f();
+      return super.f() + 5;
+    endfunction
+  endclass
+
+  int derived_via_super;
+
+  initial begin
+    Derived d;
+    d = new;
+    derived_via_super = d.f();
+  end
+endmodule

--- a/tests/cases/cpp/class_super_new_explicit_args/case.yaml
+++ b/tests/cases/cpp/class_super_new_explicit_args/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_super_new_explicit_args
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    base_val: 12
+    derived_val: 7

--- a/tests/cases/cpp/class_super_new_explicit_args/main.sv
+++ b/tests/cases/cpp/class_super_new_explicit_args/main.sv
@@ -1,0 +1,31 @@
+// LRM 8.7 explicit `super.new(args)`: the derived's constructor forwards
+// arguments to the base's constructor before its own body runs, so a
+// property the base sets from its formal is initialized to the value the
+// derived passed. The base's property is read through the derived handle to
+// confirm the forwarding actually happened.
+module Top;
+  class Base;
+    int b_val;
+    function new(int a);
+      b_val = a * 3;
+    endfunction
+  endclass
+
+  class Derived extends Base;
+    int d_val;
+    function new(int a, int b);
+      super.new(a);
+      d_val = b;
+    endfunction
+  endclass
+
+  int base_val;
+  int derived_val;
+
+  initial begin
+    Derived d;
+    d = new(4, 7);
+    base_val = d.b_val;
+    derived_val = d.d_val;
+  end
+endmodule

--- a/tests/cases/cpp/class_super_new_implicit_default/case.yaml
+++ b/tests/cases/cpp/class_super_new_implicit_default/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_super_new_implicit_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    base_val: 42
+    derived_val: 99

--- a/tests/cases/cpp/class_super_new_implicit_default/main.sv
+++ b/tests/cases/cpp/class_super_new_implicit_default/main.sv
@@ -1,0 +1,30 @@
+// LRM 8.7 implicit forwarding: a derived class that omits `super.new`
+// still runs the base's constructor as its first act. The base's own
+// initializer sets its property; the derived's body then sets its own.
+// Both values reach the observed variables because the implicit base call
+// still fires -- the base_val would be zero if the base ctor were skipped.
+module Top;
+  class Base;
+    int b_val;
+    function new();
+      b_val = 42;
+    endfunction
+  endclass
+
+  class Derived extends Base;
+    int d_val;
+    function new();
+      d_val = 99;
+    endfunction
+  endclass
+
+  int base_val;
+  int derived_val;
+
+  initial begin
+    Derived d;
+    d = new();
+    base_val = d.b_val;
+    derived_val = d.d_val;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements LRM 8.7 base-constructor call and LRM 8.15 `super` qualifier for the SV class object model. `super.new(args)` becomes a stated construction protocol fact on the class rather than a body statement, and `super.method()` reaches the base's implementation regardless of the callee's virtual role. Along the way the HIR method-call node picks up an explicit `MethodReceiver` variant and the C++ backend's direct-method render is now a uniform owner-qualified spelling.

## Design

The HIR call site names its receiver form directly. `MethodCallRef.receiver` is a `variant<HandleReceiver, ImplicitSelfReceiver, SuperReceiver>` -- three source forms, three arms, no invalid states. The prior implicit "unqualified call from inside a class method" gap is closed as a side effect: the same arms serve `h.foo()`, `foo()`, and `super.foo()`.

Base construction is a class-level fact. `hir::ClassDecl.base_call` holds the source-written `super.new(args)` when present; HIR-to-MIR emits `mir::ConstructorDecl.base_init` whenever the class extends a base -- explicit args from `base_call`, empty args when the source omitted `super.new` -- so a backend never falls back to its target language's default-construction convention. The single `NewClassExpression` that slang exposes both as the class-level fact (`getBaseConstructorCall()`) and as body residue in the ctor's statement list is elided from body lowering through a generic `ConsumedBodyExpressions` fact on `ProcessLowerer`; the statement handler queries by pointer identity and stays free of any per-SV-construct knowledge.

The C++ backend renders `Direct` on `MethodTarget` uniformly as `(recv)->Owner::name`. The owner prefix is a fixed function of the target's `owner` and lets the backend keep render a fixed function of one MIR node (no branch on `qualification`) while still bypassing the vtable when Direct reaches a virtual method through `super`.

## Testing

Four new cpp end-to-end cases exercise the surface: `class_super_method_direct`, `class_super_method_chain` (two-level override), `class_super_new_explicit_args`, and `class_super_new_implicit_default` (base ctor runs even when the source omits `super.new`).