### PR TITLE
Marshal DPI-C export outputs and packed vectors

### DIFF
--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -31,16 +31,17 @@ orchestration.
 
 ## Actionable
 
-Two frontiers are open. On the C++ backend the import surface (D1-D3) is in, and the scalar export
-call chain (D4) runs: a scalar input-only export executes end to end through the import -> export
-chain, its wrapper marshaling the C arguments and recovering the exported subroutine's single
-top-level instance from the running design. What remains for the export surface is instance-bound
-dispatch beyond that single instance via `svSetScope` and receiver-less package / `$unit` scope
-(D4a), 4-state / by-pointer / output marshaling (D4b), the generated ABI header and export linkage
-(D9), then DPI tasks (D5). On the execution backend scalar import (D10) is in: a foreign call lowers
-to an external-linkage symbol and the by-value carriers marshal. The rest of the import surface
-(D11) is blocked, and not by anything DPI owns: by-pointer marshaling is expressed as a closure,
-which that backend does not yet lower at all (`architecture-reset.md`).
+Two frontiers are open. On the C++ backend the import surface (D1-D3) is in, and the export
+marshaling surface (D4, D4b) runs: an export executes end to end through the import -> export chain
+across every argument direction and both value families -- by-value scalars, by-pointer scalar
+`output` / `inout`, and canonical 2-state / 4-state packed vectors -- with its wrapper recovering
+the exported subroutine's single top-level instance from the running design. What remains for the
+export surface is instance-bound dispatch beyond that single instance via `svSetScope` and
+receiver-less package / `$unit` scope (D4a), the generated ABI header and export linkage (D9), then
+DPI tasks (D5). On the execution backend scalar import (D10) is in: a foreign call lowers to an
+external-linkage symbol and the by-value carriers marshal. The rest of the import surface (D11) is
+blocked, and not by anything DPI owns: by-pointer marshaling is expressed as a closure, which that
+backend does not yet lower at all (`architecture-reset.md`).
 
 ## Sub-Steps
 
@@ -90,8 +91,15 @@ from an external main.
       callable in `packages.md`, PK1-PK2). This is the `mhpmcounter_num` / `mhpmcounter_get` shape
       in the Ibex bring-up; the pure-SV Ibex run never calls them, so this closes the construct, not
       the Ibex external-driver usage.
-- [ ] D4b -- 4-state and by-pointer packed export marshaling, including output / inout arguments and
-      indirect return for return types that need hidden result storage.
+- [x] D4b -- 4-state and by-pointer packed export marshaling. An `output` / `inout` scalar crosses
+      by pointer to its by-value carrier; a packed vector of any direction crosses by pointer as its
+      canonical `svBitVecVal*` / `svLogicVecVal*` buffer, its planes reshaped without a per-bit
+      transcode. The `output` / `inout` values ride the completion payload the exported subroutine
+      already returns (LRM 13.5), so the wrapper destructures the payload and marshals each
+      component out through its foreign pointer. A function result stays a by-value return, limited
+      to a small value (LRM 35.5.5): an atom such as `int` / `longint` / `real` / `string` /
+      `chandle`, or a scalar `bit` / `logic`; a packed-vector, `integer`, or `time` result is not a
+      small value and cannot be returned.
 
 ### DPI tasks
 

--- a/include/lyra/lir/type.hpp
+++ b/include/lyra/lir/type.hpp
@@ -47,6 +47,8 @@ enum class RuntimeLibraryKind : std::uint8_t {
   kHierarchySegment,
   kDpiBitBuffer,
   kDpiLogicBuffer,
+  kDpiBitChunk,
+  kDpiLogicChunk,
   kTrigger,
 };
 

--- a/include/lyra/lowering/hir_to_mir/completion_payload.hpp
+++ b/include/lyra/lowering/hir_to_mir/completion_payload.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <cstddef>
 #include <vector>
 
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/local.hpp"
+#include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -23,5 +26,15 @@ auto CompletionComponentTypes(
 auto NormalizeCompletionPayload(
     mir::CompilationUnit& unit, const std::vector<mir::TypeId>& components)
     -> mir::TypeId;
