### PR TITLE
Support SV pure virtual and abstract classes

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -87,8 +87,11 @@ each stage establishes, not how.
       when the source wrote `super.new(args)`, an empty-args implicit forward otherwise -- so a
       backend never resorts to its target language's default-construction convention.
 
-- [ ] Pure-virtual and abstract classes (LRM 8.21): a virtual method with no body is a contract the
-      derived must fill, and a class carrying such a slot is not directly constructible.
+- [x] Pure-virtual and abstract classes (LRM 8.21): a virtual method with no body is a contract the
+      derived must fill, and a class carrying such a slot is not directly constructible. Each layer
+      states the "declared, no source body" fact as a structural property of the method, orthogonal
+      to whether the source separately wrote an empty body -- the two forms are semantically
+      distinct and remain distinct end-to-end.
 
 - [ ] Interface-class conformance: a class may conform to several interfaces, a relation distinct
       from its single concrete base and carrying no second instance storage. Type-associated static

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -887,6 +887,47 @@ enough to warrant its own focused review.
       must be resolved at declaration time -- large and cross-cutting enough to warrant its own
       focused review.
 
+- [ ] R60 -- The C++ backend's value-emission entries name runtime library identifiers directly and
+      inject prologue statements the MIR does not state. `../architecture/backend_contract.md`
+      confines every runtime library type literal to the type-mapping dispatch and confines every
+      runtime library identifier (wrapper type, helper function, helper struct, method spelling) to
+      "MIR types and MIR calls that map onto them", with a bounded exception only for a leaf literal
+      materializing its own value. The current backend violates this in three related ways -- render
+      composes the identifier as a string, render fabricates the operation the identifier realizes,
+      and render injects a receiver-recovery or initialization statement that the callable body does
+      not carry. The pattern shows up in enough render entries that a fix is not one edit, but the
+      shape is uniform: the runtime library form of every MIR primitive is stated in one central
+      mapping (the peer of the type-mapping dispatch, extended to value forms), and every prologue
+      statement the wrapper needs sits in the MIR body as an ordinary statement the render walks.
+      Concrete sites today:
+  - Aggregate value-build primitives (`ConcatExpr`, `ReplicationExpr`) render as inline
+    `lyra::value::PackedArray::Concat(...)` / `PackedArray::Replicate(...)` / `ReplicateString(...)`
+    string composition in value-emission entries, with the runtime library identifier spelled at the
+    render site rather than derived from a single mapping.
+  - The queue-concatenation builder renders as inline `lyra::value::MakeQueueConcat<...>(...)` with
+    element spread/append wrapped by `QSpread(...)` / `QElem(...)` at the render site.
+  - Class construction of a managed reference renders as inline `lyra::runtime::GcNew<...>` from a
+    Construct call whose result type is `ManagedRefType`.
+  - The DPI-C foreign-export wrapper injects a prologue statement
+    `Self self = static_cast<Self>(lyra::runtime::ResolveExportInstance("..."));` around the
+    wrapper's body; the receiver recovery is not a MIR statement in the wrapper's body block, so a
+    second backend must re-derive that it needs one and where.
+  - The instance-method render injects `Self self = this;` before the body -- another prologue the
+    MIR body does not state, so every method-form callable's `self` binding is a render-side
+    convention rather than a stated MIR fact.
+  - The compilation unit's enum types render through hand-composed
+    `class E final : public lyra::value::Enum<E> { ... };` in the header, with the runtime library
+    type spelled directly and the class boilerplate structured only by the render text. The enum
+    declaration form belongs behind the type-mapping dispatch or as its own emission concept, not a
+    hand-written template. **Target shape**: one mapping per axis. A runtime library type is named
+    exactly once, in type mapping (already the shape today). A runtime library operation is named
+    exactly once, in a peer value-form dispatch a value-emission entry looks up by MIR primitive
+    kind. A prologue statement -- receiver recovery, self binding -- is a MIR statement in the
+    callable body a HIR-to-MIR lowering emits, so render walks it like any other statement.
+    **Blocker**: none for individual sites, but the value-form dispatch is a new backend surface
+    that pays off only when several sites route through it; scope the cut so at least the queue /
+    packed / managed-new forms land together with the dispatch table itself.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -7,23 +7,32 @@
 #include "lyra/base/arena.hpp"
 #include "lyra/hir/class_id.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/field_id.hpp"
 #include "lyra/hir/method_id.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
 
-// A class property (LRM 8.4): a named member variable of a class, with its own
-// per-object storage. `initializer`, when present, is the declared `= value`
-// expression (LRM 8.7): during construction the property is set to this value
-// -- which may read another property through the receiver -- before the user
-// constructor body runs; absent means the property takes its type's Table 7-1
-// default. Property initialization is part of the constructor's execution, so
-// the expression is held in the constructor body's expression arena.
+// A class property (LRM 8.4): a named member variable of a class, with its
+// own per-object storage. The declared `= value` initializer (LRM 8.7),
+// when the source writes one, is a construction-protocol fact and lives on
+// `ClassDecl.field_inits`, not on the property's declaration -- the two
+// facets belong to different concerns.
 struct ClassField {
   std::string name;
   TypeId type;
-  std::optional<ExprId> initializer;
+};
+
+// A source-written property initializer (LRM 8.7): the assignment that
+// runs against the receiver during construction, before the user
+// constructor body, on the property named by `target`. `value` lives in
+// the constructor body's expression arena so an initializer that reads
+// another property or a formal parameter reaches the same procedural var
+// the body would.
+struct FieldInit {
+  FieldId target;
+  ExprId value;
 };
 
 // A construction-protocol fact (LRM 8.7): the arguments to forward to the
