### PR TITLE
Add the chandle value domain to the execution backend

### DIFF
--- a/docs/progress/execution-backend.md
+++ b/docs/progress/execution-backend.md
@@ -45,6 +45,12 @@ ownership, or native in-frame layout) for every value.
       procedural local crosses a suspension as an activation-frame value. It extended the activation
       frame with another domain rather than forcing a new lifetime discipline, since a real is a
       non-managed value like a packed one.
+- [x] **The chandle** (LRM 6.14) -- realized on the execution backend as a pointer-like value
+      domain: the value is the pointer itself, carried inline rather than behind a handle to a
+      runtime-owned object. A chandle defaults to null, assigns from null and from another chandle,
+      takes the equality and case-equality families and the boolean test, and lives in a member slot
+      as an owned inline value (not an observable cell, since no process subscribes to it). This is
+      the first bare-pointer value domain; a class handle later reuses the shape.
 - [ ] **The remaining value domains** (aggregates, containers) -- not realized on the execution
       backend at all yet, so no cross-suspension case exists for them.
 - [ ] **A managed value (class handle) across a suspension.** A traceable frame and precise

--- a/include/lyra/backend/llvm/codegen_function.hpp
+++ b/include/lyra/backend/llvm/codegen_function.hpp
@@ -41,7 +41,9 @@ class CodeGenFunction {
   auto LowerAggregate(const lir::AggregateInstr& agg, lir::TypeId result_type)
       -> llvm::Value*;
   auto LowerBinary(const lir::BinaryInstr& binary) -> llvm::Value*;
+  auto LowerMachineBinary(const lir::BinaryInstr& binary) -> llvm::Value*;
   auto LowerUnary(const lir::UnaryInstr& unary) -> llvm::Value*;
+  auto LowerMachineUnary(const lir::UnaryInstr& unary) -> llvm::Value*;
   auto LowerBoolCast(const lir::BoolCastInstr& cast) -> llvm::Value*;
   auto LowerIntCast(const lir::IntCastInstr& cast, lir::TypeId result_type)
       -> llvm::Value*;
@@ -70,6 +72,7 @@ class CodeGenFunction {
   auto LowerIntConst(const lir::IntConst& constant) -> llvm::Value*;
   auto LowerStrConst(const lir::StrConst& constant) -> llvm::Value*;
   auto LowerRealConst(const lir::RealConst& constant) -> llvm::Value*;
+  auto LowerNullConst(const lir::NullConst& constant) -> llvm::Value*;
   void LowerTerminator(const lir::Terminator& terminator);
 
   auto BuiltinCallee(

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -29,7 +29,13 @@ class CodeGenTypes;
 // -- and a source type with no runtime realization has no domain at all. It
 // grows only when the runtime library gains a value type, never to mirror the
 // source language's type kinds.
-enum class ValueDomain : std::uint8_t { kPacked, kString, kReal, kShortReal };
+enum class ValueDomain : std::uint8_t {
+  kPacked,
+  kString,
+  kReal,
+  kShortReal,
+  kChandle,
+};
 
 auto ValueDomainName(ValueDomain domain) -> std::string_view;
 

--- a/include/lyra/lir/function.hpp
+++ b/include/lyra/lir/function.hpp
@@ -72,6 +72,14 @@ struct RealConst {
   TypeId type;
 };
 
+// A null value, the sole literal of the pointer-like types: a chandle (LRM
+// 6.14), a class handle (LRM 8.4), a pointer. It carries only its type -- there
+// is no payload, since every such value's null is the host null pointer -- and
+// the type names the domain the surrounding operator reads it in.
+struct NullConst {
+  TypeId type;
+};
+
 // The code address of a method, as a value. A closure is built from a code
 // reference plus its environment, so a method's address is an operand, not a
 // call target.
@@ -83,7 +91,8 @@ struct FuncRef {
 // A constant or code reference is an operand rather than a value of its own
 // because it has no storage and no dataflow origin to name -- it is
 // materialized at the use site.
-using Operand = std::variant<Use, IntConst, StrConst, RealConst, FuncRef>;
+using Operand =
+    std::variant<Use, IntConst, StrConst, RealConst, NullConst, FuncRef>;
 
 // A runtime-library entry. A static factory is named by its type namespace as
 // well as its function -- `String::FromPackedArray` and `PackedArray::FromInt`

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -256,6 +256,17 @@ auto lyra_rt_activation_frame_load_shortreal(const void* cell) -> void*;
 auto lyra_rt_make_print_value_item_shortreal(
     const void* value, const void* spec) -> void*;
 
+// The `chandle` domain (LRM 6.14). A chandle is a pointer, so the domain
+// carries its value inline: each operand IS the chandle value, not a handle to
+// a runtime-owned value object. LRM 6.14 admits only the equality family (which
+// yields a packed 1-bit) and the boolean test; there is no arithmetic, no
+// ordering, no format entry, and no runtime constructor -- a null chandle is
+// the host null pointer, a native constant.
+auto lyra_rt_chandle_eq(void* lhs, void* rhs) -> void*;
+auto lyra_rt_chandle_ne(void* lhs, void* rhs) -> void*;
+auto lyra_rt_chandle_case_equal(void* lhs, void* rhs) -> void*;
+auto lyra_rt_chandle_to_bool(void* operand) -> bool;
+
 // Builds one conversion's format specification, and the print item that pairs a
 // value with it. Each field arrives as a packed value, as the value model
 // routes every compile-time scalar.

--- a/include/lyra/runtime/member_storage.hpp
+++ b/include/lyra/runtime/member_storage.hpp
@@ -4,6 +4,7 @@
 
 #include "lyra/runtime/scope_program.hpp"
 #include "lyra/runtime/var.hpp"
+#include "lyra/value/chandle.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
 #include "lyra/value/string.hpp"
@@ -15,7 +16,9 @@ namespace lyra::runtime {
 // to its address; what the address means follows the member's storage kind. A
 // borrowed handle is a box holding a pointer the instance does not own, so
 // reading the member reads the box; an observable cell is the storage itself,
-// which library calls reach through its address and never read out as a value.
+// which library calls reach through its address and never read out as a value;
+// an inline value is a pointer-sized value the instance owns, read and written
+// directly at its address.
 class MemberStorage {
  public:
   explicit MemberStorage(MemberStorageDescriptor descriptor);
@@ -30,7 +33,7 @@ class MemberStorage {
  private:
   std::variant<
       void*, Var<value::PackedArray>, Var<value::String>, Var<value::Real>,
-      Var<value::ShortReal>>
+      Var<value::ShortReal>, value::Chandle>
       object_;
 };
 

--- a/include/lyra/runtime/scope_program.hpp
+++ b/include/lyra/runtime/scope_program.hpp
@@ -85,15 +85,19 @@ enum class ValueDomain : std::uint8_t {
   kString,
   kReal,
   kShortReal,
+  kChandle,
 };
 
 // How a member's storage is realized. A borrowed handle is a box holding a
 // pointer the instance does not own, the storage behind a companion reference
 // to another scope. An observable cell is the subscribable variable a process
-// reads, writes, and waits on.
+// reads, writes, and waits on. An inline value is a value the instance owns but
+// no process subscribes to -- a chandle (LRM 6.14), whose pointer-sized value
+// lives in the member slot and is read and written directly.
 enum class MemberStorageKind : std::uint8_t {
   kBorrowedHandle,
-  kObservableCell
+  kObservableCell,
+  kInlineValue,
 };
 
 struct MemberStorageDescriptor {

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -108,17 +108,70 @@ auto CodeGenFunction::ResolvePlaceAddress(const lir::Place& place)
 
 auto CodeGenFunction::LowerBinary(const lir::BinaryInstr& binary)
     -> llvm::Value* {
-  const ValueDomain domain = DomainOf(OperandType(binary.lhs));
+  const lir::TypeId operand_type = OperandType(binary.lhs);
+  // Machine-typed operands are native values, not value-domain handles: their
+  // operator is a machine instruction, not a runtime-library call. This is how
+  // the reduced predicates a real- or string-family `&&` / `||` / `<->`
+  // composes (machine booleans) are combined before `from_bool` widens the
+  // result back to a 1-bit packed.
+  if (std::holds_alternative<lir::MachineIntType>(
+          module_->Unit().types.Get(operand_type).data)) {
+    return LowerMachineBinary(binary);
+  }
+  const ValueDomain domain = DomainOf(operand_type);
   return builder_.CreateCall(
       module_->Runtime().Binary(domain, binary.op),
       {LowerOperand(binary.lhs), LowerOperand(binary.rhs)});
 }
 
+auto CodeGenFunction::LowerMachineBinary(const lir::BinaryInstr& binary)
+    -> llvm::Value* {
+  llvm::Value* lhs = LowerOperand(binary.lhs);
+  llvm::Value* rhs = LowerOperand(binary.rhs);
+  // The only binary operators that reach machine values compose machine
+  // booleans: `&&` and `||` combine two predicates, and `<->` arrives as an
+  // equality of the two predicates. Every other operator acts on a value
+  // domain, never on a machine value.
+  switch (binary.op) {
+    case lir::BinaryOp::kLogicalAnd:
+      return builder_.CreateAnd(lhs, rhs);
+    case lir::BinaryOp::kLogicalOr:
+      return builder_.CreateOr(lhs, rhs);
+    case lir::BinaryOp::kEquality:
+      return builder_.CreateICmpEQ(lhs, rhs);
+    default:
+      throw InternalError(
+          "llvm codegen: binary operator does not apply to machine values");
+  }
+}
+
 auto CodeGenFunction::LowerUnary(const lir::UnaryInstr& unary) -> llvm::Value* {
-  const ValueDomain domain = DomainOf(OperandType(unary.operand));
+  const lir::TypeId operand_type = OperandType(unary.operand);
+  // A machine-typed operand is a native value, not a value-domain handle: its
+  // operator is a machine instruction, not a runtime-library call. This is how
+  // the reduced predicate a real- or chandle-family `!` produces (a machine
+  // boolean) is negated before `from_bool` widens it back to a 1-bit packed.
+  if (std::holds_alternative<lir::MachineIntType>(
+          module_->Unit().types.Get(operand_type).data)) {
+    return LowerMachineUnary(unary);
+  }
+  const ValueDomain domain = DomainOf(operand_type);
   return builder_.CreateCall(
       module_->Runtime().Unary(domain, unary.op),
       {LowerOperand(unary.operand)});
+}
+
+auto CodeGenFunction::LowerMachineUnary(const lir::UnaryInstr& unary)
+    -> llvm::Value* {
+  llvm::Value* operand = LowerOperand(unary.operand);
+  switch (unary.op) {
+    case lir::UnaryOp::kLogicalNot:
+      return builder_.CreateICmpEQ(
+          operand, llvm::ConstantInt::get(operand->getType(), 0));
+    default:
+      throw InternalError(
+          "llvm codegen: machine-typed unary operator is not lowerable");
+  }
 }
 
 auto CodeGenFunction::LowerBoolCast(const lir::BoolCastInstr& cast)
@@ -258,6 +311,9 @@ auto CodeGenFunction::LowerOperand(const lir::Operand& operand)
           [&](const lir::RealConst& c) -> llvm::Value* {
             return LowerRealConst(c);
           },
+          [&](const lir::NullConst& c) -> llvm::Value* {
+            return LowerNullConst(c);
+          },
           [&](const lir::FuncRef& f) -> llvm::Value* {
             return module_->MethodFunction(f.method.class_id, f.method.index);
           }},
@@ -313,6 +369,15 @@ auto CodeGenFunction::LowerRealConst(const lir::RealConst& constant)
   return builder_.CreateCall(
       module_->Runtime().RealConst(domain),
       {llvm::ConstantFP::get(host, constant.value)});
+}
+
+// A null value is the host null pointer, a native LLVM constant. Every
+// pointer-like domain (chandle, class handle, pointer) shares it: the value is
+// the pointer, so its null needs no runtime constructor.
+auto CodeGenFunction::LowerNullConst(const lir::NullConst& constant)
+    -> llvm::Value* {
+  return llvm::ConstantPointerNull::get(
+      llvm::cast<llvm::PointerType>(module_->Types().Map(constant.type)));
 }
 
 auto CodeGenFunction::BuiltinCallee(

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -28,6 +28,8 @@ auto ValueDomainName(ValueDomain domain) -> std::string_view {
       return "real";
     case ValueDomain::kShortReal:
       return "shortreal";
+    case ValueDomain::kChandle:
+      return "chandle";
   }
   throw InternalError("llvm codegen: unknown value domain");
 }
@@ -46,6 +48,10 @@ auto ValueDomainOf(const lir::CompilationUnit& unit, lir::TypeId type)
           [](const lir::RealType&) { return ValueDomain::kReal; },
           [](const lir::RealTimeType&) { return ValueDomain::kReal; },
           [](const lir::ShortRealType&) { return ValueDomain::kShortReal; },
+          // A chandle (LRM 6.14) is a pointer-sized value carried inline: the
+          // domain's handle is the chandle value itself, not a reference to a
+          // runtime-owned value object.
+          [](const lir::ChandleType&) { return ValueDomain::kChandle; },
           [](const auto&) -> ValueDomain {
             throw InternalError(
                 "llvm codegen: value type has no runtime library domain");

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -288,6 +288,10 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
       &lyra_rt_activation_frame_load_shortreal);
   add("lyra_rt_make_print_value_item_shortreal",
       &lyra_rt_make_print_value_item_shortreal);
+  add("lyra_rt_chandle_eq", &lyra_rt_chandle_eq);
+  add("lyra_rt_chandle_ne", &lyra_rt_chandle_ne);
+  add("lyra_rt_chandle_case_equal", &lyra_rt_chandle_case_equal);
+  add("lyra_rt_chandle_to_bool", &lyra_rt_chandle_to_bool);
   Check(
       jit.getMainJITDylib().define(
           llvm::orc::absoluteSymbols(std::move(symbols))),
@@ -327,6 +331,8 @@ auto AbiDomain(backend::llvm_backend::ValueDomain domain)
       return runtime::ValueDomain::kReal;
     case backend::llvm_backend::ValueDomain::kShortReal:
       return runtime::ValueDomain::kShortReal;
+    case backend::llvm_backend::ValueDomain::kChandle:
+      return runtime::ValueDomain::kChandle;
   }
   throw InternalError("jit executor: unknown value domain");
 }
@@ -348,6 +354,14 @@ auto DescribeMember(const lir::CompilationUnit& unit, lir::TypeId type)
     return runtime::MemberStorageDescriptor{
         .kind = runtime::MemberStorageKind::kBorrowedHandle,
         .domain = runtime::ValueDomain::kNone};
+  }
+  // A chandle member is a value the instance owns but no process subscribes to
+  // (LRM 6.14), stored inline in its slot rather than behind an observable
+  // cell.
+  if (std::holds_alternative<lir::ChandleType>(data)) {
+    return runtime::MemberStorageDescriptor{
+        .kind = runtime::MemberStorageKind::kInlineValue,
+        .domain = runtime::ValueDomain::kChandle};
   }
   throw InternalError("jit executor: member type has no storage realization");
 }

--- a/src/lyra/lir/dump.cpp
+++ b/src/lyra/lir/dump.cpp
@@ -242,6 +242,7 @@ class LirDumper {
             [](const RealConst& c) -> std::string {
               return std::format("real:{}", c.value);
             },
+            [](const NullConst&) -> std::string { return "null"; },
             [](const FuncRef& f) -> std::string {
               return std::format(
                   "funcref {}.{}", f.method.class_id.value, f.method.index);

--- a/src/lyra/lir/function.cpp
+++ b/src/lyra/lir/function.cpp
@@ -18,6 +18,7 @@ auto OperandType(const Function& fn, const Operand& operand)
           [](const IntConst& c) -> std::optional<TypeId> { return c.type; },
           [](const StrConst& c) -> std::optional<TypeId> { return c.type; },
           [](const RealConst& c) -> std::optional<TypeId> { return c.type; },
+          [](const NullConst& c) -> std::optional<TypeId> { return c.type; },
           [](const FuncRef&) -> std::optional<TypeId> { return std::nullopt; }},
       operand);
 }

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -1033,6 +1033,10 @@ auto FunctionLowerer::LowerExpr(const mir::Block& block, mir::ExprId id)
             return lir::Operand{lir::RealConst{
                 .value = lit.value, .type = unit_->TranslateType(type)}};
           },
