### PR TITLE
Realize the unpacked struct on the execution backend

### DIFF
--- a/docs/architecture/lir.md
+++ b/docs/architecture/lir.md
@@ -223,14 +223,40 @@ runtime-library call -- the cell's get / set / mutate, because HIR-to-MIR expres
 way -- and lowers as a call, the same as any other. Whether a plain-value member's place becomes a
 load or a store, and at what address, is the physical layer's question, not LIR's.
 
-A member access always yields a place. What the use site does with that place -- read the value it
-holds, write a value into it, or name where it lives -- is the use site's decision, never a property
-of the access. Some storage has no first-class value in LIR at all: a storage cell, a scope, an
-object-tree node. Such a type is address-only, and every operation over it consumes its address, so
-loading or storing a place of that type is a lowering defect. Address-only is a fact about the
-storage object, not about how values are represented: a packed value reached through an opaque
-handle is an ordinary first-class value, and a place holding one is loaded and stored like any
-other. The cell that holds it is what may only be addressed.
+An object member access -- reaching a member of an object through its receiver -- always yields a
+place. What the use site does with that place -- read the value it holds, write a value into it, or
+name where it lives -- is the use site's decision, never a property of the access. Some storage has
+no first-class value in LIR at all: a storage cell, a scope, an object-tree node. Such a type is
+address-only, and every operation over it consumes its address, so loading or storing a place of
+that type is a lowering defect. Address-only is a fact about the storage object, not about how
+values are represented: a packed value reached through an opaque handle is an ordinary first-class
+value, and a place holding one is loaded and stored like any other. The cell that holds it is what
+may only be addressed.
+
+A place denotes independently addressable storage -- storage with an identity of its own -- not
+merely something a source-level assignment can target. Assignability and place-ness are different
+questions: in a value language, `s.b = x` on a struct is assignable but names no independent
+storage, because the struct is a value and `s.b` is a part of it, not a location. So the place
+vocabulary is for mutable, independently addressable storage (a local that needs an address, an
+object member reached through its receiver, the referent of a dereference); a value aggregate is not
+that. An unpacked struct -- the heterogeneous product value (see `mir.md`) -- reached through an
+opaque handle is a first-class value, but its interior is not a place the way an object's members
+are: value semantics forbid mutating a component in place, because the change would be visible
+through every copy of the struct. So a component is reached by value projection, not by an
+addressable sub-place. Reading a component extracts it from the product value; writing a component
+produces a new product value equal to the old one with that component replaced, which is then stored
+whole into the struct's own storage -- a component write is a whole-value store of a functional
+update, uniform whether the struct lives in a local or in an observable cell. This is the
+value-aggregate counterpart of the object member's place: an object member is mutable addressable
+storage, so it is a place loaded and stored in place; a struct component is an immutable value part,
+so it is a pair of value operations, an extract and an insert (the aggregate peers of LLVM's
+`extractvalue` / `insertvalue`). The two look different because the value / reference distinction is
+real, not because one is a special case of the other. The same principle governs the rest of the
+value-aggregate family: a packed slice, a container element, and a union member are value
+sub-accesses, so a sub-write is a functional whole-value update, never a store into an independently
+addressable sub-place -- a static, structural selector (a struct component) may ride a dedicated
+value instruction, a dynamic, runtime-indexed one (a container element) a runtime-library call, but
+the principle that a value sub-write produces a new whole value is the same.
 
 LIR carries the fact that a packed value is two-state or four-state; it does not carry how a
 four-state value is stored. The canonical encoding of a four-state value -- value bits plus a state

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -34,6 +34,9 @@ the detail lives in the entry itself.
   fixed-size unpacked array.
 - [unpacked-struct-representation](unpacked-struct-representation.md) -- an unpacked struct is the
   generic product type (MIR `TupleType`), positional access, defaults synthesized at lowering.
+- [jit-aggregate-realization](jit-aggregate-realization.md) -- on the execution backend every
+  aggregate is a runtime-owned opaque value (erasure), not structurally monomorphized; the choice is
+  below LIR, and LIR's aggregate operations stay realization-agnostic.
 - [slice-value-semantics](slice-value-semantics.md) -- a slice read materializes an owned value; the
   access model is value, not borrow.
 - [queue-operators](queue-operators.md) -- queue access operators lower to built-in method calls;

--- a/docs/decisions/jit-aggregate-realization.md
+++ b/docs/decisions/jit-aggregate-realization.md
@@ -1,0 +1,109 @@
+# Aggregate values are runtime-owned opaque values on the JIT, not monomorphized
+
+Date: 2026-07-18 Status: accepted
+
+## Why this decision matters
+
+The execution (JIT/LLVM) backend realizes every runtime value as an opaque handle into a
+runtime-library object ([jit-value-realization](jit-value-realization.md)). For a scalar this is
+pure reuse: one runtime-fat class already carries every shape of the value
+([integral-representation](integral-representation.md)), so both backends share it and the JIT
+constructs nothing new. An aggregate is not pure reuse. The value layer realizes an aggregate as a
+C++ template parameterized on its element types (`Tuple<Ts...>`, `DynamicArray<T>`, `Queue<T>`,
+`AssociativeArray<K, V>`), which the C++ backend monomorphizes by leaning on the host C++ compiler.
+The JIT emits LLVM IR directly and runs no C++ front-end, so nothing monomorphizes those templates
+for it; it must choose a realization.
+
+Two realizations are possible, and the choice governs the whole aggregate family, so it is settled
+here rather than re-argued per container.
+
+## The realization levels
+
+- **Erasure.** One runtime-owned, type-erased value object behind a single opaque handle: a struct
+  is `value::RuntimeTuple` (a `vector<value::RuntimeValue>` owning its components by value), reached
+  through one handle; every operation is a runtime-library call.
+- **Structural monomorphization.** Codegen specializes each concrete aggregate type into an LLVM
+  aggregate of component handles (`{ptr, ptr, ...}`); construct / extract / update become native
+  `insertvalue` / `extractvalue`; the components stay opaque handles, so a component's own
+  operations (copy, equality, arithmetic) remain runtime calls, and codegen unrolls each
+  whole-aggregate operation per type. This monomorphizes the aggregate's _shape_, not its element
+  _values_.
+- **Physical value monomorphization.** Component bytes live inline in the aggregate (a packed
+  value's or string's storage physically inside the struct); every operation is native. This
+  reproduces the value layer's physical layout and copy semantics in generated code -- the fully
+  C++-symmetric endpoint, and the largest one.
+
+Structural monomorphization is a hybrid, not the native endpoint: it removes the structural runtime
+calls but keeps opaque leaf handles, so most of the runtime-value lifetime remains. The clean
+endpoints are erasure (now) and physical value monomorphization (a later, whole-value-model
+project).
+
+## Decision
+
+On the opaque-handle execution baseline, **every aggregate value is realized by erasure -- a
+runtime-owned opaque value object reached through one handle.** A fixed-arity aggregate is not
+structurally monomorphized; that is deferred until the backend commits to a physical value layout
+for the whole value model, at which point the native path is adopted uniformly (scalars included),
+not for aggregates alone.
+
+The LIR aggregate operations -- `AggregateExtractInstr`, `AggregateUpdateInstr`, and the
+`AggregateSelector` they carry -- are realization-agnostic logical value operations. This decision
+is entirely below LIR, in LIR-to-LLVM codegen; LIR does not change with it, and a future physical
+layout changes only the codegen realization of the same LIR operations.
+
+`value::RuntimeTuple` and `value::RuntimeValue` are the aggregate members of the opaque-handle value
+model, not a temporary tuple mechanism. A later physical layout would make them an optimization
+alternative, not retroactively make the erased object wrong.
+
+## Why erasure, not structural monomorphization
+
+- **Variable-size containers must be erased regardless.** A dynamic array, a queue, and an
+  associative array have a runtime element count (and, for the associative array, a runtime key
+  set); an LLVM aggregate cannot hold a runtime-sized collection, so these are runtime-owned objects
+  behind a handle no matter what. Monomorphizing the fixed-arity aggregates would not remove the
+  erased family; it would split it -- native structs beside erased queues -- and split the one
+  realization shape the family otherwise shares.
+- **The hybrid complicates cross-suspension lifetime.** An erased aggregate crosses a suspension as
+  one handle to one activation-frame value; the components ride inside it. A `{ptr, ptr, ...}` of
+  component handles pointing into the per-stretch scope would dangle after resume, so every
+  component handle would need independent promotion. That fractures the lifetime model -- the
+  transient scope and the activation frame -- back into per-component bookkeeping, the opposite of
+  keeping one value's storage in one place.
+- **The benefit is partial.** Structural monomorphization removes the construct / extract / update
+  runtime calls but leaves each leaf operation a runtime call, and leaf operations dominate. The
+  full native benefit needs physical value monomorphization; the hybrid pays lifetime complexity for
+  a bounded win.
+
+## Rejected alternatives
+
+- **Structural monomorphization for fixed-arity aggregates now.** An awkward middle: it splits the
+  aggregate family from the variable-size containers that must stay erased, fractures
+  cross-suspension lifetime into per-component handles, and still leaves leaf operations as runtime
+  calls. Reconsidered only with a measured performance reason and a broader native value-layout
+  plan, never as a step taken because it "looks closer to native".
+- **Physical value monomorphization now.** The fully native endpoint, but a large project that
+  reproduces the value layer's physical layout in generated code for every value type. It is a
+  value- model-wide optimization, out of scope for realizing aggregates correctly, and gated behind
+  the correctness baseline being broad ([jit-value-realization](jit-value-realization.md)).
+
+## Consequences
+
+- The aggregate family shares one realization shape: a runtime-owned opaque value object. A new
+  aggregate (a container) is realized the same way, with no per-type realization debate.
+- Aggregate operations are runtime-library calls; a struct field access is a call, not a native
+  `extractvalue`. This is the accepted baseline cost, the aggregate counterpart of every scalar
+  operation being a runtime call on the execution backend.
+- The physical-layout path, if pursued, is adopted for the whole value model and swaps the codegen
+  realization of the unchanged LIR aggregate operations; it does not begin as a per-aggregate
+  hybrid.
+
+## Cross-references
+
+- [jit-value-realization](jit-value-realization.md) -- the opaque-handle baseline and the deferred
+  physical in-frame layout this extends to aggregates.
+- [integral-representation](integral-representation.md) -- the runtime-fat scalar class both
+  backends share, the pure-reuse case aggregates contrast with.
+- [unpacked-struct-representation](unpacked-struct-representation.md) -- the struct is MIR's product
+  type (`TupleType`); this decides how that product is realized on the execution backend.
+- `../architecture/lir.md` -- `AggregateExtractInstr` / `AggregateUpdateInstr` are logical value
+  operations; physical realization is below LIR.

