### PR TITLE
Support parameterized class specialization (LRM 8.25)

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -93,11 +93,26 @@ each stage establishes, not how.
       to whether the source separately wrote an empty body -- the two forms are semantically
       distinct and remain distinct end-to-end.
 
-- [ ] Interface-class conformance: a class may conform to several interfaces, a relation distinct
-      from its single concrete base and carrying no second instance storage. Parameterized-class
-      specialization: a generic declaration plus, per specialization, a distinct materialized object
-      record, its identity aligned with compilation-unit specialization (a stable id within a unit,
-      a by-name canonical key across units) -- the same shape a parameterized module uses.
+- [ ] Interface-class conformance (LRM 8.26): a class may conform to several interfaces, a relation
+      distinct from its single concrete base and carrying no second instance storage. Each
+      conformance is a pure-virtual method contract the class must satisfy; a shared behaviour among
+      unrelated concrete hierarchies is expressed as conformance to one interface class, not as a
+      shared base.
+
+- [x] Parameterized-class specialization (LRM 8.25): a generic class plus, per distinct set of
+      parameter bindings, a materialized class record. Matching specializations of one generic
+      definition are the same type; distinct bindings produce distinct classes with per-
+      specialization instance layout, static-property cells, and inheritance edge. Rides on the same
+      identity mechanism a parameterized module uses -- generic-def name plus a canonical content
+      encoding of the bindings.
+
+- [ ] Cross-unit class ownership: a class is owned by the compilation unit that declares it, and a
+      reference from another unit reaches it by name -- the same by-name resolution package
+      callables already use. The class-copied-into-each-referring-unit shape (which today duplicates
+      a package class into every unit that names it) is out. This is what lets LRM 8.25's
+      package-scope rule -- matching specializations of a package generic class are one type
+      throughout the system -- hold across compilation units, and it applies uniformly to
+      non-parameterized and parameterized classes.
 
 - [x] Type-associated static storage and static methods (LRM 8.9 / 8.10): a static property is one
       cell owned by the type, distinct from a per-instance field replicated on every object; a

--- a/include/lyra/lowering/ast_to_hir/specialization_name.hpp
+++ b/include/lyra/lowering/ast_to_hir/specialization_name.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 namespace slang::ast {
+class ClassType;
 class InstanceBodySymbol;
 class InstanceSymbol;
 }  // namespace slang::ast
@@ -23,5 +24,16 @@ auto SpecializationName(const slang::ast::InstanceBodySymbol& body)
 
 // Resolves the instance to its canonical body and names that specialization.
 auto SpecializationName(const slang::ast::InstanceSymbol& inst) -> std::string;
+
+// The compiled identity of a SystemVerilog class specialization (LRM 8.25):
+// the generic class name plus a content hash of its resolved parameter
+// bindings when the class is parameterized, or the bare class name when it
+// is not. Two specializations of one generic class denote the same type iff
+// every value binding is equal and every type binding is a matching type
+// (LRM 8.25 uniqueness rule); slang deduplicates on that rule, so distinct
+// bindings arrive as distinct ClassType instances and produce distinct
+// names. Bare `C` and empty-override `C #()` resolve to the same slang
+// ClassType and thus name the same specialization.
+auto SpecializationName(const slang::ast::ClassType& cls) -> std::string;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/specialization_name.cpp
+++ b/src/lyra/lowering/ast_to_hir/specialization_name.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <string_view>
 