+          [&](const mir::NullLiteral&) -> diag::Result<lir::Operand> {
+            return lir::Operand{
+                lir::NullConst{.type = unit_->TranslateType(type)}};
+          },
           [&](const mir::LocalRef& ref) -> diag::Result<lir::Operand> {
             const std::optional<LocalBinding>& binding = locals_[ref.var.value];
             if (!binding.has_value()) {
@@ -1138,8 +1142,17 @@ auto FunctionLowerer::LowerExpr(const mir::Block& block, mir::ExprId id)
               return Unsupported(
                   "mir_to_lir: unary operator has no direct realization");
             }
+            // A logical-not over a machine boolean -- the reduced predicate a
+            // real- or chandle-family `!` produces before `from_bool` widens it
+            // back -- stays a machine boolean; its surface 1-bit type is
+            // restored by the enclosing `from_bool`.
+            const lir::TypeId result_type =
+                (*op == lir::UnaryOp::kLogicalNot &&
+                 lir::OperandType(fn_, *operand) == unit_->MachineBoolType())
+                    ? unit_->MachineBoolType()
+                    : unit_->TranslateType(type);
             return Emit(
-                unit_->TranslateType(type),
+                result_type,
                 lir::UnaryInstr{.op = *op, .operand = *std::move(operand)});
           },
           [&](const mir::BinaryExpr& bin) -> diag::Result<lir::Operand> {
@@ -1156,8 +1169,17 @@ auto FunctionLowerer::LowerExpr(const mir::Block& block, mir::ExprId id)
             if (!rhs) {
               return rhs;
             }
+            // A logical or equality operator composing machine booleans -- the
+            // reduced predicates a real- or string-family `&&` / `||` / `<->`
+            // builds before `from_bool` widens the result back -- stays a
+            // machine boolean; its surface 1-bit type is restored by the
+            // enclosing `from_bool`.
+            const lir::TypeId result_type =
+                lir::OperandType(fn_, *lhs) == unit_->MachineBoolType()
+                    ? unit_->MachineBoolType()
+                    : unit_->TranslateType(type);
             return Emit(
-                unit_->TranslateType(type),
+                result_type,
                 lir::BinaryInstr{
                     .op = *op, .lhs = *std::move(lhs), .rhs = *std::move(rhs)});
           },

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -20,6 +20,7 @@
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/scope_program.hpp"
 #include "lyra/runtime/var.hpp"