--- a/docs/progress/execution-backend.md
+++ b/docs/progress/execution-backend.md
@@ -51,8 +51,20 @@ ownership, or native in-frame layout) for every value.
       takes the equality and case-equality families and the boolean test, and lives in a member slot
       as an owned inline value (not an observable cell, since no process subscribes to it). This is
       the first bare-pointer value domain; a class handle later reuses the shape.
-- [ ] **The remaining value domains** (aggregates, containers) -- not realized on the execution
-      backend at all yet, so no cross-suspension case exists for them.
+- [x] **The unpacked struct** (LRM 7.2) -- realized on the execution backend as a product value
+      domain: a runtime-owned product that owns its components by value and crosses as an opaque
+      handle, so the generated side never inspects a component's representation. It default-
+      constructs member-wise, builds from an assignment pattern, copies with value semantics, takes
+      the equality and case-equality families, reads and writes a component (including a nested
+      product and a string component), lives in a member slot as a whole-cell observable signal
+      whose partial write fires subscribers, and crosses a suspension as an activation-frame value.
+      A component write is a whole-value rebuild stored back through the value's owner, so an
+      observable partial write never bypasses the cell's update semantics -- the aggregate
+      partial-update protocol a container reuses later.
+- [ ] **The remaining value domains** (unpacked array, dynamic array, queue, associative array) --
+      not realized on the execution backend yet. Each is a homogeneous or keyed collection whose
+      element count is a runtime quantity, so unlike the fixed-arity struct its element operations
+      are runtime loops rather than generated-code expansions.
 - [ ] **A managed value (class handle) across a suspension.** A traceable frame and precise
       reclamation, none of which is implemented: the managed reference is realized as a
       reference-counted handle that does not reclaim cycles, and only in the C++ backend. Contract:

