### PR TITLE
Support SV static class properties and methods

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -94,11 +94,18 @@ each stage establishes, not how.
       distinct and remain distinct end-to-end.
 
 - [ ] Interface-class conformance: a class may conform to several interfaces, a relation distinct
-      from its single concrete base and carrying no second instance storage. Type-associated static
-      storage and static methods, where a static method has no receiver. Parameterized-class
+      from its single concrete base and carrying no second instance storage. Parameterized-class
       specialization: a generic declaration plus, per specialization, a distinct materialized object
       record, its identity aligned with compilation-unit specialization (a stable id within a unit,
       a by-name canonical key across units) -- the same shape a parameterized module uses.
+
+- [x] Type-associated static storage and static methods (LRM 8.9 / 8.10): a static property is one
+      cell owned by the type, distinct from a per-instance field replicated on every object; a
+      static method has no receiver and cannot be virtual. Each layer keeps the two categories in
+      disjoint arenas -- an instance member and a type-associated one never share identity space --
+      and the initializer of a static property runs once at design init (LRM 10.5), before any
+      initial or always procedure, from a class-level body separate from the per-instance
+      constructor.
 
 ## Managed-object lifetime: current implementation status
 

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -9,6 +9,8 @@
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/field_id.hpp"
 #include "lyra/hir/method_id.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/static_property_id.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type_id.hpp"
 
@@ -24,6 +26,19 @@ struct ClassField {
   TypeId type;
 };
 
+// A class static property (LRM 8.9): a named type-associated storage cell
+// the class owns, shared by every instance. Distinct from `ClassField` (an
+// instance member replicated per object) because a static property is one
+// cell owned by the type, not a field the instance member set includes.
+// The declared `= value` initializer, when the source writes one, is a
+// design-init fact (LRM 10.5) and lives on `ClassDecl.static_property_inits`
+// -- it runs once before any initial or always procedure, not inside the
+// constructor.
+struct ClassStaticProperty {
+  std::string name;
+  TypeId type;
+};
+
 // A source-written property initializer (LRM 8.7): the assignment that
 // runs against the receiver during construction, before the user
 // constructor body, on the property named by `target`. `value` lives in