+#include "lyra/value/chandle.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
@@ -145,6 +146,7 @@ using lyra::runtime::SubscribeValueChange;
 using lyra::runtime::Trigger;
 using lyra::runtime::UnitDefinition;
 using lyra::runtime::Var;
+using lyra::value::Chandle;
 using lyra::value::Format;
 using lyra::value::FormatSpec;
 using lyra::value::PackedArray;
@@ -896,5 +898,21 @@ auto lyra_rt_make_print_value_item_shortreal(
     const void* value, const void* spec) -> void* {
   return Own(PrintItem(
       PrintValueItem(Read<ShortReal>(value), Read<FormatSpec>(spec))));
+}
+
+auto lyra_rt_chandle_eq(void* lhs, void* rhs) -> void* {
+  return Own(Chandle{lhs} == Chandle{rhs});
+}
+
+auto lyra_rt_chandle_ne(void* lhs, void* rhs) -> void* {
+  return Own(Chandle{lhs} != Chandle{rhs});
+}
+
+auto lyra_rt_chandle_case_equal(void* lhs, void* rhs) -> void* {
+  return Own(Chandle{lhs}.CaseEqual(Chandle{rhs}));
+}
+
+auto lyra_rt_chandle_to_bool(void* operand) -> bool {
+  return static_cast<bool>(Chandle{operand});
 }
 }