--- a/include/lyra/backend/llvm/codegen_function.hpp
+++ b/include/lyra/backend/llvm/codegen_function.hpp
@@ -39,6 +39,13 @@ class CodeGenFunction {
       -> llvm::FunctionCallee;
   auto LowerAggregate(const lir::AggregateInstr& agg, lir::TypeId result_type)
       -> llvm::Value*;
+  auto LowerTupleAggregate(
+      const lir::AggregateInstr& agg, const lir::TupleType& tuple)
+      -> llvm::Value*;
+  auto LowerAggregateExtract(const lir::AggregateExtractInstr& extract)
+      -> llvm::Value*;
+  auto LowerAggregateUpdate(const lir::AggregateUpdateInstr& update)
+      -> llvm::Value*;
   auto LowerBinary(const lir::BinaryInstr& binary) -> llvm::Value*;
   auto LowerMachineBinary(const lir::BinaryInstr& binary) -> llvm::Value*;
   auto LowerUnary(const lir::UnaryInstr& unary) -> llvm::Value*;

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -35,6 +35,7 @@ enum class ValueDomain : std::uint8_t {
   kReal,
   kShortReal,
   kChandle,
+  kTuple,
 };
 
 auto ValueDomainName(ValueDomain domain) -> std::string_view;
@@ -159,6 +160,17 @@ class RuntimeAbi {
 
   // Reduces a value to the machine boolean a conditional branch tests.
   auto ToBool(ValueDomain domain) -> llvm::FunctionCallee;
+
+  // The product-value entries. A component crosses as a handle of its own
+  // domain, and boxing one into a product component rides the domain in the
+  // symbol name, as every domain-parametric entry does. Extract and update are
+  // value operations: update yields a new product with one component replaced,
+  // never an in-place write, so value semantics hold even when the product is
+  // shared.
+  auto TupleComponent(ValueDomain domain) -> llvm::FunctionCallee;
+  auto TupleMake() -> llvm::FunctionCallee;
+  auto TupleExtract() -> llvm::FunctionCallee;
+  auto TupleUpdate() -> llvm::FunctionCallee;
 
   // Builds the format specification of one conversion, and the print item that
   // pairs a value with it. A specification is written either as a bare

--- a/include/lyra/lir/function.hpp
+++ b/include/lyra/lir/function.hpp
@@ -155,6 +155,43 @@ struct AggregateInstr {
   std::vector<Operand> elements;
 };
 
+// Names a subvalue within an aggregate value. A `TupleElement` selects a
+// product component by its declaration-order position -- the static, structural
+// selector an unpacked struct uses. Other aggregate families (a packed slice, a
+// union member) add their own selectors here; a dynamic, runtime-indexed access
+// (a dynamic array or queue element) is a runtime-library call, not one of
+// these, because its bounds and index are runtime values, not a static
+// projection.
+struct TupleElement {
+  std::uint32_t index;
+};
+
+using AggregateSelector = std::variant<TupleElement>;
+
+// Extracts a subvalue of an aggregate value, named by `selector`. The aggregate
+// is a value, reached by value: the subvalue is copied out, not aliased. This
+// is the read half of value-aggregate access, the peer of LLVM's
+// `extractvalue`; it is distinct from a place projection, which reaches
+// independently addressable storage. The result's type is the selected
+// subvalue's type.
+struct AggregateExtractInstr {
+  Operand aggregate;
+  AggregateSelector selector;
+};
+
+// Produces an aggregate value equal to `aggregate` with the subvalue at
+// `selector` replaced by `replacement`. A pure value operation -- it never
+// mutates the operand -- so a component write is a whole-value store of the
+// result, and value semantics hold even when the operand is shared. The peer of
+// LLVM's `insertvalue`; a value aggregate has no independently addressable
+// interior, so a subvalue write is this functional update, not a store into a
+// sub-place. The result's type is the operand's aggregate type.
+struct AggregateUpdateInstr {
+  Operand aggregate;
+  AggregateSelector selector;
+  Operand replacement;
+};
+
 // A class-local logical member identity: the member's stable declaration-order
 // slot in its class's member list, carried over from the MIR field it lowers
 // from. It is meaningful only together with the base's class/object type --
@@ -253,8 +290,9 @@ struct IntCastInstr {
 };
 
 using InstrData = std::variant<
-    CallInstr, AggregateInstr, LoadInstr, StoreInstr, AddrOfInstr, BinaryInstr,
-    UnaryInstr, BoolCastInstr, PointerCastInstr, IntCastInstr>;
+    CallInstr, AggregateInstr, AggregateExtractInstr, AggregateUpdateInstr,
+    LoadInstr, StoreInstr, AddrOfInstr, BinaryInstr, UnaryInstr, BoolCastInstr,
+    PointerCastInstr, IntCastInstr>;
 
 // One instruction: it defines `result` (whose type lives on the function's
 // value arena) from `data`.

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -92,6 +92,23 @@ class FunctionLowerer {
       -> diag::Result<lir::Operand>;
   auto LowerAssign(const mir::Block& block, const mir::AssignExpr& assign)
       -> diag::Result<lir::Operand>;
+  // A write to one component of a product value (`s.f = x`). The chain of
+  // component projections is rebuilt bottom-up as pure functional-update values
+  // over the product's current whole value, then the rebuilt whole value is
+  // stored back through the product's storage owner -- so value semantics hold
+  // and, when the owner is an observable cell, the whole-cell update fires.
+  auto LowerComponentAssign(
+      const mir::Block& block, const mir::AssignExpr& assign)
+      -> diag::Result<lir::Operand>;
+  // Reads / writes the whole value of a product-write chain's root. The root is
+  // an ordinary place, or the mutate proxy of an observable cell -- reached by
+  // its whole-cell get / set so a component write never bypasses the cell's
+  // update semantics.
+  auto ReadWholeValue(const mir::Block& block, mir::ExprId id)
+      -> diag::Result<lir::Operand>;
+  auto WriteWholeValue(
+      const mir::Block& block, mir::ExprId id, lir::Operand value)
+      -> diag::Result<lir::Operand>;
   auto LowerIncDec(const mir::Block& block, const mir::IncDecExpr& inc_dec)
       -> diag::Result<lir::Operand>;
   auto LowerConditional(

--- a/include/lyra/lowering/mir_to_lir/unit_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/unit_lowerer.hpp
@@ -51,6 +51,7 @@ class UnitLowerer {
   // is minted once and reused.
   auto BorrowedPointerTo(lir::TypeId pointee) -> lir::TypeId;
   auto MachineBoolType() -> lir::TypeId;
+  auto VoidType() -> lir::TypeId;
 
   // The LIR method slot a class's callable lowers to. The LIR method list holds
   // a class's bodied callables in arena order; a DPI-C import (external) takes
@@ -81,6 +82,7 @@ class UnitLowerer {
   std::unordered_map<mir::ClassId, std::vector<std::optional<lir::MethodRef>>>
       method_slot_memo_;
   std::optional<lir::TypeId> machine_bool_type_;
+  std::optional<lir::TypeId> void_type_;
   // Set the first time a MIR type with no LIR mirror is reached; surfaced as
   // the unit's failure at `Run`, so translation stays non-throwing and
   // total-shaped while an unmirrored type is still a clean diagnostic, not a

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -267,6 +267,38 @@ auto lyra_rt_chandle_ne(void* lhs, void* rhs) -> void*;
 auto lyra_rt_chandle_case_equal(void* lhs, void* rhs) -> void*;
 auto lyra_rt_chandle_to_bool(void* operand) -> bool;
 
+// The unpacked-struct domain (LRM 7.2), MIR's product type. A struct value is a
+// runtime-owned product carried behind an opaque handle. It owns its components
+// by value, so construction copies each component in and access copies out; the
+// generated side only ever holds handles, never the product's internal storage.
+//
+// A component crosses as a handle of its own domain. Assembly first boxes each
+// into a component of the product (the domain rides in the symbol name, as
+// every other domain-parametric entry does), then `make` collects the
+// components into the product value. `extract` copies component `index` back
+// out; `update` returns a copy of the product with component `index` replaced
+// -- a value operation, never an in-place write, so value semantics hold even
+// when the product is shared.
+auto lyra_rt_tuple_component_packed(const void* value) -> void*;
+auto lyra_rt_tuple_component_string(const void* value) -> void*;
+auto lyra_rt_tuple_component_real(const void* value) -> void*;
+auto lyra_rt_tuple_component_shortreal(const void* value) -> void*;
+auto lyra_rt_tuple_component_chandle(void* value) -> void*;
+auto lyra_rt_tuple_component_tuple(const void* value) -> void*;
+auto lyra_rt_tuple_make(LyraSpan components) -> void*;
+auto lyra_rt_tuple_extract(const void* tuple, std::int64_t index) -> void*;
+auto lyra_rt_tuple_update(const void* tuple, std::int64_t index, void* value)
+    -> void*;
+auto lyra_rt_tuple_eq(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_tuple_ne(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_tuple_case_equal(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_cell_tuple_get(void* cell) -> const void*;
+void lyra_rt_cell_tuple_initialize(void* cell, const void* prototype);
+void lyra_rt_cell_tuple_set(void* cell, void* services, const void* value);
+auto lyra_rt_activation_frame_alloc_tuple() -> void*;
+void lyra_rt_activation_frame_store_tuple(void* cell, const void* value);
+auto lyra_rt_activation_frame_load_tuple(const void* cell) -> void*;
+
 // Builds one conversion's format specification, and the print item that pairs a
 // value with it. Each field arrives as a packed value, as the value model
 // routes every compile-time scalar.

--- a/include/lyra/runtime/member_storage.hpp
+++ b/include/lyra/runtime/member_storage.hpp
@@ -7,6 +7,7 @@
 #include "lyra/value/chandle.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
+#include "lyra/value/runtime_tuple.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
@@ -33,7 +34,7 @@ class MemberStorage {
  private:
   std::variant<
       void*, Var<value::PackedArray>, Var<value::String>, Var<value::Real>,
-      Var<value::ShortReal>, value::Chandle>
+      Var<value::ShortReal>, value::Chandle, Var<value::RuntimeTuple>>
       object_;
 };
 

--- a/include/lyra/runtime/scope_program.hpp
+++ b/include/lyra/runtime/scope_program.hpp
@@ -86,6 +86,7 @@ enum class ValueDomain : std::uint8_t {
   kReal,
   kShortReal,
   kChandle,
+  kTuple,
 };
 
 // How a member's storage is realized. A borrowed handle is a box holding a

--- a/include/lyra/value/runtime_tuple.hpp
+++ b/include/lyra/value/runtime_tuple.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstddef>
+#include <variant>
+#include <vector>
+
+#include "lyra/value/chandle.hpp"
+#include "lyra/value/concepts.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/real.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::value {
+
+struct RuntimeValue;
+
+// The runtime-owned realization of an unpacked struct (LRM 7.2), MIR's generic
+// product type `TupleType`. A product value that owns its components by value:
+// copy is a component-wise deep copy, destruction is C++ RAII, so a component
+// never borrows caller storage.
+//
+// This is the execution backend's type-erased counterpart of the C++ backend's
+// monomorphized `Tuple<Ts...>`. A compile-once runtime cannot instantiate a
+// distinct C++ type per source struct, so one `RuntimeTuple` holds a vector of
+// type-erased `RuntimeValue` components and composes the `LyraValue` contract
+// by visiting them. A component's runtime domain is the active alternative of
+// its `RuntimeValue`; the whole-value operations dispatch on those
+// alternatives, so no separate persistent type descriptor is stored --
+// construction supplies the component domains, and the alternatives carry them
+// thereafter.
+class RuntimeTuple {
+ public:
+  RuntimeTuple();
+  explicit RuntimeTuple(std::vector<RuntimeValue> components);
+  RuntimeTuple(const RuntimeTuple&);
+  RuntimeTuple(RuntimeTuple&&) noexcept;
+  auto operator=(const RuntimeTuple&) -> RuntimeTuple&;
+  auto operator=(RuntimeTuple&&) noexcept -> RuntimeTuple&;
+  ~RuntimeTuple();
+
+  // Reads component `index` by reference. The caller copies it out across the
+  // opaque-handle boundary rather than aliasing it.
+  [[nodiscard]] auto Component(std::size_t index) const -> const RuntimeValue&;
+
+  // Overwrites component `index` with `value`. The declared domain of a struct
+  // field never changes, so the replacement's alternative matches the slot's.
+  void SetComponent(std::size_t index, RuntimeValue value);
+
+  // LRM 11.4.5 `==` / `!=` (Any data type): a component-wise reduction that
+  // propagates X / Z through each component's own equality.
+  [[nodiscard]] auto operator==(const RuntimeTuple& other) const -> PackedArray;
+  [[nodiscard]] auto operator!=(const RuntimeTuple& other) const -> PackedArray;
+
+  // LRM 11.4.5 `===` / `!==` (Any data type except real / shortreal):
+  // component-wise case equality, deterministic in X / Z. A real component
+  // makes the source-level `===` an error, rejected before lowering, so it
+  // never reaches this method.
+  [[nodiscard]] auto CaseEqual(const RuntimeTuple& other) const -> PackedArray;
+
+  // LRM 9.4.2 update-event predicate (engine change-detection hook).
+  [[nodiscard]] auto IsBitIdentical(const RuntimeTuple& other) const -> bool;
+
+  // LRM 20.9: any component carrying an unknown bit propagates up.
+  [[nodiscard]] auto HasUnknown() const -> bool;
+  [[nodiscard]] auto IsUnknown() const -> PackedArray;
+
+ private:
+  std::vector<RuntimeValue> components_;
+};
+
+// A type-erased runtime value: the payload one opaque JIT handle refers to. The
+// active alternative is the value's current runtime domain. This is a runtime
+// representation, not a compiler-IR value -- it is neither an MIR nor a LIR
+// value type. It closes over `RuntimeTuple`, so a struct component may itself
+// be a struct.
+struct RuntimeValue {
+  std::variant<PackedArray, String, Real, ShortReal, Chandle, RuntimeTuple>
+      value;
+};
+
+static_assert(LyraValue<RuntimeTuple>);
+static_assert(CaseEqualComparable<RuntimeTuple>);
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -598,6 +598,7 @@ auto RenderUnitIncludes(const mir::CompilationUnit& unit) -> std::string {
   out += "#include \"lyra/value/scan.hpp\"\n";
   out += "#include \"lyra/value/string.hpp\"\n";
   out += "#include \"lyra/value/string_op.hpp\"\n";
+  out += "#include \"lyra/value/tuple.hpp\"\n";
   out += "#include \"lyra/value/unpacked_array.hpp\"\n";
   out += "#include \"lyra/value/dynamic_array.hpp\"\n";
   out += "#include \"lyra/value/union.hpp\"\n";

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -29,6 +29,12 @@ auto CodeGenFunction::LowerInstr(const lir::Instr& instr) -> llvm::Value* {
           [&](const lir::AggregateInstr& agg) -> llvm::Value* {
             return LowerAggregate(agg, result_type);
           },
+          [&](const lir::AggregateExtractInstr& extract) -> llvm::Value* {
+            return LowerAggregateExtract(extract);
+          },
+          [&](const lir::AggregateUpdateInstr& update) -> llvm::Value* {
+            return LowerAggregateUpdate(update);
+          },
           [&](const lir::LoadInstr& load) -> llvm::Value* {
             return builder_.CreateLoad(
                 module_->Types().Map(result_type),
@@ -271,11 +277,14 @@ auto CodeGenFunction::ForeignCallee(
 // are stored into contiguous storage and named by a {pointer, length} span.
 auto CodeGenFunction::LowerAggregate(
     const lir::AggregateInstr& agg, lir::TypeId result_type) -> llvm::Value* {
-  const auto* array = std::get_if<lir::UnpackedArrayType>(
-      &module_->Unit().types.Get(result_type).data);
+  const auto& result_data = module_->Unit().types.Get(result_type).data;
+  if (const auto* tuple = std::get_if<lir::TupleType>(&result_data)) {
+    return LowerTupleAggregate(agg, *tuple);
+  }
+  const auto* array = std::get_if<lir::UnpackedArrayType>(&result_data);
   if (array == nullptr) {
     throw InternalError(
-        "llvm codegen: aggregate result is not an unpacked array");
+        "llvm codegen: aggregate result is not an unpacked array or tuple");
   }
   auto* storage_ty = llvm::ArrayType::get(
       module_->Types().Map(array->element_type), agg.elements.size());
@@ -293,6 +302,67 @@ auto CodeGenFunction::LowerAggregate(
           llvm::Type::getInt64Ty(module_->Context()), agg.elements.size()),
       {1});
   return span;
+}
+
+// A product value is assembled by boxing each component into a product
+// component -- the component's domain names the box entry -- then collecting
+// the boxed components into the product. The component domains come from the
+// result product type, so the generated side never inspects the components'
+// runtime representation.
+auto CodeGenFunction::LowerTupleAggregate(
+    const lir::AggregateInstr& agg, const lir::TupleType& tuple)
+    -> llvm::Value* {
+  llvm::Type* handle_ty = module_->Types().Ptr();
+  auto* storage_ty = llvm::ArrayType::get(handle_ty, agg.elements.size());
+  llvm::Value* storage = builder_.CreateAlloca(storage_ty);
+  for (std::uint32_t i = 0; i < agg.elements.size(); ++i) {
+    const ValueDomain domain =
+        ValueDomainOf(module_->Unit(), tuple.elements[i]);
+    llvm::Value* boxed = builder_.CreateCall(
+        module_->Runtime().TupleComponent(domain),
+        {LowerOperand(agg.elements[i])});
+    llvm::Value* slot =
+        builder_.CreateConstInBoundsGEP2_64(storage_ty, storage, 0, i);
+    builder_.CreateStore(boxed, slot);
+  }
+  llvm::Value* span = llvm::UndefValue::get(module_->Types().Span());
+  span = builder_.CreateInsertValue(span, storage, {0});
+  span = builder_.CreateInsertValue(
+      span,
+      llvm::ConstantInt::get(
+          llvm::Type::getInt64Ty(module_->Context()), agg.elements.size()),
+      {1});
+  return builder_.CreateCall(module_->Runtime().TupleMake(), {span});
+}
+
+auto CodeGenFunction::LowerAggregateExtract(
+    const lir::AggregateExtractInstr& extract) -> llvm::Value* {
+  llvm::Value* aggregate = LowerOperand(extract.aggregate);
+  return std::visit(
+      Overloaded{[&](const lir::TupleElement& element) -> llvm::Value* {
+        return builder_.CreateCall(
+            module_->Runtime().TupleExtract(),
+            {aggregate,
+             llvm::ConstantInt::get(
+                 llvm::Type::getInt64Ty(module_->Context()), element.index)});
+      }},
+      extract.selector);
+}
+
+auto CodeGenFunction::LowerAggregateUpdate(
+    const lir::AggregateUpdateInstr& update) -> llvm::Value* {
+  llvm::Value* aggregate = LowerOperand(update.aggregate);
+  llvm::Value* replacement = LowerOperand(update.replacement);
+  return std::visit(
+      Overloaded{[&](const lir::TupleElement& element) -> llvm::Value* {
+        return builder_.CreateCall(
+            module_->Runtime().TupleUpdate(),
+            {aggregate,
+             llvm::ConstantInt::get(
+                 llvm::Type::getInt64Ty(module_->Context()), element.index),
+             replacement});
+      }},
+      update.selector);
 }
 
 auto CodeGenFunction::LowerOperand(const lir::Operand& operand)

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -30,6 +30,8 @@ auto ValueDomainName(ValueDomain domain) -> std::string_view {
       return "shortreal";
     case ValueDomain::kChandle:
       return "chandle";
+    case ValueDomain::kTuple:
+      return "tuple";
   }
   throw InternalError("llvm codegen: unknown value domain");
 }
@@ -52,6 +54,10 @@ auto ValueDomainOf(const lir::CompilationUnit& unit, lir::TypeId type)
           // domain's handle is the chandle value itself, not a reference to a
           // runtime-owned value object.
           [](const lir::ChandleType&) { return ValueDomain::kChandle; },
+          // An unpacked struct (LRM 7.2) is MIR's product type; its runtime
+          // realization is a type-erased product value carried inline behind an
+          // opaque handle, like every other value domain.
+          [](const lir::TupleType&) { return ValueDomain::kTuple; },
           [](const auto&) -> ValueDomain {
             throw InternalError(
                 "llvm codegen: value type has no runtime library domain");
@@ -273,6 +279,28 @@ auto RuntimeAbi::ToBool(ValueDomain domain) -> llvm::FunctionCallee {
   return Get(
       std::format("lyra_rt_{}_to_bool", ValueDomainName(domain)),
       llvm::Type::getInt1Ty(*ctx_), {types_->Ptr()});
+}
+
+auto RuntimeAbi::TupleComponent(ValueDomain domain) -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_tuple_component_{}", ValueDomainName(domain)),
+      types_->Ptr(), {types_->Ptr()});
+}
+
+auto RuntimeAbi::TupleMake() -> llvm::FunctionCallee {
+  return Get("lyra_rt_tuple_make", types_->Ptr(), {types_->Span()});
+}
+
+auto RuntimeAbi::TupleExtract() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_tuple_extract", types_->Ptr(),
+      {types_->Ptr(), llvm::Type::getInt64Ty(*ctx_)});
+}
+
+auto RuntimeAbi::TupleUpdate() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_tuple_update", types_->Ptr(),
+      {types_->Ptr(), llvm::Type::getInt64Ty(*ctx_), types_->Ptr()});
 }
 
 auto RuntimeAbi::MakeFormatSpec(std::size_t field_count)

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -292,6 +292,27 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_chandle_ne", &lyra_rt_chandle_ne);
   add("lyra_rt_chandle_case_equal", &lyra_rt_chandle_case_equal);
   add("lyra_rt_chandle_to_bool", &lyra_rt_chandle_to_bool);
+  add("lyra_rt_tuple_component_packed", &lyra_rt_tuple_component_packed);
+  add("lyra_rt_tuple_component_string", &lyra_rt_tuple_component_string);
+  add("lyra_rt_tuple_component_real", &lyra_rt_tuple_component_real);
+  add("lyra_rt_tuple_component_shortreal", &lyra_rt_tuple_component_shortreal);
+  add("lyra_rt_tuple_component_chandle", &lyra_rt_tuple_component_chandle);
+  add("lyra_rt_tuple_component_tuple", &lyra_rt_tuple_component_tuple);
+  add("lyra_rt_tuple_make", &lyra_rt_tuple_make);
+  add("lyra_rt_tuple_extract", &lyra_rt_tuple_extract);
+  add("lyra_rt_tuple_update", &lyra_rt_tuple_update);
+  add("lyra_rt_tuple_eq", &lyra_rt_tuple_eq);
+  add("lyra_rt_tuple_ne", &lyra_rt_tuple_ne);
+  add("lyra_rt_tuple_case_equal", &lyra_rt_tuple_case_equal);
+  add("lyra_rt_cell_tuple_get", &lyra_rt_cell_tuple_get);
+  add("lyra_rt_cell_tuple_initialize", &lyra_rt_cell_tuple_initialize);
+  add("lyra_rt_cell_tuple_set", &lyra_rt_cell_tuple_set);
+  add("lyra_rt_activation_frame_alloc_tuple",
+      &lyra_rt_activation_frame_alloc_tuple);
+  add("lyra_rt_activation_frame_store_tuple",
+      &lyra_rt_activation_frame_store_tuple);
+  add("lyra_rt_activation_frame_load_tuple",
+      &lyra_rt_activation_frame_load_tuple);
   Check(
       jit.getMainJITDylib().define(
           llvm::orc::absoluteSymbols(std::move(symbols))),
@@ -333,6 +354,8 @@ auto AbiDomain(backend::llvm_backend::ValueDomain domain)
       return runtime::ValueDomain::kShortReal;
     case backend::llvm_backend::ValueDomain::kChandle:
       return runtime::ValueDomain::kChandle;
+    case backend::llvm_backend::ValueDomain::kTuple:
+      return runtime::ValueDomain::kTuple;
   }
   throw InternalError("jit executor: unknown value domain");
 }

--- a/src/lyra/lir/dump.cpp
+++ b/src/lyra/lir/dump.cpp
@@ -93,6 +93,18 @@ class LirDumper {
             [&](const AggregateInstr& agg) -> std::string {
               return std::format("aggregate({})", FormatOperands(agg.elements));
             },
+            [&](const AggregateExtractInstr& extract) -> std::string {
+              return std::format(
+                  "aggregate_extract {}, {}", FormatOperand(extract.aggregate),
+                  FormatSelector(extract.selector));
+            },
+            [&](const AggregateUpdateInstr& update) -> std::string {
+              return std::format(
+                  "aggregate_update {}, {}, {}",
+                  FormatOperand(update.aggregate),
+                  FormatSelector(update.selector),
+                  FormatOperand(update.replacement));
+            },
             [&](const LoadInstr& load) -> std::string {
               return std::format("load {}", FormatPlace(load.place));
             },
@@ -222,6 +234,15 @@ class LirDumper {
           step);
     }
     return out;
+  }
+
+  [[nodiscard]] static auto FormatSelector(const AggregateSelector& selector)
+      -> std::string {
+    return std::visit(
+        Overloaded{[](const TupleElement& e) {
+          return std::format("element {}", e.index);
+        }},
+        selector);
   }
 
   [[nodiscard]] static auto FormatOperand(const Operand& op) -> std::string {

--- a/src/lyra/lir/verify.cpp
+++ b/src/lyra/lir/verify.cpp
@@ -164,8 +164,9 @@ void VerifyInstr(
             }
           },
           [](const CallInstr&) {}, [](const AggregateInstr&) {},
-          [](const BinaryInstr&) {}, [](const UnaryInstr&) {},
-          [](const BoolCastInstr&) {}},
+          [](const AggregateExtractInstr&) {},
+          [](const AggregateUpdateInstr&) {}, [](const BinaryInstr&) {},
+          [](const UnaryInstr&) {}, [](const BoolCastInstr&) {}},
       instr.data);
 }
 

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -123,17 +123,17 @@ auto PlacedLocal(const mir::Block& block, mir::ExprId id)
 // A value type whose runtime realization is an opaque handle into transient
 // storage the boundary releases at each suspension: a packed value (or the
 // enumeration and packed struct/union projections that share its shape), a
