### PR TITLE
Lower DPI-C import tasks under the task protocol

### DIFF
--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -25,23 +25,24 @@ out-of-scope external-driver boundary -- is recorded in `../decisions/dpi-foreig
 
 Done when the LRM 35 surface reproduces on both backends: import (pure and context, every argument
 direction, the full DPI type surface including 4-state, wide packed, `chandle`, and open arrays),
-export (package / `$unit`-scoped and module-scoped instance-bound), DPI tasks (non-suspending and
-suspending, both directions), the `svdpi` context surface, a generated ABI header, and link-input
-orchestration.
+export (package / `$unit`-scoped and module-scoped instance-bound), DPI tasks (both directions,
+including a foreign task that consumes simulation time and the disable protocol), the `svdpi`
+context surface, a generated ABI header, and link-input orchestration.
 
 ## Actionable
 
-Two frontiers are open. On the C++ backend the import surface (D1-D3) is in, and the export
-marshaling surface (D4, D4b) runs: an export executes end to end through the import -> export chain
-across every argument direction and both value families -- by-value scalars, by-pointer scalar
-`output` / `inout`, and canonical 2-state / 4-state packed vectors -- with its wrapper recovering
-the exported subroutine's single top-level instance from the running design. What remains for the
-export surface is instance-bound dispatch beyond that single instance via `svSetScope` and
-receiver-less package / `$unit` scope (D4a), the generated ABI header and export linkage (D9), then
-DPI tasks (D5). On the execution backend scalar import (D10) is in: a foreign call lowers to an
-external-linkage symbol and the by-value carriers marshal. The rest of the import surface (D11) is
-blocked, and not by anything DPI owns: by-pointer marshaling is expressed as a closure, which that
-backend does not yet lower at all (`architecture-reset.md`).
+Two frontiers are open. On the C++ backend the function import surface (D1-D3) is in, the export
+marshaling surface (D4, D4b) runs -- an export executes end to end through the import -> export
+chain across every argument direction and both value families (by-value scalars, by-pointer scalar
+`output` / `inout`, and canonical 2-state / 4-state packed vectors), its wrapper recovering the
+exported subroutine's single top-level instance from the running design -- and the import task (D5)
+runs: SV calls a foreign C task under the uniform task protocol. What remains is instance-bound
+export dispatch beyond that single instance via `svSetScope` and receiver-less package / `$unit`
+scope (D4a), the generated ABI header and export linkage (D9), the export task (D6), and
+foreign-boundary suspension (D6b). On the execution backend scalar import (D10) is in: a foreign
+call lowers to an external-linkage symbol and the by-value carriers marshal. The rest of the import
+surface (D11) is blocked, and not by anything DPI owns: by-pointer marshaling is expressed as a
+closure, which that backend does not yet lower at all (`architecture-reset.md`).
 
 ## Sub-Steps
 
@@ -103,11 +104,23 @@ from an external main.
 
 ### DPI tasks
 
-- [ ] D5 -- Non-suspending DPI tasks (LRM 35.5.2), import and export. Reuses the immediate-call
-      path; a task keeps its task call protocol and is never rewritten into a function.
-- [ ] D6 -- Suspending DPI tasks: a foreign task that consumes simulation time, including the
-      disable protocol (LRM 35.9). Rides on the timing and suspension machinery (`scheduling.md`,
-      `processes.md`).
+A DPI task rides the same task call protocol as any SV task (LRM 13.4.4): the call is a suspension
+point, lowered to a coroutine the caller awaits. A task is classified by kind, never by whether it
+consumes time -- a task that consumes no simulation time is the trivial case of one that does, on
+the same protocol, not a separate path. The two items below are the boundary directions; the runtime
+machinery that lets a foreign task actually suspend across the C boundary, with the disable
+protocol, extends the same awaitable and is tracked as D6b.
+
+- [x] D5 -- DPI import task (LRM 35.5.2): SV calls a foreign C task. The call rides the uniform task
+      protocol -- a coroutine the caller awaits -- with the actuals marshaled in and the writeback
+      arguments marshaled back; a task that consumes no time completes within the await.
+- [ ] D6 -- DPI export task: foreign C calls an SV task through its foreign-linkage wrapper, driving
+      the exported task's coroutine body to completion and marshaling its writebacks back across the
+      boundary.
+- [ ] D6b -- Foreign-boundary suspension: a foreign task that actually consumes simulation time,
+      yielded across the C boundary, with the disable protocol (LRM 35.9). This extends the task
+      awaitable's runtime; the call protocol and lowering are unchanged from D5 / D6. Rides on the
+      timing and suspension machinery (`scheduling.md`, `processes.md`).
 
 ### Context and the svdpi surface
 
@@ -148,7 +161,7 @@ surface at a time; export and tasks follow once the C++-backend items fix their 
       the buffer constructors and the canonical-plane marshaling primitives. A `real` import rides
       on the real value domain, not on this item.
 - [ ] D12 -- Export and DPI tasks on the execution backend, once the C++-backend export and task
-      items (D4-D6) define the shape.
+      items (D4-D6b) define the shape.
 
 ## Design record
 

--- a/include/lyra/hir/foreign_import.hpp
+++ b/include/lyra/hir/foreign_import.hpp
@@ -21,14 +21,16 @@ struct DpiParamAbi {
 
 // A subroutine declared `import "DPI-C"` (LRM 35.4). It has no SV body, so it
 // is a bodyless external callable, not a body-bearing structural subroutine.
-// The foreign linkage name, the pure property, and the ABI projection of the
-// signature are resolved once here (where slang types are available) and are
-// the sole downstream source for the import; no layer below reads slang.
+// The foreign linkage name, the pure property, whether it is a task or a
+// function (LRM 35.5), and the ABI projection of the signature are resolved
+// once here (where slang types are available) and are the sole downstream
+// source for the import; no layer below reads slang.
 // Lowered to a MIR static external callable at HIR-to-MIR.
 struct ForeignImportDecl {
   std::string name;
   std::string foreign_name;
   bool is_pure = false;
+  bool is_task = false;
   support::DpiScalarAbi ret_abi = support::DpiScalarAbi::kVoid;
   TypeId ret_sv_type{};
   std::vector<DpiParamAbi> params;

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -146,6 +146,25 @@ class StructuralScopeLowerer {
         hir::StructuralHops{.value = hops.value - 1}, id);
   }
 
+  // Resolve a DPI-C import reference to its HIR declaration by walking `hops`
+  // scopes outward. The import's task-or-function kind decides whether its call
+  // site is a suspension point (LRM 35.8), which the statement lowering reads
+  // from here.
+  [[nodiscard]] auto LookupForeignImport(
+      hir::StructuralHops hops, hir::ForeignImportId id) const
+      -> const hir::ForeignImportDecl& {
+    if (hops.value == 0) {
+      return hir_scope_->foreign_imports.Get(id);
+    }
+    if (parent_ == nullptr) {
+      throw InternalError(
+          "StructuralScopeLowerer::LookupForeignImport: hops walk ran "
+          "past the root scope");
+    }
+    return parent_->LookupForeignImport(
+        hir::StructuralHops{.value = hops.value - 1}, id);
+  }
+
   void AddRoutedRefTarget(mir::FieldId target, mir::TypeId slot_type) {
     routed_ref_targets_.push_back(
         RoutedRefMeta{.target = target, .slot_type = slot_type});

--- a/include/lyra/mir/static_callable.hpp
+++ b/include/lyra/mir/static_callable.hpp
@@ -47,11 +47,18 @@ struct ExternalSymbol {
 // -- `DpiScalarAbi`, not the full carrier variant, which makes a vector return
 // unrepresentable. The SV semantic signature stays on the frontend where type
 // checking ran; MIR carries only what marshaling and linkage need.
+//
+// `is_task` marks a task rather than a function (LRM 35.5): a task carries no
+// SV return value, its call is a suspension point the caller awaits, and its
+// foreign symbol returns the DPI disable-acknowledgment `int` (LRM 35.8) that
+// the call discards. A `void`-returning function also has no return value, so
+// the task distinction cannot be recovered from the return alone.
 struct StaticCallableDecl {
   std::string name;
   std::vector<ForeignParam> params;
   TypeId ret_sv_type;
   support::DpiScalarAbi ret_abi;
+  bool is_task;
   ExternalSymbol external;
 };
 

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -387,8 +387,10 @@ auto RenderScopeAsClass(
 // import's foreign symbol as a C-linkage prototype over its ABI carrier types
 // (LRM 35.4 / 35.5.6). An output / inout argument crosses by pointer, so its
 // carrier type gains a trailing `*` (a scalar `int` -> `int*`, a `const char*`
-// string -> `const char**`); an input argument crosses by value. Emitted before
-// the classes that call them so a foreign call resolves against a declared
+// string -> `const char**`); an input argument crosses by value. A task's
+// foreign symbol returns the DPI disable-acknowledgment `int` (LRM 35.8), which
+// the call discards; a function returns its result carrier. Emitted before the
+// classes that call them so a foreign call resolves against a declared
 // signature; the definitions come from the user's linked C. Empty when the unit
 // declares no import.
 auto RenderForeignImportDeclarations(const mir::CompilationUnit& unit)
@@ -418,9 +420,12 @@ auto RenderForeignImportDeclarations(const mir::CompilationUnit& unit)
           params += vec.four_state ? "svLogicVecVal*" : "svBitVecVal*";
         }
       }
+      const std::string_view ret_type =
+          callable.is_task
+              ? DpiScalarCarrierCppType(support::DpiScalarAbi::kInt)
+              : DpiScalarCarrierCppType(callable.ret_abi);
       out += std::format(
-                 R"(extern "C" {} {}({});)",
-                 DpiScalarCarrierCppType(callable.ret_abi),
+                 R"(extern "C" {} {}({});)", ret_type,
                  callable.external.foreign_name, params) +
              "\n";
     }

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -353,23 +353,21 @@ auto ClassifyDpiParams(
 // It has no SV body, so it is not a `SubroutineDecl`; the caller records it
 // among the scope's foreign imports, not its subroutines. The ABI
 // classification and the foreign name are resolved once here and never
-// re-derived downstream. Input-only scalar functions are accepted; the
-// remaining forms are located diagnostics.
+// re-derived downstream. A function or a task is accepted; a task carries no
+// return, so its `void` return classifies as `kVoid` through the same path. A
+// `context` import remains a located diagnostic, its scope surface a separate
+// concern.
 auto LowerForeignImport(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
     -> diag::Result<hir::ForeignImportDecl> {
   const auto& mapper = unit_lowerer.SourceMapper();
   const auto loc = mapper.PointSpanOf(sym.location);
-  if (sym.subroutineKind == slang::ast::SubroutineKind::Task) {
-    return diag::Fail(
-        loc, diag::DiagCode::kUnsupportedDpi,
-        "DPI-C import task is not yet supported");
-  }
   if (sym.flags.has(slang::ast::MethodFlags::DPIContext)) {
     return diag::Fail(
         loc, diag::DiagCode::kUnsupportedDpi,
         "DPI-C context import is not yet supported");
   }
+  const bool is_task = sym.subroutineKind == slang::ast::SubroutineKind::Task;
   auto ret_abi = ClassifyDpiScalarResult(sym.getReturnType(), loc);
   if (!ret_abi) return std::unexpected(std::move(ret_abi.error()));
   auto ret_type = unit_lowerer.InternType(sym.getReturnType(), loc);
@@ -382,6 +380,7 @@ auto LowerForeignImport(
       .name = std::string{sym.name},
       .foreign_name = ResolveImportCName(sym),
       .is_pure = sym.flags.has(slang::ast::MethodFlags::Pure),
+      .is_task = is_task,
       .ret_abi = *ret_abi,
       .ret_sv_type = *ret_type,
       .params = std::move(*abi_params)};

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -886,10 +886,12 @@ auto BuildBufferDataCall(
               carrier_type, mir::PointerOwnership::kBorrowed)});
 }
 
-// The all-input import call: every actual crosses by value, so the call is a
-// plain expression -- no statement sequencing, no boundary temps. Each actual
-// is marshaled to its ABI carrier, the foreign symbol is called over the
-// carriers, and a non-void result is marshaled back to the declared SV type.
+// The all-input function import call: every actual crosses by value, so the
+// call is a plain expression -- no statement sequencing, no boundary temps.
+// Each actual is marshaled to its ABI carrier, the foreign symbol is called
+// over the carriers, and a non-void result is marshaled back to the declared SV
+// type. A task never reaches here; its await needs a coroutine, so it always
+// sequences.
 template <ExprLowerer Lowerer>
 auto LowerForeignImportInputsOnly(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
@@ -932,25 +934,25 @@ auto LowerForeignImportInputsOnly(
       result_type);
 }
 
-// The general import call: at least one actual needs a boundary temp -- an
-// output / inout of any carrier, or a canonical vector of any direction (a
-// vector crosses by pointer even as an input). The call sequences copy-in, the
-// by-pointer foreign call, copy-back into each writeback actual's cell, and the
-// marshaled return -- a statement sequence yielding a value, so it lowers to an
-// immediately-invoked closure, uniform for void / valued and statement /
-// expression position. A by-value scalar input still crosses by value with no
-// temp.
+// Populates `closure`'s body with the DPI import boundary: each actual
+// marshaled to its carrier -- a by-value scalar input crossing by value, a
+// writeback direction or a canonical vector of any direction seeded into a
+// boundary temp passed by pointer -- then the foreign call, then the copy-back
+// of each writeback into its actual's cell. A valued call captures its carrier
+// result in a temp, returned so the caller marshals it after the copy-backs; a
+// void call (including a task, whose foreign symbol's disable-ack `int` is
+// discarded) is a bare statement and returns no temp. Shared by the function
+// and task import lowerings, which differ only in how they finish the closure.
 template <ExprLowerer Lowerer>
-auto LowerForeignImportSequenced(
-    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+auto PopulateForeignImportBoundary(
+    Lowerer& lowerer, ClosureBuilder& closure, const hir::CallExpr& c,
+    const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target)
+    -> diag::Result<std::optional<mir::LocalId>> {
   auto& unit_lowerer = lowerer.Owner();
   auto& unit = unit_lowerer.Unit();
   const auto& hir_exprs = lowerer.HirExprs();
   const mir::TypeId void_t = unit.builtins.void_type;
 
-  ClosureBuilder closure(unit, frame);
   mir::Block& body = closure.Body();
   const WalkFrame& cframe = closure.Frame();
 
@@ -1105,17 +1107,64 @@ auto LowerForeignImportSequenced(
     body.AppendStmt(mir::ExprStmt{.expr = body.exprs.Add(assign)});
   }
 
-  if (is_void) {
+  return ret_temp;
+}
+
+// The general function import call: at least one actual needs a boundary temp
+// -- an output / inout of any carrier, or a canonical vector of any direction
+// (a vector crosses by pointer even as an input). The boundary is a statement
+// sequence yielding a value, so it lowers to an immediately-invoked closure,
+// uniform for void / valued and statement / expression position. A by-value
+// scalar input still crosses by value with no temp.
+template <ExprLowerer Lowerer>
+auto LowerForeignImportSequenced(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto& unit_lowerer = lowerer.Owner();
+  auto& unit = unit_lowerer.Unit();
+
+  ClosureBuilder closure(unit, frame);
+  auto ret_temp =
+      PopulateForeignImportBoundary(lowerer, closure, c, decl, target);
+  if (!ret_temp) return std::unexpected(std::move(ret_temp.error()));
+
+  if (!ret_temp->has_value()) {
     return BuildClosureCallExpr(
         unit, *frame.current_block, closure.BuildVoid());
   }
+  mir::Block& body = closure.Body();
+  const WalkFrame& cframe = closure.Frame();
+  const mir::TypeId call_type =
+      CarrierTypeId(unit, support::ScalarCarrier{decl.ret_abi});
   const mir::ExprId ret_ref =
-      body.exprs.Add(mir::MakeLocalRefExpr(*ret_temp, call_type));
+      body.exprs.Add(mir::MakeLocalRefExpr(**ret_temp, call_type));
   const mir::ExprId result_id = body.exprs.Add(MarshalCarrierToSv(
       unit_lowerer, cframe, ret_ref, support::ScalarCarrier{decl.ret_abi},
       result_type));
   return BuildClosureCallExpr(
       unit, *frame.current_block, closure.Build(result_id));
+}
+
+// The task import call (LRM 35.5.2): the same boundary as a function, but a
+// task has no SV return, so the closure finishes as a coroutine -- the
+// awaitable the caller drives, the same call protocol as a native task enable
+// (LRM 35.8), uniform whether or not the foreign side consumes time. The
+// boundary always sequences through the closure, even all-input, because the
+// await needs a coroutine to drive. The coroutine closure is returned directly,
+// not called: it renders self-invoking to a `Coroutine`, and the statement
+// lowering awaits it.
+template <ExprLowerer Lowerer>
+auto LowerForeignImportTask(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    const mir::StaticCallableDecl& decl, mir::StaticCallableTarget target)
+    -> diag::Result<mir::Expr> {
+  auto& unit = lowerer.Owner().Unit();
+  ClosureBuilder closure(unit, frame);
+  auto ret_temp =
+      PopulateForeignImportBoundary(lowerer, closure, c, decl, target);
+  if (!ret_temp) return std::unexpected(std::move(ret_temp.error()));
+  return closure.BuildCoroutine();
 }
 
 // The compilation-unit identity of the class `hops` enclosing levels up. A
@@ -1134,10 +1183,12 @@ auto EnclosingClassIdAtHops(
 
 // LRM 35.4 import call: an ordinary call to the external static callable,
 // wrapped in boundary marshaling. The carriers and directions are read from the
-// callable's own declaration, resolved once at its declaration lowering. A call
-// whose every actual is a by-value scalar input is a plain expression; a call
-// with any actual that needs a boundary temp (an output / inout, or a canonical
-// vector of any direction) sequences through a closure.
+// callable's own declaration, resolved once at its declaration lowering. A task
+// call is a coroutine the caller awaits, so it always sequences through a
+// closure; a function call whose every actual is a by-value scalar input is a
+// plain expression, and one with any actual that needs a boundary temp (an
+// output / inout, or a canonical vector of any direction) sequences through a
+// closure.
 template <ExprLowerer Lowerer>
 auto LowerForeignImportCall(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
@@ -1156,6 +1207,9 @@ auto LowerForeignImportCall(
   const mir::StaticCallableDecl& decl =
       frame.EnclosingClassAtHops(hops).static_callables.Get(target.slot);
 
+  if (decl.is_task) {
+    return LowerForeignImportTask(lowerer, frame, c, decl, target);
+  }
   const bool needs_temp = std::ranges::any_of(decl.params, NeedsBoundaryTemp);
   if (needs_temp) {
     return LowerForeignImportSequenced(

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -460,6 +460,12 @@ auto LowerExprStmt(
         const auto* imported =
             std::get_if<hir::ImportedMethodRef>(&call->callee)) {
       suspends = support::ImportedRuntimeMethodSuspends(imported->method);
+    } else if (
+        const auto* foreign =
+            std::get_if<hir::ForeignImportRef>(&call->callee)) {
+      suspends = process.EnclosingScopeLowerer()
+                     .LookupForeignImport(foreign->hops, foreign->id)
+                     .is_task;
     }
     auto call_or = process.LowerExpr(inner, frame);
     if (!call_or) return std::unexpected(std::move(call_or.error()));

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -1576,6 +1576,7 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
             .params = std::move(params),
             .ret_sv_type = unit_lowerer.TranslateType(imp.ret_sv_type),
             .ret_abi = imp.ret_abi,
+            .is_task = imp.is_task,
             .external = mir::ExternalSymbol{
                 .foreign_name = imp.foreign_name, .is_pure = imp.is_pure}});
   }

--- a/tests/cases/cpp/dpi_import_task/case.yaml
+++ b/tests/cases/cpp/dpi_import_task/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.dpi_import_task
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      b=14 c=8
+      total=110
+      got=42

--- a/tests/cases/cpp/dpi_import_task/dpi.c
+++ b/tests/cases/cpp/dpi_import_task/dpi.c
@@ -1,0 +1,22 @@
+int set_pair(int a, int* b, int* c) {
+  *b = a * 2;
+  *c = a + 1;
+  return 0;
+}
+
+int accumulate(int delta, int* total) {
+  *total = *total + delta;
+  return 0;
+}
+
+static int saved;
+
+int remember(int x) {
+  saved = x;
+  return 0;
+}
+
+int recall(int* y) {
+  *y = saved;
+  return 0;
+}

--- a/tests/cases/cpp/dpi_import_task/main.sv
+++ b/tests/cases/cpp/dpi_import_task/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  import "DPI-C" task set_pair(input int a, output int b, output int c);
+  import "DPI-C" task accumulate(input int delta, inout int total);
+  import "DPI-C" task remember(input int x);
+  import "DPI-C" task recall(output int y);
+  int b;
+  int c;
+  int total;
+  int got;
+  initial begin
+    set_pair(7, b, c);
+    $display("b=%0d c=%0d", b, c);
+    total = 100;
+    accumulate(5, total);
+    accumulate(5, total);
+    $display("total=%0d", total);
+    remember(42);
+    recall(got);
+    $display("got=%0d", got);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Extends the DPI-C import surface to tasks (LRM 35.5.2): SystemVerilog can now call a foreign C task, not just a function. A DPI task is classified purely by kind and rides the same task call protocol as any native SV task -- the call is a suspension point lowered to a coroutine the caller awaits (LRM 35.8: "calls to import tasks in SystemVerilog code are indistinguishable from calls to native SystemVerilog tasks"). There is no non-suspending/suspending classification anywhere; a task that consumes no simulation time is simply the trivial case that completes within the await, and the runtime machinery that would let a foreign task actually suspend across the C boundary (D6b) extends the same awaitable without touching the lowering.

## Design

The cut composes existing orthogonal abstractions rather than introducing anything DPI-specific. Task-ness is carried as a flag on the import declaration (a void-returning function is indistinguishable from a task by its return alone). The import-call lowering routes a task through a coroutine closure whose body is the same marshal-in / foreign-call / copy-back boundary the function path already builds -- the two share one helper and differ only in how they finish the closure (return-marshal versus a coroutine returned directly, which renders self-invoking to a Coroutine). The statement lowering awaits it through the same per-callee suspension dispatch that native task enables use. The extern "C" prototype returns the DPI disable-acknowledgment int (LRM 35.8), which the call discards.

## Testing

A mixed-language cpp_run case exercises output, inout (called twice to show SV-variable statefulness), all-input, and an all-input-plus-output round-trip through C static state.