--- a/src/lyra/runtime/member_storage.cpp
+++ b/src/lyra/runtime/member_storage.cpp
@@ -30,10 +30,19 @@ MemberStorage::MemberStorage(MemberStorageDescriptor descriptor) {
         case ValueDomain::kShortReal:
           object_.emplace<Var<value::ShortReal>>();
           return;
+        case ValueDomain::kChandle:
+          throw InternalError(
+              "MemberStorage: a chandle is not observable storage");
         case ValueDomain::kNone:
           throw InternalError(
               "MemberStorage: an observable cell needs a value domain");
       }
+    case MemberStorageKind::kInlineValue:
+      if (descriptor.domain == ValueDomain::kChandle) {
+        object_.emplace<value::Chandle>();
+        return;
+      }
+      throw InternalError("MemberStorage: unsupported inline-value domain");
   }
   throw InternalError("MemberStorage: unknown member storage kind");
 }

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -237,6 +237,38 @@ auto WriteRealFamilySource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+auto WriteChandleSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  chandle h;\n"
+      << "  chandle g;\n"
+      << "  initial begin\n"
+      << "    $display(\"h_null=%0d not_h=%0d\", h == null, !h);\n"
+      << "    g = h;\n"
+      << "    $display(\"g_eq_h=%0d g_ne_h=%0d\", g == h, g != h);\n"
+      << "    $display(\"g_ceq_h=%0d g_cne_h=%0d\", g === h, g !== h);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
+auto WriteLogicalOperatorSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  real a;\n"
+      << "  real b;\n"
+      << "  string s;\n"
+      << "  initial begin\n"
+      << "    a = 1.0;\n"
+      << "    b = 0.0;\n"
+      << "    s = \"x\";\n"
+      << "    $display(\"and=%0d or=%0d\", a && b, a || b);\n"
+      << "    $display(\"equiv=%0d impl=%0d\", a <-> b, a -> b);\n"
+      << "    $display(\"not_a=%0d not_b=%0d\", !a, !b);\n"
+      << "    $display(\"str=%0d\", (s.len() > 0) && a);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -531,6 +563,71 @@ TEST(LyraRun, JitAndCppAgreeOnRealFamily) {
       jit.stdout_text,
       "r=4.50 widened=2.50 from_int=3.00\n"
       "rounded=5 sum=7.50\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnChandle) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteChandleSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "h_null=1 not_h=1\n"