@@ -32,6 +47,19 @@ struct ClassField {
 // the body would.
 struct FieldInit {
   FieldId target;
+  ExprId value;
+};
+
+// A source-written static property initializer (LRM 8.9 / 10.5): the
+// assignment that runs once at design init, before any initial or always
+// procedure, on the static property named by `target`. Distinct from
+// `FieldInit` because the timing is class-level program startup, not
+// per-instance construction. `value` lives in the class's `static_init`
+// body arena, an arena separate from the constructor body's, because the
+// initializer cannot read a per-instance formal or self and must not share
+// the constructor body's expression identities.
+struct StaticPropertyInit {
+  StaticPropertyId target;
   ExprId value;
 };
 
@@ -74,14 +102,32 @@ struct BaseCall {
 // arena. Only fields the source declared with an explicit `= value` appear
 // here; a field without one takes its type's Table 7-1 default at
 // construction.
+//
+// `static_properties` peers with `fields` but stores type-associated cells
+// (LRM 8.9), not instance members. Inherited static properties are reached
+// through the base's registry entry, same as inherited instance fields.
+//
+// `static_init` is the class-level design-init body (LRM 10.5): the arena
+// hosting each static property's initializer expression tree, kept separate
+// from the constructor body because the initializer runs once at program
+// startup, not per instance construction. It is a bare `ProceduralBody` --
+// no `self`, no receiver -- because the code carries no per-instance context.
+//
+// `static_property_inits` pairs each source-written `= value` initializer
+// with its static property in source order; expressions live in
+// `static_init.exprs`. A static property without a source initializer takes
+// its type's Table 7-1 default and does not appear here.
 struct ClassDecl {
   std::string name;
   std::optional<ClassId> base;
   base::Arena<ClassField, FieldId> fields;
+  base::Arena<ClassStaticProperty, StaticPropertyId> static_properties;
   base::Arena<SubroutineDecl, MethodId> methods;
   SubroutineDecl constructor;
   std::optional<BaseCall> base_call;
   std::vector<FieldInit> field_inits;
+  ProceduralBody static_init;
+  std::vector<StaticPropertyInit> static_property_inits;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -44,7 +44,7 @@ struct NullLiteral {};
 // tag.
 using Primary = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
-    DirectMemberRef, ProceduralVarRef, ClassPropertyRef, RoutedRef,
-    IterationBindingRef>;
+    DirectMemberRef, ProceduralVarRef, ClassPropertyRef, StaticPropertyRef,
+    RoutedRef, IterationBindingRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/static_property_id.hpp
+++ b/include/lyra/hir/static_property_id.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <functional>
+
+namespace lyra::hir {
+
+// The declaration-order position of a class's static property (LRM 8.9)
+// within its owning class's static-property arena. A static property is a
+// type-associated storage cell, separate from an instance field; its arena is
+// distinct from `ClassDecl.fields`, and a `StaticPropertyId` never crosses
+// from one to the other.
+struct StaticPropertyId {
+  std::uint32_t value;
+
+  auto operator<=>(const StaticPropertyId&) const
+      -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir
+
+template <>
+struct std::hash<lyra::hir::StaticPropertyId> {
+  auto operator()(lyra::hir::StaticPropertyId id) const noexcept
+      -> std::size_t {
+    return std::hash<std::uint32_t>{}(id.value);
+  }
+};

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -79,6 +79,13 @@ struct MethodRef {
 // truth: a bodyless prototype and a legal empty body (LRM 8.21 note) are
 // distinct forms that emptiness alone cannot separate. Only class methods
 // carry it; free subroutines and processes always ship a body.
+//
+// `is_static` records that the source declared this method with the `static`
+// keyword (LRM 8.10) -- the method has no receiver, cannot be virtual, and
+// cannot be a constructor. At HIR-to-MIR this bit decides whether the lowered
+// `CallableCode.params` prepends `self`: instance methods do, static methods
+// omit it. Only class methods carry it; free subroutines and processes are
+// never static in this sense.
 struct SubroutineDecl {
   std::string name;
   SubroutineKind kind;
@@ -88,6 +95,7 @@ struct SubroutineDecl {
   ProceduralBody body;
   bool is_virtual = false;
   bool is_prototype = false;
+  bool is_static = false;
   std::optional<MethodRef> overrides;
 };
 

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <optional>
 #include <string>
 #include <variant>
@@ -103,9 +102,22 @@ struct ExternalUnitSubroutineRef {
   std::string subroutine_name;
 };
 
+// Calls a static class method (LRM 8.10). Distinct from `MethodCallRef`
+// because a static method has no receiver -- neither an explicit handle, an
+// implicit self, nor a super qualifier -- and encoding it as a receiver-
+// optional variant of `MethodCallRef` would admit an invalid state. `owner`
+// names the class that declares the method; `method` is its position within
+// that class's method arena. Under inheritance, `Derived::inherited_static()`
+// still names the base as `owner` -- the method lives on the base's arena --
+// mirroring the owner-qualified rule for inherited instance access.
+struct StaticMethodCallRef {
+  ClassId class_id;
+  MethodId method;
+};
+
 using SubroutineRef = std::variant<
-    StructuralSubroutineRef, MethodCallRef, SystemSubroutineRef,
-    BuiltinMethodRef, ForeignImportRef, ImportedMethodRef,
+    StructuralSubroutineRef, MethodCallRef, StaticMethodCallRef,
+    SystemSubroutineRef, BuiltinMethodRef, ForeignImportRef, ImportedMethodRef,
     ExternalUnitSubroutineRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -7,6 +7,7 @@
 #include "lyra/hir/class_id.hpp"
 #include "lyra/hir/field_id.hpp"
 #include "lyra/hir/procedural_var.hpp"
+#include "lyra/hir/static_property_id.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/with_clause_id.hpp"
 
@@ -63,6 +64,23 @@ struct ClassPropertyRef {
   FieldId field_index;
 
   auto operator==(const ClassPropertyRef&) const -> bool = default;
+};
+
+// A reference to a class static property (LRM 8.9), the type-associated
+// storage counterpart to `ClassPropertyRef`. `owner` names the class that
+// declares the property; `prop` is its position within that class's
+// static-property arena. A static property is one cell owned by the type, not
+// a member replicated into each instance, so this reference carries no
+// receiver: the source form `Cls::prop`, an unqualified use inside a method
+// of the same class, and `p.prop` where the resolved target happens to be
+// static all resolve to the same cell and the same reference shape.
+// Under inheritance, `Derived::inherited_prop` still names the base class as
+// `owner` -- the property lives on the base's arena.
+struct StaticPropertyRef {
+  ClassId owner;
+  StaticPropertyId prop;
+
+  auto operator==(const StaticPropertyRef&) const -> bool = default;
 };
 
 // A reference to a `with`-clause iteration value (LRM 7.12.4), named by the

--- a/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
@@ -208,6 +208,28 @@ class UnitLowerer {
         "id; the owning class was not interned before this lookup");
   }
 
+  // Peer of the field-id registry on the type-associated axis. Records the
+  // HIR `StaticPropertyId` a static class property (LRM 8.9) received when
+  // its owning class's `InternClass` added it to the static-property arena,
+  // so a downstream `Cls::prop` or `handle.prop` (static-lifetime) access
+  // reads the id in O(1) rather than re-walking the arena.
+  void RegisterClassPropertyStaticId(
+      const slang::ast::ClassPropertySymbol& prop, hir::StaticPropertyId id) {
+    class_property_static_ids_.emplace(&prop, id);
+  }
+
+  [[nodiscard]] auto LookupClassPropertyStaticId(
+      const slang::ast::ClassPropertySymbol& prop) const
+      -> hir::StaticPropertyId {
+    if (const auto it = class_property_static_ids_.find(&prop);
+        it != class_property_static_ids_.end()) {
+      return it->second;
+    }
+    throw InternalError(
+        "UnitLowerer::LookupClassPropertyStaticId: static property has no "
+        "recorded id; the owning class was not interned before this lookup");
+  }
+
   // Facts.
   [[nodiscard]] auto SourceMapper() const
       -> const frontend::SlangSourceMapper& {
@@ -331,6 +353,9 @@ class UnitLowerer {
       method_cache_;
   std::unordered_map<const slang::ast::ClassPropertySymbol*, hir::FieldId>
       class_property_field_ids_;
+  std::unordered_map<
+      const slang::ast::ClassPropertySymbol*, hir::StaticPropertyId>
+      class_property_static_ids_;
   StructuralDataObjectBindings structural_data_object_bindings_;
   SubroutineBindings subroutine_bindings_;
   ForeignImportBindings foreign_import_bindings_;

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -12,11 +12,13 @@
 #include "lyra/diag/source_manager.hpp"
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/field_id.hpp"
+#include "lyra/hir/static_property_id.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/field.hpp"
+#include "lyra/mir/static_property_id.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -115,8 +117,19 @@ class UnitLowerer {
   // field arenas presently share value semantics (fields are appended in
   // lockstep during the shape pass), and a later divergence rewires the
   // mapping in one place without touching any consumer.
-  [[nodiscard]] auto TranslateField(hir::FieldId hir_id) const -> mir::FieldId {
+  [[nodiscard]] static auto TranslateField(hir::FieldId hir_id)
+      -> mir::FieldId {
     return mir::FieldId{.value = hir_id.value};
+  }
+
+  // Translates a HIR class static property's identity to its MIR counterpart.
+  // Peer of `TranslateField` on the type-associated axis; the HIR and MIR
+  // static-property arenas are appended in lockstep during class lowering, so
+  // the mapping is positional today. Kept as a named function so a later
+  // divergence rewires here without touching any consumer.
+  [[nodiscard]] static auto TranslateStaticProperty(
+      hir::StaticPropertyId hir_id) -> mir::StaticPropertyId {
+    return mir::StaticPropertyId{.value = hir_id.value};
   }
 
   [[nodiscard]] auto ClassObjectType(hir::ClassId hir_id) const -> mir::TypeId {

--- a/include/lyra/mir/callable_code.hpp
+++ b/include/lyra/mir/callable_code.hpp
@@ -29,6 +29,16 @@ struct CallableCode {
   TypeId result_type;
   base::Arena<LocalDecl, LocalId> locals;
   Block body;
+
+  // Whether the signature declares a receiver: `params[0]`, if present, is
+  // typed as the enclosing class's self-pointer. The single structural check
+  // that both the code-declaration render and the call-site render read to
+  // pick between the instance form (with receiver) and the static form
+  // (without), without any side flag restating what the params list already
+  // fixes.
+  [[nodiscard]] auto HasReceiver(TypeId self_pointer_type) const -> bool {
+    return !params.empty() && locals.Get(params[0]).type == self_pointer_type;
+  }
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -17,6 +17,7 @@
 #include "lyra/mir/foreign_export_wrapper.hpp"
 #include "lyra/mir/param.hpp"
 #include "lyra/mir/static_constant_id.hpp"
+#include "lyra/mir/static_property_id.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/struct_id.hpp"
 #include "lyra/mir/type_id.hpp"
@@ -34,6 +35,23 @@ struct StaticConstantDecl {
   TypeId type;
   Block body;
   ExprId value;
+};
+
+// A class static property (LRM 8.9): a named, mutable type-associated storage
+// cell the class owns, shared by every instance. Peer of `FieldDecl` on the
+// instance-member axis and of `StaticConstantDecl` on the type-associated
+// axis, but a class of its own: unlike `FieldDecl` a static property has no
+// per-instance replication, and unlike `StaticConstantDecl` its value is a
+// run-time cell writable through ordinary assignment.
+// The source-written `= value` initializer, when present, is a design-init
+// fact (LRM 10.5): the assignment lands as an `AssignExpr` statement in the
+// class's `static_init` body, not on this declaration -- initializer timing
+// (once at program startup, before any initial / always) and per-cell
+// identity are separate concerns, and the class-wide statement list is the
+// one home a backend reads for construction-time state.
+struct StaticPropertyDecl {
+  std::string name;
+  TypeId type;
 };
 
 // A constructor's invocation of its base's constructor. Every arg evaluates in
@@ -80,6 +98,7 @@ struct ClassShape {
   TimeResolution time_resolution;
   base::Arena<ParamDecl, ParamId> ctor_prefix_params;
   base::Arena<FieldDecl, FieldId> fields;
+  base::Arena<StaticPropertyDecl, StaticPropertyId> static_properties;
   base::Arena<CallableSignature, CallableId> callable_signatures;
   std::vector<ClassId> contained;
   // Whether the class occupies a node of the runtime object tree -- a module
@@ -120,11 +139,12 @@ struct Class {
   std::vector<StructId> structs;
   // Every callable this class owns, in one arena: instance methods (LRM 8.6),
   // process and lifecycle bodies, and the receiver-less static callables (a
-  // DPI-C import, LRM 35.4; a static method). An instance method carries `self`
-  // as its first parameter and a static callable omits it, but both are one
-  // `CallableDecl` reached by one `CallableId` -- the receiver is a property of
-  // the signature, not a separate declaration space. The constructor is not
-  // here: it is a bare body block on the protocol, never a call target.
+  // DPI-C import, LRM 35.4; a static method, LRM 8.10). An instance method
+  // carries `self` as its first parameter and a static callable omits it,
+  // but both are one `CallableDecl` reached by one `CallableId` -- the
+  // receiver is a property of the signature, not a separate declaration
+  // space. The constructor is not here: it is a bare body block on the
+  // protocol, never a call target.
   base::Arena<CallableDecl, CallableId> callables;
   // The runtime-callback adapters this class owns -- callables whose identity
   // is a plain function pointer the runtime holds, semantically distinct from
@@ -137,6 +157,22 @@ struct Class {
   // the constructor forwards its address to the runtime base through the
   // construction protocol.
   base::Arena<StaticConstantDecl, StaticConstantId> static_constants;
+  // The class's static properties (LRM 8.9): mutable type-associated storage
+  // cells shared by every instance. Peer to `fields` on the instance-versus-
+  // type-associated axis: a static property is one cell owned by the type,
+  // never a member replicated into each instance.
+  base::Arena<StaticPropertyDecl, StaticPropertyId> static_properties;
+  // The class-level design-init body (LRM 10.5): a receiver-less callable the
+  // runtime invokes once at program startup, before any initial or always
+  // procedure and before any instance's constructor. Its body is a sequence
+  // of `AssignExpr` statements, one per source-written static property
+  // initializer in declaration order; a static property without a source
+  // initializer takes its type's Table 7-1 default and gets no statement
+  // here. Peer to `constructor.code` on the axis "code the runtime runs at
+  // construction time," but per-class rather than per-instance and
+  // signature-less: `code.params` is empty (no `self`, no formals), and
+  // `code.result_type` is void.
+  CallableCode static_init;
   // The foreign-linkage wrappers this class exposes -- one per `export "DPI-C"`
   // of one of its callables (LRM 35.5). Each is an external entry a backend
   // materializes beside the class; empty for a class that exports nothing.

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -16,6 +16,7 @@
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/local_ref.hpp"
 #include "lyra/mir/static_constant_id.hpp"
+#include "lyra/mir/static_property_id.hpp"
 #include "lyra/mir/struct_construct.hpp"
 #include "lyra/mir/unary_op.hpp"
 #include "lyra/support/builtin_fn.hpp"
@@ -466,6 +467,20 @@ struct StaticConstantRef {
   StaticConstantId constant;
 };
 
+// A place naming a class's static property (`Class::name`, LRM 8.9): the
+// mutable type-associated storage cell counterpart to `StaticConstantRef`.
+// `owner` is the class whose static-property arena declares the cell (a
+// derived source access like `Derived::inherited_prop` still names the base
+// class here, mirroring the owner-qualification rule for inherited instance
+// access). `Expr::type` is the property's type; as a place it appears
+// wherever a `FieldAccessExpr` on a class instance would but without the
+// receiver operand, and it is legal both as an rvalue and as an `AssignExpr`
+// target.
+struct StaticPropertyRef {
+  ClassId owner;
+  StaticPropertyId prop;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     MachineIntLiteral, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
@@ -473,7 +488,8 @@ using ExprData = std::variant<
     MoveExpr, PointerCastExpr, IntCastExpr, FieldAccessExpr,
     StructConstructExpr, ClosureExpr, ConcatExpr, ReplicationExpr,
     ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr, UnionExpr,
-    UnionGetExpr, UnionGetRefExpr, FunctionRef, StaticConstantRef>;
+    UnionGetExpr, UnionGetRefExpr, FunctionRef, StaticConstantRef,
+    StaticPropertyRef>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/static_property_id.hpp
+++ b/include/lyra/mir/static_property_id.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::mir {
+
+// Identity of a class static property (LRM 8.9) -- a named, mutable
+// type-associated storage cell the class owns, shared by every instance.
+// Scoped to the class that declares it (`Class::static_properties`), peer of
+// `FieldId` on the instance-member axis and of `StaticConstantId` on the
+// type-associated axis. Distinct from `StaticConstantId`: a static constant is
+// immutable and built once at compile time (the data dual of a static
+// method); a static property is a run-time cell writable through ordinary
+// assignment (LRM 8.9).
+struct StaticPropertyId {
+  std::uint32_t value;
+
+  auto operator<=>(const StaticPropertyId&) const
+      -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <format>
-#include <functional>
 #include <optional>
 #include <span>
 #include <string>
@@ -56,6 +55,21 @@ auto RenderFieldList(
   return out;
 }
 
+// A class static property (LRM 8.9) renders as an `inline static` member of
+// the C++ class: one cell owned by the type, value-initialized at
+// program-startup time before any process runs, which matches LRM 10.5's
+// "before any initial or always" ordering natively. The declaration is
+// bare `<type> <name>{}`; a source-declared initializer, when present,
+// arrives as a class-level assignment statement in the design-init body,
+// never baked into the declaration.
+auto RenderClassStaticProperty(
+    const mir::CompilationUnit& unit, const mir::StaticPropertyDecl& sp,
+    std::size_t indent) -> std::string {
+  const std::string type = RenderTypeAsCpp(unit, sp.type);
+  return std::format(
+      "{}inline static {} {}{{}};\n", Indent(indent), type, sp.name);
+}
+
 auto RenderCallableParam(
     const mir::CompilationUnit& unit, const mir::LocalDecl& param)
     -> std::string {
@@ -91,15 +105,17 @@ auto OverrideSuffix(const mir::CallableDecl& m) -> std::string_view {
   return " override";
 }
 
-// The renderer for a class-owned callable -- an instance method, a process or
-// lifecycle body. Each is a C++ instance member function: `this` is what MIR
-// calls `self`, seeded through a one-line adapter so the body's expressions
-// resolve receiver-relative references uniformly. The callable's dispatch role
-// decorates the declaration with `virtual` or `override` where applicable. A
-// namespace's receiver-less callable renders through the free-function path
-// instead. A pure virtual prototype (LRM 8.21, MIR `PurePrototype`) is
-// rendered as a bodyless declaration suffixed with `= 0`; C++ then treats
-// the enclosing class as abstract without any class-level marker required.
+// The renderer for a class-owned callable -- an instance method (LRM 8.6),
+// a static method (LRM 8.10), a process, or a lifecycle body. An instance
+// callable renders as a C++ instance member function whose body opens with
+// a one-line `self = this` adapter, so the body's expressions resolve
+// receiver-relative references uniformly. A static callable renders with
+// the `static` keyword and no receiver alias. The callable's dispatch role
+// decorates the declaration with `virtual` or `override` where applicable.
+// A pure virtual prototype (LRM 8.21) is rendered as a bodyless declaration
+// suffixed with `= 0`; C++ then treats the enclosing class as abstract
+// without any class-level marker required. A namespace's receiver-less
+// callable renders through the free-function path instead.
 auto RenderClassCallable(
     const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::Class& s, const mir::CallableDecl& m, std::size_t indent)
@@ -111,10 +127,18 @@ auto RenderClassCallable(
           ? std::get<mir::PurePrototype>(m.impl).code
           : std::get<mir::InternalCallable>(m.impl).code;
   const std::string ret = RenderTypeAsCpp(unit, code.result_type);
+  // Instance vs static (LRM 8.10) is a signature-level fact carried by the
+  // presence of a self-typed `params[0]`. The C++ `static` prefix and the
+  // body's receiver-alias are gated on the same check so no side flag
+  // restates what the signature already fixes.
+  const bool has_receiver = code.HasReceiver(s.self_pointer_type);
+  const std::size_t user_params_start = has_receiver ? 1 : 0;
+  const std::string_view static_prefix = has_receiver ? "" : "static ";
 
-  std::string sig = std::format("{}auto {}(", VirtualPrefix(m), m.name);
-  for (std::size_t i = 1; i < code.params.size(); ++i) {
-    if (i != 1) sig += ", ";
+  std::string sig =
+      std::format("{}{}auto {}(", static_prefix, VirtualPrefix(m), m.name);
+  for (std::size_t i = user_params_start; i < code.params.size(); ++i) {
+    if (i != user_params_start) sig += ", ";
     sig += RenderCallableParam(unit, code.locals.Get(code.params[i]));
   }
   sig += std::format(") -> {}{}", ret, OverrideSuffix(m));
@@ -126,14 +150,16 @@ auto RenderClassCallable(
   const ScopeView body_view = (parent_struct_view == nullptr)
                                   ? ScopeView::ForRoot(unit, s, code)
                                   : parent_struct_view->WithClass(s, code);
-  const mir::LocalId self_local = code.params[0];
-  const auto& self_decl = code.locals.Get(self_local);
-  const std::string self_type = RenderTypeAsCpp(unit, self_decl.type);
 
   std::string out;
   out += std::format("{}{} {{\n", Indent(indent), sig);
-  out += std::format(
-      "{}{} {} = this;\n", Indent(indent + 1), self_type, self_decl.name);
+  if (has_receiver) {
+    const mir::LocalId self_local = code.params[0];
+    const auto& self_decl = code.locals.Get(self_local);
+    const std::string self_type = RenderTypeAsCpp(unit, self_decl.type);
+    out += std::format(
+        "{}{} {} = this;\n", Indent(indent + 1), self_type, self_decl.name);
+  }
   out += RenderBlockStatements(body_view, indent + 1);
   out += std::format("{}}}\n", Indent(indent));
   return out;
@@ -303,6 +329,32 @@ auto RenderStaticConstant(
       RenderExpr(view, view.Expr(c.value)));
 }
 
+// The class-level design-init body (LRM 8.9 / 10.5): renders as a static
+// class method whose body assigns each static property its source-declared
+// initial value, plus an `inline static const` sentinel whose initializer
+// invokes it. C++ evaluates `inline static` variables at program-startup
+// time, before `main` and before any process, which realizes the LRM
+// "before any initial or always" ordering without a runtime hook. When the
+// class declared no source initializers the body is empty and nothing is
+// emitted -- the properties' value-init on their inline declarations
+// already covers the type-default case.
+auto RenderClassStaticInit(
+    const mir::CompilationUnit& unit, const mir::Class& s, std::size_t indent)
+    -> std::string {
+  if (s.static_init.body.root_stmts.empty()) return "";
+  const ScopeView view = ScopeView::ForRoot(unit, s, s.static_init);
+  std::string out;
+  out += std::format(
+      "{}static auto __static_init__() -> void {{\n", Indent(indent));
+  out += RenderBlockStatements(view, indent + 1);
+  out += std::format("{}}}\n", Indent(indent));
+  out += std::format(
+      "{}inline static const int __static_init_trigger__ = "
+      "(__static_init__(), 0);\n",
+      Indent(indent));
+  return out;
+}
+
 auto RenderScopeAsClass(
     const mir::CompilationUnit& unit, const mir::Class& s, std::size_t indent,
     const ScopeView* parent_struct_view) -> std::string;
@@ -378,6 +430,17 @@ auto RenderScopeAsClass(
   }
   out += RenderFieldList(this_anchor, s.fields, indent + 1);
 
+  // Type-associated storage (LRM 8.9): one cell per class, value-initialized
+  // by C++ at program-startup time so the type-default case needs no
+  // explicit statement. A source-declared initializer is separately emitted
+  // through the `static_init` body below.
+  if (!s.static_properties.empty()) {
+    out += "\n";
+  }
+  for (const mir::StaticPropertyDecl& sp : s.static_properties) {
+    out += RenderClassStaticProperty(unit, sp, indent + 1);
+  }
+
   // Each callable declares its access -- a class instance method is the
   // object's public callable surface, a scope's processes and lifecycle hooks
   // are internal -- and the access specifier follows that stated visibility,
@@ -424,6 +487,17 @@ auto RenderScopeAsClass(
   // them), each emitted as a static member.
   for (const mir::StaticConstantDecl& c : s.static_constants) {
     out += RenderStaticConstant(this_anchor, s, c, indent + 1);
+  }
+
+  // The class's design-init body (LRM 8.9 / 10.5). Renders only when the
+  // source declared at least one static property initializer; otherwise the
+  // value-init on each `inline static` declaration above already realizes
+  // the type-default case.
+  const std::string static_init_text =
+      RenderClassStaticInit(unit, s, indent + 1);
+  if (!static_init_text.empty()) {
+    out += "\n";
+    out += static_init_text;
   }
 
   out += std::format("{}}};\n", Indent(indent));

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -420,17 +420,19 @@ struct CalleeRender {
   std::size_t leading_arg_count;
 };
 
-// Renders a `Direct` callee naming an owner-qualified callable this class owns
-// -- an instance method or a DPI-C import, both one `CallableDecl` arena. A
-// DPI-C import (external) is a global `extern "C"` symbol reached by its
-// foreign linkage name, with no receiver absorbed. An instance method renders
-// as `(receiver)->Owner::name`, an owner-qualified C++ member call: the owner
-// prefix is a fixed function of the target's `owner`, redundant for a
-// non-virtual method and, for a virtual method reached through Direct (LRM 8.15
-// super), forcing C++ to bypass the vtable -- precisely what the Direct arm
-// names. The receiver is `arguments[0]`, absorbed into the callee text, so one
-// leading argument is consumed. No qualification is allowed today --
-// cross-class explicit qualification is gated on SV class support.
+// Renders a `Direct` callee naming an owner-qualified callable this class
+// owns -- an instance method (LRM 8.6), a static method (LRM 8.10), or a
+// DPI-C import, all one arena. A DPI-C import (external) is a global
+// `extern "C"` symbol reached by its foreign linkage name, no receiver
+// absorbed. An instance callable renders as `(receiver)->Owner::name`, an
+// owner-qualified C++ member call: the owner prefix is a fixed function of
+// the target's owner, redundant for a non-virtual method and, for a virtual
+// method reached through Direct (LRM 8.15 super), forcing C++ to bypass the
+// vtable. The receiver is the first argument, absorbed into the callee
+// text, so one leading argument is consumed. A static callable renders as
+// the free type-qualified form `Owner::name`, with no receiver argument
+// absorbed. No qualification is allowed today -- cross-class explicit
+// qualification is gated on SV class support.
 auto RenderDirectCallableCall(
     const ScopeView& view, const mir::CallExpr& call,
     const mir::CallableTarget& target,
@@ -443,6 +445,19 @@ auto RenderDirectCallableCall(
   const auto& callable = cls.callables.Get(target.slot);
   if (const auto* ext = std::get_if<mir::ExternalCallable>(&callable.impl)) {
     return {.expr = ext->external.foreign_name, .leading_arg_count = 0};
+  }
+  // Instance vs static (LRM 8.10) reads off the target's signature: an
+  // instance call binds the receiver as `(recv)->Owner::name(rest)`, a
+  // static call is the free type-qualified form `Owner::name(args)` with no
+  // receiver absorbed.
+  const mir::CallableCode& code =
+      std::holds_alternative<mir::PurePrototype>(callable.impl)
+          ? std::get<mir::PurePrototype>(callable.impl).code
+          : std::get<mir::InternalCallable>(callable.impl).code;
+  if (!code.HasReceiver(cls.self_pointer_type)) {
+    return {
+        .expr = std::format("{}::{}", ToCppName(cls.name), callable.name),
+        .leading_arg_count = 0};
   }
   if (call.arguments.empty()) {
     throw InternalError("Direct method call expects a receiver argument");

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -429,6 +429,12 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
                 "{}::{}", ToCppName(cls.name),
                 cls.static_constants.Get(r.constant).name);
           },
+          [&](const mir::StaticPropertyRef& r) -> std::string {
+            const mir::Class& owner_cls = view.Unit().GetClass(r.owner);
+            return std::format(
+                "{}::{}", ToCppName(owner_cls.name),
+                owner_cls.static_properties.Get(r.prop).name);
+          },
           // HIR-to-MIR lowers an LHS selector chain to write-form nodes -- a
           // container-access `CallExpr` with a write callee (per
           // `mir::IsContainerAccessCall`), a `UnionGetRefExpr`, a
@@ -896,6 +902,12 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
             return std::format(
                 "{}::{}", ToCppName(cls.name),
                 cls.static_constants.Get(r.constant).name);
+          },
+          [&](const mir::StaticPropertyRef& r) -> std::string {
+            const mir::Class& owner_cls = view.Unit().GetClass(r.owner);
+            return std::format(
+                "{}::{}", ToCppName(owner_cls.name),
+                owner_cls.static_properties.Get(r.prop).name);
           },
           [&](const mir::ClosureExpr& cl) -> std::string {
             return RenderClosureExpr(view, cl);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -415,6 +415,10 @@ class HirDumper {
                   "ClassProperty[Class[{}].{}]", r.owner.value,
                   r.field_index.value);
             },
+            [](const StaticPropertyRef& r) -> std::string {
+              return std::format(
+                  "StaticProperty[Class[{}].{}]", r.owner.value, r.prop.value);
+            },
             [](const RoutedRef& r) -> std::string {
               return std::format("RoutedRef[{}]", r.id.value);
             },
@@ -557,6 +561,11 @@ class HirDumper {
               return std::format(
                   "Method class=Class[{}] index={} recv={}", m.class_id.value,
                   m.method.value, recv);
+            },
+            [](const StaticMethodCallRef& s) -> std::string {
+              return std::format(
+                  "StaticMethod class=Class[{}] index={}", s.class_id.value,
+                  s.method.value);
             },
             [](const SystemSubroutineRef& s) -> std::string {
               const auto& desc = support::LookupSystemSubroutine(s.id);

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -574,6 +574,47 @@ auto LowerCallExpr(
     };
   }
 
+  // A static class method call (LRM 8.10): the target has no receiver, so it
+  // lowers to `StaticMethodCallRef` rather than `MethodCallRef` -- a `handle`-
+  // qualified call to a static method still discards the handle because the
+  // callee never observes it (LRM 8.10 "no access to non-static members").
+  // The declaring class comes from slang's resolved callee, so an inherited
+  // static call reaches the base's arena the same way an instance-method
+  // call does under LRM 8.13.
+  if (sym->flags.has(slang::ast::MethodFlags::Static) &&
+      sym->getParentScope() != nullptr &&
+      sym->getParentScope()->asSymbol().kind ==
+          slang::ast::SymbolKind::ClassType) {
+    for (const auto* formal : sym->getArguments()) {
+      if (formal->direction != slang::ast::ArgumentDirection::In) {
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedClassFeature,
+            "static class methods with output / inout / ref arguments are not "
+            "yet supported");
+      }
+    }
+    const auto& declaring_class =
+        sym->getParentScope()->asSymbol().as<slang::ast::ClassType>();
+    auto class_id = unit_lowerer.InternClass(declaring_class, span);
+    if (!class_id) return std::unexpected(std::move(class_id.error()));
+    auto static_result_type = unit_lowerer.InternType(*call.type, span);
+    if (!static_result_type) {
+      return std::unexpected(std::move(static_result_type.error()));
+    }
+    return hir::Expr{
+        .type = *static_result_type,
+        .data =
+            hir::CallExpr{
+                .callee =
+                    hir::StaticMethodCallRef{
+                        .class_id = *class_id,
+                        .method = unit_lowerer.LookupMethodId(*sym)},
+                .arguments = std::move(arg_ids),
+            },
+        .span = span,
+    };
+  }
+
   // Instance-method call (LRM 8.6): three source shapes -- `h.foo()`,
   // implicit-`this` `foo()` from inside a class body, and `super.foo()` --
   // all lower to one `MethodCallRef` distinguished by which `MethodReceiver`

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -219,15 +219,27 @@ auto MakeClassPropertyRefExpr(
     -> diag::Result<hir::Expr> {
   auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
+  const auto& prop = sym.as<slang::ast::ClassPropertySymbol>();
   const auto& owner_class =
       sym.getParentScope()->asSymbol().as<slang::ast::ClassType>();
   auto owner_id = unit_lowerer.InternClass(owner_class, span);
   if (!owner_id) return std::unexpected(std::move(owner_id.error()));
+  // LRM 8.9: a static-lifetime property is one cell owned by the class, so
+  // its reference form carries neither the enclosing method's receiver nor
+  // a fabricated stand-in -- a type-associated cell has no per-instance
+  // context to reach. Instance properties and static properties take
+  // structurally disjoint reference primaries.
+  if (prop.lifetime == slang::ast::VariableLifetime::Static) {
+    return hir::MakeRefExpr(
+        hir::StaticPropertyRef{
+            .owner = *owner_id,
+            .prop = unit_lowerer.LookupClassPropertyStaticId(prop)},
+        *type_id, span);
+  }
   return hir::MakeRefExpr(
       hir::ClassPropertyRef{
           .owner = *owner_id,
-          .field_index = unit_lowerer.LookupClassPropertyFieldId(
-              sym.as<slang::ast::ClassPropertySymbol>())},
+          .field_index = unit_lowerer.LookupClassPropertyFieldId(prop)},
       *type_id, span);
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -192,6 +192,21 @@ auto LowerMemberAccessExpr(
         prop.getParentScope()->asSymbol().as<slang::ast::ClassType>();
     auto owner_id = lowerer.Owner().InternClass(declaring_class, span);
     if (!owner_id) return std::unexpected(std::move(owner_id.error()));
+    // LRM 8.9 permits reaching a static property through a handle
+    // (`p.static_prop`), and LRM 8.3 says accessing a static member through a
+    // null handle is legal because no per-instance dereference is required.
+    // The lowered reference form carries no receiver -- a type-associated
+    // property has no per-instance context to reach -- so the base handle
+    // expression `p` is not retained here; nothing downstream would consume
+    // it, and fabricating a receiver to stand in for "no instance" would
+    // conflict with the receiver-of-instance-methods-only rule.
+    if (prop.lifetime == slang::ast::VariableLifetime::Static) {
+      return hir::MakeRefExpr(
+          hir::StaticPropertyRef{
+              .owner = *owner_id,
+              .prop = lowerer.Owner().LookupClassPropertyStaticId(prop)},
+          *type_id, span);
+    }
     return hir::Expr{
         .type = *type_id,
         .data =

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -592,15 +592,22 @@ auto UnitLowerer::InternClass(
     if (prop.getParentScope() != &cls) {
       continue;
     }
+    auto prop_type = InternType(prop.getType(), span);
+    if (!prop_type) return std::unexpected(std::move(prop_type.error()));
+    // LRM 8.9 / 8.10 keyword position: `static <T> x` marks a type-associated
+    // property, whose storage is one cell owned by the class rather than a
+    // per-instance member. Instance properties and static properties live in
+    // disjoint arenas because their identity spaces do not overlap and each
+    // downstream reference form names one or the other.
     if (prop.lifetime == slang::ast::VariableLifetime::Static) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedClassFeature,
-          "static class properties are not yet supported");
+      const hir::StaticPropertyId static_id = decl.static_properties.Add(
+          hir::ClassStaticProperty{
+              .name = std::string(prop.name), .type = *prop_type});
+      RegisterClassPropertyStaticId(prop, static_id);
+      continue;
     }
-    auto field_type = InternType(prop.getType(), span);
-    if (!field_type) return std::unexpected(std::move(field_type.error()));
     const hir::FieldId field_id = decl.fields.Add(
-        hir::ClassField{.name = std::string(prop.name), .type = *field_type});
+        hir::ClassField{.name = std::string(prop.name), .type = *prop_type});
     RegisterClassPropertyFieldId(prop, field_id);
   }
   std::optional<hir::SubroutineDecl> user_constructor;
@@ -635,11 +642,6 @@ auto UnitLowerer::InternClass(
       decl.base_call = std::move(ctor_or->base_call);
       continue;
     }
-    if (method.flags.has(slang::ast::MethodFlags::Static)) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedClassFeature,
-          "static class methods are not yet supported");
-    }
     if (method.subroutineKind == slang::ast::SubroutineKind::Task) {
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedClassFeature,
@@ -647,45 +649,55 @@ auto UnitLowerer::InternClass(
     }
     auto method_decl = LowerSubroutineDecl(*this, method, WalkFrame{});
     if (!method_decl) return std::unexpected(std::move(method_decl.error()));
+    // Source-level facts on a class method: `static` (LRM 8.10) makes the
+    // signature receiver-less; `virtual` (LRM 8.20) puts the method in the
+    // class's dispatch table. Slang enforces at declaration that static and
+    // virtual are mutually exclusive, so the override / dispatch wiring
+    // below runs only for non-static methods.
+    method_decl->is_static = method.flags.has(slang::ast::MethodFlags::Static);
     method_decl->is_virtual =
         method.flags.has(slang::ast::MethodFlags::Virtual);
-    // The frontend has already matched signature, direction, return type, and
-    // any other LRM 8.20 override compatibility rule when it resolved this
-    // reference; the HIR consumes it as an already-resolved identity. Its
-    // base's methods were interned earlier by the recursive `InternClass`
-    // above, so their HIR identities are already in the cache the lookup
-    // reads.
-    if (const auto* overridden = method.getOverride(); overridden != nullptr) {
-      const auto& base_class =
-          overridden->getParentScope()->asSymbol().as<slang::ast::ClassType>();
-      auto base_class_id = InternClass(base_class, span);
-      if (!base_class_id)
-        return std::unexpected(std::move(base_class_id.error()));
-      method_decl->overrides = hir::MethodRef{
-          .class_id = *base_class_id, .method = LookupMethodId(*overridden)};
-    } else if (const auto* pure_base =
-                   FindOverriddenPureInBaseChain(cls, method.name);
-               pure_base != nullptr) {
-      // Slang leaves the override link unset when the base method is a pure
-      // virtual prototype (LRM 8.21); wire it here so downstream dispatch
-      // canonicalizes to the base's slot rather than treating this method
-      // as a fresh introducer.
-      const auto& base_class =
-          pure_base->getParentScope()->asSymbol().as<slang::ast::ClassType>();
-      auto base_class_id = InternClass(base_class, span);
-      if (!base_class_id)
-        return std::unexpected(std::move(base_class_id.error()));
-      const auto* proto_stub = pure_base->getSubroutine();
-      if (proto_stub == nullptr) {
-        throw InternalError(
-            "UnitLowerer::InternClass: pure virtual prototype has no stub "
-            "subroutine slang normally materializes");
+    if (!method_decl->is_static) {
+      // The frontend has already matched signature, direction, return type,
+      // and any other LRM 8.20 override compatibility rule when it resolved
+      // this reference; the HIR consumes it as an already-resolved identity.
+      // Its base's methods were interned earlier by the recursive
+      // `InternClass` above, so their HIR identities are already in the
+      // cache the lookup reads.
+      if (const auto* overridden = method.getOverride();
+          overridden != nullptr) {
+        const auto& base_class = overridden->getParentScope()
+                                     ->asSymbol()
+                                     .as<slang::ast::ClassType>();
+        auto base_class_id = InternClass(base_class, span);
+        if (!base_class_id)
+          return std::unexpected(std::move(base_class_id.error()));
+        method_decl->overrides = hir::MethodRef{
+            .class_id = *base_class_id, .method = LookupMethodId(*overridden)};
+      } else if (const auto* pure_base =
+                     FindOverriddenPureInBaseChain(cls, method.name);
+                 pure_base != nullptr) {
+        // Slang leaves the override link unset when the base method is a
+        // pure virtual prototype (LRM 8.21); wire it here so downstream
+        // dispatch canonicalizes to the base's slot rather than treating
+        // this method as a fresh introducer.
+        const auto& base_class =
+            pure_base->getParentScope()->asSymbol().as<slang::ast::ClassType>();
+        auto base_class_id = InternClass(base_class, span);
+        if (!base_class_id)
+          return std::unexpected(std::move(base_class_id.error()));
+        const auto* proto_stub = pure_base->getSubroutine();
+        if (proto_stub == nullptr) {
+          throw InternalError(
+              "UnitLowerer::InternClass: pure virtual prototype has no stub "
+              "subroutine slang normally materializes");
+        }
+        method_decl->overrides = hir::MethodRef{
+            .class_id = *base_class_id, .method = LookupMethodId(*proto_stub)};
+        // An override of a base virtual method is itself virtual (LRM 8.20),
+        // even when the derived declaration omits the `virtual` keyword.
+        method_decl->is_virtual = true;
       }
-      method_decl->overrides = hir::MethodRef{
-          .class_id = *base_class_id, .method = LookupMethodId(*proto_stub)};
-      // An override of a base virtual method is itself virtual (LRM 8.20),
-      // even when the derived declaration omits the `virtual` keyword.
-      method_decl->is_virtual = true;
     }
     const hir::MethodId method_id = decl.methods.Add(*std::move(method_decl));
     RegisterMethodId(method, method_id);
@@ -765,11 +777,29 @@ auto UnitLowerer::InternClass(
   ProcessLowerer init_lowerer(*this, cls);
   const WalkFrame init_frame = WalkFrame{}.WithProceduralBody(
       &constructor.body, &constructor.body.exprs);
+  // A static property initializer (LRM 8.9 / 10.5) runs once at design init,
+  // not per instance, so its expression lands in the class's `static_init`
+  // arena rather than the constructor body's. It cannot read a per-instance
+  // formal or `self`, and the lowering routes that no such receiver is in
+  // scope; a downstream initializer that names another static property of
+  // the same class reads it as `Cls::other_prop` (a `StaticPropertyRef`),
+  // never through the constructor's receiver.
+  const WalkFrame static_init_frame = WalkFrame{}.WithProceduralBody(
+      &decl.static_init, &decl.static_init.exprs);
   for (const auto& prop :
        cls.membersOfType<slang::ast::ClassPropertySymbol>()) {
     if (prop.getParentScope() != &cls) continue;
     const auto* init = prop.getInitializer();
     if (init == nullptr) continue;
+    if (prop.lifetime == slang::ast::VariableLifetime::Static) {
+      auto init_expr = init_lowerer.LowerExpr(*init, static_init_frame);
+      if (!init_expr) return std::unexpected(std::move(init_expr.error()));
+      decl.static_property_inits.push_back(
+          hir::StaticPropertyInit{
+              .target = LookupClassPropertyStaticId(prop),
+              .value = decl.static_init.exprs.Add(*std::move(init_expr))});
+      continue;
+    }
     auto init_expr = init_lowerer.LowerExpr(*init, init_frame);
     if (!init_expr) return std::unexpected(std::move(init_expr.error()));
     decl.field_inits.push_back(

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -106,6 +106,53 @@ auto PlanStaticStorage(
   return placements;
 }
 
+// Lowers the class's design-init body (LRM 8.9 / 10.5): a receiver-less,
+// formal-less callable code the runtime invokes once at program startup,
+// before any initial or always procedure runs. Each source-written static
+// property initializer lowers to an `AssignExpr(StaticPropertyRef, value)`
+// statement in declaration order; a static property without a source
+// initializer takes its type's Table 7-1 default and gets no statement here.
+auto LowerStaticInit(
+    UnitLowerer& unit_lowerer, const hir::ClassDecl& hir_class,
+    mir::Class& mir_class, mir::ClassId class_id)
+    -> diag::Result<mir::CallableCode> {
+  mir::CallableCode code;
+  CallableBindings bindings(unit_lowerer.Unit(), code);
+  code.params = {};
+  code.result_type = unit_lowerer.Unit().builtins.void_type;
+  mir::Block& block = code.body;
+  ScopeChainNode link{};
+  const WalkFrame frame = WalkFrame{}
+                              .WithClass(&mir_class, class_id, link)
+                              .WithBlock(&block)
+                              .WithBindings(&bindings);
+  const CallableStoragePlan plan;
+  ProcessLowerer lowerer(
+      unit_lowerer, nullptr, mir_class.time_resolution, hir_class.static_init,
+      "<static_init>", frame, plan);
+
+  for (const hir::StaticPropertyInit& init : hir_class.static_property_inits) {
+    const hir::Expr& hir_value = hir_class.static_init.exprs.Get(init.value);
+    auto value_or = lowerer.LowerExpr(hir_value, frame);
+    if (!value_or) return std::unexpected(std::move(value_or.error()));
+    const mir::ExprId value_id = block.exprs.Add(*std::move(value_or));
+
+    const mir::StaticPropertyId mir_prop_id =
+        UnitLowerer::TranslateStaticProperty(init.target);
+    const mir::TypeId prop_type =
+        mir_class.static_properties.Get(mir_prop_id).type;
+    const mir::ExprId target = block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::StaticPropertyRef{.owner = class_id, .prop = mir_prop_id},
+            .type = prop_type});
+    const mir::ExprId assign =
+        block.exprs.Add(mir::MakeAssignExpr(target, value_id, prop_type));
+    block.AppendStmt(mir::ExprStmt{.expr = assign});
+  }
+  return code;
+}
+
 }  // namespace
 
 auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
@@ -128,6 +175,7 @@ auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
       .time_resolution = {},
       .ctor_prefix_params = {},
       .fields = {},
+      .static_properties = {},
       .callable_signatures = {},
       .contained = {},
       .is_scope_tree_node = false,
@@ -142,6 +190,15 @@ auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
   for (const auto& field : hir_class.fields) {
     const mir::TypeId field_type = unit_lowerer.TranslateType(field.type);
     shape.fields.Add(mir::FieldDecl{.name = field.name, .type = field_type});
+  }
+
+  // Static properties (LRM 8.9) enter the shape's type-associated arena in
+  // declaration order. `TranslateStaticProperty` is positional today, so the
+  // MIR arena index equals the HIR one.
+  for (const auto& sp : hir_class.static_properties) {
+    const mir::TypeId sp_type = unit_lowerer.TranslateType(sp.type);
+    shape.static_properties.Add(
+        mir::StaticPropertyDecl{.name = sp.name, .type = sp_type});
   }
 
   // Each SV method's static-lifetime locals get their per-instance slot on
@@ -192,6 +249,8 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
       .callables = {},
       .abi_adapters = {},
       .static_constants = {},
+      .static_properties = shape.static_properties,
+      .static_init = {},
       .foreign_export_wrappers = {}};
 
   // The constructor's callable code is built in a local first, then added to
@@ -266,7 +325,7 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
   for (std::size_t i = 0; i < hir_class.fields.size(); ++i) {
     const hir::FieldId hir_field_id{static_cast<std::uint32_t>(i)};
     const hir::ClassField& field = hir_class.fields.Get(hir_field_id);
-    const mir::FieldId mir_field_id = unit_lowerer.TranslateField(hir_field_id);
+    const mir::FieldId mir_field_id = UnitLowerer::TranslateField(hir_field_id);
     const mir::TypeId field_type = mir_class.fields.Get(mir_field_id).type;
     mir::ExprId value_id{};
     if (const auto it = initializer_of.find(hir_field_id);
@@ -379,6 +438,12 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
       .code = std::move(ctor_code),
       .base_init = std::move(base_init),
       .member_inits = {}};
+
+  auto static_init_or =
+      LowerStaticInit(unit_lowerer, hir_class, mir_class, class_id_);
+  if (!static_init_or)
+    return std::unexpected(std::move(static_init_or.error()));
+  mir_class.static_init = *std::move(static_init_or);
 
   unit_lowerer.Unit().DefineClass(class_id_, std::move(mir_class));
   return {};

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -656,6 +656,42 @@ auto LowerMethodCall(
       .type = result_type};
 }
 
+// Lowers a static class method call (LRM 8.10). The signature has no `self`
+// so the MIR call carries exactly the user's arguments; the callee is a
+// direct owner-qualified target with no dispatch role.
+template <ExprLowerer Lowerer>
+auto LowerStaticMethodCall(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    const hir::StaticMethodCallRef& m, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  auto& block = *frame.current_block;
+  const mir::ClassId owner_class = lowerer.Owner().TranslateClass(m.class_id);
+  const mir::CallableId method_slot{m.method.value};
+
+  std::vector<mir::ExprId> args;
+  args.reserve(c.arguments.size());
+  for (const auto& arg : c.arguments) {
+    if (!arg.has_value()) {
+      throw InternalError("LowerStaticMethodCall: argument elided");
+    }
+    auto arg_or = lowerer.LowerExpr(lowerer.HirExprs().Get(*arg), frame);
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    args.push_back(block.exprs.Add(*std::move(arg_or)));
+  }
+
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::Direct{
+                      .target =
+                          mir::CallableTarget{
+                              .owner = owner_class, .slot = method_slot},
+                      .qualification = std::nullopt},
+              .arguments = std::move(args)},
+      .type = result_type};
+}
+
 // The type a value has once it is marshaled to a DPI-C carrier (LRM 35.5.6,
 // Table H.1). The carrier classifies the *formal*'s ABI; the value that crosses
 // is an ordinary machine value, so it is typed as one -- an integer of the
@@ -1339,6 +1375,9 @@ auto LowerHirCallExpr(
           },
           [&](const hir::MethodCallRef& m) -> diag::Result<mir::Expr> {
             return LowerMethodCall(lowerer, frame, c, m, result_type);
+          },
+          [&](const hir::StaticMethodCallRef& s) -> diag::Result<mir::Expr> {
+            return LowerStaticMethodCall(lowerer, frame, c, s, result_type);
           },
           [&](const hir::BuiltinMethodRef& b) -> diag::Result<mir::Expr> {
             return LowerBuiltinMethodCall(lowerer, frame, c, b, result_type);

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -256,8 +256,17 @@ auto LowerHirPrimaryExprProc(
                 self_ref,
                 mir::FieldTarget{
                     .owner = process.Owner().TranslateClass(r.owner),
-                    .slot = process.Owner().TranslateField(r.field_index)},
+                    .slot = UnitLowerer::TranslateField(r.field_index)},
                 result_type);
+          },
+          [&](const hir::StaticPropertyRef& r) -> mir::Expr {
+            return mir::Expr{
+                .data =
+                    mir::StaticPropertyRef{
+                        .owner = process.Owner().TranslateClass(r.owner),
+                        .prop = UnitLowerer::TranslateStaticProperty(r.prop),
+                    },
+                .type = result_type};
           },
           [&](const hir::RoutedRef& c) -> mir::Expr {
             return LowerReferenceRouteExpr(
@@ -303,6 +312,11 @@ auto LowerHirPrimaryExprStructural(
           [](const hir::ClassPropertyRef&) -> mir::Expr {
             throw InternalError(
                 "LowerHirPrimaryExprStructural: HIR ClassPropertyRef does not "
+                "appear in structural expressions");
+          },
+          [](const hir::StaticPropertyRef&) -> mir::Expr {
+            throw InternalError(
+                "LowerHirPrimaryExprStructural: HIR StaticPropertyRef does not "
                 "appear in structural expressions");
           },
           [&](const hir::RoutedRef& c) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -456,7 +456,7 @@ auto LowerHirClassPropertyAccessExpr(
       base_id,
       mir::FieldTarget{
           .owner = unit_lowerer.TranslateClass(sel.owner),
-          .slot = unit_lowerer.TranslateField(sel.field_index)},
+          .slot = UnitLowerer::TranslateField(sel.field_index)},
       result_type);
 }
 
@@ -588,7 +588,7 @@ auto LowerHirClassPropertyAccessExprLhs(
       base_id,
       mir::FieldTarget{
           .owner = unit_lowerer.TranslateClass(sel.owner),
-          .slot = unit_lowerer.TranslateField(sel.field_index)},
+          .slot = UnitLowerer::TranslateField(sel.field_index)},
       result_type);
 }
 

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -259,11 +259,12 @@ auto ProcessLowerer::Run(const hir::SubroutineDecl& src)
   mir::CallableCode code;
   CallableBindings bindings(owner_->Unit(), code);
   std::vector<mir::LocalId> params;
-  // The receiver is a property of the body's context: a body in an owner class
-  // is an instance method and takes `self` as its first parameter (LRM 8.6); a
-  // body in a namespace context (a package function, LRM 26.3) has no owner
-  // class and so no receiver.
-  if (parent.current_class != nullptr) {
+  // The receiver is a signature-level fact. An instance method (LRM 8.6)
+  // takes `self` as its first parameter; a package function (LRM 26.3) has
+  // no owner class and so no receiver; a static class method (LRM 8.10)
+  // has an owner class but its signature omits `self`.
+  const bool has_receiver = parent.current_class != nullptr && !src.is_static;
+  if (has_receiver) {
     params.push_back(bindings.Declare(
         BindingOriginId::Receiver(),
         mir::LocalDecl{

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -731,6 +731,11 @@ class MirDumper {
                   "StaticConstantRef constant=StaticConstant[{}]",
                   r.constant.value);
             },
+            [](const StaticPropertyRef& r) -> std::string {
+              return std::format(
+                  "StaticPropertyRef owner=Class[{}] prop=StaticProperty[{}]",
+                  r.owner.value, r.prop.value);
+            },
             [](const ClosureExpr& cl) -> std::string {
               return std::format(
                   "ClosureExpr closure=Closure[{}] field_inits={}",

--- a/tests/cases/cpp/class_static_members/case.yaml
+++ b/tests/cases/cpp/class_static_members/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.class_static_members
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    counter_at_start: 0
+    first_id: 1
+    second_id_via_qualified: 2
+    third_id_via_handle: 3
+    fourth_id_via_derived: 4
+    counter_after_all: 4
+    counter_via_derived: 4

--- a/tests/cases/cpp/class_static_members/main.sv
+++ b/tests/cases/cpp/class_static_members/main.sv
@@ -1,0 +1,44 @@
+// LRM 8.9 static class properties + LRM 8.10 static class methods.
+// Registry declares a static counter (initialized once at design init, LRM
+// 10.5, before any initial procedure) and a static factory that reads and
+// writes it. Derived inherits Registry unchanged; every reference form
+// visits the same cell -- `Registry::counter` (type-qualified),
+// `Derived::counter` (owner-qualified, still the base's cell),
+// `h.counter` (through a handle whose value is unused), and inside a
+// static method's body as a bare identifier. The `initial` block runs
+// after the static initializer, so `counter_at_start` observes the
+// source-declared 0 rather than any later mutation.
+module Top;
+  class Registry;
+    static int counter = 0;
+    static function int next_id();
+      counter = counter + 1;
+      return counter;
+    endfunction
+  endclass
+
+  class Derived extends Registry;
+  endclass
+
+  int counter_at_start;
+  int first_id;
+  int second_id_via_qualified;
+  int third_id_via_handle;
+  int fourth_id_via_derived;
+  int counter_after_all;
+  int counter_via_derived;
+
+  initial begin
+    Registry r;
+    Derived d;
+    counter_at_start = Registry::counter;
+    first_id = Registry::next_id();
+    second_id_via_qualified = Registry::next_id();
+    r = new;
+    third_id_via_handle = r.next_id();
+    d = new;
+    fourth_id_via_derived = Derived::next_id();
+    counter_after_all = Registry::counter;
+    counter_via_derived = Derived::counter;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds support for SystemVerilog static class properties (LRM 8.9) and static class methods (LRM 8.10) end to end. A static property is a type-associated storage cell shared by every instance and initialized once at design init (LRM 10.5, before any initial or always procedure); a static method has no receiver and cannot be virtual. Every reference form -- `Cls::prop`, `p.prop`, an unqualified use inside a method, and inherited access like `Derived::inherited_static` -- lowers to the same owner-qualified reference that names the declaring class.

## Design

Instance and static membership are structurally disjoint. Static properties live on a new `Class.static_properties` arena, peer to `fields`; a bare `hir::ClassStaticProperty` / `mir::StaticPropertyDecl` carries name and type only. The declared `= value` initializer runs from a class-level `static_init` body, a receiver-less `mir::CallableCode` distinct from the per-instance constructor -- the C++ backend renders it as a static function invoked by an `inline static` sentinel so C++ program-startup evaluation matches LRM 10.5 natively.

Static methods reuse the unified callable arena. Their signature omits `self` from `code.params`; a new `mir::CallableCode::HasReceiver(self_pointer_type)` reads the fact structurally and both the declaration and call-site renders gate on it, with no side flag restating what the params list already fixes. The HIR side adds one `SubroutineRef` arm (`StaticMethodCallRef`) so the receiver-less call form does not admit an invalid state as an optional-receiver variant of `MethodCallRef`.

`ClassDeclLowerer::Run` picks up a `LowerStaticInit` helper for the design-init body build, and `type.cpp` drops its early-continue for static methods in favor of a fall-through that reuses the single add-and-register at the loop tail. `TranslateStaticProperty` peers `TranslateField` at the HIR-to-MIR boundary; both are static, one-line positional translations today.

## Testing

`tests/cases/cpp/class_static_members` exercises the property + method + both access forms in one case: `Registry::counter` (type-qualified), `Derived::counter` (inherited, `owner` still the base), `r.next_id()` (through a handle whose value is unused), and `counter_at_start = Registry::counter` observed from `initial` proves the LRM 10.5 timing (static init runs before any initial procedure).