+
+// Reads one payload component out of a completion value bound to `completion`,
+// in the shape a normalized payload takes: a single-component payload is the
+// bare value, a multi-component payload a tuple the component is read from by
+// index. The one place the read-back encoding lives, so a call site projecting
+// outputs never re-derives whether the value is bare or a tuple.
+auto ProjectCompletionComponent(
+    mir::Block& block, mir::LocalId completion, mir::TypeId payload_type,
+    std::size_t component_count, std::size_t index, mir::TypeId component_type)
+    -> mir::ExprId;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/foreign_export_wrapper.hpp
+++ b/include/lyra/mir/foreign_export_wrapper.hpp
@@ -9,17 +9,23 @@ namespace lyra::mir {
 
 // A foreign-linkage wrapper realizing a DPI-C export (LRM 35.5): the C entry
 // point foreign code calls to reach an exported SV method. `code` is a
-// receiver-less callable whose C-ABI parameters are the marshaled carriers and
-// whose body marshals each carrier to its SV value, calls the exported method
-// on the recovered receiver, and marshals the result back. The marshaling is
-// stated in the body as ordinary calls so a backend renders it mechanically;
-// only the receiver recovery and the external linkage are the backend's shell.
+// receiver-less callable whose parameters are the marshaled carriers and whose
+// body marshals each argument to its SV value, calls the exported method on the
+// recovered receiver, and marshals the result and any `output` / `inout`
+// argument back. The marshaling is stated in the body as ordinary calls so a
+// backend renders it mechanically; only the receiver recovery and the external
+// linkage are the backend's shell. Each parameter's C ABI type is carried by
+// its MIR type (the carrier realized as a machine value or a canonical-chunk
+// pointer), so a backend spells the signature through ordinary type mapping,
+// with no per-parameter ABI decision in render.
 //
 // `foreign_name` is the C linkage name (LRM 35.5.3); `instance_name` names the
 // design instance the exported subroutine runs against, recovered when foreign
 // code enters; `self_local` is the receiver binding the recovery fills, read by
-// the body's method call. A backend emits one external-linkage definition per
-// wrapper.
+// the body's method call. The foreign caller owns the memory behind every
+// by-pointer argument and is trusted to pass valid pointers per the DPI
+// contract, as the runtime is otherwise explicit-pointer-threaded with no null
+// checks. A backend emits one external-linkage definition per wrapper.
 struct ForeignExportWrapper {
   std::string foreign_name;
   std::string instance_name;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -357,6 +357,18 @@ enum class RuntimeLibraryKind : std::uint8_t {
   // canonical chunk pointer.
   kDpiBitBuffer,
   kDpiLogicBuffer,
+  // One canonical packed-vector chunk element (LRM 35.5.6, Annex H.10.1.2): the
+  // backend-neutral runtime-ABI storage unit a packed value crosses the foreign
+  // boundary as, used as a borrowed-pointer pointee to spell the by-pointer
+  // carrier an export wrapper receives. This is a plumbing type, never an SV
+  // value type: it has no declared range, signedness, or four-state expression
+  // semantics, and no `PackedArray` operation acts on it. `kDpiBitChunk` is a
+  // 32-bit value-plane word; `kDpiLogicChunk` is a two-plane `{ aval, bval }`
+  // record, each plane a 32-bit word. Each backend's type mapping realizes it:
+  // the C++ backend as `svBitVecVal` / `svLogicVecVal`, a lower backend as the
+  // layout-equivalent word / record.
+  kDpiBitChunk,
+  kDpiLogicChunk,
 };
 
 struct RuntimeLibraryType {

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -323,24 +323,26 @@ enum class BuiltinFn : std::uint16_t {
   kChandlePtr,
   // Canonical DPI-C packed and 1-bit-4-state marshaling (LRM Annex H.10.1).
   // `kToSvLogic` reads a 1-bit 4-state value out as its `svLogic` scalar
-  // encoding
-  // (`value | unknown << 1`); `kFromSvLogic` builds it back in a prototype's
-  // shape (`args[0]` the byte, `args[1]` the prototype). The `kReadCanonical*`
-  // helpers build an SV value from a canonical buffer in a prototype's shape
-  // (`args[0]` the buffer pointer, `args[1]` the prototype). These three are
-  // free
-  // functions in `lyra::value`. A packed value's copy-in is not a helper: the
-  // boundary buffer is a `DpiBitBuffer` / `DpiLogicBuffer` value constructed
-  // from
-  // the SV value (which fills it), and `kDpiBufferData` (an instance method)
+  // encoding (`value | unknown << 1`); `kFromSvLogic` builds it back in a
+  // prototype's shape (`args[0]` the byte, `args[1]` the prototype). The
+  // `kReadCanonical*` helpers build an SV value from a canonical buffer in a
+  // prototype's shape (`args[0]` the buffer pointer, `args[1]` the prototype);
+  // the `kWriteCanonical*` helpers are their inverse, writing an SV value out
+  // into a canonical buffer (`args[0]` the buffer pointer, `args[1]` the SV
+  // value), as an export wrapper does through the foreign caller's pointer.
+  // These are free functions in `lyra::value`. An import's packed copy-in is
+  // not
+  // a builtin: the boundary buffer is a `DpiBitBuffer` / `DpiLogicBuffer` value
+  // constructed from the SV value, and `kDpiBufferData` (an instance method)
   // reads its writable chunk pointer for the foreign call and the copy-back
-  // read.
-  // `Bit` carries a 2-state (aval-only) buffer, `Logic` a 4-state buffer whose
-  // `aval` is the value plane and `bval` the unknown plane.
+  // read. `Bit` carries a 2-state (aval-only) buffer, `Logic` a 4-state buffer
+  // whose `aval` is the value plane and `bval` the unknown plane.
   kToSvLogic,
   kFromSvLogic,
   kReadCanonicalBitVec,
   kReadCanonicalLogicVec,
+  kWriteCanonicalBitVec,
+  kWriteCanonicalLogicVec,
   kDpiBufferData,
   kFromInt,
   kConvertFrom,

--- a/include/lyra/value/dpi_canonical.hpp
+++ b/include/lyra/value/dpi_canonical.hpp
@@ -66,4 +66,14 @@ class DpiLogicBuffer {
 [[nodiscard]] auto ReadCanonicalLogicVec(
     const svLogicVecVal* src, const PackedArray& prototype) -> PackedArray;
 
+// Write an SV value's planes into a canonical chunk buffer at `dst`, the write
+// direction that pairs with the read helpers: a plane reshape sized by the SV
+// value, with no per-bit transcode. `dst` is either Lyra-owned (filling a
+// `DpiBitBuffer` / `DpiLogicBuffer`'s chunks) or foreign-owned (an export
+// wrapper writing an output argument through the caller's pointer). `Bit`
+// writes the value plane only; `Logic` writes both planes (`aval` the value
+// plane, `bval` the unknown plane).
+auto WriteCanonicalBitVec(svBitVecVal* dst, const PackedArray& sv) -> void;
+auto WriteCanonicalLogicVec(svLogicVecVal* dst, const PackedArray& sv) -> void;
+
 }  // namespace lyra::value

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -22,6 +22,7 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/field.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/support/dpi_abi.hpp"
 
 namespace lyra::backend::cpp {
 
@@ -446,7 +447,11 @@ auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
 // definition foreign code calls. It recovers the exported method's receiver
 // from the running design, then runs the marshaling body -- an ordinary
 // statement render, so every carrier conversion and the method call come from
-// MIR. Emitted after the class it dispatches into so that class is complete.
+// MIR. Each parameter renders from its MIR type through ordinary type mapping;
+// a packed-vector carrier's C spelling (`svBitVecVal*` / `svLogicVecVal*`, made
+// `const` for an input by the pointer's mutability) is carried by that type, so
+// render makes no per-parameter ABI decision. Emitted after the class it
+// dispatches into so that class is complete.
 auto RenderForeignExportWrapper(
     const mir::CompilationUnit& unit, const mir::Class& s,
     const mir::ForeignExportWrapper& w) -> std::string {

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -278,6 +278,10 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "ReadCanonicalBitVec";
     case support::BuiltinFn::kReadCanonicalLogicVec:
       return "ReadCanonicalLogicVec";
+    case support::BuiltinFn::kWriteCanonicalBitVec:
+      return "WriteCanonicalBitVec";
+    case support::BuiltinFn::kWriteCanonicalLogicVec:
+      return "WriteCanonicalLogicVec";
     case support::BuiltinFn::kDpiBufferData:
       return "Data";
     case support::BuiltinFn::kFromSvLogic:
@@ -378,6 +382,8 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
     case support::BuiltinFn::kToSvLogic:
     case support::BuiltinFn::kReadCanonicalBitVec:
     case support::BuiltinFn::kReadCanonicalLogicVec:
+    case support::BuiltinFn::kWriteCanonicalBitVec:
+    case support::BuiltinFn::kWriteCanonicalLogicVec:
     case support::BuiltinFn::kFromSvLogic:
       return "lyra::value";
     case support::BuiltinFn::kDelay:

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -209,6 +209,10 @@ auto RenderTypeAsCpp(
                 return std::string{"lyra::value::DpiBitBuffer"};
               case mir::RuntimeLibraryKind::kDpiLogicBuffer:
                 return std::string{"lyra::value::DpiLogicBuffer"};
+              case mir::RuntimeLibraryKind::kDpiBitChunk:
+                return std::string{"svBitVecVal"};
+              case mir::RuntimeLibraryKind::kDpiLogicChunk:
+                return std::string{"svLogicVecVal"};
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -260,6 +260,32 @@ auto LowerSubroutineDecl(
       .overrides = std::nullopt};
 }
 
+// Classifies each formal argument's ABI projection (LRM 35.5.6): its direction,
+// C ABI carrier, and SV type. Import and export declarations project their
+// arguments identically, so both build their parameter list here.
+auto ClassifyDpiParams(
+    UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
+    -> diag::Result<std::vector<hir::DpiParamAbi>> {
+  const auto& mapper = unit_lowerer.SourceMapper();
+  std::vector<hir::DpiParamAbi> abi_params;
+  abi_params.reserve(sym.getArguments().size());
+  for (const auto* formal : sym.getArguments()) {
+    const auto floc = mapper.PointSpanOf(formal->location);
+    auto direction = ClassifyDpiDirection(*formal, floc);
+    if (!direction) return std::unexpected(std::move(direction.error()));
+    auto carrier = ClassifyDpiCarrier(formal->getType(), floc);
+    if (!carrier) return std::unexpected(std::move(carrier.error()));
+    auto param_type = unit_lowerer.InternType(formal->getType(), floc);
+    if (!param_type) return std::unexpected(std::move(param_type.error()));
+    abi_params.push_back(
+        hir::DpiParamAbi{
+            .sv_type = *param_type,
+            .carrier = *carrier,
+            .direction = *direction});
+  }
+  return abi_params;
+}
+
 // Lowers a DPI-C import declaration (LRM 35.4) to a bodyless external callable.
 // It has no SV body, so it is not a `SubroutineDecl`; the caller records it
 // among the scope's foreign imports, not its subroutines. The ABI
@@ -286,22 +312,8 @@ auto LowerForeignImport(
   auto ret_type = unit_lowerer.InternType(sym.getReturnType(), loc);
   if (!ret_type) return std::unexpected(std::move(ret_type.error()));
 
-  std::vector<hir::DpiParamAbi> abi_params;
-  abi_params.reserve(sym.getArguments().size());
-  for (const auto* formal : sym.getArguments()) {
-    const auto floc = mapper.PointSpanOf(formal->location);
-    auto direction = ClassifyDpiDirection(*formal, floc);
-    if (!direction) return std::unexpected(std::move(direction.error()));
-    auto carrier = ClassifyDpiCarrier(formal->getType(), floc);
-    if (!carrier) return std::unexpected(std::move(carrier.error()));
-    auto param_type = unit_lowerer.InternType(formal->getType(), floc);
-    if (!param_type) return std::unexpected(std::move(param_type.error()));
-    abi_params.push_back(
-        hir::DpiParamAbi{
-            .sv_type = *param_type,
-            .carrier = *carrier,
-            .direction = *direction});
-  }
+  auto abi_params = ClassifyDpiParams(unit_lowerer, sym);
+  if (!abi_params) return std::unexpected(std::move(abi_params.error()));
 
   return hir::ForeignImportDecl{
       .name = std::string{sym.name},
@@ -309,7 +321,7 @@ auto LowerForeignImport(
       .is_pure = sym.flags.has(slang::ast::MethodFlags::Pure),
       .ret_abi = *ret_abi,
       .ret_sv_type = *ret_type,
-      .params = std::move(abi_params)};
+      .params = std::move(*abi_params)};
 }
 
 auto LowerForeignExport(
@@ -327,39 +339,15 @@ auto LowerForeignExport(
   auto ret_type = unit_lowerer.InternType(sym.getReturnType(), loc);
   if (!ret_type) return std::unexpected(std::move(ret_type.error()));
 
-  std::vector<hir::DpiParamAbi> abi_params;
-  abi_params.reserve(sym.getArguments().size());
-  for (const auto* formal : sym.getArguments()) {
-    const auto floc = mapper.PointSpanOf(formal->location);
-    auto direction = ClassifyDpiDirection(*formal, floc);
-    if (!direction) return std::unexpected(std::move(direction.error()));
-    if (*direction != support::DpiDirection::kInput) {
-      return diag::Fail(
-          floc, diag::DiagCode::kUnsupportedDpi,
-          "DPI-C export with an output / inout argument is not yet supported");
-    }
-    auto carrier = ClassifyDpiCarrier(formal->getType(), floc);
-    if (!carrier) return std::unexpected(std::move(carrier.error()));
-    if (std::holds_alternative<support::VectorCarrier>(*carrier)) {
-      return diag::Fail(
-          floc, diag::DiagCode::kUnsupportedDpi,
-          "DPI-C export of a packed-vector argument is not yet supported");
-    }
-    auto param_type = unit_lowerer.InternType(formal->getType(), floc);
-    if (!param_type) return std::unexpected(std::move(param_type.error()));
-    abi_params.push_back(
-        hir::DpiParamAbi{
-            .sv_type = *param_type,
-            .carrier = *carrier,
-            .direction = *direction});
-  }
+  auto abi_params = ClassifyDpiParams(unit_lowerer, sym);
+  if (!abi_params) return std::unexpected(std::move(abi_params.error()));
 
   return hir::ForeignExportDecl{
       .sv_name = std::string{sym.name},
       .foreign_name = std::string{foreign_name},
       .ret_abi = *ret_abi,
       .ret_sv_type = *ret_type,
-      .params = std::move(abi_params)};
+      .params = std::move(*abi_params)};
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/hir_to_mir/completion_payload.cpp
+++ b/src/lyra/lowering/hir_to_mir/completion_payload.cpp
@@ -1,8 +1,10 @@
 #include "lyra/lowering/hir_to_mir/completion_payload.hpp"
 
+#include <cstddef>
 #include <vector>
 
 #include "lyra/hir/subroutine.hpp"
+#include "lyra/mir/expr.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -30,6 +32,21 @@ auto NormalizeCompletionPayload(
   if (components.empty()) return unit.builtins.void_type;
   if (components.size() == 1) return components.front();
   return unit.types.Intern(mir::TupleType{.elements = components});
+}
+
+auto ProjectCompletionComponent(
+    mir::Block& block, mir::LocalId completion, mir::TypeId payload_type,
+    std::size_t component_count, std::size_t index, mir::TypeId component_type)
+    -> mir::ExprId {
+  if (component_count == 1) {
+    return block.exprs.Add(mir::MakeLocalRefExpr(completion, component_type));
+  }
+  const mir::ExprId tuple_ref =
+      block.exprs.Add(mir::MakeLocalRefExpr(completion, payload_type));
+  return block.exprs.Add(
+      mir::Expr{
+          .data = mir::TupleGetExpr{.tuple = tuple_ref, .index = index},
+          .type = component_type});
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -19,6 +19,7 @@
 #include "lyra/hir/with_clause_id.hpp"
 #include "lyra/lowering/hir_to_mir/binding_origin.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
+#include "lyra/lowering/hir_to_mir/completion_payload.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/control.hpp"
@@ -1244,6 +1245,42 @@ template auto LowerHirCallExpr(
     const hir::CallExpr& c, diag::SourceSpan span, mir::TypeId result_type)
     -> diag::Result<mir::Expr>;
 
+// The MIR type of one foreign wrapper parameter, the ABI carrier realized as a
+// concrete type so a backend spells it through ordinary type mapping. A scalar
+// `input` is its by-value carrier; a scalar `output` / `inout` is a borrowed
+// pointer to it. A packed vector is a borrowed pointer to its canonical chunk,
+// read-only for an `input` the wrapper only reads (rendering `const
+// svBitVecVal*` through the pointer's mutability) and mutable for a writeback
+// direction.
+auto ExportParamType(
+    mir::CompilationUnit& unit, const support::DpiCarrier& carrier,
+    support::DpiDirection direction) -> mir::TypeId {
+  if (const auto* vec = std::get_if<support::VectorCarrier>(&carrier)) {
+    const mir::TypeId chunk = unit.types.Intern(
+        mir::TypeData{mir::RuntimeLibraryType{
+            .kind = vec->four_state ? mir::RuntimeLibraryKind::kDpiLogicChunk
+                                    : mir::RuntimeLibraryKind::kDpiBitChunk}});
+    const mir::Mutability mutability =
+        direction == support::DpiDirection::kInput ? mir::Mutability::kReadOnly
+                                                   : mir::Mutability::kMutable;
+    return unit.types.PointerTo(
+        chunk, mir::PointerOwnership::kBorrowed, mutability);
+  }
+  const mir::TypeId carrier_type = CarrierTypeId(unit, carrier);
+  if (support::DpiDirectionWritesBack(direction)) {
+    return unit.types.PointerTo(carrier_type, mir::PointerOwnership::kBorrowed);
+  }
+  return carrier_type;
+}
+
+// The builtin that writes an SV value out into a foreign-owned canonical
+// buffer, the write direction that pairs with the vector read builtin.
+[[nodiscard]] auto VectorWriteBuiltin(const support::VectorCarrier& v)
+    -> support::BuiltinFn {
+  return v.four_state ? support::BuiltinFn::kWriteCanonicalLogicVec
+                      : support::BuiltinFn::kWriteCanonicalBitVec;
+}
+
 auto SynthesizeForeignExportWrapper(
     UnitLowerer& module, const WalkFrame& ctor_frame, mir::ClassId class_id,
     mir::MethodId method_id, const hir::ForeignExportDecl& export_decl,
@@ -1251,9 +1288,11 @@ auto SynthesizeForeignExportWrapper(
   mir::CompilationUnit& unit = module.Unit();
   const mir::Class& mir_class = *ctor_frame.current_class;
   const mir::TypeId self_ptr = mir_class.self_pointer_type;
+  const mir::TypeId void_type = unit.builtins.void_type;
 
   mir::CallableCode code;
   CallableBindings bindings(unit, code);
+  mir::Block& body = code.body;
 
   // The receiver the exported method runs against is recovered by the backend's
   // wrapper shell from the running design, not passed by the foreign caller
@@ -1262,37 +1301,74 @@ auto SynthesizeForeignExportWrapper(
       BindingOriginId::Receiver(),
       mir::LocalDecl{.name = "self", .type = self_ptr});
 
+  const WalkFrame body_frame =
+      ctor_frame.WithBlock(&body).WithBindings(&bindings);
+
+  // One foreign parameter per SV formal, in declaration order (the C ABI
+  // order). The parameter's MIR type is the ABI carrier realized concretely, so
+  // nothing downstream re-derives the C signature from the direction / carrier.
   std::vector<mir::LocalId> params;
-  std::vector<mir::TypeId> carrier_types;
   params.reserve(export_decl.params.size());
-  carrier_types.reserve(export_decl.params.size());
   for (std::size_t i = 0; i < export_decl.params.size(); ++i) {
-    const mir::TypeId carrier_type =
-        CarrierTypeId(unit, export_decl.params[i].carrier);
-    carrier_types.push_back(carrier_type);
+    const hir::DpiParamAbi& p = export_decl.params[i];
     params.push_back(bindings.DeclareAnonymous(
         mir::LocalDecl{
-            .name = "arg" + std::to_string(i), .type = carrier_type}));
+            .name = "arg" + std::to_string(i),
+            .type = ExportParamType(unit, p.carrier, p.direction)}));
   }
 
-  const WalkFrame body_frame =
-      ctor_frame.WithBlock(&code.body).WithBindings(&bindings);
+  const auto param_ref = [&](std::size_t i) -> mir::ExprId {
+    return body.exprs.Add(
+        mir::MakeLocalRefExpr(params[i], code.locals.Get(params[i]).type));
+  };
 
+  // Marshal each `input` / `inout` argument to an explicit SV-typed temporary
+  // before the call, so the read of an `inout`'s incoming value is sequenced
+  // ahead of the copy-back that later overwrites it, and multiple arguments do
+  // not alias inside one nested call expression. An `output` formal is not a
+  // method parameter -- it rides the completion payload (LRM 13.5). A vector
+  // reads its SV value from the incoming canonical buffer; a scalar `input`
+  // crosses by value; a scalar `inout` reads through its pointer.
   std::vector<mir::ExprId> call_args;
-  call_args.reserve(export_decl.params.size() + 1);
   call_args.push_back(
-      code.body.exprs.Add(mir::MakeLocalRefExpr(self_local, self_ptr)));
+      body.exprs.Add(mir::MakeLocalRefExpr(self_local, self_ptr)));
   for (std::size_t i = 0; i < export_decl.params.size(); ++i) {
-    const mir::ExprId carrier_ref =
-        code.body.exprs.Add(mir::MakeLocalRefExpr(params[i], carrier_types[i]));
-    call_args.push_back(code.body.exprs.Add(MarshalCarrierToSv(
-        module, body_frame, carrier_ref, export_decl.params[i].carrier,
-        module.TranslateType(export_decl.params[i].sv_type))));
+    const hir::DpiParamAbi& p = export_decl.params[i];
+    if (p.direction == support::DpiDirection::kOutput) {
+      continue;
+    }
+    const mir::TypeId sv_type = module.TranslateType(p.sv_type);
+    mir::ExprId sv_init{};
+    if (const auto* vec = std::get_if<support::VectorCarrier>(&p.carrier)) {
+      const mir::ExprId prototype =
+          body.exprs.Add(BuildDefaultValueExpr(module, body_frame, sv_type));
+      sv_init = body.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee = mir::Direct{.target = VectorReadBuiltin(*vec)},
+                      .arguments = {param_ref(i), prototype}},
+              .type = sv_type});
+    } else {
+      const mir::ExprId carrier =
+          p.direction == support::DpiDirection::kInout
+              ? body.exprs.Add(
+                    mir::Expr{
+                        .data = mir::DerefExpr{.pointer = param_ref(i)},
+                        .type = CarrierTypeId(unit, p.carrier)})
+              : param_ref(i);
+      sv_init = body.exprs.Add(
+          MarshalCarrierToSv(module, body_frame, carrier, p.carrier, sv_type));
+    }
+    const mir::LocalId sv_in = bindings.DeclareAnonymous(
+        mir::LocalDecl{.name = "in" + std::to_string(i), .type = sv_type});
+    body.AppendStmt(mir::LocalDeclStmt{.target = sv_in, .init = sv_init});
+    call_args.push_back(body.exprs.Add(mir::MakeLocalRefExpr(sv_in, sv_type)));
   }
 
-  const mir::TypeId method_result_type =
+  const mir::TypeId payload_type =
       mir_class.methods.Get(method_id).code.result_type;
-  const mir::ExprId method_call = code.body.exprs.Add(
+  const mir::ExprId method_call = body.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{
@@ -1302,16 +1378,106 @@ auto SynthesizeForeignExportWrapper(
                               mir::MethodTarget{
                                   .owner = class_id, .slot = method_id}},
                   .arguments = std::move(call_args)},
-          .type = method_result_type});
+          .type = payload_type});
 