-// string, or a real-family value (real / shortreal / realtime). A local of such
-// a type that a suspending body reads across a suspension needs
-// activation-stable storage, because its handle cannot outlive the stretch that
-// produced it. A pointer, a reference, an object handle, or a machine scalar is
-// not one of these -- it is stable across a suspension on its own -- so it is
-// unaffected.
+// string, a real-family value (real / shortreal / realtime), or an unpacked
+// struct product value. A local of such a type that a suspending body reads
+// across a suspension needs activation-stable storage, because its handle
+// cannot outlive the stretch that produced it. A pointer, a reference, an
+// object handle, or a machine scalar is not one of these -- it is stable across
+// a suspension on its own -- so it is unaffected.
 auto IsActivationValueType(const mir::Type& type) -> bool {
   const mir::TypeKind kind = type.Kind();
   return type.IsIntegralPacked() || kind == mir::TypeKind::kString ||
          kind == mir::TypeKind::kReal || kind == mir::TypeKind::kShortReal ||
-         kind == mir::TypeKind::kRealTime;
+         kind == mir::TypeKind::kRealTime || kind == mir::TypeKind::kTuple;
 }
 
 // Marks every local the canonical lowering needs an address for: one that is
@@ -888,6 +888,14 @@ auto FunctionLowerer::LowerCall(
 auto FunctionLowerer::LowerAssign(
     const mir::Block& block, const mir::AssignExpr& assign)
     -> diag::Result<lir::Operand> {
+  // A write to a product component is not a place store: the product is an
+  // opaque value, so the component write is a whole-value rebuild stored back
+  // through the product's owner.
+  if (std::holds_alternative<mir::TupleGetExpr>(
+          block.exprs.Get(assign.target).data)) {
+    return LowerComponentAssign(block, assign);
+  }
+
   const lir::TypeId type =
       unit_->TranslateType(block.exprs.Get(assign.target).type);
 
@@ -942,6 +950,177 @@ auto FunctionLowerer::LowerAssign(
   }
   Store(*std::move(place), written);
   return written;
+}
+
+namespace {
+
+struct MutateCell {
+  mir::ExprId cell;
+  mir::ExprId services;
+};
+
+// Detects the observable-cell mutate proxy a partial write to an observable
+// cell roots in -- a dereference of a `kMutate` call -- and returns its cell
+// and services argument expressions. An ordinary place root yields nothing.
+auto MutateCellOf(const mir::Block& block, mir::ExprId id)
+    -> std::optional<MutateCell> {
+  const auto* deref = std::get_if<mir::DerefExpr>(&block.exprs.Get(id).data);
+  if (deref == nullptr) {
+    return std::nullopt;
+  }
+  const auto* call =
+      std::get_if<mir::CallExpr>(&block.exprs.Get(deref->pointer).data);
+  if (call == nullptr) {
+    return std::nullopt;
+  }
+  const auto* direct = std::get_if<mir::Direct>(&call->callee);
+  if (direct == nullptr) {
+    return std::nullopt;
+  }
+  const auto* fn = std::get_if<support::BuiltinFn>(&direct->target);
+  if (fn == nullptr || *fn != support::BuiltinFn::kMutate) {
+    return std::nullopt;
+  }
+  return MutateCell{.cell = call->arguments[0], .services = call->arguments[1]};
+}
+
+}  // namespace
+
+auto FunctionLowerer::ReadWholeValue(const mir::Block& block, mir::ExprId id)
+    -> diag::Result<lir::Operand> {
+  if (const std::optional<MutateCell> mutate = MutateCellOf(block, id)) {
+    auto cell = LowerArgument(block, mutate->cell);
+    if (!cell) {
+      return std::unexpected(std::move(cell.error()));
+    }
+    return Emit(
+        unit_->TranslateType(block.exprs.Get(id).type),
+        lir::CallInstr{
+            .target =
+                lir::BuiltinTarget{
+                    .fn = support::BuiltinFn::kGet, .qualifier = std::nullopt},
+            .args = {*std::move(cell)}});
+  }
+  return LowerExpr(block, id);
+}
+
+auto FunctionLowerer::WriteWholeValue(
+    const mir::Block& block, mir::ExprId id, lir::Operand value)
+    -> diag::Result<lir::Operand> {
+  if (const std::optional<MutateCell> mutate = MutateCellOf(block, id)) {
+    auto cell = LowerArgument(block, mutate->cell);
+    if (!cell) {
+      return std::unexpected(std::move(cell.error()));
+    }
+    auto services = LowerExpr(block, mutate->services);
+    if (!services) {
+      return std::unexpected(std::move(services.error()));
+    }
+    Emit(
+        unit_->VoidType(),
+        lir::CallInstr{
+            .target =
+                lir::BuiltinTarget{
+                    .fn = support::BuiltinFn::kSet, .qualifier = std::nullopt},
+            .args = {*std::move(cell), *std::move(services), value}});
+    return value;
+  }
+  if (const std::optional<lir::Operand> handle =
+          ActivationValueHandleForTarget(block, id)) {
+    StoreActivationValue(*handle, value);
+    return value;
+  }
+  auto place = LowerPlace(block, id);
+  if (!place) {
+    return std::unexpected(std::move(place.error()));
+  }
+  Store(*std::move(place), value);
+  return value;
+}
+
+auto FunctionLowerer::LowerComponentAssign(
+    const mir::Block& block, const mir::AssignExpr& assign)
+    -> diag::Result<lir::Operand> {
+  // Walk the component-projection chain from the target down to its storage
+  // root, collecting each level's component index and product type.
+  struct Level {
+    std::uint32_t index;
+    lir::TypeId tuple_type;
+    lir::TypeId component_type;
+  };
+  std::vector<Level> levels;
+  mir::ExprId cursor = assign.target;
+  while (true) {
+    const mir::Expr& expr = block.exprs.Get(cursor);
+    const auto* get = std::get_if<mir::TupleGetExpr>(&expr.data);
+    if (get == nullptr) {
+      break;
+    }
+    levels.push_back(
+        Level{
+            .index = static_cast<std::uint32_t>(get->index),
+            .tuple_type =
+                unit_->TranslateType(block.exprs.Get(get->tuple).type),
+            .component_type = unit_->TranslateType(expr.type)});
+    cursor = get->tuple;
+  }
+  std::ranges::reverse(levels);
+  const mir::ExprId root = cursor;
+
+  auto root_value = ReadWholeValue(block, root);
+  if (!root_value) {
+    return std::unexpected(std::move(root_value.error()));
+  }
+
+  // The product value at each chain level, descending from the root toward the
+  // component being written.
+  std::vector<lir::Operand> tuples;
+  tuples.reserve(levels.size());
+  tuples.push_back(*std::move(root_value));
+  for (std::size_t depth = 1; depth < levels.size(); ++depth) {
+    tuples.push_back(Emit(
+        levels[depth].tuple_type,
+        lir::AggregateExtractInstr{
+            .aggregate = tuples[depth - 1],
+            .selector = lir::TupleElement{.index = levels[depth - 1].index}}));
+  }
+
+  auto rhs = LowerExpr(block, assign.value);
+  if (!rhs) {
+    return std::unexpected(std::move(rhs.error()));
+  }
+  const std::size_t leaf = levels.size() - 1;
+  lir::Operand leaf_value = *std::move(rhs);
+  if (assign.compound_op.has_value()) {
+    const std::optional<lir::BinaryOp> op =
+        TranslateBinaryOp(*assign.compound_op);
+    if (!op) {
+      return Unsupported(
+          "mir_to_lir: compound assignment operator has no direct realization");
+    }
+    lir::Operand old = Emit(
+        levels[leaf].component_type,
+        lir::AggregateExtractInstr{
+            .aggregate = tuples[leaf],
+            .selector = lir::TupleElement{.index = levels[leaf].index}});
+    leaf_value = Emit(
+        levels[leaf].component_type,
+        lir::BinaryInstr{
+            .op = *op, .lhs = std::move(old), .rhs = std::move(leaf_value)});
+  }
+
+  // Rebuild the whole value from the written component outward.
+  lir::Operand rebuilt = std::move(leaf_value);
+  for (std::size_t depth = levels.size(); depth-- > 0;) {
+    rebuilt = Emit(
+        levels[depth].tuple_type,
+        lir::AggregateUpdateInstr{
+            .aggregate = tuples[depth],
+            .selector = lir::TupleElement{.index = levels[depth].index},
+            .replacement = std::move(rebuilt)});
+  }
+
+  return WriteWholeValue(block, root, std::move(rebuilt));
 }
 
 auto FunctionLowerer::LowerIncDec(
@@ -1077,6 +1256,32 @@ auto FunctionLowerer::LowerExpr(const mir::Block& block, mir::ExprId id)
             return Emit(
                 unit_->TranslateType(type),
                 lir::AggregateInstr{.elements = std::move(elements)});
+          },
+          [&](const mir::TupleExpr& tuple) -> diag::Result<lir::Operand> {
+            std::vector<lir::Operand> components;
+            components.reserve(tuple.components.size());
+            for (const mir::ExprId component : tuple.components) {
+              auto lowered = LowerExpr(block, component);
+              if (!lowered) {
+                return std::unexpected(std::move(lowered.error()));
+              }
+              components.push_back(*std::move(lowered));
+            }
+            return Emit(
+                unit_->TranslateType(type),
+                lir::AggregateInstr{.elements = std::move(components)});
+          },
+          [&](const mir::TupleGetExpr& get) -> diag::Result<lir::Operand> {
+            auto tuple = LowerExpr(block, get.tuple);
+            if (!tuple) {
+              return std::unexpected(std::move(tuple.error()));
+            }
+            return Emit(
+                unit_->TranslateType(type),
+                lir::AggregateExtractInstr{
+                    .aggregate = *std::move(tuple),
+                    .selector = lir::TupleElement{
+                        .index = static_cast<std::uint32_t>(get.index)}});
           },
           [&](const mir::PointerCastExpr& c) -> diag::Result<lir::Operand> {
             auto operand = LowerExpr(block, c.operand);

--- a/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/unit_lowerer.cpp
@@ -143,6 +143,13 @@ auto UnitLowerer::MachineBoolType() -> lir::TypeId {
   return *machine_bool_type_;
 }
 
+auto UnitLowerer::VoidType() -> lir::TypeId {
+  if (!void_type_.has_value()) {
+    void_type_ = out_.types.Add(lir::Type{.data = lir::VoidType{}});
+  }
+  return *void_type_;
+}
+
 auto UnitLowerer::LowerBase(const mir::ClassRef& base) -> lir::Base {
   return std::visit(
       Overloaded{

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -1,11 +1,14 @@
 #include "lyra/runtime/jit_execution.hpp"
 
 #include <coroutine>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <span>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/time.hpp"
@@ -24,6 +27,7 @@
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
+#include "lyra/value/runtime_tuple.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
@@ -154,6 +158,8 @@ using lyra::value::PrintItem;
 using lyra::value::PrintLiteralItem;
 using lyra::value::PrintValueItem;
 using lyra::value::Real;
+using lyra::value::RuntimeTuple;
+using lyra::value::RuntimeValue;
 using lyra::value::ShortReal;
 using lyra::value::String;
 using lyra::value::TimeFormat;
@@ -914,5 +920,118 @@ auto lyra_rt_chandle_case_equal(void* lhs, void* rhs) -> void* {
 
 auto lyra_rt_chandle_to_bool(void* operand) -> bool {
   return static_cast<bool>(Chandle{operand});
+}
+
+auto lyra_rt_tuple_component_packed(const void* value) -> void* {
+  return Own(RuntimeValue{Read<PackedArray>(value)});
+}
+
+auto lyra_rt_tuple_component_string(const void* value) -> void* {
+  return Own(RuntimeValue{Read<String>(value)});
+}
+
+auto lyra_rt_tuple_component_real(const void* value) -> void* {
+  return Own(RuntimeValue{Read<Real>(value)});
+}
+
+auto lyra_rt_tuple_component_shortreal(const void* value) -> void* {
+  return Own(RuntimeValue{Read<ShortReal>(value)});
+}
+
+// A chandle's handle is the pointer it carries, not a pointer to a runtime
+// object, so its component boxes the pointer directly rather than reading a
+// value object out of it.
+auto lyra_rt_tuple_component_chandle(void* value) -> void* {
+  return Own(RuntimeValue{Chandle{value}});
+}
+
+auto lyra_rt_tuple_component_tuple(const void* value) -> void* {
+  return Own(RuntimeValue{Read<RuntimeTuple>(value)});
+}
+
+auto lyra_rt_tuple_make(LyraSpan components) -> void* {
+  std::span<RuntimeValue*> handles(
+      static_cast<RuntimeValue**>(components.data), components.count);
+  std::vector<RuntimeValue> collected;
+  collected.reserve(components.count);
+  for (RuntimeValue* handle : handles) {
+    collected.push_back(std::move(*handle));
+  }
+  return Own(RuntimeTuple(std::move(collected)));
+}
+
+auto lyra_rt_tuple_extract(const void* tuple, std::int64_t index) -> void* {
+  const RuntimeValue& component =
+      Read<RuntimeTuple>(tuple).Component(static_cast<std::size_t>(index));
+  return std::visit(
+      [](const auto& value) -> void* {
+        using T = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<T, Chandle>) {
+          return value.Ptr();
+        } else {
+          return Own(value);
+        }
+      },
+      component.value);
+}
+
+auto lyra_rt_tuple_update(const void* tuple, std::int64_t index, void* value)
+    -> void* {
+  RuntimeTuple result = Read<RuntimeTuple>(tuple);
+  const auto slot = static_cast<std::size_t>(index);
+  RuntimeValue replacement = std::visit(
+      [&](const auto& current) -> RuntimeValue {
+        using T = std::decay_t<decltype(current)>;
+        if constexpr (std::is_same_v<T, Chandle>) {
+          return RuntimeValue{Chandle{value}};
+        } else {
+          return RuntimeValue{Read<T>(value)};
+        }
+      },
+      result.Component(slot).value);
+  result.SetComponent(slot, std::move(replacement));
+  return Own(std::move(result));
+}
+
+auto lyra_rt_tuple_eq(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<RuntimeTuple>(lhs) == Read<RuntimeTuple>(rhs));
+}
+
+auto lyra_rt_tuple_ne(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<RuntimeTuple>(lhs) != Read<RuntimeTuple>(rhs));
+}
+
+auto lyra_rt_tuple_case_equal(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<RuntimeTuple>(lhs).CaseEqual(Read<RuntimeTuple>(rhs)));
+}
+
+auto lyra_rt_cell_tuple_get(void* cell) -> const void* {
+  return &static_cast<Var<RuntimeTuple>*>(cell)->Get();
+}
+
+void lyra_rt_cell_tuple_initialize(void* cell, const void* prototype) {
+  static_cast<Var<RuntimeTuple>*>(cell)->Initialize(
+      Read<RuntimeTuple>(prototype));
+}
+
+void lyra_rt_cell_tuple_set(void* cell, void* services, const void* value) {
+  static_cast<Var<RuntimeTuple>*>(cell)->Set(
+      *static_cast<RuntimeServices*>(services), Read<RuntimeTuple>(value));
+}
+
+auto lyra_rt_activation_frame_alloc_tuple() -> void* {
+  return GeneratedCallScope::Current()
+      .ActivationFrame()
+      .New<ActivationValueCell<RuntimeTuple>>();
+}
+
+void lyra_rt_activation_frame_store_tuple(void* cell, const void* value) {
+  static_cast<ActivationValueCell<RuntimeTuple>*>(cell)->Store(
+      Read<RuntimeTuple>(value));
+}
+
+auto lyra_rt_activation_frame_load_tuple(const void* cell) -> void* {
+  return Own(
+      static_cast<const ActivationValueCell<RuntimeTuple>*>(cell)->Get());
 }
 }

--- a/src/lyra/runtime/member_storage.cpp
+++ b/src/lyra/runtime/member_storage.cpp
@@ -7,6 +7,7 @@
 #include "lyra/runtime/scope_program.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
+#include "lyra/value/runtime_tuple.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
@@ -29,6 +30,9 @@ MemberStorage::MemberStorage(MemberStorageDescriptor descriptor) {
           return;
         case ValueDomain::kShortReal:
           object_.emplace<Var<value::ShortReal>>();
+          return;
+        case ValueDomain::kTuple:
+          object_.emplace<Var<value::RuntimeTuple>>();
           return;
         case ValueDomain::kChandle:
           throw InternalError(

--- a/src/lyra/value/runtime_tuple.cpp
+++ b/src/lyra/value/runtime_tuple.cpp
@@ -1,0 +1,151 @@
+#include "lyra/value/runtime_tuple.hpp"
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+RuntimeTuple::RuntimeTuple() = default;
+RuntimeTuple::RuntimeTuple(std::vector<RuntimeValue> components)
+    : components_(std::move(components)) {
+}
+RuntimeTuple::RuntimeTuple(const RuntimeTuple&) = default;
+RuntimeTuple::RuntimeTuple(RuntimeTuple&&) noexcept = default;
+auto RuntimeTuple::operator=(const RuntimeTuple&) -> RuntimeTuple& = default;
+auto RuntimeTuple::operator=(RuntimeTuple&&) noexcept
+    -> RuntimeTuple& = default;
+RuntimeTuple::~RuntimeTuple() = default;
+
+auto RuntimeTuple::Component(std::size_t index) const -> const RuntimeValue& {
+  if (index >= components_.size()) {
+    throw InternalError("RuntimeTuple::Component: index out of range");
+  }
+  return components_[index];
+}
+
+void RuntimeTuple::SetComponent(std::size_t index, RuntimeValue value) {
+  if (index >= components_.size()) {
+    throw InternalError("RuntimeTuple::SetComponent: index out of range");
+  }
+  if (components_[index].value.index() != value.value.index()) {
+    throw InternalError(
+        "RuntimeTuple::SetComponent: replacement domain differs from the "
+        "field's declared domain");
+  }
+  components_[index] = std::move(value);
+}
+
+namespace {
+
+auto RequireSameCount(std::size_t a_count, std::size_t b_count) -> void {
+  if (a_count != b_count) {
+    throw InternalError(
+        "RuntimeTuple: comparing products of different component counts");
+  }
+}
+
+auto SameDomain(const RuntimeValue& a, const RuntimeValue& b) -> void {
+  if (a.value.index() != b.value.index()) {
+    throw InternalError(
+        "RuntimeTuple: comparing components of different runtime domains");
+  }
+}
+
+auto ComponentEqual(const RuntimeValue& a, const RuntimeValue& b)
+    -> PackedArray {
+  SameDomain(a, b);
+  return std::visit(
+      [&](const auto& lhs) -> PackedArray {
+        using T = std::decay_t<decltype(lhs)>;
+        return lhs == std::get<T>(b.value);
+      },
+      a.value);
+}
+
+auto ComponentCaseEqual(const RuntimeValue& a, const RuntimeValue& b)
+    -> PackedArray {
+  SameDomain(a, b);
+  return std::visit(
+      [&](const auto& lhs) -> PackedArray {
+        using T = std::decay_t<decltype(lhs)>;
+        if constexpr (std::is_same_v<T, Real> || std::is_same_v<T, ShortReal>) {
+          throw InternalError(
+              "RuntimeTuple::CaseEqual: === is not defined on a real component "
+              "(LRM Table 11-1)");
+        } else {
+          return lhs.CaseEqual(std::get<T>(b.value));
+        }
+      },
+      a.value);
+}
+
+auto ComponentBitIdentical(const RuntimeValue& a, const RuntimeValue& b)
+    -> bool {
+  SameDomain(a, b);
+  return std::visit(
+      [&](const auto& lhs) -> bool {
+        using T = std::decay_t<decltype(lhs)>;
+        return lhs.IsBitIdentical(std::get<T>(b.value));
+      },
+      a.value);
+}
+
+}  // namespace
+
+auto RuntimeTuple::operator==(const RuntimeTuple& other) const -> PackedArray {
+  RequireSameCount(components_.size(), other.components_.size());
+  PackedArray result = PackedArray::Bit(true);
+  for (std::size_t i = 0; i < components_.size(); ++i) {
+    result = result && ComponentEqual(components_[i], other.components_[i]);
+  }
+  return result;
+}
+
+auto RuntimeTuple::operator!=(const RuntimeTuple& other) const -> PackedArray {
+  return !(*this == other);
+}
+
+auto RuntimeTuple::CaseEqual(const RuntimeTuple& other) const -> PackedArray {
+  RequireSameCount(components_.size(), other.components_.size());
+  PackedArray result = PackedArray::Bit(true);
+  for (std::size_t i = 0; i < components_.size(); ++i) {
+    result = result && ComponentCaseEqual(components_[i], other.components_[i]);
+  }
+  return result;
+}
+
+auto RuntimeTuple::IsBitIdentical(const RuntimeTuple& other) const -> bool {
+  if (components_.size() != other.components_.size()) {
+    return false;
+  }
+  for (std::size_t i = 0; i < components_.size(); ++i) {
+    if (!ComponentBitIdentical(components_[i], other.components_[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto RuntimeTuple::HasUnknown() const -> bool {
+  for (const RuntimeValue& component : components_) {
+    const bool unknown = std::visit(
+        [](const auto& value) -> bool { return value.HasUnknown(); },
+        component.value);
+    if (unknown) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto RuntimeTuple::IsUnknown() const -> PackedArray {
+  return PackedArray::Bit(HasUnknown());
+}
+
+}  // namespace lyra::value

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -269,6 +269,53 @@ auto WriteLogicalOperatorSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+// Exercises the unpacked-struct value domain end to end: default value,
+// assignment-pattern construction, whole-value copy with value semantics, the
+// equality families, component read and write (including a nested product and a
+// string component), a struct local that crosses a suspension, and partial
+// writes to an observable struct signal that a reader reacts to.
+auto WriteStructSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  typedef struct { int a; int b; } Pair;\n"
+      << "  typedef struct { Pair p; int c; string s; } Nest;\n"
+      << "  Pair s;\n"
+      << "  Pair t;\n"
+      << "  Nest n;\n"
+      << "  Pair sig;\n"
+      << "  int mirror = 0;\n"
+      << "  always_comb mirror = sig.a * 100 + sig.b;\n"
+      << "  initial begin\n"
+      << "    $display(\"def a=%0d b=%0d\", s.a, s.b);\n"
+      << "    s = '{a: 3, b: 7};\n"
+      << "    $display(\"con a=%0d b=%0d\", s.a, s.b);\n"
+      << "    t = s;\n"
+      << "    s.a = 100;\n"
+      << "    $display(\"copy t.a=%0d s.a=%0d\", t.a, s.a);\n"
+      << "    t = '{a: 100, b: 7};\n"
+      << "    $display(\"eq=%0d ne=%0d ceq=%0d\", s == t, s != t, s === t);\n"
+      << "    t.b = 8;\n"
+      << "    $display(\"eq2=%0d\", s == t);\n"
+      << "    n = '{p: '{a: 1, b: 2}, c: 9, s: \"hi\"};\n"
+      << "    n.p.b = 20;\n"
+      << "    n.s = \"bye\";\n"
+      << "    $display(\"nest a=%0d b=%0d c=%0d s=%s\", n.p.a, n.p.b, n.c, "
+         "n.s);\n"
+      << "    begin\n"
+      << "      automatic Pair loc = '{a: 42, b: 43};\n"
+      << "      #1;\n"
+      << "      $display(\"xsusp a=%0d b=%0d\", loc.a, loc.b);\n"
+      << "    end\n"
+      << "    sig = '{a: 1, b: 2};\n"
+      << "    #1;\n"
+      << "    $display(\"whole mirror=%0d\", mirror);\n"
+      << "    sig.a = 7;\n"
+      << "    #1;\n"
+      << "    $display(\"partial mirror=%0d sig.a=%0d\", mirror, sig.a);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -628,6 +675,44 @@ TEST(LyraRun, JitAndCppAgreeOnLogicalOperators) {
       "equiv=0 impl=0\n"
       "not_a=0 not_b=1\n"
       "str=1\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnStruct) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteStructSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "def a=0 b=0\n"
+      "con a=3 b=7\n"
+      "copy t.a=3 s.a=100\n"
+      "eq=1 ne=0 ceq=1\n"
+      "eq2=0\n"
+      "nest a=1 b=20 c=9 s=bye\n"
+      "xsusp a=42 b=43\n"
+      "whole mirror=102\n"
+      "partial mirror=702 sig.a=7\n")
       << "stdout: " << jit.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

This realizes the SystemVerilog unpacked struct (LRM 7.2, MIR's `TupleType`) on the LLVM/JIT execution backend, bringing it to parity with the C++ backend. A struct is a runtime-owned product value carried behind an opaque handle: it default-constructs member-wise, builds from an assignment pattern, copies with value semantics, takes the equality and case-equality families, reads and writes a component (including a nested struct and a string component), lives in a member slot as a whole-cell observable signal whose partial write fires subscribers, and crosses a suspension as an activation-frame value.

## Design

The runtime realization is type erasure. The C++ backend renders a struct as `lyra::value::Tuple<...>` and leans on the host C++ compiler to monomorphize it; the JIT emits LLVM IR directly and has no such front-end, so it realizes an aggregate as one type-erased runtime object -- `value::RuntimeValue` (a variant of the value domains) and `value::RuntimeTuple` (a vector of components owned by value), reached through one opaque handle. `docs/decisions/jit-aggregate-realization.md` records why erasure is the baseline rather than codegen monomorphization: the variable-size containers (dynamic array, queue, associative array) have a runtime element count and must be erased regardless, so structural monomorphization would only split the family and complicate cross-suspension lifetime for a partial win, while the fully native path is a whole-value-model project deferred with the rest of physical in-frame layout.

LIR gains two realization-agnostic value-aggregate operations, `AggregateExtractInstr` and `AggregateUpdateInstr` (the peers of LLVM `extractvalue` / `insertvalue`), carrying an `AggregateSelector`. A value aggregate has no independently addressable interior, so a component is a value projection, not a place: reading a component extracts it, and writing a component is a whole-value store of a functional update, uniform whether the struct lives in a local or an observable cell. `lir.md` is updated to scope the place model to independently addressable storage and to state this value-aggregate access model, so a later native realization changes only codegen and not the LIR contract. A partial write to an observable struct signal reuses the existing mutate protocol -- read the whole cell, rebuild it with the component replaced, set it whole so subscribers fire -- and a struct local that crosses a suspension joins the value domains that live in the activation frame.

## Testing

A JIT-vs-C++ agreement test exercises the full surface: default value, assignment-pattern construction, whole-value copy with value semantics, the equality families, component read and write over a nested struct and a string component, a struct local across a suspension, and partial writes to an observable struct signal that a reader reacts to. The work also surfaced and fixed a latent C++ backend gap -- the emitted project did not include the tuple runtime header, which a precompiled header masked, so a no-PCH build of a struct-using design failed.