+#include <slang/ast/Symbol.h>
+#include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
@@ -30,10 +32,11 @@ auto Fnv1a64(std::string_view bytes) -> std::uint64_t {
 
 // Position-free encoding of one binding: the parameter name, then its resolved
 // value or resolved type, on the same value/type split slang uses to decide
-// canonical-body equivalence (ParameterSymbolBase::allMatching).
-void EncodeBinding(
-    const slang::ast::ParameterSymbolBase& param, std::string& out) {
-  const slang::ast::Symbol& symbol = param.symbol;
+// canonical-body equivalence (ParameterSymbolBase::allMatching). The parameter
+// arrives as its concrete Symbol so this serves both spaces slang exposes
+// bindings through -- a module body's ParameterSymbolBase span (`.symbol` per
+// entry) and a class specialization's genericParameters (a Symbol span).
+void EncodeBinding(const slang::ast::Symbol& symbol, std::string& out) {
   out += symbol.name;
   out += '=';
   if (symbol.kind == slang::ast::SymbolKind::Parameter) {
@@ -57,7 +60,7 @@ auto SpecializationName(const slang::ast::InstanceBodySymbol& body)
   }
   std::string encoding;
   for (const auto* param : params) {
-    EncodeBinding(*param, encoding);
+    EncodeBinding(param->symbol, encoding);
   }
   return std::format("{}__{:016x}", name, Fnv1a64(encoding));
 }
@@ -65,6 +68,18 @@ auto SpecializationName(const slang::ast::InstanceBodySymbol& body)
 auto SpecializationName(const slang::ast::InstanceSymbol& inst) -> std::string {
   const auto* canonical = inst.getCanonicalBody();
   return SpecializationName(canonical != nullptr ? *canonical : inst.body);
+}
+
+auto SpecializationName(const slang::ast::ClassType& cls) -> std::string {
+  std::string name{cls.name};
+  if (cls.genericClass == nullptr) {
+    return name;
+  }
+  std::string encoding;
+  for (const auto* sym : cls.genericParameters) {
+    EncodeBinding(*sym, encoding);
+  }
+  return std::format("{}__{:016x}", name, Fnv1a64(encoding));
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -32,6 +32,7 @@
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
 #include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 
@@ -567,7 +568,7 @@ auto UnitLowerer::InternClass(
   class_cache_.emplace(&cls, id);
 
   hir::ClassDecl decl;
-  decl.name = std::string(cls.name);
+  decl.name = SpecializationName(cls);
 
   // Base class (LRM 8.13). Slang exposes the base as a `ClassType*` on the
   // derived class and flattens inherited members into the derived's member

--- a/tests/cases/cpp/class_parameterized/case.yaml
+++ b/tests/cases/cpp/class_parameterized/case.yaml
@@ -1,0 +1,23 @@
+id: cpp.class_parameterized
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    vec8_incr1: 1
+    vec8_incr2: 2
+    vec16_incr1: 1
+    vec8_count_final: 2
+    vec16_count_final: 1
+    vec8_data: 0xCD
+    vec16_data: 0xDEAD
+    box_int_made: 1
+    box_byte_made: 1
+    box_int_value: 42
+    box_byte_value: 7
+    derived_x: 5
+    derived_y: 6

--- a/tests/cases/cpp/class_parameterized/main.sv
+++ b/tests/cases/cpp/class_parameterized/main.sv
@@ -1,0 +1,87 @@
+// LRM 8.25 parameterized classes. Each specialization is its own type:
+// distinct instance layout, distinct static-property cells, distinct
+// construction. Bare `Vec v;` denotes the default specialization `Vec #()`;
+// LRM 8.25.1 requires the scope-resolution operator to always carry an
+// explicit parameter override (`Vec #()::count`, not `Vec::count`). Vec
+// covers value parameters, Box covers type parameters (both facets of LRM
+// 8.25), and Derived extending Base #(T) covers the parameterized-base
+// forwarding rule (Derived #(byte) picks Base #(byte)).
+module Top;
+
+  class Vec #(int W = 8);
+    logic [W-1:0] data;
+    static int count = 0;
+    static function int incr();
+      count = count + 1;
+      return count;
+    endfunction
+  endclass
+
+  class Box #(type T = int);
+    T value;
+    static int made = 0;
+    function new();
+      made = made + 1;
+    endfunction
+  endclass
+
+  class Base #(type T = int);
+    T x;
+  endclass
+
+  class Derived #(type T = int) extends Base #(T);
+    T y;
+  endclass
+
+  int vec8_incr1;
+  int vec8_incr2;
+  int vec16_incr1;
+  int vec8_count_final;
+  int vec16_count_final;
+
+  logic [7:0]  vec8_data;
+  logic [15:0] vec16_data;
+
+  int box_int_made;
+  int box_byte_made;
+  int box_int_value;
+  byte box_byte_value;
+
+  byte derived_x;
+  byte derived_y;
+
+  initial begin
+    Vec v8_a, v8_b;
+    Vec #(16) v16;
+    Box b_int;
+    Box #(byte) b_byte;
+    Derived #(byte) d;
+
+    vec8_incr1 = Vec #()::incr();
+    vec8_incr2 = Vec #()::incr();
+    vec16_incr1 = Vec #(16)::incr();
+
+    v8_a = new;   v8_a.data = 8'hAB;
+    v8_b = new;   v8_b.data = 8'hCD;
+    v16  = new;   v16.data  = 16'hDEAD;
+
+    b_int  = new;   b_int.value  = 42;
+    b_byte = new;   b_byte.value = 8'sd7;
+
+    d = new;   d.x = 8'sd5;   d.y = 8'sd6;
+
+    vec8_count_final  = Vec #()::count;
+    vec16_count_final = Vec #(16)::count;
+
+    vec8_data  = v8_b.data;
+    vec16_data = v16.data;
+
+    box_int_made   = Box #()::made;
+    box_byte_made  = Box #(byte)::made;
+    box_int_value  = b_int.value;
+    box_byte_value = b_byte.value;
+
+    derived_x = d.x;
+    derived_y = d.y;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Give each SystemVerilog class specialization its own compiled identity, so `Vec #(8)` and `Vec #(16)` produce distinct classes with independent instance layout, static-property cells, and inheritance edges. Matching specializations of one generic definition remain the same type (LRM 8.25 uniqueness rule) because slang deduplicates them upstream and hands us one `ClassType` per equivalence class; distinct bindings arrive as distinct `ClassType` and produce distinct names here.

## Design

The identity mechanism is the one `docs/decisions/specialization-identity.md` already established for parameterized modules: the generic name plus a canonical content encoding of the resolved bindings, hashed with FNV-1a-64 and rendered as `<name>__<16-hex>`. Because the two producers (module `InstanceBodySymbol::getParameters()` and class `ClassType::genericParameters`) both hand us `ParameterSymbol` and `TypeParameterSymbol` at the leaves, the encoder collapses onto one path: `EncodeBinding` takes a `slang::ast::Symbol&`, and the module caller extracts `.symbol` per entry while the class caller passes the span directly.

Bare `C`, empty-override `C #()`, and default-value `C #(default)` all resolve to the same slang `ClassType` and therefore name the same specialization; a non-parameterized class (`genericClass == nullptr`) keeps its bare name unchanged, so no existing class test's emitted name shifts. The class cache is keyed on `ClassType*`, which slang already dedupes per LRM matching, so no additional intern logic is needed on our side.

## Scope

This lands the intra-unit slice: within one compilation unit, distinct specializations produce distinct compiled classes with correct per-spec statics and inheritance. Cross-unit class ownership -- where a package-declared class is currently copied into every referring unit's registry -- is a separate defect that predates this change and applies to non-parameterized and parameterized classes alike. It is tracked as its own progress item (`docs/progress/object-model.md` "Cross-unit class ownership") and does not affect the intra-unit behaviour landed here.

## Testing

`tests/cases/cpp/class_parameterized` covers value parameters (`Vec #(W)` with distinct static counters per specialization and per-spec field widths), type parameters (`Box #(T)` with distinct constructor-side counters and per-spec field types), and parameterized-base forwarding (`Derived #(byte) extends Base #(T)` where `T = byte`).