-  const mir::ExprId ret_carrier = MarshalSvToCarrier(
-      unit, code.body, method_call,
-      support::ScalarCarrier{export_decl.ret_abi});
-  code.body.AppendStmt(mir::ReturnStmt{.value = ret_carrier});
+  // The completion payload's components, in the callee's payload order: the
+  // function return (when non-void) first, then each `output` / `inout` formal
+  // in declaration order. Built in that exact order so each component's index
+  // lines up with the payload the callee returns. `param_index` is unused for
+  // the return component.
+  struct Component {
+    mir::TypeId sv_type;
+    bool is_return;
+    std::size_t param_index;
+  };
+  std::vector<Component> components;
+  const bool has_return = export_decl.ret_abi != support::DpiScalarAbi::kVoid;
+  if (has_return) {
+    components.push_back(
+        Component{
+            .sv_type = module.TranslateType(export_decl.ret_sv_type),
+            .is_return = true,
+            .param_index = 0});
+  }
+  for (std::size_t i = 0; i < export_decl.params.size(); ++i) {
+    if (support::DpiDirectionWritesBack(export_decl.params[i].direction)) {
+      components.push_back(
+          Component{
+              .sv_type = module.TranslateType(export_decl.params[i].sv_type),
+              .is_return = false,
+              .param_index = i});
+    }
+  }
+
+  // Bind the completion value to a local every component projects out of; the
+  // projection encoding (bare value vs tuple) lives in one shared place. An
+  // empty payload has nothing to bind, so the call is a bare statement.
+  std::optional<mir::LocalId> completion;
+  if (!components.empty()) {
+    completion = bindings.DeclareAnonymous(
+        mir::LocalDecl{.name = "_lyra_completion", .type = payload_type});
+    body.AppendStmt(
+        mir::LocalDeclStmt{.target = *completion, .init = method_call});
+  } else {
+    body.AppendStmt(mir::ExprStmt{.expr = method_call});
+  }
+  const auto component_value = [&](std::size_t k) -> mir::ExprId {
+    return ProjectCompletionComponent(
+        body, *completion, payload_type, components.size(), k,
+        components[k].sv_type);
+  };
+
+  // Copy each `output` / `inout` component back through its foreign pointer: a
+  // scalar stores its marshaled carrier through the pointer; a vector reshapes
+  // the SV value into the foreign-owned canonical buffer.
+  for (std::size_t k = 0; k < components.size(); ++k) {
+    const Component& c = components[k];
+    if (c.is_return) {
+      continue;
+    }
+    const hir::DpiParamAbi& p = export_decl.params[c.param_index];
+    const mir::ExprId value = component_value(k);
+    if (const auto* vec = std::get_if<support::VectorCarrier>(&p.carrier)) {
+      body.AppendStmt(
+          mir::ExprStmt{
+              .expr = body.exprs.Add(
+                  mir::Expr{
+                      .data =
+                          mir::CallExpr{
+                              .callee =
+                                  mir::Direct{
+                                      .target = VectorWriteBuiltin(*vec)},
+                              .arguments = {param_ref(c.param_index), value}},
+                      .type = void_type})});
+      continue;
+    }
+    const mir::TypeId carrier_type = CarrierTypeId(unit, p.carrier);
+    const mir::ExprId carrier =
+        MarshalSvToCarrier(unit, body, value, p.carrier);
+    const mir::ExprId place = body.exprs.Add(
+        mir::Expr{
+            .data = mir::DerefExpr{.pointer = param_ref(c.param_index)},
+            .type = carrier_type});
+    body.AppendStmt(
+        mir::ExprStmt{
+            .expr = body.exprs.Add(
+                mir::MakeAssignExpr(place, carrier, void_type))});
+  }
+
+  if (has_return) {
+    const mir::ExprId ret_carrier = MarshalSvToCarrier(
+        unit, body, component_value(0),
+        support::ScalarCarrier{export_decl.ret_abi});
+    body.AppendStmt(mir::ReturnStmt{.value = ret_carrier});
+  } else {
+    body.AppendStmt(mir::ReturnStmt{.value = std::nullopt});
+  }
 
   code.params = std::move(params);
   code.result_type =