+      "g_eq_h=1 g_ne_h=0\n"
+      "g_ceq_h=1 g_cne_h=0\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnLogicalOperators) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteLogicalOperatorSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "and=0 or=1\n"
+      "equiv=0 impl=0\n"
+      "not_a=0 not_b=1\n"
+      "str=1\n")
       << "stdout: " << jit.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

This realizes the SystemVerilog `chandle` (LRM 6.14) on the LLVM/JIT execution backend, bringing it to parity with the C++ backend, and fixes a latent bug the work exposed in the logical-operator lowering for every non-packed value domain.

## Design

### chandle as a bare-pointer value domain

A chandle is a pointer, so unlike packed / string / real -- which are opaque handles to runtime-owned value objects -- its value *is* the pointer and is carried inline as the `ptr` the generated code already holds. Equality (`==` / `!=` / `===` / `!==`) and the boolean test route through `value::Chandle`'s own operators; a null literal is the host null pointer emitted as a native `ConstantPointerNull`, needing no runtime constructor. Because the MIR accesses a chandle member with a plain load / store (a chandle is never observable -- no process subscribes to it), its member storage is a new `kInlineValue` kind: an owned pointer-sized value in the member slot, distinct from an observable cell and from a borrowed handle. This is the first bare-pointer value domain, and a class handle will reuse the shape.

### Native machine logical operators

The `!` over real and chandle, and `&&` / `||` / `<->` / `->` over real and string, lower through a host boolean: `bool(x)` yields a native machine `i1`, the logical operator composes those, and `from_bool` widens the result back to a 1-bit packed. The backend previously routed every binary and unary through the value-domain runtime library, which has no entry for a machine boolean, so these threw `value type has no runtime library domain` on the JIT backend -- a bug shipped but never exercised, since the real-family tests used no logical operators. `LowerUnary` / `LowerBinary` now dispatch a machine-typed operand to a native LLVM instruction (`icmp`, `and`, `or`), mirroring how the C++ backend renders these as native operators on a host bool, and mir_to_lir types the machine-boolean predicate correctly so `from_bool` re-widens it. This is the same operand-type-driven dispatch the layer already uses to pick a value domain.

## Testing

Two JIT-vs-C++ agreement tests: one for the chandle surface (null default, member storage, assignment, the equality and case-equality families, the boolean test) and one for logical operators over real and string (`&&`, `||`, `<->`, `->`, `!`).
