### PR TITLE
Support package variables

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -242,10 +242,12 @@ cc_library(
 
 cc_library(
     name = "unit_metadata",
+    srcs = ["src/lyra/compiler/unit_metadata.cpp"],
     hdrs = ["include/lyra/compiler/unit_metadata.hpp"],
     copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
+    deps = [":mir"],
 )
 
 cc_library(
@@ -272,8 +274,14 @@ cc_library(
 
 cc_library(
     name = "compiler",
-    srcs = ["src/lyra/compiler/compile.cpp"],
-    hdrs = ["include/lyra/compiler/compile.hpp"],
+    srcs = glob(
+        ["src/lyra/compiler/*.cpp"],
+        exclude = ["src/lyra/compiler/unit_metadata.cpp"],
+    ),
+    hdrs = glob(
+        ["include/lyra/compiler/*.hpp"],
+        exclude = ["include/lyra/compiler/unit_metadata.hpp"],
+    ),
     copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
@@ -293,19 +301,11 @@ cc_library(
 
 cc_library(
     name = "driver",
-    srcs = [
-        "src/lyra/driver/cpp_build.cpp",
-        "src/lyra/driver/dpi_link.cpp",
-        "src/lyra/driver/pch.cpp",
-        "src/lyra/driver/runtime_export.cpp",
-    ],
-    hdrs = [
-        "include/lyra/driver/cpp_build.hpp",
-        "include/lyra/driver/dpi_link.hpp",
-        "include/lyra/driver/pch.hpp",
-        "include/lyra/driver/project_layout.hpp",
-        "include/lyra/driver/runtime_export.hpp",
-    ],
+    srcs = glob(
+        ["src/lyra/driver/*.cpp"],
+        exclude = ["src/lyra/driver/cli.cpp"],
+    ),
+    hdrs = glob(["include/lyra/driver/*.hpp"]),
     copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],

--- a/docs/architecture/emission_model.md
+++ b/docs/architecture/emission_model.md
@@ -46,10 +46,11 @@ non-conforming code, not as a relaxation of the contract.
    artifacts. This is what keeps compilation parallel and incremental (`north_star.md` inv 3, 4).
 2. **A unit's emission depends only on itself, the interfaces of the units it references, and the
    SDK.** The inputs to emitting unit U are: U's own MIR; the interface (name, parameters, ports for
-   an instantiated unit; declared callables for a called package) of each unit U references -- one
-   it instantiates, or one it calls a receiver-less callable of (LRM 26.3); and the runtime SDK. U's
-   artifact never depends on a unit it neither instantiates nor calls, and never on another unit's
-   body or internal layout (`compilation_unit_model.md` inv 8, which already scopes this to a unit U
+   an instantiated unit; declared callables and variables for a referenced package) of each unit U
+   references -- one it instantiates, one it calls a receiver-less callable of (LRM 26.3), or one it
+   reads or writes a static variable of by name (LRM 26.2); and the runtime SDK. U's artifact never
+   depends on a unit it neither instantiates nor references, and never on another unit's body or
+   internal layout (`compilation_unit_model.md` inv 8, which already scopes this to a unit U
    "instantiates or references").
 3. **The runtime SDK is the link-time-resolution substrate.** Cross-unit operations the referrer
    cannot resolve from its own inputs are expressed as SDK operations. In the C++ backend the SDK is
@@ -155,6 +156,20 @@ own emitted header; the linker binds the symbol. There is no runtime object-grap
 no SDK step -- the SDK exists to resolve a reference into another unit's per-instance layout, which
 a package does not have. This is the one cross-unit reference realized by a plain linked name rather
 than the SDK, and it is sound precisely because there is no instance identity to resolve.
+
+**Cross-unit package variable.** `x = pkg::cnt;` or `pkg::cnt = 7;` (LRM 26.2) is the storage
+counterpart of the call. A package variable is one program-global cell, not a per-instance member,
+so it too is an ordinary link-time symbol: the caller renders the direct qualified access and
+includes the package's header, and the linker binds the one definition. Reading, writing, and waking
+on the cell's change all reach that same linked cell directly -- there is no route, no per-instance
+endpoint to seal, and no SDK step, again because a package has no instance identity. Its LRM 10.5
+initialization is not a per-instance constructor action but two receiver-less callables the design
+root invokes during the Initialize phase, before the top modules initialize: one installs every
+package's cells (declared type and default) design-wide, then one runs each package's value
+initializers -- so a value initializer that reads another package's cell always reaches installed
+storage. The LRM leaves the relative order of initializers unspecified; the design root chooses a
+stable, best-effort order, and a cell whose dependency is unknown or cyclic reads a default rather
+than failing.
 
 Any artifact that aggregates multiple units' bodies into one is forbidden, however a build step
 packages the emitted sources: the per-unit artifact boundary and the segment-classification rules

--- a/docs/progress/packages.md
+++ b/docs/progress/packages.md
@@ -20,10 +20,12 @@ inside a package ride on the class workstream and are out of scope here.
 
 ## Actionable
 
-PK1 (compile-time contents) and PK2 (the package as a first-class unit, carrying functions) are
-done: a package function with input arguments is now called across the unit boundary on the C++
-backend. PK3 (package variables) is the next actionable step; it reuses the package-as-unit
-foundation PK2 established.
+PK1 (compile-time contents), PK2 (the package as a first-class unit, carrying functions), and PK3
+(package variables) are done on the C++ backend: a package variable is declared with an initializer,
+initialized once at time zero before the top modules, and read and written from another unit by
+name, including waking a process on its change. The one remaining increment is a package subroutine
+writing a package variable, rejected with a diagnostic rather than mis-emitted. PK4 (the import
+forms and the LRM 26.3 name-search rules) is the next actionable step.
 
 ## Sub-Steps
 
@@ -48,10 +50,25 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
       package function with an output / inout / ref argument; a call from one package function to a
       sibling; and a DPI-C import declared inside a package (LRM 35.4), which is rejected with a
       diagnostic rather than mis-emitted.
-- [ ] PK3 -- Package variables. A package variable is static storage owned by the namespace -- one
+- [x] PK3 -- Package variables. A package variable is static storage owned by the namespace -- one
       program-global cell, shared, not a member of any instance -- read and written from other units
       by name. It is the same type-associated storage a class static property uses, not a
-      package-specific singleton object.
+      package-specific singleton object. The variable is reached by name uniformly (a referrer in
+      another unit and the package's own function agree on the by-name form, since neither has a
+      receiver), and a process may wake on its change. Initialization (LRM 10.5) runs at time zero,
+      driven by the design root before the top modules initialize, in two design-wide passes: every
+      package's cells are installed with their declared type and default first, then every package's
+      value initializers run, so an initializer that reads another package's variable always reaches
+      installed storage. The relative order of initializers is unspecified by the LRM; the design
+      root picks a stable, best-effort order (a dependency before its dependent where a direct read
+      makes it known) as a quality-of-implementation choice, and an unknown or cyclic dependency
+      degrades to reading a default, never a crash. Remaining increments: a package function or task
+      writing a package variable (needs the runtime services threaded into a receiver-less callable;
+      rejected with a diagnostic until then, though reading one from a subroutine works); an
+      initializer read reached through a called function does not yet contribute to the preferred
+      order; and two packages that reference each other's symbols still produce circular emitted
+      headers (a header-only emission limit, shared with cross-package subroutine calls, not
+      specific to variables).
 - [ ] PK4 -- The `import` forms for the remaining item kinds and the LRM 26.3 name-search and
       shadowing rules. An import brings a name into a scope's lookup; it does not create a new kind
       of reference, so a name resolved through an import lowers identically to the explicit
@@ -65,7 +82,7 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
 
 ## Blocked
 
-Nothing blocked. PK3 is actionable now.
+Nothing blocked. PK4 is actionable now.
 
 ## Out of Scope
 

--- a/include/lyra/compiler/design_root.hpp
+++ b/include/lyra/compiler/design_root.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <optional>
+#include <span>
+#include <string>
+
+#include "lyra/compiler/compile.hpp"
+#include "lyra/compiler/unit_metadata.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_manager.hpp"
+#include "lyra/lir/compilation_unit.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+
+namespace lyra::compiler {
+
+// The synthesized design-root unit, lowered as far as `StopAfter` asks: its
+// MIR, and when LIR is requested its executable body and definition metadata.
+// It is a distinct compiler output, not one of the source units.
+struct DesignRootArtifacts {
+  mir::CompilationUnit mir;
+  std::optional<lir::CompilationUnit> lir;
+  std::optional<ElaboratedUnitMetadata> metadata;
+};
+
+// Links the compiled units into the design: synthesizes the design-root unit
+// whose constructor elaborates the design (it builds the top-level units as its
+// owned children) and whose Initialize phase brings up the packages' variables
+// (LRM 26.2 / 10.5). This is the one whole-design step -- it reads across the
+// units to resolve the package-initialization plan and to name the tops -- so
+// it is held apart from the per-unit lowering, which reads a single unit. The
+// units are consumed only through their interfaces (name, root presence,
+// exported callables and variables), never their bodies.
+auto LinkDesign(
+    std::span<const mir::CompilationUnit> units,
+    std::span<const std::string> top_names, StopAfter stop_after,
+    const diag::SourceManager& source_manager)
+    -> diag::Result<DesignRootArtifacts>;
+
+}  // namespace lyra::compiler

--- a/include/lyra/compiler/unit_metadata.hpp
+++ b/include/lyra/compiler/unit_metadata.hpp
@@ -3,6 +3,10 @@
 #include <cstdint>
 #include <string>
 
+namespace lyra::mir {
+struct CompilationUnit;
+}  // namespace lyra::mir
+
 namespace lyra::compiler {
 
 // The immutable, source-level metadata of one compiled design unit, held apart
@@ -18,5 +22,13 @@ struct ElaboratedUnitMetadata {
   std::string def_name;
   std::int8_t time_precision_power = 0;
 };
+
+// A unit's definition metadata is a source-level fact known once elaboration
+// fixes the unit's root scope: its def name is the root's name, its precision
+// the root's declared resolution. Derived from MIR so the executable body
+// downstream never carries these source-language concepts. The unit must have a
+// root class (a module or the design root, not a package).
+auto BuildUnitMetadata(const mir::CompilationUnit& unit)
+    -> ElaboratedUnitMetadata;
 
 }  // namespace lyra::compiler

--- a/include/lyra/compiler/unit_pipeline.hpp
+++ b/include/lyra/compiler/unit_pipeline.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <optional>
+
+#include "lyra/compiler/compile.hpp"
+#include "lyra/compiler/unit_metadata.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_manager.hpp"
+#include "lyra/hir/compilation_unit.hpp"
+#include "lyra/lir/compilation_unit.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+
+namespace lyra::compiler {
+
+// The lowered outputs of one compilation unit's vertical: its MIR, and for an
+// executable unit its LIR body and definition metadata. Each optional is
+// std::nullopt when the requested `StopAfter` stops before that stage, and the
+// LIR / metadata pair is always absent for a package (a namespace has no
+// executable body).
+struct UnitArtifacts {
+  std::optional<mir::CompilationUnit> mir;
+  std::optional<lir::CompilationUnit> lir;
+  std::optional<ElaboratedUnitMetadata> metadata;
+};
+
+// Lowers one HIR unit down its whole vertical (HIR -> MIR -> LIR) as far as
+// `stop_after` asks. It reads only this unit and the shared frontend, never
+// another unit's lowered artifacts, so units may be lowered in any order and in
+// parallel. The unit's `UnitKind` selects the MIR lowering: a module composes a
+// top class and continues to LIR; a package lowers to a namespace of callables
+// and stops at MIR, having no executable body.
+auto LowerUnitPipeline(
+    const hir::CompilationUnit& unit, StopAfter stop_after,
+    const diag::SourceManager& source_manager) -> diag::Result<UnitArtifacts>;
+
+}  // namespace lyra::compiler

--- a/include/lyra/hir/compilation_unit.hpp
+++ b/include/lyra/hir/compilation_unit.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <utility>
 
@@ -12,6 +13,14 @@
 #include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
+
+// Which SystemVerilog compilation-unit form a `CompilationUnit` models: a
+// module (LRM 23), whose root scope is an object type composing a top class, or
+// a package (LRM 26), a namespace whose declarations are reached by name and
+// which has no instance root. The distinction is intrinsic to the source
+// construct, so it travels on the unit rather than being re-inferred from its
+// scope shape at each stage that must branch on it.
+enum class UnitKind : std::uint8_t { kModule, kPackage };
 
 // Canonical TypeIds for primitives the lowering frequently materializes
 // (literal int type, void result of system tasks, etc.). Populated by
@@ -30,6 +39,7 @@ struct BuiltinHirTypes {
 
 struct CompilationUnit {
   std::string name;
+  UnitKind kind = UnitKind::kModule;
   base::Arena<Type, TypeId> types;
   BuiltinHirTypes builtins;
   StructuralScope root_scope;

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -45,6 +45,6 @@ struct NullLiteral {};
 using Primary = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     DirectMemberRef, ProceduralVarRef, ClassPropertyRef, StaticPropertyRef,
-    RoutedRef, IterationBindingRef>;
+    RoutedRef, IterationBindingRef, ExternalUnitValueRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -195,7 +195,7 @@ struct DelayControl {
 // event control `@(posedge ...)` / `@(negedge ...)` / `@(edge ...)` set the
 // per-leaf edge.
 struct SensitivityEntry {
-  ReferenceRoute ref;
+  SensitivityTarget ref;
   std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint;
   support::EventEdge edge_kind = support::EventEdge::kAnyChange;
 };

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -2,6 +2,7 @@
 
 #include <compare>
 #include <cstdint>
+#include <string>
 #include <variant>
 
 #include "lyra/hir/class_id.hpp"
@@ -9,6 +10,7 @@
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/static_property_id.hpp"
 #include "lyra/hir/structural_data_object.hpp"
+#include "lyra/hir/type_id.hpp"
 #include "lyra/hir/with_clause_id.hpp"
 
 namespace lyra::hir {
@@ -94,11 +96,38 @@ struct IterationBindingRef {
   auto operator==(const IterationBindingRef&) const -> bool = default;
 };
 
+// A reference to a variable that belongs to another compilation unit's
+// namespace -- a package variable (LRM 26.2), reached by name. Like
+// `ExternalUnitSubroutineRef` for a call, it carries no unit-local id: a
+// package has no instance and no receiver, so its variable is named and
+// resolved against the target unit's interface at link time, never through a
+// `self`-based route within any unit. The same by-name form serves a referrer
+// in another unit and the package's own callable reading its own variable,
+// since neither has a receiver to reach it through. One form serves read,
+// write, and observation.
+struct ExternalUnitValueRef {
+  std::string unit_name;
+  std::string variable_name;
+  // The variable's value type. Carried on the node so it is self-describing: a
+  // sensitivity leaf reaches the observed cell's type from the reference alone,
+  // with no enclosing expression to type it.
+  TypeId value_type;
+
+  auto operator==(const ExternalUnitValueRef&) const -> bool = default;
+};
+
 // A reader-relative reference to a value: either a direct member of the
 // reader's own scope, or a routed reference sealed to a per-instance endpoint
 // in the resolve phase. One route serves every consumer of the reference --
 // value read, value write, and change observation -- so the name is neutral to
 // the consumer, not owned by sensitivity.
 using ReferenceRoute = std::variant<DirectMemberRef, RoutedRef>;
+
+// What a sensitivity leaf watches: a reader-relative route to an intra-unit
+// observable cell, or a by-name reference to a package variable's one
+// program-global cell (LRM 26.2). A package variable's change wakes the process
+// the same way an intra-unit signal's does, but it is reached by name, not
+// through a route, since a package has no per-instance storage to route to.
+using SensitivityTarget = std::variant<ReferenceRoute, ExternalUnitValueRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/expression/references.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/references.hpp
@@ -14,9 +14,19 @@
 namespace slang::ast {
 class HierarchicalValueExpression;
 class NamedValueExpression;
+class PackageSymbol;
+class ValueSymbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
+
+// A variable declared directly in a package scope (LRM 26.2), or nullptr
+// otherwise. A package variable is reached by name across the unit boundary,
+// the way a package subroutine call is; both the value-reference path and the
+// sensitivity path detect it here so a package variable read and a wait on its
+// change agree on the by-name form.
+auto EnclosingPackageOfValue(const slang::ast::ValueSymbol& value)
+    -> const slang::ast::PackageSymbol*;
 
 auto LowerNamedValueProc(
     ProcessLowerer& proc, WalkFrame frame,

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -10,11 +10,6 @@
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 
-namespace slang::ast {
-class InstanceBodySymbol;
-class PackageSymbol;
-}  // namespace slang::ast
-
 namespace lyra::lowering::ast_to_hir {
 
 // Driver-supplied facts threaded into AST-to-HIR lowering. `Compilation&` is
@@ -55,33 +50,13 @@ class LowerCompilationFacts {
   bool disable_assertions_;
 };
 
-// The distinct unit bodies reachable from the tops, deduped to one canonical
-// body per specialization -- the work-list for per-unit lowering. A module
-// instantiated many times appears once; the descent is transitive, so a unit
-// reached only through instantiation is included though it is not a top.
-auto CollectUnitBodies(const LowerCompilationFacts& facts)
-    -> std::vector<const slang::ast::InstanceBodySymbol*>;
-
-// Lowers one unit body to its HIR. Independent of every other unit: it reads
-// only this body and the shared frontend, so units may be lowered in any order.
-auto LowerUnit(
-    const LowerCompilationFacts& facts,
-    const slang::ast::InstanceBodySymbol& body)
-    -> diag::Result<hir::CompilationUnit>;
-
-// The packages the design declares (LRM 26). A package is a namespace
-// compilation unit: it owns declarations reached by name from other units, and
-// unlike a module it is never instantiated, so the list comes from the
-// declaration set, not the instance tree.
-auto CollectPackages(const LowerCompilationFacts& facts)
-    -> std::vector<const slang::ast::PackageSymbol*>;
-
-// Lowers one package to its HIR unit. Like `LowerUnit`, it reads only the
-// package's own scope and the shared frontend.
-auto LowerPackageUnit(
-    const LowerCompilationFacts& facts,
-    const slang::ast::PackageSymbol& package)
-    -> diag::Result<hir::CompilationUnit>;
+// Lowers the whole compilation to its HIR units: every package the design
+// declares, then every distinct module body reachable from the tops, each
+// tagged with its `UnitKind`. Each unit is lowered independently -- it reads
+// only its own scope and the shared frontend -- so the result is a flat set of
+// self-contained units with no cross-unit HIR references.
+auto LowerCompilationToHir(const LowerCompilationFacts& facts)
+    -> diag::Result<std::vector<hir::CompilationUnit>>;
 
 // A top-level block is an auto-promoted, uninstantiated module. These names
 // are a subset of the compiled units: a unit reached only through

--- a/include/lyra/lowering/hir_to_mir/package_initialization.hpp
+++ b/include/lyra/lowering/hir_to_mir/package_initialization.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace lyra::lowering::hir_to_mir {
+
+// Package variable initialization at time zero runs in two design-wide phases,
+// each a synthesized receiver-less callable the design root calls. Named
+// through constants so the package that defines each callable and the design
+// root that calls it agree on the spelling.
+//
+// Phase 1 (`Install`): install every package cell's declared type and language
+// default. It fires nothing and takes no services. The design root calls it for
+// every package with variables before any value initializer runs anywhere, so a
+// cross-package read always reaches installed storage -- at worst a default.
+//
+// Phase 2 (`Initialize`): run each LRM 10.5 value initializer through its cell,
+// firing subscribers; it takes the runtime services. The design root calls it
+// in a stable, best-effort dependency order (a quality-of-implementation choice
+// -- the LRM leaves the relative order of initializers unspecified, not a
+// race).
+inline constexpr std::string_view kPackageInstallCallableName =
+    "InstallPackageVariables";
+inline constexpr std::string_view kPackageInitializeCallableName =
+    "InitializePackageVariables";
+
+// The design root's plan for initializing package variables (LRM 26.2 / 10.5),
+// resolved once by the whole-design assembly from each package unit's by-name
+// exports. `install_order` is every package with variables; the phase-1 install
+// is order-independent, so any stable order serves. `value_initialize_order` is
+// every package with a value initializer, in the best-effort order the assembly
+// chose (a dependency before its dependent where a direct read makes it known,
+// a stable order otherwise). The design root realizes both into calls; it never
+// re-derives the plan.
+struct PackageInitializationPlan {
+  std::vector<std::string> install_order;
+  std::vector<std::string> value_initialize_order;
+};
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -14,6 +14,7 @@
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
+#include "lyra/lowering/hir_to_mir/package_initialization.hpp"
 #include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/class_id.hpp"
@@ -72,11 +73,13 @@ class StructuralScopeLowerer {
  public:
   StructuralScopeLowerer(
       UnitLowerer& unit_lowerer, const StructuralScopeLowerer* parent,
-      std::string name, const hir::StructuralScope& hir_scope)
+      std::string name, const hir::StructuralScope& hir_scope,
+      PackageInitializationPlan package_init_plan = {})
       : owner_(&unit_lowerer),
         parent_(parent),
         name_(std::move(name)),
-        hir_scope_(&hir_scope) {
+        hir_scope_(&hir_scope),
+        package_init_plan_(std::move(package_init_plan)) {
   }
 
   // Mints this class's identity, builds its structural shape, publishes the
@@ -407,6 +410,14 @@ class StructuralScopeLowerer {
   const StructuralScopeLowerer* parent_;
   std::string name_;
   const hir::StructuralScope* hir_scope_;
+  // The design root's plan for bringing up package variables in its Initialize
+  // phase (LRM 26.2 / 10.5): install every package's cells, then run every
+  // package's value initializers in the resolved order. Non-empty only on the
+  // design root's own scope -- the sole scope whose elaboration spans the whole
+  // design; the lowering only realizes the resolved plan into cross-unit calls
+  // and never re-derives it. Every source unit's scope and every nested scope
+  // leaves it empty.
+  PackageInitializationPlan package_init_plan_;
   std::vector<mir::FieldId> structural_data_object_map_;
   std::vector<mir::CallableId> structural_subroutine_map_;
   std::vector<RoutedRefMeta> routed_ref_targets_;

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -14,6 +14,7 @@
 #include "lyra/hir/field_id.hpp"
 #include "lyra/hir/static_property_id.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/lowering/hir_to_mir/package_initialization.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -43,8 +44,17 @@ class UnitLowerer {
 
   // Lowers a module unit: a scope whose root is an object type, so its body
   // (variables, processes, instances, subroutines) composes the unit's top
-  // class. The synthesized design-root unit lowers this way too.
+  // class.
   auto RunModule() -> diag::Result<mir::CompilationUnit>;
+
+  // Lowers the synthetic design-root unit. It is a module in every respect
+  // except that its Initialize phase also installs and initializes the
+  // packages' variables (LRM 26.2 / 10.5). The plan is a whole-design fact the
+  // assembly resolves and passes in; the lowering only realizes it into
+  // cross-unit calls, so this special input stays at the design-root boundary
+  // and never reaches a source unit's lowering.
+  auto RunDesignRoot(PackageInitializationPlan package_init_plan)
+      -> diag::Result<mir::CompilationUnit>;
 
   // Lowers a package unit (LRM 26): a namespace whose root is not an object
   // type. Its functions and tasks lower to receiver-less callables owned by the
@@ -199,6 +209,13 @@ class UnitLowerer {
   }
 
  private:
+  // Lowers a scope whose root is an object type into the unit's top class. The
+  // package initialization plan is empty for a source module and carries the
+  // design root's resolved plan (LRM 26.2 / 10.5), which the root scope's
+  // Initialize phase realizes into cross-unit install and initialize calls.
+  auto LowerModuleUnit(PackageInitializationPlan package_init_plan)
+      -> diag::Result<mir::CompilationUnit>;
+
   // Mints every class identity, interns every HIR type, and lowers every HIR
   // class body into the unit. Shared prologue of `Run` and `RunPackage`: both a
   // module and a package own the same declaration kinds; they differ only in

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -17,6 +17,7 @@
 #include "lyra/mir/deferred_check_site.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/static_variable_id.hpp"
 #include "lyra/mir/struct_decl.hpp"
 #include "lyra/mir/struct_id.hpp"
 #include "lyra/mir/type.hpp"
@@ -26,6 +27,22 @@
 namespace lyra::mir {
 
 struct DeferredCheckSite {};
+
+// A unit-level static variable: a named mutable value the unit's namespace owns
+// with static storage -- one program-global cell, shared across the whole
+// simulation, not a member of any instance (LRM 26.2 package variables, LRM
+// 6.21 static lifetime). The mutable, observable counterpart of a
+// `StaticConstantDecl`: a backend emits it as a namespace-scope observable cell
+// and every reference reaches it by name (`unit::name`), the storage dual of
+// the unit's receiver-less callables. `type` is the observable-cell type; the
+// declared value type is its inner value. The initializer is not here: it runs
+// in the unit's synthesized initializer at time zero (LRM 10.5), the way a
+// class member's initializer runs in its Initialize phase, never as a field on
+// the declaration.
+struct StaticVariableDecl {
+  std::string name;
+  TypeId type;
+};
 
 // Named TypeIds the lowering and rendering reuse. Most are language or runtime
 // atomic types (the literal `int` type, the 1-bit selector type, the `void`
@@ -88,6 +105,12 @@ struct CompilationUnit {
   // bodied. A class's own callables live on that class; these are the
   // unit-level namespace's, one scope up.
   base::Arena<CallableDecl, CallableId> callables;
+  // Static variables the unit's namespace owns directly rather than through one
+  // of its classes -- a package's variables (LRM 26.2), one program-global cell
+  // each, shared and reached by name. A class's own static storage lives on
+  // that class; these are the unit-level namespace's, one scope up. Their
+  // initializers run in the unit's synthesized initializer at time zero.
+  base::Arena<StaticVariableDecl, StaticVariableId> static_variables;
   // The source name of each nominal type that carries none of its own, keyed by
   // that type's id. An enum is the case: it has no intrinsic name (an anonymous
   // enum has none, a multi-typedef enum has several), so a `typedef` names it
@@ -108,13 +131,24 @@ struct CompilationUnit {
   // is its own callable-value category, not a struct.
   base::Registry<ClosureDecl, ClosureId> closures;
   std::vector<DeferredCheckSite> deferred_check_sites;
-  // Names of other compilation units this unit calls a receiver-less callable
-  // of -- a package function or task (LRM 26.3). A cross-unit call carries no
+  // Names of other compilation units this unit reaches a namespace-level symbol
+  // of by name -- a package function or task called (LRM 26.3), or a package
+  // variable read or written (LRM 26.2). Such a reference carries no
   // value-typed object of the target unit, so unlike an instantiation it
   // interns no `ExternalUnitObjectType`; a backend reads this dependency list
-  // to emit the include and link edge to each called unit. Recorded once per
-  // distinct unit name.
-  std::vector<std::string> external_callable_units;
+  // to emit the include and link edge to each referenced unit. Recorded once
+  // per distinct unit name.
+  std::vector<std::string> external_referenced_units;
+  // The packages whose variables this package's variable initializers read
+  // directly (LRM 26.2 / 10.5) -- the by-name dependency the design root uses
+  // to pick a stable value-initialization order. It records only reads written
+  // directly in an initializer expression; a read reached through a called
+  // function does not contribute yet. This is a preference, not a correctness
+  // input: every cell is installed with its default before any initializer
+  // runs, so a missed or cyclic dependency only means a read observes a
+  // default, never an uninstalled cell. Empty for a non-package unit and for a
+  // package with no initializer that reads another package's variable.
+  std::vector<std::string> direct_initializer_package_reads;
 
   CompilationUnit()
       : builtins{
@@ -229,15 +263,16 @@ struct CompilationUnit {
     closures.Define(id, std::move(value));
   }
 
-  // Records a cross-unit callable dependency, deduplicated. Called from
-  // HIR-to-MIR when a call names a receiver-less callable of another unit.
-  void AddExternalCallableUnit(std::string unit_name) {
-    for (const std::string& existing : external_callable_units) {
+  // Records a cross-unit namespace-symbol dependency, deduplicated. Called from
+  // HIR-to-MIR when a reference names a receiver-less callable or a static
+  // variable of another unit.
+  void AddExternalReferencedUnit(std::string unit_name) {
+    for (const std::string& existing : external_referenced_units) {
       if (existing == unit_name) {
         return;
       }
     }
-    external_callable_units.push_back(std::move(unit_name));
+    external_referenced_units.push_back(std::move(unit_name));
   }
 
   // Backing-vector position is the id, matching TypeId / LocalId.

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -481,6 +481,20 @@ struct StaticPropertyRef {
   StaticPropertyId prop;
 };
 
+// A place naming a static variable of another compilation unit's namespace by
+// name (`unit_name::variable_name`) -- a package variable (LRM 26.2) read or
+// written from this unit. The reference kind for a package variable is uniform:
+// a package has no instance and no receiver, so its variable is reached by name
+// whether the referrer is another unit or the package's own callable, never
+// through a `self`-based field access. `Expr::type` is the variable's
+// observable-cell type, so a read wraps it in `Get` and a write in `Set`,
+// exactly as an intra-unit signal's cell does. The storage dual of
+// `ExternalUnitCallableTarget`.
+struct ExternalUnitVariableRef {
+  std::string unit_name;
+  std::string variable_name;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     MachineIntLiteral, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
@@ -489,7 +503,7 @@ using ExprData = std::variant<
     StructConstructExpr, ClosureExpr, ConcatExpr, ReplicationExpr,
     ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr, UnionExpr,
     UnionGetExpr, UnionGetRefExpr, FunctionRef, StaticConstantRef,
-    StaticPropertyRef>;
+    StaticPropertyRef, ExternalUnitVariableRef>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/static_variable_id.hpp
+++ b/include/lyra/mir/static_variable_id.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::mir {
+
+// Identity of a unit-level static variable -- a named, mutable value the unit's
+// namespace owns with static storage, one program-global cell shared across the
+// whole simulation (LRM 6.21 static lifetime, LRM 26.2 package variables). The
+// data dual of a receiver-less namespace callable, scoped to the unit that
+// declares it. The id keys the declaring unit's emission arena, while every
+// reference reaches the cell by name (`unit::name`), so it is never carried in
+// a reference expression.
+struct StaticVariableId {
+  std::uint32_t value;
+
+  auto operator<=>(const StaticVariableId&) const
+      -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/type_interner.hpp
+++ b/include/lyra/mir/type_interner.hpp
@@ -86,6 +86,17 @@ class TypeInterner {
             .mutability = mutability});
   }
 
+  // The observable-cell type for a variable of `value_type`: a SystemVerilog
+  // value-storage data object (LRM 6.5) is an observable cell, so its writes
+  // fire subscribers and its reads / writes go through the cell protocol; any
+  // other type -- a handle, a container, an object, a named event (which
+  // carries its own subscribe mechanism), a runtime facade, a machine primitive
+  // -- is its own storage and passes through unwrapped. This is the
+  // constructing counterpart of the pure observable-cell queries: it interns
+  // the wrapper, so it lives on the interner rather than beside those
+  // value-type predicates.
+  auto ObservableCellOf(TypeId value_type) -> TypeId;
+
  private:
   base::Arena<Type, TypeId> storage_;
   std::unordered_map<TypeData, TypeId, SemanticTypeHash, SemanticTypeEqual>

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -566,15 +566,16 @@ auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
     }
   };
   // A unit an instance is built from names its unit through the child object's
-  // `ExternalUnitObjectType`; a unit a receiver-less callable is called from
-  // names its unit in the call-dependency list, since a call interns no such
-  // type. Both are external units this unit's artifact includes.
+  // `ExternalUnitObjectType`; a unit whose namespace symbol is reached by name
+  // names its unit in the reference-dependency list, since such a reference
+  // interns no such type. Both are external units this unit's artifact
+  // includes.
   for (const auto& t : unit.types) {
     if (const auto* ext = std::get_if<mir::ExternalUnitObjectType>(&t.data)) {
       add(ext->unit_name);
     }
   }
-  for (const std::string& name : unit.external_callable_units) {
+  for (const std::string& name : unit.external_referenced_units) {
     add(name);
   }
   return names;
@@ -789,6 +790,20 @@ auto RenderNamespaceUnitHeaderFile(const mir::CompilationUnit& unit)
   out += "\n";
   out += std::format("namespace {} {{\n\n", ToCppName(unit.name));
   out += RenderUnitTypeDeclarations(unit);
+  // A package variable is one program-global observable cell (LRM 26.2). C++17
+  // `inline` gives it a single definition across every translation unit that
+  // includes the header, matching the header-only, link-by-name model the
+  // namespace callables use. It is declared before the callables because the
+  // synthesized `Initialize` callable, itself one of them, references it.
+  for (std::size_t i = 0; i < unit.static_variables.size(); ++i) {
+    const auto& var = unit.static_variables.Get(
+        mir::StaticVariableId{static_cast<std::uint32_t>(i)});
+    out += std::format(
+        "inline {} {}{{}};\n", RenderTypeAsCpp(unit, var.type), var.name);
+  }
+  if (unit.static_variables.size() != 0) {
+    out += "\n";
+  }
   for (std::size_t i = 0; i < unit.callables.size(); ++i) {
     const auto& callable =
         unit.callables.Get(mir::CallableId{static_cast<std::uint32_t>(i)});

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -435,6 +435,10 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
                 "{}::{}", ToCppName(owner_cls.name),
                 owner_cls.static_properties.Get(r.prop).name);
           },
+          [&](const mir::ExternalUnitVariableRef& r) -> std::string {
+            return std::format(
+                "{}::{}", ToCppName(r.unit_name), r.variable_name);
+          },
           // HIR-to-MIR lowers an LHS selector chain to write-form nodes -- a
           // container-access `CallExpr` with a write callee (per
           // `mir::IsContainerAccessCall`), a `UnionGetRefExpr`, a
@@ -908,6 +912,10 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
             return std::format(
                 "{}::{}", ToCppName(owner_cls.name),
                 owner_cls.static_properties.Get(r.prop).name);
+          },
+          [&](const mir::ExternalUnitVariableRef& r) -> std::string {
+            return std::format(
+                "{}::{}", ToCppName(r.unit_name), r.variable_name);
           },
           [&](const mir::ClosureExpr& cl) -> std::string {
             return RenderClosureExpr(view, cl);

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -4,51 +4,17 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/compiler/design_root.hpp"
 #include "lyra/compiler/unit_metadata.hpp"
+#include "lyra/compiler/unit_pipeline.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/frontend/load.hpp"
-#include "lyra/hir/compilation_unit.hpp"
-#include "lyra/hir/structural_scope.hpp"
-#include "lyra/lir/verify.hpp"
+#include "lyra/lir/compilation_unit.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
-#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
-#include "lyra/lowering/mir_to_lir/lower.hpp"
-#include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
 namespace lyra::compiler {
-
-namespace {
-
-// A unit's definition metadata is a source-level fact known once elaboration
-// fixes the unit's root scope: its def name is the root's name, its precision
-// the root's declared resolution. Derived from MIR here, so the executable body
-// downstream never carries these source-language concepts.
-auto BuildUnitMetadata(const mir::CompilationUnit& unit)
-    -> ElaboratedUnitMetadata {
-  const mir::Class& root = unit.GetClass(*unit.root);
-  return ElaboratedUnitMetadata{
-      .def_name = root.name,
-      .time_precision_power = root.time_resolution.precision_power};
-}
-
-// The design-root unit is a module whose only members are the top-level units,
-// instantiated as its owned children. Its constructor then elaborates the
-// design through the same owned-child construction any parent uses for a
-// submodule, so no code path is special-cased for the top level.
-auto BuildRootHirUnit(const std::vector<std::string>& top_names)
-    -> hir::CompilationUnit {
-  hir::CompilationUnit root{std::string{kDesignRootUnitName}};
-  for (const auto& name : top_names) {
-    root.root_scope.instance_members.Add(
-        hir::InstanceMemberDecl{
-            .instance_name = name, .target_unit = name, .array_dims = {}});
-  }
-  return root;
-}
-
-}  // namespace
 
 auto Compile(
     const frontend::CompilationInput& input, diag::DiagnosticSink& sink,
@@ -67,7 +33,6 @@ auto Compile(
   if (!result.slang_ok) {
     return result;
   }
-
   if (stop_after == StopAfter::kParse) {
     return result;
   }
@@ -80,112 +45,67 @@ auto Compile(
   result.artifacts.top_unit_names = lowering::ast_to_hir::TopLevelUnitNames(
       *result.artifacts.parse->compilation);
 
-  // Each unit runs its whole lowering pipeline (HIR -> MIR -> LIR) as an
-  // independent vertical: a unit reads only its own body and the shared
-  // frontend, never another unit's lowered artifacts.
+  // Step 1: lower the whole compilation to a flat set of self-contained HIR
+  // units -- every package, then every module body -- each tagged with its
+  // kind.
+  auto hir_units = lowering::ast_to_hir::LowerCompilationToHir(facts);
+  if (!hir_units) {
+    sink.Report(std::move(hir_units.error()));
+    return result;
+  }
+
+  // Step 2: lower each unit down its own vertical (HIR -> MIR -> LIR),
+  // independently -- a unit reads only itself and the shared frontend. The
+  // parallel result vectors preserve the output contract: `mir_units` is a
+  // superset of `lir_units`, since a package lowers to MIR but has no
+  // executable body, and `unit_metadata` stays co-indexed with `lir_units`.
   const bool want_mir = stop_after >= StopAfter::kMir;
   const bool want_lir = stop_after >= StopAfter::kLir;
-  const auto packages = lowering::ast_to_hir::CollectPackages(facts);
-  const auto bodies = lowering::ast_to_hir::CollectUnitBodies(facts);
-
-  std::vector<hir::CompilationUnit> hir_units;
   std::vector<mir::CompilationUnit> mir_units;
   std::vector<lir::CompilationUnit> lir_units;
   std::vector<ElaboratedUnitMetadata> unit_metadata;
-  hir_units.reserve(packages.size() + bodies.size());
-  mir_units.reserve(packages.size() + bodies.size());
-  lir_units.reserve(bodies.size());
-  unit_metadata.reserve(bodies.size());
-
-  // A package is a namespace unit (LRM 26): a backend emits it as its own
-  // artifact so a caller of a package function links against it, but it has no
-  // executable body, so it lowers only to MIR and never joins the LIR path.
-  for (const auto* package : packages) {
-    auto hir_or = lowering::ast_to_hir::LowerPackageUnit(facts, *package);
-    if (!hir_or) {
-      sink.Report(std::move(hir_or.error()));
+  mir_units.reserve(hir_units->size());
+  lir_units.reserve(hir_units->size());
+  unit_metadata.reserve(hir_units->size());
+  for (const auto& hir_unit : *hir_units) {
+    auto unit = LowerUnitPipeline(
+        hir_unit, stop_after, result.artifacts.parse->diag_sources);
+    if (!unit) {
+      sink.Report(std::move(unit.error()));
       return result;
     }
-    hir_units.push_back(*std::move(hir_or));
-    if (!want_mir) {
-      continue;
+    if (unit->mir) {
+      mir_units.push_back(*std::move(unit->mir));
     }
-    lowering::hir_to_mir::UnitLowerer lowerer(
-        hir_units.back(), result.artifacts.parse->diag_sources);
-    auto mir_or = lowerer.RunPackage();
-    if (!mir_or) {
-      sink.Report(std::move(mir_or.error()));
-      return result;
+    if (unit->lir) {
+      lir_units.push_back(*std::move(unit->lir));
     }
-    mir_units.push_back(*std::move(mir_or));
+    if (unit->metadata) {
+      unit_metadata.push_back(*std::move(unit->metadata));
+    }
   }
 
-  for (const auto* body : bodies) {
-    auto hir_or = lowering::ast_to_hir::LowerUnit(facts, *body);
-    if (!hir_or) {
-      sink.Report(std::move(hir_or.error()));
-      return result;
-    }
-    hir_units.push_back(*std::move(hir_or));
-    if (!want_mir) {
-      continue;
-    }
-
-    lowering::hir_to_mir::UnitLowerer lowerer(
-        hir_units.back(), result.artifacts.parse->diag_sources);
-    auto mir_or = lowerer.RunModule();
-    if (!mir_or) {
-      sink.Report(std::move(mir_or.error()));
-      return result;
-    }
-    mir_units.push_back(*std::move(mir_or));
-    if (!want_lir) {
-      continue;
-    }
-
-    auto lir_or = lowering::mir_to_lir::LowerUnit(mir_units.back());
-    if (!lir_or) {
-      sink.Report(std::move(lir_or.error()));
-      return result;
-    }
-    lir_units.push_back(*std::move(lir_or));
-    lir::Verify(lir_units.back());
-    unit_metadata.push_back(BuildUnitMetadata(mir_units.back()));
-  }
-
-  // The design-root unit is synthesized after the source units it instantiates,
-  // so it references them by the same cross-unit-by-name link every submodule
-  // instantiation uses. It is a distinct compiler output, not one of the source
-  // units, so it is held apart rather than mixed into `mir_units`. Its
-  // constructor elaborates the design through the same owned-child construction
-  // any parent uses, lowered like any other unit.
+  // Step 3: link the units into the design. The one whole-design step -- it
+  // reads across the units to synthesize the design root and resolve the
+  // package initialization plan -- so it stands apart from the per-unit
+  // lowering above.
   std::optional<mir::CompilationUnit> root_unit;
   std::optional<lir::CompilationUnit> root_lir_unit;
   std::optional<ElaboratedUnitMetadata> root_metadata;
   if (want_mir) {
-    const hir::CompilationUnit root_hir =
-        BuildRootHirUnit(result.artifacts.top_unit_names);
-    lowering::hir_to_mir::UnitLowerer root_lowerer(
-        root_hir, result.artifacts.parse->diag_sources);
-    auto root_mir = root_lowerer.RunModule();
-    if (!root_mir) {
-      sink.Report(std::move(root_mir.error()));
+    auto design_root = LinkDesign(
+        mir_units, result.artifacts.top_unit_names, stop_after,
+        result.artifacts.parse->diag_sources);
+    if (!design_root) {
+      sink.Report(std::move(design_root.error()));
       return result;
     }
-    root_unit = *std::move(root_mir);
-    if (want_lir) {
-      auto root_lir = lowering::mir_to_lir::LowerUnit(*root_unit);
-      if (!root_lir) {
-        sink.Report(std::move(root_lir.error()));
-        return result;
-      }
-      root_lir_unit = *std::move(root_lir);
-      lir::Verify(*root_lir_unit);
-      root_metadata = BuildUnitMetadata(*root_unit);
-    }
+    root_unit = std::move(design_root->mir);
+    root_lir_unit = std::move(design_root->lir);
+    root_metadata = std::move(design_root->metadata);
   }
 
-  result.artifacts.hir_units = std::move(hir_units);
+  result.artifacts.hir_units = std::move(*hir_units);
   if (want_mir) {
     result.artifacts.mir_units = std::move(mir_units);
     result.artifacts.root_unit = std::move(root_unit);
@@ -196,7 +116,6 @@ auto Compile(
     result.artifacts.root_lir_unit = std::move(root_lir_unit);
     result.artifacts.root_metadata = std::move(root_metadata);
   }
-
   return result;
 }
 

--- a/src/lyra/compiler/design_root.cpp
+++ b/src/lyra/compiler/design_root.cpp
@@ -1,0 +1,158 @@
+#include "lyra/compiler/design_root.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "lyra/compiler/unit_metadata.hpp"
+#include "lyra/hir/compilation_unit.hpp"
+#include "lyra/hir/structural_scope.hpp"
+#include "lyra/lir/verify.hpp"
+#include "lyra/lowering/hir_to_mir/package_initialization.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
+#include "lyra/lowering/mir_to_lir/lower.hpp"
+#include "lyra/mir/callable_id.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+
+namespace lyra::compiler {
+
+namespace {
+
+// The design-root unit is a module whose only members are the top-level units,
+// instantiated as its owned children. Its constructor then elaborates the
+// design through the same owned-child construction any parent uses for a
+// submodule, so no code path is special-cased for the top level. Its HIR
+// carries only this source-faithful structure; running the packages'
+// initializers is a whole-design composition step handled at lowering, not HIR
+// content.
+auto BuildDesignRootHir(std::span<const std::string> top_names)
+    -> hir::CompilationUnit {
+  hir::CompilationUnit root{std::string{kDesignRootUnitName}};
+  for (const auto& name : top_names) {
+    root.root_scope.instance_members.Add(
+        hir::InstanceMemberDecl{
+            .instance_name = name, .target_unit = name, .array_dims = {}});
+  }
+  return root;
+}
+
+// Whether the unit owns a callable of this name -- used to tell a package that
+// has a value initializer (and so a synthesized initialize callable) from one
+// whose variables all take their default.
+auto HasCallableNamed(const mir::CompilationUnit& unit, std::string_view name)
+    -> bool {
+  for (std::uint32_t i = 0; i < unit.callables.size(); ++i) {
+    if (unit.callables.Get(mir::CallableId{i}).name == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Post-order DFS emitting `name` after the packages its initializer reads (LRM
+// 26.2 / 10.5), so a dependency precedes its dependent. The LRM leaves the
+// relative order of initializers unspecified; this is a stable, best-effort
+// preference, not a correctness input -- every cell is installed with its
+// default before any initializer runs, so a missed or cyclic dependency only
+// means a read observes a default, never an uninstalled cell. Visiting `name`
+// before descending makes a cyclic dependency terminate with a deterministic
+// order rather than recur; `deps` is walked in the caller's stable
+// (name-sorted) order, so the whole result is reproducible for a given design.
+void OrderPackageInit(
+    const std::string& name,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        package_deps,
+    const std::unordered_set<std::string>& init_set,
+    std::unordered_set<std::string>& placed,
+    std::vector<std::string>& ordered) {
+  if (!placed.insert(name).second) {
+    return;
+  }
+  if (const auto it = package_deps.find(name); it != package_deps.end()) {
+    for (const std::string& dep : it->second) {
+      if (init_set.contains(dep)) {
+        OrderPackageInit(dep, package_deps, init_set, placed, ordered);
+      }
+    }
+  }
+  ordered.push_back(name);
+}
+
+// Resolves the whole-design package initialization plan from the compiled
+// units. A package unit is the one with no root class (`root == nullopt`); the
+// install pass covers every package that declares a variable, and the
+// value-initialize pass every package that has a value initializer, ordered so
+// a package a given initializer reads directly comes first where that is
+// possible. Both passes are name-sorted first so the result is deterministic
+// for a given design.
+auto BuildPackageInitializationPlan(std::span<const mir::CompilationUnit> units)
+    -> lowering::hir_to_mir::PackageInitializationPlan {
+  std::vector<std::string> packages_with_value_init;
+  std::unordered_map<std::string, std::vector<std::string>> package_init_deps;
+  lowering::hir_to_mir::PackageInitializationPlan plan;
+  for (const auto& unit : units) {
+    if (unit.root.has_value()) {
+      continue;
+    }
+    if (!unit.static_variables.empty()) {
+      plan.install_order.push_back(unit.name);
+    }
+    if (HasCallableNamed(
+            unit, lowering::hir_to_mir::kPackageInitializeCallableName)) {
+      packages_with_value_init.push_back(unit.name);
+      package_init_deps.emplace(
+          unit.name, unit.direct_initializer_package_reads);
+    }
+  }
+  std::ranges::sort(plan.install_order);
+  std::ranges::sort(packages_with_value_init);
+  const std::unordered_set<std::string> init_set(
+      packages_with_value_init.begin(), packages_with_value_init.end());
+  std::unordered_set<std::string> placed;
+  for (const std::string& name : packages_with_value_init) {
+    OrderPackageInit(
+        name, package_init_deps, init_set, placed, plan.value_initialize_order);
+  }
+  return plan;
+}
+
+}  // namespace
+
+auto LinkDesign(
+    std::span<const mir::CompilationUnit> units,
+    std::span<const std::string> top_names, StopAfter stop_after,
+    const diag::SourceManager& source_manager)
+    -> diag::Result<DesignRootArtifacts> {
+  const hir::CompilationUnit root_hir = BuildDesignRootHir(top_names);
+  lowering::hir_to_mir::UnitLowerer root_lowerer(root_hir, source_manager);
+  auto root_mir =
+      root_lowerer.RunDesignRoot(BuildPackageInitializationPlan(units));
+  if (!root_mir) {
+    return std::unexpected(std::move(root_mir.error()));
+  }
+  DesignRootArtifacts artifacts{
+      .mir = *std::move(root_mir),
+      .lir = std::nullopt,
+      .metadata = std::nullopt};
+
+  if (stop_after < StopAfter::kLir) {
+    return artifacts;
+  }
+  auto root_lir = lowering::mir_to_lir::LowerUnit(artifacts.mir);
+  if (!root_lir) {
+    return std::unexpected(std::move(root_lir.error()));
+  }
+  artifacts.lir = *std::move(root_lir);
+  lir::Verify(*artifacts.lir);
+  artifacts.metadata = BuildUnitMetadata(artifacts.mir);
+  return artifacts;
+}
+
+}  // namespace lyra::compiler

--- a/src/lyra/compiler/unit_metadata.cpp
+++ b/src/lyra/compiler/unit_metadata.cpp
@@ -1,0 +1,16 @@
+#include "lyra/compiler/unit_metadata.hpp"
+
+#include "lyra/mir/class.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+
+namespace lyra::compiler {
+
+auto BuildUnitMetadata(const mir::CompilationUnit& unit)
+    -> ElaboratedUnitMetadata {
+  const mir::Class& root = unit.GetClass(*unit.root);
+  return ElaboratedUnitMetadata{
+      .def_name = root.name,
+      .time_precision_power = root.time_resolution.precision_power};
+}
+
+}  // namespace lyra::compiler

--- a/src/lyra/compiler/unit_pipeline.cpp
+++ b/src/lyra/compiler/unit_pipeline.cpp
@@ -1,0 +1,46 @@
+#include "lyra/compiler/unit_pipeline.hpp"
+
+#include <expected>
+#include <utility>
+
+#include "lyra/compiler/unit_metadata.hpp"
+#include "lyra/hir/compilation_unit.hpp"
+#include "lyra/lir/verify.hpp"
+#include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
+#include "lyra/lowering/mir_to_lir/lower.hpp"
+
+namespace lyra::compiler {
+
+auto LowerUnitPipeline(
+    const hir::CompilationUnit& unit, StopAfter stop_after,
+    const diag::SourceManager& source_manager) -> diag::Result<UnitArtifacts> {
+  UnitArtifacts artifacts;
+  if (stop_after < StopAfter::kMir) {
+    return artifacts;
+  }
+
+  lowering::hir_to_mir::UnitLowerer lowerer(unit, source_manager);
+  auto mir = unit.kind == hir::UnitKind::kPackage ? lowerer.RunPackage()
+                                                  : lowerer.RunModule();
+  if (!mir) {
+    return std::unexpected(std::move(mir.error()));
+  }
+  artifacts.mir = *std::move(mir);
+
+  // A package is a namespace unit (LRM 26): it has no executable body, so it
+  // never joins the LIR path.
+  if (unit.kind == hir::UnitKind::kPackage || stop_after < StopAfter::kLir) {
+    return artifacts;
+  }
+
+  auto lir = lowering::mir_to_lir::LowerUnit(*artifacts.mir);
+  if (!lir) {
+    return std::unexpected(std::move(lir.error()));
+  }
+  artifacts.lir = *std::move(lir);
+  lir::Verify(*artifacts.lir);
+  artifacts.metadata = BuildUnitMetadata(*artifacts.mir);
+  return artifacts;
+}
+
+}  // namespace lyra::compiler

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -428,6 +428,10 @@ class HirDumper {
                                      : "Index";
               return std::format("Iteration[{}].{}", r.clause.value, role);
             },
+            [](const ExternalUnitValueRef& r) -> std::string {
+              return std::format(
+                  "ExternalUnitValue({}::{})", r.unit_name, r.variable_name);
+            },
         },
         p);
   }
@@ -443,6 +447,20 @@ class HirDumper {
             },
         },
         ref);
+  }
+
+  static auto FormatSensitivityTarget(const SensitivityTarget& target)
+      -> std::string {
+    return std::visit(
+        Overloaded{
+            [](const ReferenceRoute& route) -> std::string {
+              return FormatReferenceRoute(route);
+            },
+            [](const ExternalUnitValueRef& r) -> std::string {
+              return std::format("var={}::{}", r.unit_name, r.variable_name);
+            },
+        },
+        target);
   }
 
   static auto FormatFootprint(
@@ -489,7 +507,7 @@ class HirDumper {
                   if (j != 0) out += ", ";
                   const auto& r = e.triggers[i].sensitivity_list[j];
                   out += std::format(
-                      "{{{} bits={} edge={}}}", FormatReferenceRoute(r.ref),
+                      "{{{} bits={} edge={}}}", FormatSensitivityTarget(r.ref),
                       FormatFootprint(r.footprint),
                       FormatEventEdge(r.edge_kind));
                 }
@@ -504,7 +522,7 @@ class HirDumper {
                 if (i != 0) out += ", ";
                 const auto& r = ie.sensitivity_list[i];
                 out += std::format(
-                    "{{{} bits={} edge={}}}", FormatReferenceRoute(r.ref),
+                    "{{{} bits={} edge={}}}", FormatSensitivityTarget(r.ref),
                     FormatFootprint(r.footprint), FormatEventEdge(r.edge_kind));
               }
               out += "]";
@@ -1104,7 +1122,7 @@ class HirDumper {
       for (const auto& r : p.implicit_sensitivity_list) {
         Line(
             std::format(
-                "{} bits={}", FormatReferenceRoute(r.ref),
+                "{} bits={}", FormatSensitivityTarget(r.ref),
                 FormatFootprint(r.footprint)));
       }
       Dedent();
@@ -1156,7 +1174,7 @@ class HirDumper {
       for (const auto& r : ca.sensitivity_list) {
         Line(
             std::format(
-                "{} bits={}", FormatReferenceRoute(r.ref),
+                "{} bits={}", FormatSensitivityTarget(r.ref),
                 FormatFootprint(r.footprint)));
       }
       Dedent();
@@ -1532,7 +1550,7 @@ class HirDumper {
                 if (i != 0) sens += ", ";
                 const auto& r = w.sensitivity_list[i];
                 sens += std::format(
-                    "{{{} bits={}}}", FormatReferenceRoute(r.ref),
+                    "{{{} bits={}}}", FormatSensitivityTarget(r.ref),
                     FormatFootprint(r.footprint));
               }
               sens += "]";

--- a/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
@@ -9,7 +9,6 @@
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 
-#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
@@ -41,8 +40,6 @@ struct UnitCollector
   }
 };
 
-}  // namespace
-
 auto CollectUnitBodies(const LowerCompilationFacts& facts)
     -> std::vector<const slang::ast::InstanceBodySymbol*> {
   const auto& root = facts.Compilation().getRoot();
@@ -60,7 +57,11 @@ auto LowerUnit(
   const LoweringFacts unit_facts(
       facts.SourceMapper(), facts.Sensitivity(), facts.DisableAssertions());
   UnitLowerer lowerer(unit_facts, body, SpecializationName(body));
-  return lowerer.Run();
+  auto unit = lowerer.Run();
+  if (unit) {
+    unit->kind = hir::UnitKind::kModule;
+  }
+  return unit;
 }
 
 auto CollectPackages(const LowerCompilationFacts& facts)
@@ -85,7 +86,36 @@ auto LowerPackageUnit(
   const LoweringFacts unit_facts(
       facts.SourceMapper(), facts.Sensitivity(), facts.DisableAssertions());
   UnitLowerer lowerer(unit_facts, package, std::string{package.name});
-  return lowerer.Run();
+  auto unit = lowerer.Run();
+  if (unit) {
+    unit->kind = hir::UnitKind::kPackage;
+  }
+  return unit;
+}
+
+}  // namespace
+
+auto LowerCompilationToHir(const LowerCompilationFacts& facts)
+    -> diag::Result<std::vector<hir::CompilationUnit>> {
+  std::vector<hir::CompilationUnit> units;
+  const auto packages = CollectPackages(facts);
+  const auto bodies = CollectUnitBodies(facts);
+  units.reserve(packages.size() + bodies.size());
+  for (const auto* package : packages) {
+    auto unit = LowerPackageUnit(facts, *package);
+    if (!unit) {
+      return std::unexpected(std::move(unit.error()));
+    }
+    units.push_back(*std::move(unit));
+  }
+  for (const auto* body : bodies) {
+    auto unit = LowerUnit(facts, *body);
+    if (!unit) {
+      return std::unexpected(std::move(unit.error()));
+    }
+    units.push_back(*std::move(unit));
+  }
+  return units;
 }
 
 auto TopLevelUnitNames(slang::ast::Compilation& compilation)

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -8,9 +8,11 @@
 
 #include <slang/ast/Expression.h>
 #include <slang/ast/HierarchicalReference.h>
+#include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/symbols/ClassSymbols.h>
+#include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -256,6 +258,24 @@ auto RouteRefExpr(
       route);
 }
 
+// Lowers a reference to a package variable as an `ExternalUnitValueRef` naming
+// the package and the variable. The same by-name form serves a referrer in
+// another unit and the package's own callable reading its own variable; neither
+// has a receiver to route through.
+auto LowerExternalUnitValueRef(
+    UnitLowerer& unit_lowerer, const slang::ast::PackageSymbol& pkg,
+    const slang::ast::ValueSymbol& value, const slang::ast::Type& type,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto type_id = unit_lowerer.InternType(type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::MakeRefExpr(
+      hir::ExternalUnitValueRef{
+          .unit_name = std::string{pkg.name},
+          .variable_name = std::string{value.name},
+          .value_type = *type_id},
+      *type_id, span);
+}
+
 // Lowers a reference to a structural signal (a variable or net of an enclosing
 // scope) through the one reference-route translator. Shared by the procedural
 // and structural named-value paths once each has ruled out the non-signal forms
@@ -277,6 +297,15 @@ auto LowerStructuralSignalRef(
 }
 
 }  // namespace
+
+auto EnclosingPackageOfValue(const slang::ast::ValueSymbol& value)
+    -> const slang::ast::PackageSymbol* {
+  const slang::ast::Scope* scope = value.getParentScope();
+  if (scope == nullptr) return nullptr;
+  const slang::ast::Symbol& owner = scope->asSymbol();
+  if (owner.kind != slang::ast::SymbolKind::Package) return nullptr;
+  return &owner.as<slang::ast::PackageSymbol>();
+}
 
 auto LowerNamedValueProc(
     ProcessLowerer& proc, WalkFrame frame,
@@ -313,9 +342,13 @@ auto LowerNamedValueProc(
         return hir::MakeRefExpr(
             hir::ProceduralVarRef{.var = *local}, type, span);
       }
+      const auto& value = sym.as<slang::ast::ValueSymbol>();
+      if (const auto* pkg = EnclosingPackageOfValue(value)) {
+        return LowerExternalUnitValueRef(
+            unit_lowerer, *pkg, value, *named.type, span);
+      }
       return LowerStructuralSignalRef(
-          unit_lowerer, frame, sym.as<slang::ast::ValueSymbol>(), *named.type,
-          span);
+          unit_lowerer, frame, value, *named.type, span);
     }
     // A net (LRM 6.5) is always a structural signal, never a procedural local.
     case Referent::kNetStorage:
@@ -366,10 +399,14 @@ auto LowerHierarchicalValue(
           "supported");
     case Referent::kVariableStorage:
     case Referent::kNetStorage: {
+      const auto& value = target.as<slang::ast::ValueSymbol>();
+      if (const auto* pkg = EnclosingPackageOfValue(value)) {
+        return LowerExternalUnitValueRef(
+            unit_lowerer, *pkg, value, *hve.type, span);
+      }
       auto type_id = unit_lowerer.InternType(*hve.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
-      auto route = unit_lowerer.TranslateReferenceRoute(
-          frame, target.as<slang::ast::ValueSymbol>());
+      auto route = unit_lowerer.TranslateReferenceRoute(frame, value);
       if (!route) {
         return diag::Fail(
             span, diag::DiagCode::kUnsupportedExpressionForm,
@@ -397,10 +434,15 @@ auto LowerNamedValueStructural(
     case Referent::kEnumConstant:
       return MakeEnumConstantExpr(unit_lowerer, sym, *named.type, span);
     case Referent::kVariableStorage:
-    case Referent::kNetStorage:
+    case Referent::kNetStorage: {
+      const auto& value = sym.as<slang::ast::ValueSymbol>();
+      if (const auto* pkg = EnclosingPackageOfValue(value)) {
+        return LowerExternalUnitValueRef(
+            unit_lowerer, *pkg, value, *named.type, span);
+      }
       return LowerStructuralSignalRef(
-          unit_lowerer, frame, sym.as<slang::ast::ValueSymbol>(), *named.type,
-          span);
+          unit_lowerer, frame, value, *named.type, span);
+    }
     // A class property has no structural (non-procedural) meaning: it is only
     // reachable through a method receiver, so outside a method it is rejected
     // alongside the genuinely unsupported kinds.

--- a/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
@@ -15,6 +15,7 @@
 #include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
+#include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
@@ -29,6 +30,7 @@
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/ast_to_hir/expression/references.hpp"
 #include "lyra/lowering/ast_to_hir/instance_array_shape.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
@@ -466,6 +468,23 @@ auto UnitLowerer::TranslateSensitivityReads(
     const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
         read_type.isIntegral() && !read_type.isEnum() ? read.footprint
                                                       : std::nullopt;
+    // A package variable is watched the same way, but by name: it has no
+    // reader-relative route, so it wakes the process through a reference to its
+    // one program-global cell (LRM 26.2), the observation dual of reading it.
+    if (const auto* pkg = EnclosingPackageOfValue(*value)) {
+      auto value_type =
+          InternType(read_type, SourceMapper().PointSpanOf(value->location));
+      if (!value_type) continue;
+      out.push_back(
+          hir::SensitivityEntry{
+              .ref =
+                  hir::ExternalUnitValueRef{
+                      .unit_name = std::string{pkg->name},
+                      .variable_name = std::string{value->name},
+                      .value_type = *value_type},
+              .footprint = footprint});
+      continue;
+    }
     if (auto ref = TranslateReferenceRoute(frame, *value)) {
       out.push_back(
           hir::SensitivityEntry{

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -224,13 +224,26 @@ auto ApplyAssignEffect(
     std::span<const mir::ExprId> operands_in_outer, EffectFn effect_fn)
     -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
+  // Only an observable-cell write notifies subscribers, so only it reaches a
+  // services value; a plain-local write carries none.
+  const bool target_is_observable_cell =
+      LhsRootIsObservableCell(process.Owner().Unit(), block, target_in_outer);
+  // Firing subscribers needs the runtime services, reached through the
+  // callable's `self`. A receiver-less callable (a package function or task,
+  // LRM 26.3) has no `self`, so it cannot yet write an observable cell -- which
+  // for it is a package variable (LRM 26.2). Reading one is fine (a read needs
+  // no services); writing awaits threading the services into a receiver-less
+  // callable. Reject cleanly here rather than reach for a receiver that is not
+  // there.
+  if (target_is_observable_cell && frame.current_class == nullptr) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedAssignmentTarget,
+        "writing a package variable from a package subroutine is not yet "
+        "supported");
+  }
   if (kind == hir::AssignKind::kBlocking) {
-    // Only an observable-cell write notifies subscribers, so only it reaches a
-    // services value; a plain-local write carries none. This is what lets a
-    // receiver-less callable -- whose locals are never observable -- lower an
-    // assignment without a receiver to reach services through.
     const std::optional<mir::ExprId> services_id =
-        LhsRootIsObservableCell(process.Owner().Unit(), block, target_in_outer)
+        target_is_observable_cell
             ? std::optional{block.exprs.Add(
                   BuildServicesCallExpr(process.Owner(), frame))}
             : std::nullopt;

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -1269,7 +1269,7 @@ auto LowerExternalUnitSubroutineCall(
     -> diag::Result<mir::Expr> {
   const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  lowerer.Owner().Unit().AddExternalCallableUnit(ref.unit_name);
+  lowerer.Owner().Unit().AddExternalReferencedUnit(ref.unit_name);
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size());
   for (const auto& argument : c.arguments) {

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -148,6 +148,26 @@ auto LowerReferenceRouteExpr(
       frame, lowerer.Owner().Unit(), BindEndpoint(lowerer, frame, route));
 }
 
+// A package variable (LRM 26.2) is reached by name, never through a
+// `self`-based route: the same by-name form serves a referrer in another unit
+// and the package's own callable reading its own variable. The result is the
+// variable's observable-cell type, so the dispatcher wraps the read in `kGet`
+// and a write in `kSet`, exactly as an intra-unit signal's cell. A referrer in
+// another unit records the dependency so the backend emits the include and link
+// edge; a package's own reference to its own variable records nothing.
+auto LowerExternalUnitValueRefExpr(
+    mir::CompilationUnit& unit, const hir::ExternalUnitValueRef& r,
+    mir::TypeId value_type) -> mir::Expr {
+  if (r.unit_name != unit.name) {
+    unit.AddExternalReferencedUnit(r.unit_name);
+  }
+  return mir::Expr{
+      .data =
+          mir::ExternalUnitVariableRef{
+              .unit_name = r.unit_name, .variable_name = r.variable_name},
+      .type = unit.types.ObservableCellOf(value_type)};
+}
+
 auto LowerProceduralVarRefExpr(
     ProcessLowerer& process, const WalkFrame& frame,
     const hir::ProceduralVarRef& l, mir::TypeId type) -> mir::Expr {
@@ -275,6 +295,10 @@ auto LowerHirPrimaryExprProc(
           [&](const hir::IterationBindingRef& r) -> mir::Expr {
             return LowerIterationBindingRefExpr(r, frame);
           },
+          [&](const hir::ExternalUnitValueRef& r) -> mir::Expr {
+            return LowerExternalUnitValueRefExpr(
+                process.Owner().Unit(), r, result_type);
+          },
       },
       p);
 }
@@ -325,6 +349,10 @@ auto LowerHirPrimaryExprStructural(
           },
           [&](const hir::IterationBindingRef& r) -> mir::Expr {
             return LowerIterationBindingRefExpr(r, frame);
+          },
+          [&](const hir::ExternalUnitValueRef& r) -> mir::Expr {
+            return LowerExternalUnitValueRefExpr(
+                lowerer.Owner().Unit(), r, result_type);
           },
       },
       p);

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -4,7 +4,9 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/base/overloaded.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/endpoint.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
@@ -29,8 +31,33 @@ auto BuildTriggerExpr(
     mir::Block& block, const WalkFrame& frame, mir::CompilationUnit& unit,
     const StructuralScopeLowerer& lowerer, const hir::SensitivityEntry& entry)
     -> mir::ExprId {
-  const mir::ExprId observable_ptr = EndpointObservablePtr(
-      block, frame, unit, BindEndpoint(lowerer, frame, entry.ref));
+  // The leaf watches either an intra-unit cell reached through its route, or a
+  // package variable's one program-global cell reached by name (LRM 26.2). Both
+  // resolve to a borrowed pointer to the observable cell the runtime subscribes
+  // to; only the way the cell is reached differs.
+  const mir::ExprId observable_ptr = std::visit(
+      Overloaded{
+          [&](const hir::ReferenceRoute& route) -> mir::ExprId {
+            return EndpointObservablePtr(
+                block, frame, unit, BindEndpoint(lowerer, frame, route));
+          },
+          [&](const hir::ExternalUnitValueRef& pkg) -> mir::ExprId {
+            unit.AddExternalReferencedUnit(pkg.unit_name);
+            const mir::TypeId cell_type = unit.types.ObservableCellOf(
+                lowerer.Owner().TranslateType(pkg.value_type));
+            const mir::ExprId cell = block.exprs.Add(
+                mir::Expr{
+                    .data =
+                        mir::ExternalUnitVariableRef{
+                            .unit_name = pkg.unit_name,
+                            .variable_name = pkg.variable_name},
+                    .type = cell_type});
+            const mir::TypeId ptr_type = unit.types.PointerTo(
+                cell_type, mir::PointerOwnership::kBorrowed);
+            return block.exprs.Add(mir::MakeAddressOfExpr(cell, ptr_type));
+          },
+      },
+      entry.ref);
   const std::int64_t lsb_bit_offset =
       entry.footprint.has_value()
           ? static_cast<std::int64_t>(entry.footprint->first)

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -27,6 +27,7 @@
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/calls.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
+#include "lyra/lowering/hir_to_mir/package_initialization.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
@@ -57,31 +58,6 @@ void AttachRuntimeScopeCtorPrefix(
       mir::ParamDecl{.name = "segment", .type = builtins.hierarchy_segment});
   shape.ctor_prefix_params.Add(
       mir::ParamDecl{.name = "services", .type = builtins.services});
-}
-
-// Wrap a value type in `ObservableType` iff it is a SystemVerilog value-storage
-// data type (LRM 6.5 / 7.x). Handle / wrapper types (pointer / vector / object
-// / external ref / external unit object) and named events (LRM 15 -- carry
-// their own subscribe mechanism) pass through unwrapped.
-auto MaybeWrapObservable(UnitLowerer& unit_lowerer, mir::TypeId t)
-    -> mir::TypeId {
-  const auto& data = unit_lowerer.Unit().types.Get(t).data;
-  const bool wrap = std::holds_alternative<mir::PackedArrayType>(data) ||
-                    std::holds_alternative<mir::EnumType>(data) ||
-                    std::holds_alternative<mir::StringType>(data) ||
-                    std::holds_alternative<mir::RealType>(data) ||
-                    std::holds_alternative<mir::ShortRealType>(data) ||
-                    std::holds_alternative<mir::RealTimeType>(data) ||
-                    std::holds_alternative<mir::UnpackedArrayType>(data) ||
-                    std::holds_alternative<mir::DynamicArrayType>(data) ||
-                    std::holds_alternative<mir::QueueType>(data) ||
-                    std::holds_alternative<mir::AssociativeArrayType>(data) ||
-                    std::holds_alternative<mir::TupleType>(data) ||
-                    std::holds_alternative<mir::UnionType>(data);
-  if (!wrap) {
-    return t;
-  }
-  return unit_lowerer.Unit().types.Intern(mir::ObservableType{.value = t});
 }
 
 struct GenerateChildSpec {
@@ -300,10 +276,11 @@ void DeclareRoutedRefSlots(
       }
     }
     const mir::TypeId value = unit_lowerer.TranslateType(cu.recipe.type);
-    const mir::TypeId leaf = cu.target_net_type.has_value()
-                                 ? unit_lowerer.Unit().types.Intern(
-                                       mir::ResolvedType{.value = value})
-                                 : MaybeWrapObservable(unit_lowerer, value);
+    const mir::TypeId leaf =
+        cu.target_net_type.has_value()
+            ? unit_lowerer.Unit().types.Intern(
+                  mir::ResolvedType{.value = value})
+            : unit_lowerer.Unit().types.ObservableCellOf(value);
     const mir::TypeId slot_type = unit_lowerer.Unit().types.PointerTo(
         leaf, mir::PointerOwnership::kBorrowed);
     const mir::FieldId slot = shape.fields.Add(
@@ -1083,7 +1060,7 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
         return unit_lowerer.Unit().types.Intern(
             mir::ResolvedType{.value = mir_value_type});
       }
-      return MaybeWrapObservable(unit_lowerer, mir_value_type);
+      return unit_lowerer.Unit().types.ObservableCellOf(mir_value_type);
     }();
     const mir::FieldId mir_id = shape.fields.Add(
         mir::FieldDecl{.name = d.name, .type = mir_field_type});
@@ -1312,7 +1289,8 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
       const std::string mangled =
           std::format("{}__{}_{}", callable_name, v.name, var_id.value);
       const mir::TypeId type = unit_lowerer.TranslateType(v.type);
-      const mir::TypeId field_type = MaybeWrapObservable(unit_lowerer, type);
+      const mir::TypeId field_type =
+          unit_lowerer.Unit().types.ObservableCellOf(type);
       mir::FieldDecl field_decl{.name = mangled, .type = field_type};
       // The source-name registration follows the var's lexical scope, not its
       // physical owner. Only a static in a named block is hierarchically
@@ -1793,6 +1771,44 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
               .type = void_type});
       ctor_block.AppendStmt(mir::ExprStmt{.expr = call});
     }
+  }
+
+  // The design root's Initialize phase brings up the packages' variables (LRM
+  // 26.2 / 10.5). A package owns no runtime tree node, so the root calls its
+  // receiver-less callables here, before the top modules initialize -- this
+  // scope's Initialize runs parent-first, and the design root is every module's
+  // ancestor. It runs design-wide in two passes: install every package's cells
+  // (their declared type and default), then run every package's value
+  // initializers, so a value initializer that reads another package's variable
+  // always reaches installed storage. The plan is resolved by the whole-design
+  // assembly and realized here; this scope carries it only for the design root,
+  // so a source unit's scope and a nested scope both leave it empty.
+  const auto call_package = [&](const std::string& pkg,
+                                std::string_view callable,
+                                std::vector<mir::ExprId> args) {
+    unit_lowerer.Unit().AddExternalReferencedUnit(pkg);
+    const mir::ExprId call = initialize_block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::CallExpr{
+                    .callee =
+                        mir::Direct{
+                            .target =
+                                mir::ExternalUnitCallableTarget{
+                                    .unit_name = pkg,
+                                    .callable_name = std::string{callable}}},
+                    .arguments = std::move(args)},
+            .type = void_type});
+    initialize_block.AppendStmt(mir::ExprStmt{.expr = call});
+  };
+  for (const std::string& pkg : package_init_plan_.install_order) {
+    call_package(pkg, kPackageInstallCallableName, {});
+  }
+  for (const std::string& pkg : package_init_plan_.value_initialize_order) {
+    const mir::ExprId services = initialize_block.exprs.Add(
+        mir::MakeServicesCallExpr(
+            init_self_read(), unit_lowerer.Unit().builtins.services));
+    call_package(pkg, kPackageInitializeCallableName, {services});
   }
 
   // Build each materialized procedural-storage scope's class: copy its

--- a/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
@@ -1,28 +1,172 @@
 #include "lyra/lowering/hir_to_mir/unit_lowerer.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <format>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
 
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/callable_storage_plan.hpp"
 #include "lyra/lowering/hir_to_mir/class_decl_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/package_initialization.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/callable.hpp"
+#include "lyra/mir/callable_code.hpp"
 #include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/local.hpp"
+#include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+// Lowers a package's variables (LRM 26.2) into unit-level static storage and
+// synthesizes the two receiver-less callables that bring them up at time zero:
+// `Install` installs every cell's declared representation and default (no
+// services -- nothing to fire before any process), and `Initialize` runs each
+// LRM 10.5 value initializer through its cell (taking the services, since a
+// package has no `self` to reach them through). The design root installs every
+// package before initializing any, so a value initializer always reaches
+// installed storage. A package variable is reached by name (`unit::name`), so a
+// variable initializer's references to sibling or other-package variables lower
+// through the same by-name path with no enclosing scope or receiver; the
+// other-package reads are recorded as the unit's initializer dependency.
+auto PopulatePackageStaticVariables(
+    UnitLowerer& unit_lowerer, const hir::StructuralScope& scope)
+    -> diag::Result<void> {
+  mir::CompilationUnit& unit = unit_lowerer.Unit();
+
+  mir::CallableCode install_code;
+  install_code.result_type = unit.builtins.void_type;
+  mir::Block& install_block = install_code.body;
+  const WalkFrame install_frame = WalkFrame{}.WithBlock(&install_block);
+
+  mir::CallableCode value_code;
+  value_code.result_type = unit.builtins.void_type;
+  const mir::LocalId services_local = value_code.locals.Add(
+      mir::LocalDecl{.name = "services", .type = unit.builtins.services});
+  value_code.params.push_back(services_local);
+  mir::Block& value_block = value_code.body;
+  const WalkFrame value_frame = WalkFrame{}.WithBlock(&value_block);
+
+  // The package root scope is an ExprLowerer over its own expressions: a
+  // variable initializer's operands are literals, operators, and by-name
+  // package symbols, none of which reach a class or a `self`.
+  const StructuralScopeLowerer expr_lowerer(
+      unit_lowerer, nullptr, unit.name, scope);
+
+  const auto make_cell = [&](mir::Block& block, const std::string& name,
+                             mir::TypeId cell_type) -> mir::ExprId {
+    return block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::ExternalUnitVariableRef{
+                    .unit_name = unit.name, .variable_name = name},
+            .type = cell_type});
+  };
+
+  for (std::size_t i = 0; i < scope.structural_data_objects.size(); ++i) {
+    const hir::StructuralDataObjectId hir_id{static_cast<std::uint32_t>(i)};
+    const hir::StructuralDataObjectDecl& d =
+        scope.structural_data_objects.Get(hir_id);
+    const auto* var = std::get_if<hir::StructuralVariableDecl>(&d.kind);
+    if (var == nullptr) {
+      return diag::Fail(
+          diag::DiagCode::kUnsupportedExpressionForm,
+          "a net declared in a package is not supported");
+    }
+    const mir::TypeId value_type = unit_lowerer.TranslateType(d.type);
+    const mir::TypeId cell_type = unit.types.ObservableCellOf(value_type);
+    if (!mir::IsObservableCellType(unit.types.Get(cell_type))) {
+      return diag::Fail(
+          diag::DiagCode::kUnsupportedExpressionForm,
+          "a package variable of this type is not yet supported");
+    }
+    unit.static_variables.Add(
+        mir::StaticVariableDecl{.name = d.name, .type = cell_type});
+
+    // Phase 1: install the cell's declared representation and default.
+    const mir::ExprId prototype = install_block.exprs.Add(
+        BuildDefaultValueFromHir(unit_lowerer, install_frame, d.type));
+    install_block.AppendStmt(
+        mir::ExprStmt{
+            .expr = install_block.exprs.Add(
+                mir::MakeObservableInitializeCallExpr(
+                    make_cell(install_block, d.name, cell_type), prototype,
+                    unit.builtins.void_type))});
+
+    // Phase 2: a user initializer (LRM 10.5) writes the value through the cell;
+    // the services comes from the callable's parameter, since there is no
+    // `self`.
+    if (var->initializer.has_value()) {
+      auto value_or = expr_lowerer.LowerExpr(
+          scope.exprs.Get(*var->initializer), value_frame);
+      if (!value_or) return std::unexpected(std::move(value_or.error()));
+      const mir::ExprId value_id = value_block.exprs.Add(*std::move(value_or));
+      const mir::ExprId services_ref = value_block.exprs.Add(
+          mir::MakeLocalRefExpr(services_local, unit.builtins.services));
+      value_block.AppendStmt(
+          mir::ExprStmt{
+              .expr = value_block.exprs.Add(
+                  mir::MakeObservableSetCallExpr(
+                      make_cell(value_block, d.name, cell_type), services_ref,
+                      value_id, unit.builtins.void_type))});
+    }
+  }
+
+  // A package with variables always installs them.
+  if (!install_block.root_stmts.empty()) {
+    unit.callables.Add(
+        mir::CallableDecl{
+            .name = std::string{kPackageInstallCallableName},
+            .impl = mir::InternalCallable{.code = std::move(install_code)},
+            .virtual_dispatch = std::nullopt,
+            .visibility = mir::CallableVisibility::kInternal});
+  }
+  // Only a package with a value initializer needs the initialize callable. Its
+  // direct other-package variable reads are the by-name dependency the design
+  // root orders on: scan the initializer body for cross-package cell
+  // references.
+  if (!value_block.root_stmts.empty()) {
+    std::unordered_set<std::string> reads;
+    for (std::size_t i = 0; i < value_block.exprs.size(); ++i) {
+      const auto& data =
+          value_block.exprs.Get(mir::ExprId{static_cast<std::uint32_t>(i)})
+              .data;
+      if (const auto* ref = std::get_if<mir::ExternalUnitVariableRef>(&data);
+          ref != nullptr && ref->unit_name != unit.name) {
+        reads.insert(ref->unit_name);
+      }
+    }
+    unit.direct_initializer_package_reads.assign(reads.begin(), reads.end());
+    std::ranges::sort(unit.direct_initializer_package_reads);
+    unit.callables.Add(
+        mir::CallableDecl{
+            .name = std::string{kPackageInitializeCallableName},
+            .impl = mir::InternalCallable{.code = std::move(value_code)},
+            .virtual_dispatch = std::nullopt,
+            .visibility = mir::CallableVisibility::kInternal});
+  }
+  return {};
+}
+
+}  // namespace
 
 auto UnitLowerer::PopulateTypesAndClasses() -> diag::Result<void> {
   unit_.name = hir_->name;
@@ -73,6 +217,16 @@ auto UnitLowerer::PopulateTypesAndClasses() -> diag::Result<void> {
 }
 
 auto UnitLowerer::RunModule() -> diag::Result<mir::CompilationUnit> {
+  return LowerModuleUnit({});
+}
+
+auto UnitLowerer::RunDesignRoot(PackageInitializationPlan package_init_plan)
+    -> diag::Result<mir::CompilationUnit> {
+  return LowerModuleUnit(std::move(package_init_plan));
+}
+
+auto UnitLowerer::LowerModuleUnit(PackageInitializationPlan package_init_plan)
+    -> diag::Result<mir::CompilationUnit> {
   WalkFrame root_frame;
   if (auto prologue = PopulateTypesAndClasses(); !prologue) {
     return std::unexpected(std::move(prologue.error()));
@@ -80,8 +234,11 @@ auto UnitLowerer::RunModule() -> diag::Result<mir::CompilationUnit> {
 
   // Two-sweep structural lowering: the first sweep mints every class identity
   // and publishes its shape; the second lowers every body and commits the
-  // composed class to the unit.
-  StructuralScopeLowerer root(*this, nullptr, hir_->name, hir_->root_scope);
+  // composed class to the unit. The design root's package initialization plan
+  // rides on the root scope's lowering and is empty for a source module.
+  StructuralScopeLowerer root(
+      *this, nullptr, hir_->name, hir_->root_scope,
+      std::move(package_init_plan));
   auto top_r = root.DeclareShape();
   if (!top_r) return std::unexpected(std::move(top_r.error()));
   auto body_r = root.PopulateBodies(root_frame);
@@ -96,13 +253,14 @@ auto UnitLowerer::RunPackage() -> diag::Result<mir::CompilationUnit> {
     return std::unexpected(std::move(prologue.error()));
   }
 
-  // A package's root scope holds no processes, no structural data, and no
-  // instances -- only its functions and tasks (LRM 26.2). Each lowers to a
-  // receiver-less callable owned by the unit's namespace, so a package produces
-  // no root class and never enters the structural-scope body machinery.
-  // A package function reaches no static storage and no enclosing scope, so it
-  // lowers against an empty storage plan and no enclosing-scope lowerer. The
-  // frame has no owner class, so the produced body carries no `self`.
+  // A package's root scope holds no processes and no instances -- only its
+  // variables, functions, and tasks (LRM 26.2). Each function and task lowers
+  // to a receiver-less callable, and each variable to unit-level static
+  // storage, so a package produces no root class and never enters the
+  // structural-scope body machinery. A package function reaches no static
+  // storage and no enclosing scope, so it lowers against an empty storage plan
+  // and no enclosing-scope lowerer. The frame has no owner class, so the
+  // produced body carries no `self`.
   const CallableStoragePlan empty_storage_plan;
   const hir::StructuralScope& scope = hir_->root_scope;
 
@@ -138,6 +296,10 @@ auto UnitLowerer::RunPackage() -> diag::Result<mir::CompilationUnit> {
             .impl = mir::InternalCallable{.code = *std::move(code_or)},
             .virtual_dispatch = std::nullopt,
             .visibility = mir::CallableVisibility::kInternal});
+  }
+
+  if (auto vars = PopulatePackageStaticVariables(*this, scope); !vars) {
+    return std::unexpected(std::move(vars.error()));
   }
 
   unit_.root = std::nullopt;

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -736,6 +736,11 @@ class MirDumper {
                   "StaticPropertyRef owner=Class[{}] prop=StaticProperty[{}]",
                   r.owner.value, r.prop.value);
             },
+            [](const ExternalUnitVariableRef& r) -> std::string {
+              return std::format(
+                  "ExternalUnitVariableRef unit={} variable={}", r.unit_name,
+                  r.variable_name);
+            },
             [](const ClosureExpr& cl) -> std::string {
               return std::format(
                   "ClosureExpr closure=Closure[{}] field_inits={}",

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <variant>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::mir {
@@ -155,6 +156,67 @@ auto TypeInterner::Intern(TypeData data) -> TypeId {
   const TypeId id = storage_.Add(Type{.data = data});
   index_.emplace(std::move(data), id);
   return id;
+}
+
+auto TypeInterner::ObservableCellOf(TypeId value_type) -> TypeId {
+  // Exhaustive over TypeKind with no default: a MIR type added later fails to
+  // compile here until it is classified, rather than silently defaulting to
+  // non-observable -- which would leave a new value type's writes firing no
+  // subscribers, a bug no test would obviously catch.
+  switch (Get(value_type).Kind()) {
+    // A SystemVerilog value-storage data object (LRM 6.5): a variable of one of
+    // these is an observable signal, so it is wrapped in the cell that fires
+    // subscribers on change.
+    case TypeKind::kPackedArray:
+    case TypeKind::kEnum:
+    case TypeKind::kUnpackedArray:
+    case TypeKind::kDynamicArray:
+    case TypeKind::kQueue:
+    case TypeKind::kAssociativeArray:
+    case TypeKind::kString:
+    case TypeKind::kReal:
+    case TypeKind::kShortReal:
+    case TypeKind::kRealTime:
+    case TypeKind::kTuple:
+    case TypeKind::kUnion:
+      return Intern(ObservableType{.value = value_type});
+    // Not value storage, so its own declaration shape is its storage and it is
+    // not wrapped: a handle or container (pointer, managed / borrowed
+    // reference, vector, chandle), an object (a class instance or an
+    // instantiated child), a named event (LRM 15 -- it carries its own
+    // subscribe mechanism), a runtime facade (services, files, diagnostics, a
+    // runtime-library type), a coroutine result, a machine primitive (a machine
+    // int / float / C string used at an ABI boundary), a compiler-generated
+    // promoted scope struct or closure, an internal index, `void`, and the
+    // observable / net-cell wrappers themselves, which are already storage
+    // cells.
+    case TypeKind::kWildcardIndex:
+    case TypeKind::kMachineCString:
+    case TypeKind::kMachineInt:
+    case TypeKind::kMachineFloat:
+    case TypeKind::kEvent:
+    case TypeKind::kChandle:
+    case TypeKind::kVoid:
+    case TypeKind::kObject:
+    case TypeKind::kExternalUnitObject:
+    case TypeKind::kExternalClass:
+    case TypeKind::kServices:
+    case TypeKind::kFiles:
+    case TypeKind::kDiagnostic:
+    case TypeKind::kRuntimeLibrary:
+    case TypeKind::kCoroutine:
+    case TypeKind::kReference:
+    case TypeKind::kPointer:
+    case TypeKind::kManagedRef:
+    case TypeKind::kVector:
+    case TypeKind::kObservable:
+    case TypeKind::kResolved:
+    case TypeKind::kDriver:
+    case TypeKind::kStruct:
+    case TypeKind::kClosure:
+      return value_type;
+  }
+  throw InternalError("TypeInterner::ObservableCellOf: unhandled TypeKind");
 }
 
 }  // namespace lyra::mir

--- a/tests/cases/cpp/package_variables/case.yaml
+++ b/tests/cases/cpp/package_variables/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.package_variables
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    init_read: 5
+    fn_read: 10
+    after_write: 7
+    mirror: 8

--- a/tests/cases/cpp/package_variables/main.sv
+++ b/tests/cases/cpp/package_variables/main.sv
@@ -1,0 +1,34 @@
+// A package variable (LRM 26.2): static storage the package namespace owns, one
+// program-global cell shared across the design, read and written from another
+// unit by name. It is initialized once at time zero (LRM 10.5) before any top
+// module initializes, so a cross-unit read sees the initialized value. The same
+// by-name cell serves a read, a write, a package function reading it, and a
+// process waking on its change.
+package pkg;
+  int cnt = 5;
+
+  function automatic int doubled();
+    return cnt * 2;
+  endfunction
+endpackage
+
+module Top;
+  // Cross-unit read of the initialized value.
+  int init_read;
+  // Intra-package read: a package function reads the package variable.
+  int fn_read;
+  // Cross-unit write, then read back.
+  int after_write;
+  // Observation: this process wakes when the package variable changes.
+  int mirror = 0;
+
+  always @(pkg::cnt) mirror = pkg::cnt + 1;
+
+  initial begin
+    init_read = pkg::cnt;
+    fn_read = pkg::doubled();
+    pkg::cnt = 7;
+    #1;
+    after_write = pkg::cnt;
+  end
+endmodule

--- a/tests/cases/cpp/package_variables_cross_init/case.yaml
+++ b/tests/cases/cpp/package_variables_cross_init/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.package_variables_cross_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    got: 11

--- a/tests/cases/cpp/package_variables_cross_init/main.sv
+++ b/tests/cases/cpp/package_variables_cross_init/main.sv
@@ -1,0 +1,18 @@
+// A package variable initializer that reads another package's variable (LRM
+// 26.2 / 10.5): the design root must initialize the read package first so the
+// dependent package's initializer observes an initialized cell. The dependency
+// is a cross-unit reference the referring package records, and the root orders
+// its initializer calls by it, regardless of the order the packages are declared
+// or lowered in.
+package pb;
+  int b = 10;
+endpackage
+
+package pa;
+  int a = pb::b + 1;
+endpackage
+
+module Top;
+  int got;
+  initial got = pa::a;
+endmodule

--- a/tests/cases/errors/package_variable_write_from_subroutine/case.yaml
+++ b/tests/cases/errors/package_variable_write_from_subroutine/case.yaml
@@ -1,0 +1,16 @@
+id: errors.package_variable_write_from_subroutine
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "writing a package variable from a package subroutine is not yet supported"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/package_variable_write_from_subroutine/main.sv
+++ b/tests/cases/errors/package_variable_write_from_subroutine/main.sv
@@ -1,0 +1,17 @@
+// Writing a package variable from a package subroutine is not yet supported: the
+// write fires subscribers, which needs the runtime services, and a receiver-less
+// callable (LRM 26.3) has no `self` to reach them through. Reading a package
+// variable from a subroutine works; writing awaits threading the services into a
+// receiver-less callable. The declaration is well-formed, so the diagnostic
+// comes from lowering, not the frontend.
+package pkg;
+  int cnt = 0;
+
+  function automatic void bump();
+    cnt = cnt + 1;
+  endfunction
+endpackage
+
+module Top;
+  initial pkg::bump();
+endmodule


### PR DESCRIPTION
## Summary

Adds SystemVerilog package variables (LRM 26.2): static storage a package namespace owns -- one program-global cell, shared, not a member of any instance -- declared with an initializer, initialized once at time zero before the top modules run, and read and written from another unit by name, including waking a process on its change. A package variable is reached uniformly by name (`pkg::var`) whether the referrer is another unit or the package's own function, since neither has a receiver, so read, write, and change observation all share one reference form. The one remaining gap is a package subroutine writing a package variable, which is rejected with a diagnostic rather than mis-emitted.

## Design

### Two-phase time-zero initialization

Package variable initialization (LRM 10.5) runs in two design-wide passes driven by the design root before the top modules initialize. First every package's cells are installed with their declared type and default; only then does every package's value initializer run. This install-all-first order is a correctness invariant, not a fallback: an initializer that reads another package's variable always reaches installed storage, at worst a default. The LRM leaves the relative order of initializers unspecified, so within the value pass the design root picks a stable, best-effort order -- a dependency before its dependent where a direct read makes it known -- and an unknown or cyclic dependency degrades to reading a default, never a crash.

### Compile pipeline shape

`Compile` is expressed as three visible steps that keep per-unit compilation independent: lower the whole compilation to a flat set of self-contained HIR units, lower each unit down its own vertical (HIR -> MIR -> LIR) reading only itself, then link the units into the design. The design-link step is the one whole-design action -- it synthesizes the design root and resolves the package-initialization plan by reading across units' interfaces, never their bodies. A package lowers to MIR (a namespace a backend emits as its own artifact) but has no executable body, so it never joins the LIR path.

### What did not change

A package variable reuses the same observable-cell storage and by-name cross-unit reference the existing package function call established; there is no package-specific singleton object and no second reference species. Reading, writing, and waking on a package variable's change all reach the one linked cell directly, with no route and no runtime SDK step, because a package has no instance identity to resolve.