-      CarrierTypeId(unit, support::ScalarCarrier{export_decl.ret_abi});
+      has_return
+          ? CarrierTypeId(unit, support::ScalarCarrier{export_decl.ret_abi})
+          : void_type;
 
   return mir::ForeignExportWrapper{
       .foreign_name = export_decl.foreign_name,

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -380,21 +380,9 @@ auto LowerSubroutineCallWithWritebacks(
       wrapper.exprs.Add(BuildServicesCallExpr(unit_lowerer, wrapper_frame));
   const mir::TypeId void_type = unit.builtins.void_type;
   for (const CompletionWriteback& wb : writebacks) {
-    // A single-component payload is the bare value; otherwise project the
-    // component out of the tuple.
-    mir::ExprId value_id{};
-    if (components.size() == 1) {
-      value_id = wrapper.exprs.Add(mir::MakeLocalRefExpr(completion, wb.type));
-    } else {
-      const mir::ExprId tuple_read =
-          wrapper.exprs.Add(mir::MakeLocalRefExpr(completion, payload_type));
-      value_id = wrapper.exprs.Add(
-          mir::Expr{
-              .data =
-                  mir::TupleGetExpr{
-                      .tuple = tuple_read, .index = wb.component_index},
-              .type = wb.type});
-    }
+    const mir::ExprId value_id = ProjectCompletionComponent(
+        wrapper, completion, payload_type, components.size(),
+        wb.component_index, wb.type);
     const mir::Expr assign_expr = BuildObservableAssignExpr(
         unit, wrapper, services_id, wb.place, value_id, std::nullopt, wb.type,
         void_type);

--- a/src/lyra/lowering/mir_to_lir/translate_type.cpp
+++ b/src/lyra/lowering/mir_to_lir/translate_type.cpp
@@ -94,6 +94,10 @@ auto TranslateRuntimeLibraryKind(mir::RuntimeLibraryKind k)
       return lir::RuntimeLibraryKind::kDpiBitBuffer;
     case mir::RuntimeLibraryKind::kDpiLogicBuffer:
       return lir::RuntimeLibraryKind::kDpiLogicBuffer;
+    case mir::RuntimeLibraryKind::kDpiBitChunk:
+      return lir::RuntimeLibraryKind::kDpiBitChunk;
+    case mir::RuntimeLibraryKind::kDpiLogicChunk:
+      return lir::RuntimeLibraryKind::kDpiLogicChunk;
     case mir::RuntimeLibraryKind::kTrigger:
       return lir::RuntimeLibraryKind::kTrigger;
     case mir::RuntimeLibraryKind::kScopeProgram:

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -286,6 +286,10 @@ class MirDumper {
                   return "RuntimeLibrary(DpiBitBuffer)";
                 case RuntimeLibraryKind::kDpiLogicBuffer:
                   return "RuntimeLibrary(DpiLogicBuffer)";
+                case RuntimeLibraryKind::kDpiBitChunk:
+                  return "RuntimeLibrary(DpiBitChunk)";
+                case RuntimeLibraryKind::kDpiLogicChunk:
+                  return "RuntimeLibrary(DpiLogicChunk)";
               }
               throw InternalError("dump: unknown RuntimeLibraryKind");
             },

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -394,6 +394,10 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "read_canonical_bit_vec";
     case BuiltinFn::kReadCanonicalLogicVec:
       return "read_canonical_logic_vec";
+    case BuiltinFn::kWriteCanonicalBitVec:
+      return "write_canonical_bit_vec";
+    case BuiltinFn::kWriteCanonicalLogicVec:
+      return "write_canonical_logic_vec";
     case BuiltinFn::kDpiBufferData:
       return "dpi_buffer_data";
     case BuiltinFn::kFromSvLogic:

--- a/src/lyra/value/dpi_canonical.cpp
+++ b/src/lyra/value/dpi_canonical.cpp
@@ -67,11 +67,7 @@ auto FromSvLogic(unsigned char encoded, const PackedArray& prototype)
 
 DpiBitBuffer::DpiBitBuffer(const PackedArray& sv)
     : chunks_(ChunkCount(sv.BitWidth())) {
-  const auto value = sv.ValueWords();
-  for (std::size_t i = 0; i < chunks_.size(); ++i) {
-    const ChunkSlot slot = SlotForChunk(i);
-    chunks_[i] = LowHalf(value[slot.word], slot.shift);
-  }
+  WriteCanonicalBitVec(chunks_.data(), sv);
 }
 
 auto DpiBitBuffer::Data() -> svBitVecVal* {
@@ -80,14 +76,7 @@ auto DpiBitBuffer::Data() -> svBitVecVal* {
 
 DpiLogicBuffer::DpiLogicBuffer(const PackedArray& sv)
     : chunks_(ChunkCount(sv.BitWidth())) {
-  const auto value = sv.ValueWords();
-  const auto unknown = sv.UnknownWords();
-  for (std::size_t i = 0; i < chunks_.size(); ++i) {
-    const ChunkSlot slot = SlotForChunk(i);
-    chunks_[i].aval = LowHalf(value[slot.word], slot.shift);
-    chunks_[i].bval =
-        unknown.empty() ? 0U : LowHalf(unknown[slot.word], slot.shift);
-  }
+  WriteCanonicalLogicVec(chunks_.data(), sv);
 }
 
 auto DpiLogicBuffer::Data() -> svLogicVecVal* {
@@ -124,6 +113,29 @@ auto ReadCanonicalLogicVec(
   MaskTopWord(unknown, width);
   return PackedArray::FromWords(
       value, unknown, width, prototype.IsSigned(), true);
+}
+
+auto WriteCanonicalBitVec(svBitVecVal* dst, const PackedArray& sv) -> void {
+  const auto value = sv.ValueWords();
+  const std::size_t chunks = ChunkCount(sv.BitWidth());
+  const std::span<svBitVecVal> out{dst, chunks};
+  for (std::size_t i = 0; i < chunks; ++i) {
+    const ChunkSlot slot = SlotForChunk(i);
+    out[i] = LowHalf(value[slot.word], slot.shift);
+  }
+}
+
+auto WriteCanonicalLogicVec(svLogicVecVal* dst, const PackedArray& sv) -> void {
+  const auto value = sv.ValueWords();
+  const auto unknown = sv.UnknownWords();
+  const std::size_t chunks = ChunkCount(sv.BitWidth());
+  const std::span<svLogicVecVal> out{dst, chunks};
+  for (std::size_t i = 0; i < chunks; ++i) {
+    const ChunkSlot slot = SlotForChunk(i);
+    out[i].aval = LowHalf(value[slot.word], slot.shift);
+    out[i].bval =
+        unknown.empty() ? 0U : LowHalf(unknown[slot.word], slot.shift);
+  }
 }
 
 }  // namespace lyra::value

--- a/tests/cases/cpp/dpi_export_output_inout/case.yaml
+++ b/tests/cases/cpp/dpi_export_output_inout/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.dpi_export_output_inout
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      r=130

--- a/tests/cases/cpp/dpi_export_output_inout/dpi.c
+++ b/tests/cases/cpp/dpi_export_output_inout/dpi.c
@@ -1,0 +1,29 @@
+#include <stdint.h>
+
+/* A scalar output / inout crosses by pointer to its by-value carrier; a packed
+   bit vector crosses by pointer as a canonical svBitVecVal chunk buffer (LRM
+   35.5.6, Annex H.10.1). The emitted program provides each exported function as
+   an extern "C" symbol; this imported driver calls them back. */
+typedef uint32_t svBitVecVal;
+
+extern void get_pair(int* lo, int* hi);
+extern void accumulate(int* acc);
+extern void fill_wide(svBitVecVal* w);
+extern int sum_wide(const svBitVecVal* w);
+
+int drive(void) {
+  int lo = 0;
+  int hi = 0;
+  get_pair(&lo, &hi); /* lo=3, hi=7 */
+
+  int acc = 5;
+  accumulate(&acc); /* acc=105 */
+
+  svBitVecVal w[4] = {0, 0, 0, 0};
+  fill_wide(w); /* w = {1, 2, 3, 4} */
+  int chunk_sum = (int)(w[0] + w[1] + w[2] + w[3]); /* 10 */
+
+  int s = sum_wide(w); /* w[31:0] + w[127:96] = 1 + 4 = 5 */
+
+  return lo + hi + acc + chunk_sum + s; /* 3+7+105+10+5 = 130 */
+}

--- a/tests/cases/cpp/dpi_export_output_inout/main.sv
+++ b/tests/cases/cpp/dpi_export_output_inout/main.sv
@@ -1,0 +1,41 @@
+// LRM 35.5 DPI-C export with argument directions beyond a by-value input: a
+// foreign C function, called from a running simulation, calls back exported SV
+// functions whose formals carry `output` / `inout` scalars and by-pointer
+// packed vectors. The imported `drive` exercises every direction and folds the
+// results into one integer the SV side asserts, so a marshaling defect in any
+// direction moves the total.
+//
+// Coverage in one module: two scalar `output` formals (a void export), a scalar
+// `inout`, a multi-word 2-state vector `output`, and a multi-word 2-state
+// vector `input` feeding a non-void return.
+module Top;
+  import "DPI-C" function int drive();
+
+  export "DPI-C" function get_pair;
+  export "DPI-C" function accumulate;
+  export "DPI-C" function fill_wide;
+  export "DPI-C" function sum_wide;
+
+  function void get_pair(output int lo, output int hi);
+    lo = 3;
+    hi = 7;
+  endfunction
+
+  function void accumulate(inout int acc);
+    acc = acc + 100;
+  endfunction
+
+  function void fill_wide(output bit [127:0] w);
+    w = 128'h00000004_00000003_00000002_00000001;
+  endfunction
+
+  function int sum_wide(input bit [127:0] w);
+    return w[31:0] + w[127:96];
+  endfunction
+
+  int r;
+  initial begin
+    r = drive();
+    $display("r=%0d", r);
+  end
+endmodule

--- a/tests/cases/cpp/dpi_export_wide_four_state/case.yaml
+++ b/tests/cases/cpp/dpi_export_wide_four_state/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.dpi_export_wide_four_state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      r=1104

--- a/tests/cases/cpp/dpi_export_wide_four_state/dpi.c
+++ b/tests/cases/cpp/dpi_export_wide_four_state/dpi.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+
+/* Minimal canonical DPI-C representation (LRM Annex H.10.1). aval is the value
+   plane, bval the X/Z (unknown) plane; a scalar svLogic encodes sv_0=0, sv_1=1,
+   sv_z=2, sv_x=3. The emitted program provides each exported function as an
+   extern "C" symbol; this imported driver calls them back and checks the planes
+   both ways. */
+typedef unsigned char svLogic;
+typedef struct {
+  uint32_t aval;
+  uint32_t bval;
+} svLogicVecVal;
+
+extern void make_zx(svLogicVecVal* v);
+extern int count_x(const svLogicVecVal* v);
+extern void pass_logic(svLogic a, svLogic* b);
+
+int drive(void) {
+  svLogicVecVal v;
+  v.aval = 0;
+  v.bval = 0;
+  make_zx(&v); /* SV 8'b1x0z_1x0z: aval=0xCC, bval=0x55 */
+  int vok = (v.aval == 0xCC && v.bval == 0x55) ? 1 : 0;
+
+  int nx = count_x(&v); /* four unknown bits -> 4 */
+
+  svLogic b = 0;
+  pass_logic(3, &b); /* x in, x out -> b == 3 */
+  int lok = (b == 3) ? 1 : 0;
+
+  return vok * 1000 + lok * 100 + nx; /* 1000 + 100 + 4 = 1104 */
+}

--- a/tests/cases/cpp/dpi_export_wide_four_state/main.sv
+++ b/tests/cases/cpp/dpi_export_wide_four_state/main.sv
@@ -1,0 +1,41 @@
+// LRM 35.5 DPI-C export marshaling of 4-state values across the boundary: a
+// foreign C function calls back exported SV functions carrying `logic` scalars
+// and `logic` vectors, whose unknown (X/Z) bits cross as the canonical
+// svLogicVecVal / svLogic bval plane (Annex H.10.1). The imported `drive`
+// validates the planes both ways and folds the outcome into one integer.
+//
+// Coverage in one module: a `logic` vector `output` carrying X and Z, a `logic`
+// vector `input` counting unknown bits, and a scalar `logic` input / output
+// round-tripping an X.
+module Top;
+  import "DPI-C" function int drive();
+
+  export "DPI-C" function make_zx;
+  export "DPI-C" function count_x;
+  export "DPI-C" function pass_logic;
+
+  function void make_zx(output logic [7:0] v);
+    v = 8'b1x0z_1x0z;
+  endfunction
+
+  function int count_x(input logic [7:0] v);
+    int c;
+    c = 0;
+    for (int i = 0; i < 8; i++) begin
+      if (v[i] === 1'bx || v[i] === 1'bz) begin
+        c = c + 1;
+      end
+    end
+    return c;
+  endfunction
+
+  function void pass_logic(input logic a, output logic b);
+    b = a;
+  endfunction
+
+  int r;
+  initial begin
+    r = drive();
+    $display("r=%0d", r);
+  end
+endmodule

--- a/tests/cases/errors/dpi_export_unsupported/case.yaml
+++ b/tests/cases/errors/dpi_export_unsupported/case.yaml
@@ -11,7 +11,7 @@ expect:
   stderr:
     contains:
       - "unsupported:"
-      - "DPI-C export with an output / inout argument is not yet supported"
+      - "DPI-C export of a task is not yet supported"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/dpi_export_unsupported/main.sv
+++ b/tests/cases/errors/dpi_export_unsupported/main.sv
@@ -1,11 +1,10 @@
-// A DPI-C export whose argument is not a by-value input is not yet supported:
-// an output argument crosses the boundary by pointer, which the export
-// marshaling does not yet handle (LRM 35.5.5).
+// Exporting a DPI-C task is not yet supported: only functions are lowered so
+// far (LRM 35.5.2). The declaration is well-formed, so slang accepts it and the
+// unsupported-construct diagnostic comes from lowering, not the frontend.
 module Top;
-  export "DPI-C" function set_val;
+  export "DPI-C" task do_work;
 
-  function automatic int set_val(output int o);
-    o = 1;
-    return 42;
-  endfunction
+  task do_work(input int x);
+    $display("x=%0d", x);
+  endtask
 endmodule


### PR DESCRIPTION
## Summary

Completes the DPI-C export marshaling surface on the C++ backend (LRM 35.5): an exported SV function now executes end to end across every argument direction and both value families -- by-value scalars, by-pointer `output` / `inout` scalars, and canonical 2-state / 4-state packed vectors. The `output` / `inout` values ride the completion payload the exported subroutine already returns, so the wrapper destructures that payload and marshals each component out through the foreign caller's pointer; a small-value function result stays a by-value return (LRM 35.5.5).

## Design

The C ABI carrier of each wrapper parameter is realized as a concrete MIR type -- a machine value or a borrowed pointer to a canonical chunk (`svBitVecVal` / `svLogicVecVal`), with `const` for an input carried by the pointer's mutability. A backend therefore spells the signature purely through ordinary type mapping, with no per-parameter ABI decision in render, honoring the mechanical-backend contract while the ABI classification stays decided once at lowering. The canonical chunk is a backend-neutral runtime-library type -- its C++ realization is one mapping and a lower backend realizes the same layout -- not an SV value type.

## Testing

New mixed-language cases exercise scalar `output` / `inout`, multi-word 2-state vector `output` and `input`, and 4-state `logic` vector round-trips carrying X/Z, all driven through the import -> export chain under Lyra as the driver. `bazel test //...` passes.