@@ -50,21 +59,29 @@ struct BaseCall {
 //
 // `constructor` is the class's `new` (LRM 8.7). Every class has one: the
 // user-written `function new` when the source declares it, otherwise a
-// synthesized empty constructor, matching the implicit `new` the LRM provides
-// when the source omits one. Property initializers are evaluated as part of
-// its execution, so their expressions live in its body's expression arena.
+// synthesized empty constructor, matching the implicit `new` the LRM
+// provides when the source omits one.
 //
-// `base_call` peers with `constructor` because base-constructor forwarding is
-// a class-level construction fact, not a statement inside the ctor body
-// (LRM 8.7): source-written `super.new(args)` populates it, and any expression
-// referencing the ctor's own formals lives in the same body arena.
+// `base_call` peers with `constructor` because base-constructor forwarding
+// is a class-level construction fact, not a statement inside the ctor body
+// (LRM 8.7): source-written `super.new(args)` populates it, and any
+// expression referencing the ctor's own formals lives in the same body
+// arena.
+//
+// `field_inits` peers with `constructor` for the same reason: an initializer
+// executes as part of the class's construction protocol before the user
+// body's statements, and its expressions live in the constructor body's
+// arena. Only fields the source declared with an explicit `= value` appear
+// here; a field without one takes its type's Table 7-1 default at
+// construction.
 struct ClassDecl {
   std::string name;
   std::optional<ClassId> base;
-  std::vector<ClassField> fields;
+  base::Arena<ClassField, FieldId> fields;
   base::Arena<SubroutineDecl, MethodId> methods;
   SubroutineDecl constructor;
   std::optional<BaseCall> base_call;
+  std::vector<FieldInit> field_inits;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -11,6 +11,7 @@
 #include "lyra/hir/class_id.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/field_id.hpp"
 #include "lyra/hir/inc_dec_op.hpp"
 #include "lyra/hir/inside_item.hpp"
 #include "lyra/hir/primary.hpp"
@@ -123,7 +124,7 @@ struct RangeSelectExpr {
 // is carried on the access.
 struct MemberAccessExpr {
   ExprId base_value;
-  std::uint32_t field_index;
+  FieldId field_index;
 };
 
 // Class property access (LRM 8.4 / 8.13): `owner` names the class that
@@ -135,7 +136,7 @@ struct MemberAccessExpr {
 struct ClassPropertyAccessExpr {
   ExprId base_value;
   ClassId owner;
-  std::uint32_t field_index;
+  FieldId field_index;
 };
 
 struct ConcatExpr {

--- a/include/lyra/hir/field_id.hpp
+++ b/include/lyra/hir/field_id.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <functional>
+
+namespace lyra::hir {
+
+// The declaration-order position of a class or aggregate field within its
+// owning declaration's field arena. Two `FieldId` values compare on the raw
+// position; the arena that mints them decides which declaration the id
+// belongs to, so an id from one arena is never a valid handle in another.
+struct FieldId {
+  std::uint32_t value;
+
+  auto operator<=>(const FieldId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir
+
+template <>
+struct std::hash<lyra::hir::FieldId> {
+  auto operator()(lyra::hir::FieldId id) const noexcept -> std::size_t {
+    return std::hash<std::uint32_t>{}(id.value);
+  }
+};

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -69,6 +69,16 @@ struct MethodRef {
 // resolved reference to the base method this one overrides -- carried as an
 // already-resolved identity so downstream consumers never repeat the name and
 // signature matching the frontend has done.
+//
+// `is_prototype` records that the source declared this method as a pure
+// virtual prototype (LRM 8.21 `pure virtual function ...;`) -- the signature
+// exists but the source supplied no body. `body.procedural_vars` still
+// carries the parameter var arena so a backend can emit the declaration,
+// but every other body field (stmts, exprs, root_stmt, root_scope) is left
+// at construction default and never consumed. This bit is source-level
+// truth: a bodyless prototype and a legal empty body (LRM 8.21 note) are
+// distinct forms that emptiness alone cannot separate. Only class methods
+// carry it; free subroutines and processes always ship a body.
 struct SubroutineDecl {
   std::string name;
   SubroutineKind kind;
@@ -77,6 +87,7 @@ struct SubroutineDecl {
   std::optional<ProceduralVarId> result_var;
   ProceduralBody body;
   bool is_virtual = false;
+  bool is_prototype = false;
   std::optional<MethodRef> overrides;
 };
 

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <variant>
 
+#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/field_id.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/with_clause_id.hpp"
@@ -49,11 +51,16 @@ struct ProceduralVarRef {
 };
 
 // A reference to a class property (LRM 8.4) from within an instance method
-// body, where the property is named without an explicit handle and reaches the
-// invoking object through the method's receiver. `field_index` is the
-// property's declaration-order position in the enclosing class.
+// body, where the property is named without an explicit handle and reaches
+// the invoking object through the method's receiver. `owner` is the class
+// that declares the property, and `field_index` is its declaration-order
+// position within that class's property arena. Under inheritance (LRM 8.13)
+// a bare name may resolve to a property declared on an ancestor class, so
+// identity is owner-qualified rather than derived from the enclosing method
+// body's class.
 struct ClassPropertyRef {
-  std::uint32_t field_index;
+  ClassId owner;
+  FieldId field_index;
 
   auto operator==(const ClassPropertyRef&) const -> bool = default;
 };

--- a/include/lyra/lowering/ast_to_hir/expression/selects.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/selects.hpp
@@ -5,8 +5,6 @@
 // MemberAccess (LRM 11.5.2 struct/union member access). Both procedural and
 // structural contexts.
 
-#include <cstdint>
-
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
@@ -23,12 +21,6 @@ class ClassPropertySymbol;
 namespace lyra::lowering::ast_to_hir {
 
 class ProcessLowerer;
-
-// A class property's declaration-order index among its class's properties
-// (LRM 8.4), matching the order the HIR ClassDecl registers its fields, so the
-// index identifies the same property on either side.
-auto ClassPropertyIndex(const slang::ast::ClassPropertySymbol& prop)
-    -> std::uint32_t;
 
 // LRM 7.10 `$` (UnboundedLiteral) in a queue index / slice bound. Resolves to
 // the queue's last index via the base bound on the walk frame. A queue is a

--- a/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
+++ b/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
@@ -12,6 +12,7 @@
 
 namespace slang::ast {
 class Expression;
+class MethodPrototypeSymbol;
 class SubroutineSymbol;
 }  // namespace slang::ast
 
@@ -48,6 +49,18 @@ auto LowerConstructorDecl(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym,
     WalkFrame frame, const slang::ast::Expression* base_call_ast)
     -> diag::Result<ConstructorAndBaseCall>;
+
+// Lowers a slang `pure virtual` class method prototype (LRM 8.21) into a
+// hir::SubroutineDecl with `is_prototype = true` and `is_virtual = true`.
+// The signature -- return type, parameter list, and the parameter binding
+// arena -- is populated so a backend can emit the C++ pure declaration; the
+// body arenas are left at construction default. The caller records the
+// result in the owning class's method arena, exactly like an ordinary
+// instance method, and sets `overrides` if slang identified the prototype
+// as re-declaring an existing pure slot in an abstract descendant.
+auto LowerMethodPrototypeDecl(
+    UnitLowerer& unit_lowerer, const slang::ast::MethodPrototypeSymbol& proto)
+    -> diag::Result<hir::SubroutineDecl>;
 
 // Lowers a slang `import "DPI-C"` subroutine (LRM 35.4) into a bodyless
 // hir::ForeignImportDecl: the resolved foreign name, the pure property, and the

--- a/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
@@ -18,6 +19,7 @@
 #include "lyra/frontend/slang_source_mapper.hpp"
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/field_id.hpp"
 #include "lyra/hir/method_id.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_scope.hpp"
@@ -186,6 +188,26 @@ class UnitLowerer {
         "owning class was not interned before this lookup");
   }
 
+  // Records the HIR `FieldId` a class property received when its owning
+  // class's `InternClass` added it to the field arena. A downstream
+  // `handle.field` access reads the id in O(1) through this lookup instead
+  // of re-walking the property list at every reference site.
+  void RegisterClassPropertyFieldId(
+      const slang::ast::ClassPropertySymbol& prop, hir::FieldId id) {
+    class_property_field_ids_.emplace(&prop, id);
+  }
+
+  [[nodiscard]] auto LookupClassPropertyFieldId(
+      const slang::ast::ClassPropertySymbol& prop) const -> hir::FieldId {
+    if (const auto it = class_property_field_ids_.find(&prop);
+        it != class_property_field_ids_.end()) {
+      return it->second;
+    }
+    throw InternalError(
+        "UnitLowerer::LookupClassPropertyFieldId: property has no recorded "
+        "id; the owning class was not interned before this lookup");
+  }
+
   // Facts.
   [[nodiscard]] auto SourceMapper() const
       -> const frontend::SlangSourceMapper& {
@@ -307,6 +329,8 @@ class UnitLowerer {
   std::unordered_map<const slang::ast::ClassType*, hir::ClassId> class_cache_;
   std::unordered_map<const slang::ast::SubroutineSymbol*, hir::MethodId>
       method_cache_;
+  std::unordered_map<const slang::ast::ClassPropertySymbol*, hir::FieldId>
+      class_property_field_ids_;
   StructuralDataObjectBindings structural_data_object_bindings_;
   SubroutineBindings subroutine_bindings_;
   ForeignImportBindings foreign_import_bindings_;

--- a/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
@@ -7,9 +7,7 @@
 #include "lyra/hir/class_decl.hpp"
 #include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
 #include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
-#include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
-#include "lyra/mir/field.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -64,10 +62,11 @@ class ClassDeclLowerer {
   const hir::ClassDecl* hir_class_;
 
   // Storage layout the shape stage settles and the body stage reuses: the
-  // property field ids in declaration order, and the per-callable
-  // static-storage plans whose placements name the exact field ids the
-  // published shape declares.
-  std::vector<mir::FieldId> field_ids_;
+  // per-callable static-storage plans whose placements name the exact field
+  // ids the published shape declares. Property field ids are not stored --
+  // they are the same identity as the HIR field ids the class carries, so
+  // any consumer reaches a mir field id from a hir field id through
+  // `UnitLowerer::TranslateField`.
   ProceduralScopeMaterializationTable class_scopes_;
   std::vector<CallableStoragePlan> method_plans_;
   std::optional<CallableStoragePlan> ctor_plan_;

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -11,10 +11,12 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_manager.hpp"
 #include "lyra/hir/compilation_unit.hpp"
+#include "lyra/hir/field_id.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/field.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -105,6 +107,16 @@ class UnitLowerer {
       throw InternalError("UnitLowerer::TranslateClass: unmapped HIR class");
     }
     return class_map_[hir_id.value];
+  }
+
+  // Translates a HIR class field's identity to its MIR counterpart. Peer to
+  // `TranslateClass` / `TranslateType`: the layer-boundary crossing is one
+  // named function so a consumer never has to know that the HIR and MIR
+  // field arenas presently share value semantics (fields are appended in
+  // lockstep during the shape pass), and a later divergence rewires the
+  // mapping in one place without touching any consumer.
+  [[nodiscard]] auto TranslateField(hir::FieldId hir_id) const -> mir::FieldId {
+    return mir::FieldId{.value = hir_id.value};
   }
 
   [[nodiscard]] auto ClassObjectType(hir::ClassId hir_id) const -> mir::TypeId {

--- a/include/lyra/mir/callable.hpp
+++ b/include/lyra/mir/callable.hpp
@@ -75,21 +75,34 @@ struct InternalCallable {
   CallableCode code;
 };
 
+// A pure virtual class method's prototype (LRM 8.21): the source declared the
+// method without a body. `code` still carries the signature -- the receiver,
+// the named parameters, and the result type -- so a backend can emit the
+// declaration, but `code.body` is a default-constructed empty `Block` that no
+// consumer traverses. Only a virtual class method can carry this arm, so a
+// callable with `impl = PurePrototype` always has `virtual_dispatch` set. A
+// bodyless prototype and a legal empty body (LRM 8.21 note) are distinct
+// forms body emptiness alone cannot separate.
+struct PurePrototype {
+  CallableCode code;
+};
+
 // A named callable a class or a package namespace owns. Every SystemVerilog
 // function and task, every process body, every synthesized lifecycle body, and
 // every DPI-C import is this one concept, distinguished only by its
-// implementation form (an SV body or a foreign symbol), whether its signature
-// carries a receiver, and how a referencing site reaches it -- a direct call, a
-// constructor-time process registration, an engine-dispatched lifecycle hook.
-// The receiver is not a kind of callable: an instance method carries `self` as
-// its first parameter, a static callable omits it. `virtual_dispatch`, when
-// present, states this callable's role in the class's dispatch table (LRM 8.20)
-// -- introducing a new slot or overriding an ancestor's -- so a backend renders
-// the marker off stated structure, never re-deriving virtualness by name; it is
-// absent for a direct-only callable (every static callable and DPI import).
+// implementation form (an SV body, a foreign symbol, or a pure virtual
+// prototype), whether its signature carries a receiver, and how a referencing
+// site reaches it -- a direct call, a constructor-time process registration,
+// an engine-dispatched lifecycle hook. The receiver is not a kind of
+// callable: an instance method carries `self` as its first parameter, a
+// static callable omits it. `virtual_dispatch`, when present, states this
+// callable's role in the class's dispatch table (LRM 8.20) -- introducing a
+// new slot or overriding an ancestor's -- so a backend renders the marker off
+// stated structure, never re-deriving virtualness by name; it is absent for a
+// direct-only callable (every static callable and DPI import).
 struct CallableDecl {
   std::string name;
-  std::variant<InternalCallable, ExternalCallable> impl;
+  std::variant<InternalCallable, ExternalCallable, PurePrototype> impl;
   std::optional<VirtualDispatchRole> virtual_dispatch;
   CallableVisibility visibility;
 };

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -97,20 +97,20 @@ auto OverrideSuffix(const mir::CallableDecl& m) -> std::string_view {
 // resolve receiver-relative references uniformly. The callable's dispatch role
 // decorates the declaration with `virtual` or `override` where applicable. A
 // namespace's receiver-less callable renders through the free-function path
-// instead.
+// instead. A pure virtual prototype (LRM 8.21, MIR `PurePrototype`) is
+// rendered as a bodyless declaration suffixed with `= 0`; C++ then treats
+// the enclosing class as abstract without any class-level marker required.
 auto RenderClassCallable(
     const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::Class& s, const mir::CallableDecl& m, std::size_t indent)
     -> std::string {
-  const mir::CallableCode& code = std::get<mir::InternalCallable>(m.impl).code;
-  const ScopeView body_view = (parent_struct_view == nullptr)
-                                  ? ScopeView::ForRoot(unit, s, code)
-                                  : parent_struct_view->WithClass(s, code);
-
+  // A pure virtual prototype (LRM 8.21) exposes only the signature; body
+  // rendering is skipped in favor of a `= 0` marker on the declaration.
+  const mir::CallableCode& code =
+      std::holds_alternative<mir::PurePrototype>(m.impl)
+          ? std::get<mir::PurePrototype>(m.impl).code
+          : std::get<mir::InternalCallable>(m.impl).code;
   const std::string ret = RenderTypeAsCpp(unit, code.result_type);
-  const mir::LocalId self_local = code.params[0];
-  const auto& self_decl = code.locals.Get(self_local);
-  const std::string self_type = RenderTypeAsCpp(unit, self_decl.type);
 
   std::string sig = std::format("{}auto {}(", VirtualPrefix(m), m.name);
   for (std::size_t i = 1; i < code.params.size(); ++i) {
@@ -118,6 +118,17 @@ auto RenderClassCallable(
     sig += RenderCallableParam(unit, code.locals.Get(code.params[i]));
   }
   sig += std::format(") -> {}{}", ret, OverrideSuffix(m));
+
+  if (std::holds_alternative<mir::PurePrototype>(m.impl)) {
+    return std::format("{}{} = 0;\n", Indent(indent), sig);
+  }
+
+  const ScopeView body_view = (parent_struct_view == nullptr)
+                                  ? ScopeView::ForRoot(unit, s, code)
+                                  : parent_struct_view->WithClass(s, code);
+  const mir::LocalId self_local = code.params[0];
+  const auto& self_decl = code.locals.Get(self_local);
+  const std::string self_type = RenderTypeAsCpp(unit, self_decl.type);
 
   std::string out;
   out += std::format("{}{} {{\n", Indent(indent), sig);
@@ -294,6 +305,35 @@ auto RenderStaticConstant(
 
 auto RenderScopeAsClass(
     const mir::CompilationUnit& unit, const mir::Class& s, std::size_t indent,
+    const ScopeView* parent_struct_view) -> std::string;
+
+// Renders a class and every intra-unit base it depends on into `out`, in
+// an order that guarantees each base is a complete C++ type before its
+// derived (C++ requires base completeness at derivation). The interning
+// walk sets the registry order, which may reach a derived class first, so
+// this walker climbs the base chain first and marks visited classes in
+// `emitted`. Skips runtime-tree-node classes; those emit through the
+// scope-tree walk.
+void RenderClassInDependencyOrder(
+    const mir::CompilationUnit& unit, mir::ClassId id,
+    std::vector<bool>& emitted, std::string& out) {
+  if (emitted[id.value]) return;
+  if (!unit.classes.IsDefined(id)) return;
+  const mir::Class& cls = unit.GetClass(id);
+  if (cls.is_scope_tree_node) return;
+  if (cls.base.has_value()) {
+    if (const auto* intra = std::get_if<mir::IntraUnitClassRef>(&*cls.base)) {
+      RenderClassInDependencyOrder(unit, intra->class_id, emitted, out);
+    }
+  }
+  if (emitted[id.value]) return;
+  emitted[id.value] = true;
+  out += RenderScopeAsClass(unit, cls, 0, nullptr);
+  out += "\n";
+}
+
+auto RenderScopeAsClass(
+    const mir::CompilationUnit& unit, const mir::Class& s, std::size_t indent,
     const ScopeView* parent_struct_view) -> std::string {
   // `this_anchor` is bound to `s.constructor` so it doubles as the view for
   // rendering the constructor body. Children's bodies use it as their enclosing
@@ -342,14 +382,16 @@ auto RenderScopeAsClass(
   // object's public callable surface, a scope's processes and lifecycle hooks
   // are internal -- and the access specifier follows that stated visibility,
   // coalescing a run of callables that share one. The constructor is not in
-  // this arena; it was emitted above with C++ mem-init-list syntax.
+  // this arena; it was emitted above with C++ mem-init-list syntax. An
+  // external (DPI-C import) callable is a global `extern "C"` symbol, not a
+  // class member; it is emitted as a prototype outside the class. A pure
+  // virtual prototype (LRM 8.21) is a class member and renders inline with
+  // its `= 0` marker.
   std::optional<mir::CallableVisibility> open_section;
   for (std::size_t i = 0; i < s.callables.size(); ++i) {
     const mir::CallableId cid{static_cast<std::uint32_t>(i)};
     const auto& callable = s.callables.Get(cid);
-    // An external (DPI-C import) callable is a global `extern "C"` symbol, not
-    // a class member; it is emitted as a prototype outside the class.
-    if (!std::holds_alternative<mir::InternalCallable>(callable.impl)) continue;
+    if (std::holds_alternative<mir::ExternalCallable>(callable.impl)) continue;
     if (open_section != callable.visibility) {
       open_section = callable.visibility;
       out += std::format(
@@ -618,38 +660,17 @@ auto RenderScopeHeaderFile(
   }
   out += RenderUnitTypeDeclarations(unit);
 
-  // A SystemVerilog class is a free-standing registry object with no structural
-  // parent, so it is not reached by the scope tree's `contained` walk. Emit
-  // every non-tree-node class before the scope tree that may reference it
-  // through a handle or `new`. (The scope objects -- the module and its
-  // generate scopes -- are runtime tree nodes emitted by the tree walk below.)
-  //
-  // C++ requires a base class to be a complete type at the point of a derived
-  // class's declaration, so an intra-unit base must render before its derived
-  // class. Registry order is set by the interning walk, which may reach the
-  // derived class first (via `Derived h;` before `class Base` is seen), so
-  // the emission order climbs each class's base chain first.
+  // A SystemVerilog class is a free-standing registry object with no
+  // structural parent, so it is not reached by the scope tree's `contained`
+  // walk. Emit every non-tree-node class before the scope tree that may
+  // reference it through a handle or `new`. (The scope objects -- the module
+  // and its generate scopes -- are runtime tree nodes emitted by the tree
+  // walk below.) The dependency-order walker inside handles base-before-
+  // derived ordering.
   std::vector<bool> emitted(unit.classes.size(), false);
-  const std::function<void(mir::ClassId)> emit_class =
-      [&](mir::ClassId id) -> void {
-    if (emitted[id.value]) return;
-    if (!unit.classes.IsDefined(id)) return;
-    const mir::Class& cls = unit.GetClass(id);
-    if (cls.is_scope_tree_node) {
-      return;
-    }
-    if (cls.base.has_value()) {
-      if (const auto* intra = std::get_if<mir::IntraUnitClassRef>(&*cls.base)) {
-        emit_class(intra->class_id);
-      }
-    }
-    if (emitted[id.value]) return;
-    emitted[id.value] = true;
-    out += RenderScopeAsClass(unit, cls, 0, nullptr);
-    out += "\n";
-  };
   for (std::size_t i = 0; i < unit.classes.size(); ++i) {
-    emit_class(mir::ClassId{static_cast<std::uint32_t>(i)});
+    RenderClassInDependencyOrder(
+        unit, mir::ClassId{static_cast<std::uint32_t>(i)}, emitted, out);
   }
 
   out += RenderScopeAsClass(unit, s, 0, nullptr);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -411,7 +411,9 @@ class HirDumper {
               return std::format("ProceduralVar[{}]", r.var.value);
             },
             [](const ClassPropertyRef& r) -> std::string {
-              return std::format("ClassProperty[{}]", r.field_index);
+              return std::format(
+                  "ClassProperty[Class[{}].{}]", r.owner.value,
+                  r.field_index.value);
             },
             [](const RoutedRef& r) -> std::string {
               return std::format("RoutedRef[{}]", r.id.value);
@@ -733,13 +735,13 @@ class HirDumper {
             [](const MemberAccessExpr& sel) -> std::string {
               return std::format(
                   "MemberAccessExpr base=Expr[{}] field={}",
-                  sel.base_value.value, sel.field_index);
+                  sel.base_value.value, sel.field_index.value);
             },
             [](const ClassPropertyAccessExpr& sel) -> std::string {
               return std::format(
                   "ClassPropertyAccessExpr base=Expr[{}] owner=Class[{}] "
                   "field={}",
-                  sel.base_value.value, sel.owner.value, sel.field_index);
+                  sel.base_value.value, sel.owner.value, sel.field_index.value);
             },
             [](const ConcatExpr& c) -> std::string {
               std::string operands;
@@ -873,14 +875,13 @@ class HirDumper {
     Line(std::format("[{}] class \"{}\"", index, c.name));
     Indent();
     for (const auto& field : c.fields) {
-      if (field.initializer.has_value()) {
-        Line(
-            std::format(
-                "{}:Type[{}] = Expr[{}]", field.name, field.type.value,
-                field.initializer->value));
-      } else {
-        Line(std::format("{}:Type[{}]", field.name, field.type.value));
-      }
+      Line(std::format("{}:Type[{}]", field.name, field.type.value));
+    }
+    for (const auto& init : c.field_inits) {
+      Line(
+          std::format(
+              "FieldInit target=Field[{}] value=Expr[{}]", init.target.value,
+              init.value.value));
     }
     for (std::size_t i = 0; i < c.methods.size(); ++i) {
       DumpSubroutine(
@@ -1001,11 +1002,19 @@ class HirDumper {
 
   void DumpSubroutine(
       std::string_view label, std::size_t index, const SubroutineDecl& d) {
+    std::string flags;
+    if (d.is_virtual) flags += " virtual";
+    if (d.is_prototype) flags += " prototype";
+    if (d.overrides.has_value()) {
+      flags += std::format(
+          " overrides=Class[{}].Method[{}]", d.overrides->class_id.value,
+          d.overrides->method.value);
+    }
     Line(
         std::format(
-            "{}[{}] {} \"{}\" : Type[{}]", label, index,
+            "{}[{}] {} \"{}\" : Type[{}]{}", label, index,
             d.kind == SubroutineKind::kTask ? "task" : "function", d.name,
-            d.result_type.value));
+            d.result_type.value, flags));
     Indent();
     for (std::size_t i = 0; i < d.params.size(); ++i) {
       const auto& param = d.params[i];
@@ -1017,7 +1026,9 @@ class HirDumper {
     if (d.result_var.has_value()) {
       Line(std::format("Result var=ProceduralVar[{}]", d.result_var->value));
     }
-    DumpProceduralBody(d.body);
+    if (!d.is_prototype) {
+      DumpProceduralBody(d.body);
+    }
     Dedent();
   }
 

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -219,10 +219,15 @@ auto MakeClassPropertyRefExpr(
     -> diag::Result<hir::Expr> {
   auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
+  const auto& owner_class =
+      sym.getParentScope()->asSymbol().as<slang::ast::ClassType>();
+  auto owner_id = unit_lowerer.InternClass(owner_class, span);
+  if (!owner_id) return std::unexpected(std::move(owner_id.error()));
   return hir::MakeRefExpr(
       hir::ClassPropertyRef{
-          .field_index =
-              ClassPropertyIndex(sym.as<slang::ast::ClassPropertySymbol>())},
+          .owner = *owner_id,
+          .field_index = unit_lowerer.LookupClassPropertyFieldId(
+              sym.as<slang::ast::ClassPropertySymbol>())},
       *type_id, span);
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -163,20 +163,6 @@ auto LowerRangeSelectExpr(
   };
 }
 
-auto ClassPropertyIndex(const slang::ast::ClassPropertySymbol& prop)
-    -> std::uint32_t {
-  const auto* scope = prop.getParentScope();
-  std::uint32_t index = 0;
-  for (const auto& member :
-       scope->membersOfType<slang::ast::ClassPropertySymbol>()) {
-    if (&member == &prop) {
-      return index;
-    }
-    ++index;
-  }
-  throw InternalError("ClassPropertyIndex: property not found in its class");
-}
-
 template <ExprLowerer Lowerer>
 auto LowerMemberAccessExpr(
     Lowerer& lowerer, WalkFrame frame,
@@ -194,7 +180,8 @@ auto LowerMemberAccessExpr(
             hir::MemberAccessExpr{
                 .base_value = base_id,
                 .field_index =
-                    sel.member.as<slang::ast::FieldSymbol>().fieldIndex,
+                    hir::FieldId{
+                        sel.member.as<slang::ast::FieldSymbol>().fieldIndex},
             },
         .span = span,
     };
@@ -211,7 +198,7 @@ auto LowerMemberAccessExpr(
             hir::ClassPropertyAccessExpr{
                 .base_value = base_id,
                 .owner = *owner_id,
-                .field_index = ClassPropertyIndex(prop),
+                .field_index = lowerer.Owner().LookupClassPropertyFieldId(prop),
             },
         .span = span,
     };

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -323,6 +323,59 @@ auto LowerConstructorDecl(
       .base_call = std::move(result_or->base_call)};
 }
 
+auto LowerMethodPrototypeDecl(
+    UnitLowerer& unit_lowerer, const slang::ast::MethodPrototypeSymbol& proto)
+    -> diag::Result<hir::SubroutineDecl> {
+  const auto& mapper = unit_lowerer.SourceMapper();
+
+  auto return_type_or = unit_lowerer.InternType(
+      proto.getReturnType(), mapper.PointSpanOf(proto.location));
+  if (!return_type_or) {
+    return std::unexpected(std::move(return_type_or.error()));
+  }
+
+  hir::ProceduralBody body;
+  ProcessLowerer lowerer(unit_lowerer, proto);
+
+  // A pure virtual prototype has no body to walk, but it still has parameter
+  // vars whose types the signature must expose. The scope accumulators are
+  // written into by `AddProceduralVar` and discarded on return -- a prototype
+  // has no lexical body scope for downstream consumers to attach to.
+  std::vector<hir::ProceduralVarId> root_declarations;
+  std::vector<hir::ProceduralScopeId> root_children;
+  const WalkFrame body_frame =
+      WalkFrame{}
+          .WithProceduralBody(&body, &body.exprs)
+          .WithProceduralScopeAccumulators(&root_declarations, &root_children);
+
+  std::vector<hir::SubroutineParam> params;
+  params.reserve(proto.getArguments().size());
+  for (const auto* formal : proto.getArguments()) {
+    auto formal_type_or = unit_lowerer.InternType(
+        formal->getType(), mapper.PointSpanOf(formal->location));
+    if (!formal_type_or) {
+      return std::unexpected(std::move(formal_type_or.error()));
+    }
+    const hir::ProceduralVarId var =
+        lowerer.AddProceduralVar(body_frame, body, *formal, *formal_type_or);
+    params.push_back(
+        hir::SubroutineParam{
+            .var = var, .direction = ParamDirectionOf(*formal)});
+  }
+
+  return hir::SubroutineDecl{
+      .name = std::string{proto.name},
+      .kind = ToHirSubroutineKind(proto.subroutineKind),
+      .result_type = *return_type_or,
+      .params = std::move(params),
+      .result_var = std::nullopt,
+      .body = std::move(body),
+      .is_virtual = true,
+      .is_prototype = true,
+      .overrides = std::nullopt,
+  };
+}
+
 // Classifies each formal argument's ABI projection (LRM 35.5.6): its direction,
 // C ABI carrier, and SV type. Import and export declarations project their
 // arguments identically, so both build their parameter list here.

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -508,6 +508,34 @@ auto TranslateTypeData(
 // initialization every class performs. It is modeled as a constructor with no
 // formals and an empty body; the initialization itself is composed onto the
 // body separately, the same way it is for a user-written constructor.
+// Looks up the given method name in `derived_cls`'s base chain for a pure
+// virtual prototype (LRM 8.21) an implementation on `derived_cls` should
+// override. Slang's `checkForOverride` establishes a
+// `SubroutineSymbol::getOverride()` link only when the base method is itself
+// a `SubroutineSymbol`; when the base declares the method as `pure virtual`
+// (a `MethodPrototypeSymbol`), slang leaves the derived method's
+// `overrides` unset, so this lookup re-establishes the link. Slang's own
+// `Scope::find` already flattens the ancestor chain by unwrapping the
+// `TransparentMember` wrappers each inheriting scope inserts, so one query
+// on the immediate base scope reaches the actual declaration wherever it
+// sits in the chain.
+auto FindOverriddenPureInBaseChain(
+    const slang::ast::ClassType& derived_cls, std::string_view method_name)
+    -> const slang::ast::MethodPrototypeSymbol* {
+  const auto* base_type = derived_cls.getBaseClass();
+  if (base_type == nullptr) return nullptr;
+  const auto& base_cls =
+      base_type->getCanonicalType().as<slang::ast::ClassType>();
+  const auto* found = base_cls.find(method_name);
+  if (found == nullptr ||
+      found->kind != slang::ast::SymbolKind::MethodPrototype) {
+    return nullptr;
+  }
+  const auto& proto = found->as<slang::ast::MethodPrototypeSymbol>();
+  if (!proto.flags.has(slang::ast::MethodFlags::Pure)) return nullptr;
+  return &proto;
+}
+
 auto SynthesizeDefaultConstructor(hir::TypeId void_type, diag::SourceSpan span)
     -> hir::SubroutineDecl {
   hir::ProceduralBody body;
@@ -571,11 +599,9 @@ auto UnitLowerer::InternClass(
     }
     auto field_type = InternType(prop.getType(), span);
     if (!field_type) return std::unexpected(std::move(field_type.error()));
-    decl.fields.push_back(
-        hir::ClassField{
-            .name = std::string(prop.name),
-            .type = *field_type,
-            .initializer = std::nullopt});
+    const hir::FieldId field_id = decl.fields.Add(
+        hir::ClassField{.name = std::string(prop.name), .type = *field_type});
+    RegisterClassPropertyFieldId(prop, field_id);
   }
   std::optional<hir::SubroutineDecl> user_constructor;
   for (const auto& method : cls.membersOfType<slang::ast::SubroutineSymbol>()) {
@@ -614,11 +640,6 @@ auto UnitLowerer::InternClass(
           span, diag::DiagCode::kUnsupportedClassFeature,
           "static class methods are not yet supported");
     }
-    if (method.flags.has(slang::ast::MethodFlags::Pure)) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedClassFeature,
-          "pure virtual class methods are not yet supported");
-    }
     if (method.subroutineKind == slang::ast::SubroutineKind::Task) {
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedClassFeature,
@@ -642,9 +663,92 @@ auto UnitLowerer::InternClass(
         return std::unexpected(std::move(base_class_id.error()));
       method_decl->overrides = hir::MethodRef{
           .class_id = *base_class_id, .method = LookupMethodId(*overridden)};
+    } else if (const auto* pure_base =
+                   FindOverriddenPureInBaseChain(cls, method.name);
+               pure_base != nullptr) {
+      // Slang leaves the override link unset when the base method is a pure
+      // virtual prototype (LRM 8.21); wire it here so downstream dispatch
+      // canonicalizes to the base's slot rather than treating this method
+      // as a fresh introducer.
+      const auto& base_class =
+          pure_base->getParentScope()->asSymbol().as<slang::ast::ClassType>();
+      auto base_class_id = InternClass(base_class, span);
+      if (!base_class_id)
+        return std::unexpected(std::move(base_class_id.error()));
+      const auto* proto_stub = pure_base->getSubroutine();
+      if (proto_stub == nullptr) {
+        throw InternalError(
+            "UnitLowerer::InternClass: pure virtual prototype has no stub "
+            "subroutine slang normally materializes");
+      }
+      method_decl->overrides = hir::MethodRef{
+          .class_id = *base_class_id, .method = LookupMethodId(*proto_stub)};
+      // An override of a base virtual method is itself virtual (LRM 8.20),
+      // even when the derived declaration omits the `virtual` keyword.
+      method_decl->is_virtual = true;
     }
     const hir::MethodId method_id = decl.methods.Add(*std::move(method_decl));
     RegisterMethodId(method, method_id);
+  }
+
+  // A pure virtual method (LRM 8.21 `pure virtual function ...;`) lands in
+  // slang as a `MethodPrototypeSymbol`, not a `SubroutineSymbol`, because it
+  // has no body. Its signature still occupies a class-owned method slot the
+  // dispatch table introduces and every extended concrete class must fill,
+  // so it enters the same `methods` arena that carries ordinary instance
+  // methods; the record is marked `is_prototype` so the backend renders it
+  // as a C++ pure declaration (`= 0;`) instead of a body.
+  for (const auto& proto :
+       cls.membersOfType<slang::ast::MethodPrototypeSymbol>()) {
+    if (proto.getParentScope() != &cls) {
+      continue;
+    }
+    if (!proto.flags.has(slang::ast::MethodFlags::Pure)) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "extern / out-of-block class method prototypes are not yet "
+          "supported");
+    }
+    if (proto.subroutineKind == slang::ast::SubroutineKind::Task) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "pure virtual class task prototypes are not yet supported");
+    }
+    auto proto_decl = LowerMethodPrototypeDecl(*this, proto);
+    if (!proto_decl) return std::unexpected(std::move(proto_decl.error()));
+    // A middle abstract class re-declaring an ancestor's pure virtual method
+    // as another `pure virtual` produces a prototype whose overrides link
+    // slang exposes as a `Symbol*` (either the ancestor prototype's stub or
+    // another prototype). Translate the reachable stub form to the HIR
+    // identity registered when that ancestor was interned.
+    if (const auto* overridden = proto.getOverride(); overridden != nullptr) {
+      const slang::ast::SubroutineSymbol* overridden_sub = nullptr;
+      if (overridden->kind == slang::ast::SymbolKind::Subroutine) {
+        overridden_sub = &overridden->as<slang::ast::SubroutineSymbol>();
+      } else if (overridden->kind == slang::ast::SymbolKind::MethodPrototype) {
+        overridden_sub =
+            overridden->as<slang::ast::MethodPrototypeSymbol>().getSubroutine();
+      }
+      if (overridden_sub != nullptr) {
+        const auto& base_class = overridden_sub->getParentScope()
+                                     ->asSymbol()
+                                     .as<slang::ast::ClassType>();
+        auto base_class_id = InternClass(base_class, span);
+        if (!base_class_id)
+          return std::unexpected(std::move(base_class_id.error()));
+        proto_decl->overrides = hir::MethodRef{
+            .class_id = *base_class_id,
+            .method = LookupMethodId(*overridden_sub)};
+      }
+    }
+    const hir::MethodId method_id = decl.methods.Add(*std::move(proto_decl));
+    // Register the prototype's stub subroutine so a downstream override
+    // walker or the `FindOverriddenPureInBaseChain` fallback can translate
+    // the prototype to its HIR method identity through the same
+    // `SubroutineSymbol`-keyed registry every other override lookup uses.
+    if (const auto* proto_stub = proto.getSubroutine(); proto_stub != nullptr) {
+      RegisterMethodId(*proto_stub, method_id);
+    }
   }
 
   hir::SubroutineDecl constructor =
@@ -661,16 +765,17 @@ auto UnitLowerer::InternClass(
   ProcessLowerer init_lowerer(*this, cls);
   const WalkFrame init_frame = WalkFrame{}.WithProceduralBody(
       &constructor.body, &constructor.body.exprs);
-  std::size_t field_index = 0;
   for (const auto& prop :
        cls.membersOfType<slang::ast::ClassPropertySymbol>()) {
-    if (const auto* init = prop.getInitializer(); init != nullptr) {
-      auto init_expr = init_lowerer.LowerExpr(*init, init_frame);
-      if (!init_expr) return std::unexpected(std::move(init_expr.error()));
-      decl.fields[field_index].initializer =
-          constructor.body.exprs.Add(*std::move(init_expr));
-    }
-    ++field_index;
+    if (prop.getParentScope() != &cls) continue;
+    const auto* init = prop.getInitializer();
+    if (init == nullptr) continue;
+    auto init_expr = init_lowerer.LowerExpr(*init, init_frame);
+    if (!init_expr) return std::unexpected(std::move(init_expr.error()));
+    decl.field_inits.push_back(
+        hir::FieldInit{
+            .target = LookupClassPropertyFieldId(prop),
+            .value = constructor.body.exprs.Add(*std::move(init_expr))});
   }
   decl.constructor = std::move(constructor);
 

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -135,11 +136,12 @@ auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
   // Property fields come first in declaration order (LRM 8.4), so an SV
   // reference to a property by its declaration index reaches the same shape
   // slot regardless of what static-lifetime storage the class also owns.
-  field_ids_.reserve(hir_class.fields.size());
+  // The returned mir field id at position `i` equals `TranslateField` of
+  // the hir field id `i`, so no side vector is kept -- every consumer
+  // resolves a hir field id through the same layer-boundary translation.
   for (const auto& field : hir_class.fields) {
     const mir::TypeId field_type = unit_lowerer.TranslateType(field.type);
-    field_ids_.push_back(shape.fields.Add(
-        mir::FieldDecl{.name = field.name, .type = field_type}));
+    shape.fields.Add(mir::FieldDecl{.name = field.name, .type = field_type});
   }
 
   // Each SV method's static-lifetime locals get their per-instance slot on
@@ -251,13 +253,26 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
   // the receiver -- and one without takes its type's Table 7-1 default. The
   // ordering is the single declaration-order pass because an initializer may
   // read an earlier property whose own initialization has already run.
+  // Index the source-declared initializers by their target so the per-field
+  // loop below reads each one in O(1). The class-level `field_inits` list
+  // stays the sparse "only fields the source wrote" form, mirroring
+  // `mir::ConstructorDecl::member_inits`; the dense per-field iteration is a
+  // consumer concern this lookup encapsulates.
+  std::unordered_map<hir::FieldId, hir::ExprId> initializer_of;
+  initializer_of.reserve(hir_class.field_inits.size());
+  for (const hir::FieldInit& init : hir_class.field_inits) {
+    initializer_of.emplace(init.target, init.value);
+  }
   for (std::size_t i = 0; i < hir_class.fields.size(); ++i) {
-    const hir::ClassField& field = hir_class.fields[i];
-    const mir::TypeId field_type = mir_class.fields.Get(field_ids_[i]).type;
+    const hir::FieldId hir_field_id{static_cast<std::uint32_t>(i)};
+    const hir::ClassField& field = hir_class.fields.Get(hir_field_id);
+    const mir::FieldId mir_field_id = unit_lowerer.TranslateField(hir_field_id);
+    const mir::TypeId field_type = mir_class.fields.Get(mir_field_id).type;
     mir::ExprId value_id{};
-    if (field.initializer.has_value()) {
-      auto value_or = ctor_lowerer.LowerExpr(
-          ctor.body.exprs.Get(*field.initializer), frame);
+    if (const auto it = initializer_of.find(hir_field_id);
+        it != initializer_of.end()) {
+      auto value_or =
+          ctor_lowerer.LowerExpr(ctor.body.exprs.Get(it->second), frame);
       if (!value_or) return std::unexpected(std::move(value_or.error()));
       value_id = ctor_block.exprs.Add(*std::move(value_or));
     } else {
@@ -269,7 +284,7 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
     const mir::ExprId target = ctor_block.exprs.Add(
         mir::MakeFieldAccessExpr(
             self_ref,
-            mir::FieldTarget{.owner = class_id_, .slot = field_ids_[i]},
+            mir::FieldTarget{.owner = class_id_, .slot = mir_field_id},
             field_type));
     const mir::ExprId assign =
         ctor_block.exprs.Add(mir::MakeAssignExpr(target, value_id, field_type));
@@ -284,9 +299,46 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
   // Initialize lifecycle phase, so a method's pending static initializers
   // integrate into this class's constructor block (matching the per-instance
   // storage shape used for class-method statics).
+  //
+  // A pure virtual prototype (LRM 8.21) has no source-defined body to walk;
+  // its MIR record still carries the signature -- receiver, named parameters,
+  // and result type -- so the backend can emit the class's declaration, but
+  // no callable body is produced. The `PurePrototype` variant arm of
+  // `CallableDecl::impl` states the shape structurally.
   for (std::size_t i = 0; i < hir_class.methods.size(); ++i) {
     const hir::MethodId method_id{static_cast<std::uint32_t>(i)};
     const auto& method = hir_class.methods.Get(method_id);
+    const auto method_dispatch =
+        shape.callable_signatures.Get(mir::CallableId{method_id.value})
+            .virtual_dispatch;
+    if (method.is_prototype) {
+      mir::CallableCode proto_code;
+      CallableBindings proto_bindings(unit_lowerer.Unit(), proto_code);
+      const mir::LocalId proto_self_id = proto_bindings.Declare(
+          BindingOriginId::Receiver(),
+          mir::LocalDecl{.name = "self", .type = shape.self_pointer_type});
+      std::vector<mir::LocalId> proto_params{proto_self_id};
+      proto_params.reserve(method.params.size() + 1);
+      for (const auto& hir_param : method.params) {
+        const auto& hir_var = method.body.procedural_vars.Get(hir_param.var);
+        const mir::TypeId param_type = unit_lowerer.TranslateType(hir_var.type);
+        const mir::LocalId param_id = proto_bindings.Declare(
+            BindingOriginId::Procedural(hir_param.var),
+            mir::LocalDecl{.name = hir_var.name, .type = param_type});
+        proto_params.push_back(param_id);
+      }
+      proto_code.params = std::move(proto_params);
+      proto_code.result_type = unit_lowerer.TranslateType(method.result_type);
+      // proto_code.body stays default-constructed (empty Block); the
+      // `PurePrototype` variant arm is what marks the shape as bodyless.
+      mir_class.callables.Add(
+          mir::CallableDecl{
+              .name = method.name,
+              .impl = mir::PurePrototype{.code = std::move(proto_code)},
+              .virtual_dispatch = method_dispatch,
+              .visibility = mir::CallableVisibility::kPublic});
+      continue;
+    }
     ScopeChainNode method_link{};
     const WalkFrame method_owner_frame =
         WalkFrame{}.WithClass(&mir_class, class_id_, method_link);
@@ -301,9 +353,7 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
         mir::CallableDecl{
             .name = method.name,
             .impl = mir::InternalCallable{.code = *std::move(method_code_or)},
-            .virtual_dispatch =
-                shape.callable_signatures.Get(mir::CallableId{method_id.value})
-                    .virtual_dispatch,
+            .virtual_dispatch = method_dispatch,
             .visibility = mir::CallableVisibility::kPublic});
     for (const auto& pending : method_lowerer.TakePendingStaticInitializers()) {
       auto integ = IntegratePendingStaticInitializer(

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -255,8 +255,8 @@ auto LowerHirPrimaryExprProc(
             return mir::MakeFieldAccessExpr(
                 self_ref,
                 mir::FieldTarget{
-                    .owner = frame.current_class_id,
-                    .slot = mir::FieldId{.value = r.field_index}},
+                    .owner = process.Owner().TranslateClass(r.owner),
+                    .slot = process.Owner().TranslateField(r.field_index)},
                 result_type);
           },
           [&](const hir::RoutedRef& c) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -409,7 +409,8 @@ auto LowerHirMemberAccessExpr(
     if (!base_or) return std::unexpected(std::move(base_or.error()));
     const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     return mir::Expr{
-        .data = mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index},
+        .data =
+            mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index.value},
         .type = result_type};
   }
   if (unit_lowerer.Hir().types.Get(base_hir_expr.type).Kind() ==
@@ -419,19 +420,20 @@ auto LowerHirMemberAccessExpr(
     const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     return mir::Expr{
         .data =
-            mir::UnionGetExpr{.union_value = base_id, .index = sel.field_index},
+            mir::UnionGetExpr{
+                .union_value = base_id, .index = sel.field_index.value},
         .type = result_type};
   }
   const auto& fields =
       GetAggregateFields(unit_lowerer.Hir().types.Get(base_hir_expr.type));
-  if (sel.field_index >= fields.size()) {
+  if (sel.field_index.value >= fields.size()) {
     throw InternalError("LowerHirMemberAccessExpr: field_index out of range");
   }
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
-      unit_lowerer, block, fields[sel.field_index], base_id, result_type,
+      unit_lowerer, block, fields[sel.field_index.value], base_id, result_type,
       AccessSide::kRead);
 }
 
@@ -454,7 +456,7 @@ auto LowerHirClassPropertyAccessExpr(
       base_id,
       mir::FieldTarget{
           .owner = unit_lowerer.TranslateClass(sel.owner),
-          .slot = mir::FieldId{sel.field_index}},
+          .slot = unit_lowerer.TranslateField(sel.field_index)},
       result_type);
 }
 
@@ -534,7 +536,8 @@ auto LowerHirMemberAccessExprLhs(
     if (!base_or) return std::unexpected(std::move(base_or.error()));
     const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     return mir::Expr{
-        .data = mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index},
+        .data =
+            mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index.value},
         .type = result_type};
   }
   // LRM 7.3: an unpacked union member write is the write-side access form
@@ -549,12 +552,12 @@ auto LowerHirMemberAccessExprLhs(
     return mir::Expr{
         .data =
             mir::UnionGetRefExpr{
-                .union_value = base_id, .index = sel.field_index},
+                .union_value = base_id, .index = sel.field_index.value},
         .type = result_type};
   }
   const auto& fields =
       GetAggregateFields(unit_lowerer.Hir().types.Get(base_hir_expr.type));
-  if (sel.field_index >= fields.size()) {
+  if (sel.field_index.value >= fields.size()) {
     throw InternalError(
         "LowerHirMemberAccessExprLhs: field_index out of range");
   }
@@ -562,7 +565,7 @@ auto LowerHirMemberAccessExprLhs(
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
-      unit_lowerer, block, fields[sel.field_index], base_id, result_type,
+      unit_lowerer, block, fields[sel.field_index.value], base_id, result_type,
       AccessSide::kLhs);
 }
 
@@ -585,7 +588,7 @@ auto LowerHirClassPropertyAccessExprLhs(
       base_id,
       mir::FieldTarget{
           .owner = unit_lowerer.TranslateClass(sel.owner),
-          .slot = mir::FieldId{sel.field_index}},
+          .slot = unit_lowerer.TranslateField(sel.field_index)},
       result_type);
 }
 

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -950,6 +950,33 @@ class MirDumper {
                         FormatVarType(ext.params[i].sv_type)));
               }
               Dedent();
+            },
+            [&](const PurePrototype& proto) {
+              Line(
+                  std::format(
+                      "[{}] \"{}\" : Type[{}] prototype", index, d.name,
+                      proto.code.result_type.value));
+              Indent();
+              Line(
+                  std::format(
+                      "Visibility: {}",
+                      d.visibility == CallableVisibility::kPublic
+                          ? "public"
+                          : "internal"));
+              if (d.virtual_dispatch.has_value()) {
+                Line(
+                    std::format(
+                        "VirtualDispatch: {}",
+                        FormatVirtualDispatchRole(*d.virtual_dispatch)));
+              }
+              for (std::size_t i = 0; i < proto.code.params.size(); ++i) {
+                const auto& param = proto.code.locals.Get(proto.code.params[i]);
+                Line(
+                    std::format(
+                        "Param[{}] \"{}\" : Type[{}]", i, param.name,
+                        param.type.value));
+              }
+              Dedent();
             }},
         d.impl);
   }

--- a/tests/cases/cpp/class_abstract_ctor_chain/case.yaml
+++ b/tests/cases/cpp/class_abstract_ctor_chain/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.class_abstract_ctor_chain
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    stored_seed: 42
+    computed_rank: 84

--- a/tests/cases/cpp/class_abstract_ctor_chain/main.sv
+++ b/tests/cases/cpp/class_abstract_ctor_chain/main.sv
@@ -1,0 +1,39 @@
+// LRM 8.21 an abstract class carries its own constructor (LRM 8.7); it is
+// never called directly (LRM 8.21 forbids `new` on abstract), but a concrete
+// subclass chains through `super.new(...)` to run it. Derived's own pure
+// virtual override reads the property Base's constructor wrote, proving the
+// chain executed the abstract ctor's body before the pure override was
+// entered through a virtual call.
+module Top;
+  virtual class Base;
+    int stored;
+
+    function new(int seed);
+      stored = seed;
+    endfunction
+
+    pure virtual function int rank();
+  endclass
+
+  class Derived extends Base;
+    function new(int seed);
+      super.new(seed);
+    endfunction
+
+    virtual function int rank();
+      return stored * 2;
+    endfunction
+  endclass
+
+  int stored_seed;
+  int computed_rank;
+
+  initial begin
+    Derived d;
+    Base b;
+    d = new(42);
+    stored_seed = d.stored;
+    b = d;
+    computed_rank = b.rank();
+  end
+endmodule

--- a/tests/cases/cpp/class_pure_virtual_dispatch/case.yaml
+++ b/tests/cases/cpp/class_pure_virtual_dispatch/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.class_pure_virtual_dispatch
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    from_leaf_direct: 43
+    from_base_to_leaf: 43
+    from_base_to_leaf2: 12

--- a/tests/cases/cpp/class_pure_virtual_dispatch/main.sv
+++ b/tests/cases/cpp/class_pure_virtual_dispatch/main.sv
@@ -1,0 +1,46 @@
+// LRM 8.21 pure virtual method + abstract class + virtual dispatch.
+// Base is abstract (`virtual class`) and declares `rank` as a pure virtual
+// prototype. Mid extends Base without providing an implementation and stays
+// abstract itself, so its own class body has no `rank` at all -- the slot is
+// inherited unfilled. Leaf extends Mid and provides the implementation;
+// Leaf2 extends Base directly and provides its own. Every reachable call
+// site dispatches virtually to the concrete override that filled the slot:
+// through the concrete handle directly and through a base handle whose
+// dynamic type is the concrete class.
+module Top;
+  virtual class Base;
+    pure virtual function int rank(int seed);
+  endclass
+
+  virtual class Mid extends Base;
+  endclass
+
+  class Leaf extends Mid;
+    virtual function int rank(int seed);
+      return seed * 10 + 3;
+    endfunction
+  endclass
+
+  class Leaf2 extends Base;
+    virtual function int rank(int seed);
+      return seed + 7;
+    endfunction
+  endclass
+
+  int from_leaf_direct;
+  int from_base_to_leaf;
+  int from_base_to_leaf2;
+
+  initial begin
+    Leaf l;
+    Leaf2 l2;
+    Base b;
+    l = new;
+    from_leaf_direct = l.rank(4);
+    b = l;
+    from_base_to_leaf = b.rank(4);
+    l2 = new;
+    b = l2;
+    from_base_to_leaf2 = b.rank(5);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds SystemVerilog LRM 8.21 pure virtual methods and abstract classes (`virtual class`), completing the inheritance-family cluster of R47 alongside the virtual dispatch and super-and-base-ctor chaining already landed. A pure prototype is stated as a structural property of the method carried end-to-end through HIR and MIR, so the backend renders it as a bodyless C++ declaration and the target language treats the enclosing class as abstract without any class-level marker required. Two concrete tests cover the shape: a two-level abstract chain dispatched via a base handle to two different concrete overrides, and a concrete class that chains `super.new(seed)` into an abstract base whose bodied constructor initializes an inherited field the concrete override later reads through virtual dispatch.

## Design

The frontend catches every abstract-class construction, pure-in-non-abstract declaration, missing override, and pure body error, so the compiler consumes only well-formed inputs and never restates a diagnostic slang emits. A pure prototype lands as a `MethodPrototypeSymbol` on slang's side and is lowered into the same method arena as an ordinary method with `is_prototype = true` and its parameter signature intact, so backend consumers reach the receiver, parameters, and result type uniformly. Slang leaves the derived override link unset when the base is itself a prototype, so a single inheritance-aware name lookup on the base scope re-establishes the override target through slang's own `TransparentMember`-flattening lookup, aligning the resulting HIR override chain with the concrete-base case dispatch already consumes.

An inherited class property read from within a derived method used to crash: the HIR `ClassPropertyRef` carried only a field index and the receiver's declaring class was inferred from the enclosing method's owner, so an inherited field's index resolved against an empty arena on the derived class. The property reference now carries an explicit `owner: ClassId` populated from slang's parent scope, matching the qualified-access form the codebase already used and the owner-qualified invariant `object_model.md` states.

The class field surface aligned with `methods`: `hir::FieldId` is a strong id, `ClassDecl.fields` is a `base::Arena<ClassField, FieldId>`, and each property initializer moved off `ClassField` onto `ClassDecl.field_inits` mirroring `mir::ConstructorDecl.member_inits`; the two-pass "add nullopt then mutate" pattern is gone. `TranslateField` on the hir-to-mir unit lowerer peers with `TranslateType` / `TranslateClass` so the layer-boundary crossing is one named function every consumer routes through. `class_decl_lowerer` no longer keeps a parallel `field_ids_` vector -- consumers reach a mir field id from a hir field id through the boundary translation the same way they reach a class id.

The backend cleanup is scoped to reduce accreted repetition: `RenderParamList` and `BodyScopeView` collapse the three "signature + body" render sites (method, adapter, foreign-export wrapper); `VisibilitySections` encapsulates the manual `open_section` state so methods and adapter loops share one section header; the recursive dependency-order class emitter is a plain free function instead of a `std::function` + lambda closure; the 30-line hardcoded include list is now two `std::array` constants.

The audit for backend renders that compose runtime library identifiers as strings or inject prologue statements the MIR does not state is captured as `R59` in `docs/progress/refactor.md` -- pre-existing sites across the aggregate-value-build primitives, queue construction, class construction on a managed reference, the DPI-C foreign-export wrapper, method receiver adapters, and enum class emission. Not fixed in this cut, tracked for its own review.