### PR TITLE
Support cross-unit class ownership (LRM 8)

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -133,6 +133,10 @@ the detail lives in the entry itself.
   and sensitivity extraction; Lyra translates resolved facts to executable route and endpoint
   capability; sensitivity uses the correct per-consumer slang surface and never reclassifies from
   `ValueSymbol + global table + HopsTo`.
+- [cross-unit-class-translation](cross-unit-class-translation.md) -- AST-to-HIR splits class
+  interning into a top-down `InternLocalClass` (never asks "which CU?") and a boundary
+  `ResolveClassRef` (walks slang's parent chain only when a class is not already cached);
+  design-wide precomputed maps and single-conflated interning are rejected.
 - [generated-behavior-boundary](generated-behavior-boundary.md) -- generated behavior reaches the
   runtime through an explicit, backend-neutral per-specialization unit definition (native lifecycle
   entries + a method dispatch table + constant metadata), not a backend-language object ABI; the C++

--- a/docs/decisions/cross-unit-class-translation.md
+++ b/docs/decisions/cross-unit-class-translation.md
@@ -1,0 +1,124 @@
+# Cross-Unit Class Translation
+
+## Date
+
+2026-07-18
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+Lyra treats each package, module, and interface as an independent compilation unit. Slang's frontend
+elaborates the entire design into a single tree with global symbol identity -- every
+`slang::ClassType*` is a global pointer, and compilation-unit boundaries are implicit, visible only
+by walking `getParentScope()` chains. AST-to-HIR must reverse slang's global elaboration back into
+per-CU HIR structures: a class this unit declares gets a compiler-owned local id, and a class
+another unit declares gets a by-name reference. This entry pins how the AST-to-HIR class-reference
+translator is structured, so the tension between slang's global identity and Lyra's per-CU model
+resolves the same way at every future call site.
+
+## The tension this addresses
+
+Two forces conflict at AST-to-HIR when a class reference lands:
+
+- **Top-down build discipline** (the codebase's dominant pattern): a lowering pass starts at its
+  CU's root scope, walks down, mints identities as it descends. At any point during the walk "which
+  CU am I in" is the walk's origin -- never queried.
+
+- **Slang's global elaboration**: hands us `slang::ClassType*` pointers with no direct "declaring
+  CU" accessor. To classify a class as local or external, some code must walk the class's parent
+  chain until hitting a `Package` or `InstanceBody` symbol, then compare to this unit's own scope.
+
+These conflict at the site where a class-reference expression sees a class pointer for the first
+time: the walk-up "who am I from?" is a bottom-up query on slang's tree, not a top-down descent on
+our own. Prior to this entry, a single `UnitLowerer::InternClass` function conflated both concerns
+-- every intern call ran the parent-chain walk, whether the class was our own (walk redundant,
+context already guaranteed local) or external (walk needed). Readers of a call site could not tell
+which use case the function was serving, and the pre-pass that walks our own scope re-derived
+information the walk-context already carried.
+
+## The decision
+
+### D1. The AST-to-HIR translator splits into two functions with disjoint concerns
+
+- `InternLocalClass(cls)` -- **the top-down builder**. Called only from the pre-pass that walks this
+  unit's own scope, and (indirectly, via `ResolveClassRef`) from a same-unit base link. Mints a
+  `ClassId` in the unit's own class registry and populates the shape. **Never asks "which CU?"**
+  because the caller's context guarantees local ownership.
+
+- `ResolveClassRef(cls)` -- **the boundary translator**. Called from every expression site that
+  names a class through a slang pointer, and from a class body's recursive base link. Cache lookup
+  first: a class the pre-pass already interned resolves in O(1). On a cache miss, walks
+  `cls.getParentScope()` up to a `Package` or `InstanceBody` to derive the declaring CU. If the
+  declaring CU is this unit (a case the pre-pass did not cover -- for instance, a class nested
+  inside a generate block), routes to `InternLocalClass` to mint it locally. If the declaring CU is
+  a different unit, produces an `ExternalClassRef` naming the declaring unit and the class's
+  canonical (specialization) name.
+
+The class cache stores the full `slang::ClassType* -> hir::ClassRef` classification, not just local
+ids, so a second reference to the same class re-uses the classification without re-walking.
+
+### D2. The walk lives in exactly one function, whose name states its role
+
+`ResolveClassRef` is the sole location where AST-to-HIR walks the slang parent chain to answer
+"which CU declares this class?". This concentrates the slang / Lyra CU-model impedance into one
+visible boundary translator: readers understand that walking is the mechanism for crossing the
+boundary, not a pattern scattered through the lowering. The pre-pass and the top-down mint path are
+**structurally walk-free** -- the function names say so. The codebase's top-down build discipline is
+now visible in code shape, not just in individual call-site comments.
+
+## Rejected alternatives
+
+- **Single conflated `InternClass` (the prior shape).** One function that walks and either mints or
+  classifies as external, distinguished by comparing the walk result to `scope_`. Concerns are
+  entangled: the pre-pass runs the walk redundantly for every own class (walk is redundant, we know
+  it's local), and readers cannot tell which use case the function is serving at a given call site.
+  Rejected in favor of role-named separation.
+
+- **Design-wide precomputed `slang::ClassType* -> CU_Name` map, populated at compilation setup.**
+  Moves the walk to a driver-owned pre-pass so `InternClass` is O(1) lookup, walk-free at the
+  lowering pass. Rejected because it violates `identity_and_ownership.md` ("A central registry or
+  driver-owned map that holds the authoritative relationship between two architectural entities")
+  and `compilation_unit_model.md` invariant 8 (units share no identifier space and exchange no
+  internal state). Even though the map's key is slang-side, not Lyra identity, it introduces a
+  design-wide shared table where independent per-CU compilation was the target. The walk is not
+  eliminated -- only relocated -- and the architectural cost is real.
+
+- **Threading source-syntax `pkg::` scope information from parse time**, avoiding the walk by
+  carrying the source qualifier as a HIR-visible fact. Rejected as brittle: an unqualified reference
+  through `import pkg::*;` has no source qualifier at the reference site, so the walk-up fallback is
+  unavoidable anyway. Two mechanisms for one classification job.
+
+## Consequences
+
+- Cross-unit-class classification decisions are made in exactly one place (`ResolveClassRef`).
+- The pre-pass (`InternOwnClassDeclarations`) is textually walk-free -- every own class is minted
+  via `InternLocalClass`, which trusts context.
+- The class cache stores the full classification, not just local ids, so an external reference walks
+  the slang tree at most once per unit and thereafter is O(1).
+- Recursive base-class references from `InternLocalClass` route through `ResolveClassRef`, correctly
+  handling `Derived extends pkg::Base` where the base is external.
+- A class textually local to this unit but not caught by the pre-pass (e.g. nested inside a generate
+  block) is minted lazily by `ResolveClassRef` at first reference, funnelling through
+  `InternLocalClass` -- both routes converge on the same minting operation.
+
+## Relation to existing decisions
+
+- `front-end-semantic-boundary.md` D1 -- "slang owns semantic resolution; Lyra owns translation."
+  This entry names the class-side companion to the reference-side translator that decision records:
+  both are boundary translators using slang's already-resolved structural facts, never re-deriving
+  from degraded information.
+- `declarations-before-bodies.md` -- the pre-pass is the CU-level analogue of the
+  "mint-all-identities-before-bodies-lower" discipline applied to class declarations.
+  `InternLocalClass` is the operation that mints; `ResolveClassRef` is what body lowerings and
+  mutually-recursive base links use to reach peers.
+- `object-model-storage.md` -- the class registry this decision populates is the same "one canonical
+  registry of local nominal object declarations" that decision owns.
+- `hir.md` invariant 2 -- this entry names the mechanism by which HIR's Local / External `ClassRef`
+  arms are produced at AST-to-HIR.
+- `specialization-identity.md` -- the canonical class name a cross-unit reference names is the
+  specialization name that decision owns; the producer (the declaring unit) and the consumer (the
+  referring unit's `ResolveClassRef`) compute the same name from the same bindings with no shared
+  table.

--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -106,12 +106,11 @@ each stage establishes, not how.
       identity mechanism a parameterized module uses -- generic-def name plus a canonical content
       encoding of the bindings.
 
-- [ ] Cross-unit class ownership: a class is owned by the compilation unit that declares it, and a
+- [x] Cross-unit class ownership: a class is owned by the compilation unit that declares it, and a
       reference from another unit reaches it by name -- the same by-name resolution package
-      callables already use. The class-copied-into-each-referring-unit shape (which today duplicates
-      a package class into every unit that names it) is out. This is what lets LRM 8.25's
-      package-scope rule -- matching specializations of a package generic class are one type
-      throughout the system -- hold across compilation units, and it applies uniformly to
+      callables already use. The class-copied-into-each-referring-unit shape is out. This is what
+      lets LRM 8.25's package-scope rule -- matching specializations of a package generic class are
+      one type throughout the system -- hold across compilation units, and it applies uniformly to
       non-parameterized and parameterized classes.
 
 - [x] Type-associated static storage and static methods (LRM 8.9 / 8.10): a static property is one

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "lyra/base/arena.hpp"
-#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/field_id.hpp"
 #include "lyra/hir/method_id.hpp"
@@ -119,7 +119,7 @@ struct BaseCall {
 // its type's Table 7-1 default and does not appear here.
 struct ClassDecl {
   std::string name;
-  std::optional<ClassId> base;
+  std::optional<ClassRef> base;
   base::Arena<ClassField, FieldId> fields;
   base::Arena<ClassStaticProperty, StaticPropertyId> static_properties;
   base::Arena<SubroutineDecl, MethodId> methods;

--- a/include/lyra/hir/class_ref.hpp
+++ b/include/lyra/hir/class_ref.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/field_id.hpp"
+#include "lyra/hir/method_id.hpp"
+#include "lyra/hir/static_property_id.hpp"
+
+namespace lyra::hir {
+
+// A reference to a class declared by this compilation unit. Named by its
+// canonical local identity; the unit's class registry resolves the id to the
+// declaration.
+struct LocalClassRef {
+  ClassId class_id;
+
+  auto operator==(const LocalClassRef&) const -> bool = default;
+};
+
+// A reference to a class declared by another compilation unit. Named by the
+// declaring unit's name and the class's canonical name (the specialization
+// name for a parameterized class, the bare name otherwise). The producer (the
+// unit naming itself) and every consumer (a referring unit naming a class it
+// reaches) compute the same canonical class name from the same bindings by
+// the same deterministic function, so a cross-unit reference matches by name
+// with no shared table.
+struct ExternalClassRef {
+  std::string unit_name;
+  std::string class_name;
+
+  auto operator==(const ExternalClassRef&) const -> bool = default;
+};
+
+// A reference naming a class from a use site: a base's target, a `new`'s
+// target, a receiver's declared class, an override's declaring class.
+// Intra-unit identity is a compiler-owned id; cross-unit identity is a
+// by-name reference resolved against another unit's interface at link time.
+// The two never share a key space.
+using ClassRef = std::variant<LocalClassRef, ExternalClassRef>;
+
+// A reference to a class property (LRM 8.4) at an access site: the class
+// arena the property is declared in, and the slot within that arena. Owner
+// is the declaring class, not the receiver's class; the two coincide when
+// the receiver's class declares the property itself and diverge when the
+// property is inherited from a base.
+struct LocalClassPropertyTarget {
+  ClassId owner;
+  FieldId field;
+
+  auto operator==(const LocalClassPropertyTarget&) const -> bool = default;
+};
+
+// A reference to a class property (LRM 8.4) declared by another compilation
+// unit: the declaring unit, the class's canonical name, and the property's
+// source name. The declaring unit's arena position is not visible here, so
+// the property is named directly.
+struct ExternalClassPropertyTarget {
+  std::string unit_name;
+  std::string class_name;
+  std::string property_name;
+
+  auto operator==(const ExternalClassPropertyTarget&) const -> bool = default;
+};
+
+using ClassPropertyTarget =
+    std::variant<LocalClassPropertyTarget, ExternalClassPropertyTarget>;
+
+// A reference to a class static property (LRM 8.9) at an access site: the
+// declaring class and the slot within its static-property arena. Owner-
+// qualified because the type-associated cell belongs to the declaring class
+// even when the source reached it through a derived name.
+struct LocalStaticPropertyTarget {
+  ClassId owner;
+  StaticPropertyId prop;
+
+  auto operator==(const LocalStaticPropertyTarget&) const -> bool = default;
+};
+
+// A reference to a class static property (LRM 8.9) declared by another
+// compilation unit: the declaring unit, the class's canonical name, and the
+// property's source name.
+struct ExternalStaticPropertyTarget {
+  std::string unit_name;
+  std::string class_name;
+  std::string property_name;
+
+  auto operator==(const ExternalStaticPropertyTarget&) const -> bool = default;
+};
+
+using StaticPropertyTarget =
+    std::variant<LocalStaticPropertyTarget, ExternalStaticPropertyTarget>;
+
+// A reference to a class method (LRM 8.6 / 8.10) at an access site: the
+// declaring class arena and the method slot within it. The declaring class
+// is the owner, not the receiver's class.
+struct LocalClassMethodTarget {
+  ClassId owner;
+  MethodId method;
+
+  auto operator==(const LocalClassMethodTarget&) const -> bool = default;
+};
+
+// A reference to a class method (LRM 8.6 / 8.10) declared by another
+// compilation unit: the declaring unit, the class's canonical name, and the
+// method's source name.
+struct ExternalClassMethodTarget {
+  std::string unit_name;
+  std::string class_name;
+  std::string method_name;
+
+  auto operator==(const ExternalClassMethodTarget&) const -> bool = default;
+};
+
+using ClassMethodTarget =
+    std::variant<LocalClassMethodTarget, ExternalClassMethodTarget>;
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -8,7 +8,7 @@
 
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/binary_op.hpp"
-#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/field_id.hpp"
@@ -127,16 +127,15 @@ struct MemberAccessExpr {
   FieldId field_index;
 };
 
-// Class property access (LRM 8.4 / 8.13): `owner` names the class that
-// declares the property, and `field_index` is the slot within that class's
-// property arena. Under inheritance, the receiver's runtime class may not be
-// the declaring class -- the receiver reaches the object through a handle to
-// a class that extends `owner` -- so identity is owner-qualified rather than
-// derived from the receiver's type.
+// Class property access (LRM 8.4 / 8.13): `target` names the declaring
+// class and the slot within that class's property arena. Owner-qualified
+// because under inheritance the receiver's runtime class may not be the
+// declaring class -- the receiver reaches the object through a handle to a
+// class that extends the property owner. The external arm is used when the
+// declaring class lives in another compilation unit.
 struct ClassPropertyAccessExpr {
   ExprId base_value;
-  ClassId owner;
-  FieldId field_index;
+  ClassPropertyTarget target;
 };
 
 struct ConcatExpr {
@@ -186,11 +185,13 @@ struct DynamicArrayNewExpr {
 };
 
 // LRM 8.5 class object construction `new`. Allocates a new object of the named
-// class and runs its constructor, yielding a handle. The class is named by its
-// declaration id; `Expr::type` is the class handle type. `arguments` are the
+// class and runs its constructor, yielding a handle. The class is named by a
+// `ClassRef`: a local id when the class is declared by this unit, or a by-name
+// reference against another unit's interface when the class is declared
+// elsewhere. `Expr::type` is the class handle type. `arguments` are the
 // constructor actuals (LRM 8.7), empty for the default `new`.
 struct ClassNewExpr {
-  ClassId class_id;
+  ClassRef class_ref;
   std::vector<ExprId> arguments;
 };
 

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -5,8 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "lyra/hir/class_id.hpp"
-#include "lyra/hir/method_id.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -44,18 +43,6 @@ struct SubroutineParam {
   return direction == ParamDirection::kOutput ||
          direction == ParamDirection::kInOut;
 }
-
-// The declaration identity of a class instance method in HIR: a
-// (class, method) pair naming one entry in the owning class's method arena.
-// A frontend symbol translates to this identity at the AST-to-HIR boundary;
-// downstream consumers hold it as-is and never re-derive it from another
-// enumeration order.
-struct MethodRef {
-  ClassId class_id;
-  MethodId method;
-
-  auto operator==(const MethodRef&) const -> bool = default;
-};
 
 // LRM 13.4.1 implicit result variable: a non-void function implicitly declares
 // a body-local variable of the return type that the body reads and writes
@@ -96,7 +83,7 @@ struct SubroutineDecl {
   bool is_virtual = false;
   bool is_prototype = false;
   bool is_static = false;
-  std::optional<MethodRef> overrides;
+  std::optional<ClassMethodTarget> overrides;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -4,10 +4,9 @@
 #include <string>
 #include <variant>
 
-#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/foreign_import_id.hpp"
-#include "lyra/hir/method_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/subroutine_id.hpp"
 #include "lyra/support/builtin_fn.hpp"
@@ -58,14 +57,14 @@ struct SuperReceiver {};
 using MethodReceiver =
     std::variant<HandleReceiver, ImplicitSelfReceiver, SuperReceiver>;
 
-// Calls an instance method (LRM 8.6). `class_id` names the declaring class
-// and `method` is the method's declaration-order position in that class's HIR
-// method arena. `receiver` states which of the three LRM-defined source
-// forms reached this call site.
+// Calls an instance method (LRM 8.6). `target` names the declaring class and
+// the method's declaration-order position in that class's method arena.
+// `receiver` states which of the three LRM-defined source forms reached this
+// call site. The external arm is used when the method's declaring class
+// lives in another compilation unit.
 struct MethodCallRef {
   MethodReceiver receiver;
-  ClassId class_id;
-  MethodId method;
+  ClassMethodTarget target;
 };
 
 // Calls a `$xxx` system subroutine. The id resolves through
@@ -105,14 +104,15 @@ struct ExternalUnitSubroutineRef {
 // Calls a static class method (LRM 8.10). Distinct from `MethodCallRef`
 // because a static method has no receiver -- neither an explicit handle, an
 // implicit self, nor a super qualifier -- and encoding it as a receiver-
-// optional variant of `MethodCallRef` would admit an invalid state. `owner`
-// names the class that declares the method; `method` is its position within
-// that class's method arena. Under inheritance, `Derived::inherited_static()`
-// still names the base as `owner` -- the method lives on the base's arena --
-// mirroring the owner-qualified rule for inherited instance access.
+// optional variant of `MethodCallRef` would admit an invalid state. `target`
+// names the declaring class and the method's declaration-order position in
+// that class's method arena. Under inheritance,
+// `Derived::inherited_static()` still names the base -- the method lives on
+// the base's arena -- mirroring the owner-qualified rule for inherited
+// instance access. The external arm is used when the declaring class lives
+// in another compilation unit.
 struct StaticMethodCallRef {
-  ClassId class_id;
-  MethodId method;
+  ClassMethodTarget target;
 };
 
 using SubroutineRef = std::variant<

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -6,7 +6,7 @@
 #include <variant>
 #include <vector>
 
-#include "lyra/hir/class_id.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/constant_value.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -207,10 +207,11 @@ struct VoidType {};
 
 // LRM 8.3 class handle: the type of a variable that refers to a class object.
 // Null is a legal value, the object is reached through the handle, and the
-// referenced class is named by its declaration id (resolved through the unit's
-// class registry).
+// referenced class is named by a `ClassRef`: a local declaration id when the
+// class is declared by this unit, or a by-name reference resolved against
+// another unit's interface when the class is declared elsewhere.
 struct ClassHandleType {
-  ClassId class_id;
+  ClassRef class_ref;
 };
 
 // LRM 8.3 class handle whose referenced class is an imported runtime-library

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -5,10 +5,8 @@
 #include <string>
 #include <variant>
 
-#include "lyra/hir/class_id.hpp"
-#include "lyra/hir/field_id.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/procedural_var.hpp"
-#include "lyra/hir/static_property_id.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/type_id.hpp"
 #include "lyra/hir/with_clause_id.hpp"
@@ -55,32 +53,30 @@ struct ProceduralVarRef {
 
 // A reference to a class property (LRM 8.4) from within an instance method
 // body, where the property is named without an explicit handle and reaches
-// the invoking object through the method's receiver. `owner` is the class
-// that declares the property, and `field_index` is its declaration-order
-// position within that class's property arena. Under inheritance (LRM 8.13)
-// a bare name may resolve to a property declared on an ancestor class, so
-// identity is owner-qualified rather than derived from the enclosing method
-// body's class.
+// the invoking object through the method's receiver. `target` names the
+// declaring class and the slot within its property arena. Owner-qualified
+// (not derived from the enclosing method body's class) because under
+// inheritance (LRM 8.13) a bare name may resolve to a property declared on
+// an ancestor class. The external arm is used when the property's declaring
+// class lives in another compilation unit.
 struct ClassPropertyRef {
-  ClassId owner;
-  FieldId field_index;
+  ClassPropertyTarget target;
 
   auto operator==(const ClassPropertyRef&) const -> bool = default;
 };
 
-// A reference to a class static property (LRM 8.9), the type-associated
-// storage counterpart to `ClassPropertyRef`. `owner` names the class that
-// declares the property; `prop` is its position within that class's
-// static-property arena. A static property is one cell owned by the type, not
-// a member replicated into each instance, so this reference carries no
-// receiver: the source form `Cls::prop`, an unqualified use inside a method
-// of the same class, and `p.prop` where the resolved target happens to be
-// static all resolve to the same cell and the same reference shape.
-// Under inheritance, `Derived::inherited_prop` still names the base class as
-// `owner` -- the property lives on the base's arena.
+// A reference to a class static property (LRM 8.9). `target` names the
+// declaring class and the slot within its static-property arena. A static
+// property is one cell owned by the type, not a member replicated into each
+// instance, so this reference carries no receiver: the source form
+// `Cls::prop`, an unqualified use inside a method of the same class, and
+// `p.prop` where the resolved target happens to be static all resolve to the
+// same cell and the same reference shape. Under inheritance,
+// `Derived::inherited_prop` still names the base class -- the property lives
+// on the base's arena. The external arm is used when the declaring class
+// lives in another compilation unit.
 struct StaticPropertyRef {
-  ClassId owner;
-  StaticPropertyId prop;
+  StaticPropertyTarget target;
 
   auto operator==(const StaticPropertyRef&) const -> bool = default;
 };

--- a/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
@@ -17,6 +17,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/frontend/slang_source_mapper.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/field_id.hpp"
@@ -160,12 +161,58 @@ class UnitLowerer {
   // no frontend type to key the cache on, so it is added directly.
   auto AddComposedType(hir::TypeData data) -> hir::TypeId;
 
-  // Registers a class declaration on first encounter and returns its id,
-  // memoizing by slang class pointer. The id is declared before the body is
-  // built so a property whose type names the same class (a self-reference)
-  // resolves against a stable identity.
-  auto InternClass(const slang::ast::ClassType& cls, diag::SourceSpan span)
+  // Mints a class of this unit into the unit's class registry: allocates the
+  // `ClassId`, populates the shape, and returns the id. The caller carries the
+  // proof that the class belongs to this unit -- the pre-pass walks this
+  // unit's own scope, and a same-unit base link resolves through the reference
+  // translator before flowing back here -- so no parent-chain query runs. A
+  // repeat call for the same class is idempotent: the cache entry the first
+  // mint installed returns without re-work, which admits mutual reference
+  // during body population.
+  auto InternLocalClass(const slang::ast::ClassType& cls, diag::SourceSpan span)
       -> diag::Result<hir::ClassId>;
+
+  // Translates a slang class pointer -- reached from an expression site or a
+  // base-class link -- into HIR's owner-qualified reference form. The result
+  // is a `LocalClassRef` when the class is declared by this unit, an
+  // `ExternalClassRef{unit_name, class_name}` when it is declared by another.
+  // Classification runs at most once per class per unit: the first encounter
+  // walks `cls.getParentScope()` up to the enclosing compilation unit and
+  // caches the answer; every later encounter reads it. A local class not yet
+  // interned is minted lazily on this path, so a body reads the same identity
+  // regardless of which route saw the class first. This is the sole
+  // AST-to-HIR site that walks slang's parent chain to answer "which CU
+  // declares this class?" -- the top-down mint path is walk-free by design.
+  auto ResolveClassRef(const slang::ast::ClassType& cls, diag::SourceSpan span)
+      -> diag::Result<hir::ClassRef>;
+
+  // Builds a class-method target from a class reference and the resolved
+  // callee symbol. Local when the class was interned by this unit -- the
+  // method's arena position is queryable through the `SubroutineSymbol`-keyed
+  // cache the interning populated. External when the class lives in another
+  // compilation unit -- the method is named by (declaring unit, class
+  // canonical name, method name), the same by-name form a cross-unit
+  // reference to any other class member uses.
+  [[nodiscard]] auto MakeClassMethodTarget(
+      const hir::ClassRef& class_ref,
+      const slang::ast::SubroutineSymbol& method) const
+      -> hir::ClassMethodTarget;
+
+  // The instance-property peer of `MakeClassMethodTarget`. Local when the
+  // class was interned by this unit; external when the class lives in another
+  // compilation unit, in which case the property is named by its source name.
+  [[nodiscard]] auto MakeClassPropertyTarget(
+      const hir::ClassRef& class_ref,
+      const slang::ast::ClassPropertySymbol& prop) const
+      -> hir::ClassPropertyTarget;
+
+  // The static-property peer of `MakeClassMethodTarget`. Local when the class
+  // was interned by this unit; external when the class lives in another
+  // compilation unit, in which case the property is named by its source name.
+  [[nodiscard]] auto MakeStaticPropertyTarget(
+      const hir::ClassRef& class_ref,
+      const slang::ast::ClassPropertySymbol& prop) const
+      -> hir::StaticPropertyTarget;
 
   // Records a frontend method symbol's HIR arena identity as the class
   // interning that owns it adds the method. Downstream consumers translate a
@@ -188,10 +235,10 @@ class UnitLowerer {
         "owning class was not interned before this lookup");
   }
 
-  // Records the HIR `FieldId` a class property received when its owning
-  // class's `InternClass` added it to the field arena. A downstream
-  // `handle.field` access reads the id in O(1) through this lookup instead
-  // of re-walking the property list at every reference site.
+  // Records the HIR `FieldId` a class property received when the owning
+  // class was minted. A downstream `handle.field` access reads the id in
+  // O(1) through this lookup instead of re-walking the property list at
+  // every reference site.
   void RegisterClassPropertyFieldId(
       const slang::ast::ClassPropertySymbol& prop, hir::FieldId id) {
     class_property_field_ids_.emplace(&prop, id);
@@ -208,11 +255,11 @@ class UnitLowerer {
         "id; the owning class was not interned before this lookup");
   }
 
-  // Peer of the field-id registry on the type-associated axis. Records the
-  // HIR `StaticPropertyId` a static class property (LRM 8.9) received when
-  // its owning class's `InternClass` added it to the static-property arena,
-  // so a downstream `Cls::prop` or `handle.prop` (static-lifetime) access
-  // reads the id in O(1) rather than re-walking the arena.
+  // Records the HIR `StaticPropertyId` a static class property (LRM 8.9)
+  // received when the owning class was minted, so a downstream `Cls::prop`
+  // or `handle.prop` (static-lifetime) access reads the id in O(1) rather
+  // than re-walking the arena. The type-associated storage counterpart to
+  // the instance-property registry above.
   void RegisterClassPropertyStaticId(
       const slang::ast::ClassPropertySymbol& prop, hir::StaticPropertyId id) {
     class_property_static_ids_.emplace(&prop, id);
@@ -307,6 +354,14 @@ class UnitLowerer {
   // it.
   [[nodiscard]] auto NextWithClauseId() -> hir::WithClauseId;
 
+  // Interns every class this unit declares -- a non-parameterized class as a
+  // single entry, and a parameterized class as one entry per live
+  // specialization slang deduplicated during elaboration. Runs before any
+  // body lowering so the unit's class registry is complete before any
+  // reference resolves; a specialization reached only from another unit
+  // still lands here, in its declaring unit.
+  auto InternOwnClassDeclarations() -> diag::Result<void>;
+
   // Builds a HIR Expr referring to a leaf reached by navigating `path` down
   // from `head`. `target` is the leaf value symbol (routed-ref dedup key);
   // `slot_owner_frame` is the frame whose `routed_refs` arena holds the slot
@@ -348,7 +403,13 @@ class UnitLowerer {
 
   // Registries.
   std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;
-  std::unordered_map<const slang::ast::ClassType*, hir::ClassId> class_cache_;
+  // The classification of every class this unit's lowering has resolved: the
+  // Local / External arm chosen by walking slang's parent chain to find the
+  // class's declaring compilation unit. Caching the classification -- not just
+  // the local id -- lets an external class's parent-chain walk run once per
+  // class per unit; a second reference to the same slang `ClassType` reads
+  // the answer, whether it is Local or External.
+  std::unordered_map<const slang::ast::ClassType*, hir::ClassRef> class_cache_;
   std::unordered_map<const slang::ast::SubroutineSymbol*, hir::MethodId>
       method_cache_;
   std::unordered_map<const slang::ast::ClassPropertySymbol*, hir::FieldId>

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -10,14 +10,18 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_manager.hpp"
+#include "lyra/hir/class_ref.hpp"
 #include "lyra/hir/compilation_unit.hpp"
 #include "lyra/hir/field_id.hpp"
 #include "lyra/hir/static_property_id.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/hir_to_mir/package_initialization.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
+#include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
 #include "lyra/mir/field.hpp"
 #include "lyra/mir/static_property_id.hpp"
 #include "lyra/mir/type.hpp"
@@ -162,6 +166,39 @@ class UnitLowerer {
         "UnitLowerer::ImportedRuntimeObjectType: unknown imported class");
   }
 
+  // Cross-unit reference builders. Each converts a HIR-level cross-unit
+  // reference into its MIR peer AND records the referenced unit's name on
+  // the unit's cross-unit dependency list in one operation, so a caller
+  // never touches the raw dependency-list mutators. The class-side builders
+  // below record on the class dependency list; the trailing callable
+  // builder records on the callable dependency list, since a package
+  // callable and a class member of another unit are two independent
+  // include axes for a backend.
+  auto MakeExternalClassPointee(const hir::ExternalClassRef& ref)
+      -> mir::TypeId;
+
+  auto MakeExternalClassBaseRef(const hir::ExternalClassRef& ref)
+      -> mir::ClassRef;
+
+  auto MakeExternalFieldTarget(const hir::ExternalClassPropertyTarget& target)
+      -> mir::ExternalFieldTarget;
+
+  auto MakeExternalStaticPropertyRef(
+      const hir::ExternalStaticPropertyTarget& target)
+      -> mir::ExternalStaticPropertyRef;
+
+  auto MakeExternalMethodTarget(const hir::ExternalClassMethodTarget& target)
+      -> mir::ExternalUnitClassMethodTarget;
+
+  auto MakeExternalMethodOverride(const hir::ExternalClassMethodTarget& target)
+      -> mir::OverridesExternalSlot;
+
+  // Receiver-less callable of another compilation unit (LRM 26.3 package
+  // function or task). Recorded on the callable dependency list, not the
+  // class one.
+  auto MakeExternalCallableTarget(const hir::ExternalUnitSubroutineRef& ref)
+      -> mir::ExternalUnitCallableTarget;
+
   // Mints a collision-free class name for one generate scope, tagged by its
   // arm kind (`loop` / `then` / `else` / ...). The name is only an
   // implementation handle for the emitted type -- a generate scope's runtime
@@ -222,7 +259,7 @@ class UnitLowerer {
   // whether the root scope becomes a top class or a set of namespace callables.
   auto PopulateTypesAndClasses() -> diag::Result<void>;
 
-  [[nodiscard]] auto TranslateTypeData(const hir::TypeData& data) const
+  [[nodiscard]] auto TranslateTypeData(const hir::TypeData& data)
       -> mir::TypeData;
 
   const hir::CompilationUnit* hir_;

--- a/include/lyra/mir/class_ref.hpp
+++ b/include/lyra/mir/class_ref.hpp
@@ -61,13 +61,31 @@ struct OverridesIntraUnitSlot {
   auto operator==(const OverridesIntraUnitSlot&) const -> bool = default;
 };
 
+// A method that overrides a virtual dispatch slot introduced by a class in
+// another compilation unit -- LRM 8.20 across the unit boundary. The slot's
+// canonical identity carries no unit-local ids: it names the declaring unit,
+// the introducing class's canonical name, and the introducing method's source
+// name. A virtual slot has no independent name of its own; its canonical
+// identity in a by-name world is the introducing method's source name.
+// A backend renders the override through the target language's own virtual-
+// override machinery -- the same shape as an intra-unit override -- reached
+// by including the declaring unit's header.
+struct OverridesExternalSlot {
+  std::string unit_name;
+  std::string class_name;
+  std::string method_name;
+
+  auto operator==(const OverridesExternalSlot&) const -> bool = default;
+};
+
 // A method's participation in the class-object dispatch table (LRM 8.20). A
 // non-participating method (a regular direct-only callable) carries no value
 // of this optional; a participating method carries the arm whose payload
 // names the slot's canonical identity: an introducer names itself, an
-// intra-unit override names the introducing (class, method) pair. A
-// consumer reads the slot's identity in one step.
-using VirtualDispatchRole =
-    std::variant<IntroducesVirtualSlot, OverridesIntraUnitSlot>;
+// intra-unit override names the introducing (class, method) pair, a
+// cross-unit override names the introducing (unit, class, method) name
+// triple. A consumer reads the slot's identity in one step.
+using VirtualDispatchRole = std::variant<
+    IntroducesVirtualSlot, OverridesIntraUnitSlot, OverridesExternalSlot>;
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -139,6 +139,14 @@ struct CompilationUnit {
   // to emit the include and link edge to each referenced unit. Recorded once
   // per distinct unit name.
   std::vector<std::string> external_referenced_units;
+  // Names of other compilation units this unit references a class of (LRM 8,
+  // as a handle type, a `new` target, a field / method / static access, or a
+  // super-extended base). A backend reads this list -- a separate axis from
+  // `external_referenced_units`, because a package callable / variable and a
+  // class member of another unit are independent include edges -- to emit the
+  // include and link edge to each referenced unit. Recorded once per distinct
+  // unit name.
+  std::vector<std::string> external_class_units;
   // The packages whose variables this package's variable initializers read
   // directly (LRM 26.2 / 10.5) -- the by-name dependency the design root uses
   // to pick a stable value-initialization order. It records only reads written
@@ -273,6 +281,18 @@ struct CompilationUnit {
       }
     }
     external_referenced_units.push_back(std::move(unit_name));
+  }
+
+  // Records a cross-unit class-reference dependency, deduplicated. Called
+  // from HIR-to-MIR when a class handle type, a `new`, a field / method /
+  // static access, or a base extension names a class of another unit.
+  void AddExternalClassUnit(std::string unit_name) {
+    for (const std::string& existing : external_class_units) {
+      if (existing == unit_name) {
+        return;
+      }
+    }
+    external_class_units.push_back(std::move(unit_name));
   }
 
   // Backing-vector position is the id, matching TypeId / LocalId.

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -173,17 +173,35 @@ struct ExternalUnitCallableTarget {
   auto operator==(const ExternalUnitCallableTarget&) const -> bool = default;
 };
 
+// Identity of a class method declared by another compilation unit -- an
+// instance method or a static method (LRM 8.6 / 8.10) on a class the referring
+// unit reaches by name. The declaring class carries no unit-local id here, so
+// the target names the declaring unit, the class's canonical (specialization)
+// name, and the method's source name, resolved against that unit's interface
+// at link time. A backend renders a static call as the qualified
+// `unit::Class::method(args)` and an instance call as `receiver->method(args)`
+// after including the declaring unit's header.
+struct ExternalUnitClassMethodTarget {
+  std::string unit_name;
+  std::string class_name;
+  std::string method_name;
+
+  auto operator==(const ExternalUnitClassMethodTarget&) const -> bool = default;
+};
+
 // The target of a `Direct` call -- the symbol identity. The identity spaces: an
 // owner-qualified callable of this unit (`CallableTarget` -- an instance
 // method, a receiver-less static callable, or a DPI-C import, all one arena), a
 // built-in runtime entry (closed-namespace `BuiltinFn`), a method the runtime
 // library provides for an imported class (`ImportedRuntimeCallTarget`,
-// LRM 9.7), and a receiver-less callable of another compilation unit
-// (`ExternalUnitCallableTarget`, named across the unit boundary). None is
-// recovered from the receiver's runtime type.
+// LRM 9.7), a receiver-less callable of another compilation unit
+// (`ExternalUnitCallableTarget`, named across the unit boundary), and a class
+// method of another compilation unit
+// (`ExternalUnitClassMethodTarget`, class-qualified across the unit boundary).
+// None is recovered from the receiver's runtime type.
 using DirectTarget = std::variant<
     CallableTarget, support::BuiltinFn, ImportedRuntimeCallTarget,
-    ExternalUnitCallableTarget>;
+    ExternalUnitCallableTarget, ExternalUnitClassMethodTarget>;
 
 // A direct call to a named symbol. The single shape for every direct
 // invocation -- user method, built-in instance method, type-qualified
@@ -320,12 +338,31 @@ struct FieldTarget {
   auto operator==(const FieldTarget&) const -> bool = default;
 };
 
-// Which arena's field a `FieldAccessExpr` reaches. Two shapes because the
-// class case is the only one where "which arena" is a semantic decision:
+// Identity of a class field on a class declared by another compilation unit.
+// The declaring class carries no unit-local id here, so the field is named by
+// (declaring unit, class canonical name, field name). A backend reads the
+// field name and resolves the access through the target-language member
+// lookup, exactly as it resolves any other cross-unit reference.
+struct ExternalFieldTarget {
+  std::string unit_name;
+  std::string class_name;
+  std::string field_name;
+
+  auto operator==(const ExternalFieldTarget&) const -> bool = default;
+};
+
+// Which arena's field a `FieldAccessExpr` reaches. Three shapes because the
+// class case is where "which arena" is a semantic decision that also splits
+// on unit boundary:
 //
 // - `FieldTarget` (owner-qualified) is used when the receiver is a class
-//   instance. The receiver's runtime class type may not be the field's
-//   declaring class (inheritance), so the target states both.
+//   instance whose class this unit declares. The receiver's runtime class
+//   type may not be the field's declaring class (inheritance), so the target
+//   states both.
+//
+// - `ExternalFieldTarget` is used when the receiver's class lives in another
+//   compilation unit -- the declaring unit and class canonical name plus the
+//   field's source name, matched at link time.
 //
 // - Bare `FieldId` is used when the receiver is a struct value or a closure.
 //   These aggregates carry their arena identity in their own type payload
@@ -333,7 +370,7 @@ struct FieldTarget {
 //   in an inheritance chain, so the arena is uniquely determined by the
 //   receiver's type; stating it again would restate what the structural
 //   context already fixes.
-using FieldRef = std::variant<FieldTarget, FieldId>;
+using FieldRef = std::variant<FieldTarget, FieldId, ExternalFieldTarget>;
 
 // Field access through an explicit receiver expression. `receiver` evaluates to
 // a field-bearing value reached by pointer -- a class instance, a closure, or a
@@ -495,6 +532,17 @@ struct ExternalUnitVariableRef {
   std::string variable_name;
 };
 
+// A static property (LRM 8.9 / 8.10) declared on a class of another
+// compilation unit. Its owner has no unit-local id here; the property is
+// named by (declaring unit, class canonical name, property name). A backend
+// renders the access as the qualified `unit::Class::prop` after including
+// the declaring unit's header.
+struct ExternalStaticPropertyRef {
+  std::string unit_name;
+  std::string class_name;
+  std::string property_name;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     MachineIntLiteral, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
@@ -503,7 +551,7 @@ using ExprData = std::variant<
     StructConstructExpr, ClosureExpr, ConcatExpr, ReplicationExpr,
     ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr, UnionExpr,
     UnionGetExpr, UnionGetRefExpr, FunctionRef, StaticConstantRef,
-    StaticPropertyRef, ExternalUnitVariableRef>;
+    StaticPropertyRef, ExternalUnitVariableRef, ExternalStaticPropertyRef>;
 
 struct Expr {
   ExprData data;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -567,8 +567,11 @@ auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
   };
   // A unit an instance is built from names its unit through the child object's
   // `ExternalUnitObjectType`; a unit whose namespace symbol is reached by name
-  // names its unit in the reference-dependency list, since such a reference
-  // interns no such type. Both are external units this unit's artifact
+  // (a receiver-less callable or a package variable) names its unit in the
+  // reference-dependency list, since such a reference interns no such type;
+  // a unit a class is referenced from -- as a handle, a `new`, a field /
+  // method / static access, or a base extension -- names its unit in the
+  // class-dependency list. All three are external units this unit's artifact
   // includes.
   for (const auto& t : unit.types) {
     if (const auto* ext = std::get_if<mir::ExternalUnitObjectType>(&t.data)) {
@@ -576,6 +579,9 @@ auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
     }
   }
   for (const std::string& name : unit.external_referenced_units) {
+    add(name);
+  }
+  for (const std::string& name : unit.external_class_units) {
     add(name);
   }
   return names;
@@ -779,9 +785,10 @@ auto RenderNamespaceCallable(
 }
 
 // A unit whose root is a namespace rather than a class (a package): its C++
-// peer is a namespace holding the unit's type declarations and its
-// receiver-less callables. It owns no runtime object, so there is no scope-tree
-// construction.
+// peer is a namespace holding the unit's type declarations, class
+// declarations (LRM 8 classes declared at package scope), and its
+// receiver-less callables. It owns no runtime object, so there is no scope-
+// tree construction.
 auto RenderNamespaceUnitHeaderFile(const mir::CompilationUnit& unit)
     -> std::string {
   std::string out;
@@ -804,6 +811,17 @@ auto RenderNamespaceUnitHeaderFile(const mir::CompilationUnit& unit)
   if (unit.static_variables.size() != 0) {
     out += "\n";
   }
+
+  // A package class is a free-standing registry object with no structural
+  // parent; a referring unit reaches it by name through the include, so it
+  // must be emitted here. The dependency-order walker handles base-before-
+  // derived ordering.
+  std::vector<bool> emitted(unit.classes.size(), false);
+  for (std::size_t i = 0; i < unit.classes.size(); ++i) {
+    RenderClassInDependencyOrder(
+        unit, mir::ClassId{static_cast<std::uint32_t>(i)}, emitted, out);
+  }
+
   for (std::size_t i = 0; i < unit.callables.size(); ++i) {
     const auto& callable =
         unit.callables.Get(mir::CallableId{static_cast<std::uint32_t>(i)});

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -521,6 +521,37 @@ auto RenderDirectExternalUnitCall(const mir::ExternalUnitCallableTarget& target)
       .leading_arg_count = 0};
 }
 
+// Renders a `Direct` callee whose target is a class method of another
+// compilation unit (LRM 8.6 / 8.10 across the unit boundary). Instance
+// method: the receiver arrives as `arguments[0]` (a pointer to the object)
+// and the callee is `(receiver)->method`, so target-language name-lookup
+// resolves the method through the receiver's static type after the
+// declaring unit's header is included, and any virtual dispatch happens
+// through the target language's own vtable. Static method: no receiver in
+// the argument list, and the callee is the free qualified form
+// `unit::Class::method`. The two shapes are told apart by the receiver
+// argument -- an instance call always prepends a pointer-typed receiver.
+auto RenderDirectExternalUnitClassMethodCall(
+    const ScopeView& view, const mir::CallExpr& call,
+    const mir::ExternalUnitClassMethodTarget& target) -> CalleeRender {
+  const bool has_receiver_arg =
+      !call.arguments.empty() &&
+      std::holds_alternative<mir::PointerType>(
+          view.Unit().types.Get(view.Expr(call.arguments[0]).type).data);
+  if (!has_receiver_arg) {
+    return {
+        .expr = std::format(
+            "{}::{}::{}", ToCppName(target.unit_name),
+            ToCppName(target.class_name), target.method_name),
+        .leading_arg_count = 0};
+  }
+  return {
+      .expr = std::format(
+          "({})->{}", RenderExpr(view, view.Expr(call.arguments[0])),
+          target.method_name),
+      .leading_arg_count = 1};
+}
+
 // Renders a call to a method the runtime library provides for an imported class
 // (LRM 9.7 `process`). The callee is the runtime symbol named by the method
 // identity; every argument -- a receiver handle or the services handle -- is
@@ -552,6 +583,10 @@ auto RenderCalleePart(
                     },
                     [&](const mir::ExternalUnitCallableTarget& e) {
                       return RenderDirectExternalUnitCall(e);
+                    },
+                    [&](const mir::ExternalUnitClassMethodTarget& e) {
+                      return RenderDirectExternalUnitClassMethodCall(
+                          view, call, e);
                     },
                     [&](const mir::ImportedRuntimeCallTarget& i) {
                       return RenderDirectImportedRuntimeCall(i);

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -371,6 +371,13 @@ auto ResolveFieldAccess(const ScopeView& view, const mir::FieldAccessExpr& m)
             return FieldAccess{
                 .name = cls.fields.Get(t.slot).name, .through_receiver = true};
           },
+          [&](const mir::ExternalFieldTarget& t) -> FieldAccess {
+            // Cross-unit class field: the declaring unit's header pulls the
+            // field name into scope through the include; the receiver reaches
+            // it by its source name, which the target-language compiler
+            // resolves against the receiver's static type.
+            return FieldAccess{.name = t.field_name, .through_receiver = true};
+          },
           [&](const mir::FieldId& id) -> FieldAccess {
             const mir::TypeId recv_type = view.Expr(m.receiver).type;
             const auto& recv_data = view.Unit().types.Get(recv_type).data;
@@ -438,6 +445,11 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
           [&](const mir::ExternalUnitVariableRef& r) -> std::string {
             return std::format(
                 "{}::{}", ToCppName(r.unit_name), r.variable_name);
+          },
+          [&](const mir::ExternalStaticPropertyRef& r) -> std::string {
+            return std::format(
+                "{}::{}::{}", ToCppName(r.unit_name), ToCppName(r.class_name),
+                r.property_name);
           },
           // HIR-to-MIR lowers an LHS selector chain to write-form nodes -- a
           // container-access `CallExpr` with a write callee (per
@@ -916,6 +928,11 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
           [&](const mir::ExternalUnitVariableRef& r) -> std::string {
             return std::format(
                 "{}::{}", ToCppName(r.unit_name), r.variable_name);
+          },
+          [&](const mir::ExternalStaticPropertyRef& r) -> std::string {
+            return std::format(
+                "{}::{}::{}", ToCppName(r.unit_name), ToCppName(r.class_name),
+                r.property_name);
           },
           [&](const mir::ClosureExpr& cl) -> std::string {
             return RenderClosureExpr(view, cl);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -45,6 +45,63 @@ auto ForkJoinModeLabel(JoinMode mode) -> std::string_view {
   return "join";
 }
 
+auto FormatClassRef(const ClassRef& ref) -> std::string {
+  return std::visit(
+      Overloaded{
+          [](const LocalClassRef& r) -> std::string {
+            return std::format("Class[{}]", r.class_id.value);
+          },
+          [](const ExternalClassRef& r) -> std::string {
+            return std::format(
+                "Class[external={}::{}]", r.unit_name, r.class_name);
+          }},
+      ref);
+}
+
+auto FormatClassPropertyTarget(const ClassPropertyTarget& target)
+    -> std::string {
+  return std::visit(
+      Overloaded{
+          [](const LocalClassPropertyTarget& t) -> std::string {
+            return std::format("Class[{}].{}", t.owner.value, t.field.value);
+          },
+          [](const ExternalClassPropertyTarget& t) -> std::string {
+            return std::format(
+                "Class[external={}::{}].{}", t.unit_name, t.class_name,
+                t.property_name);
+          }},
+      target);
+}
+
+auto FormatStaticPropertyTarget(const StaticPropertyTarget& target)
+    -> std::string {
+  return std::visit(
+      Overloaded{
+          [](const LocalStaticPropertyTarget& t) -> std::string {
+            return std::format("Class[{}].{}", t.owner.value, t.prop.value);
+          },
+          [](const ExternalStaticPropertyTarget& t) -> std::string {
+            return std::format(
+                "Class[external={}::{}].{}", t.unit_name, t.class_name,
+                t.property_name);
+          }},
+      target);
+}
+
+auto FormatClassMethodTarget(const ClassMethodTarget& target) -> std::string {
+  return std::visit(
+      Overloaded{
+          [](const LocalClassMethodTarget& t) -> std::string {
+            return std::format("Class[{}].{}", t.owner.value, t.method.value);
+          },
+          [](const ExternalClassMethodTarget& t) -> std::string {
+            return std::format(
+                "Class[external={}::{}].{}", t.unit_name, t.class_name,
+                t.method_name);
+          }},
+      target);
+}
+
 class HirDumper {
  public:
   auto Dump(const std::vector<CompilationUnit>& units) -> std::string {
@@ -226,7 +283,7 @@ class HirDumper {
             [](const ChandleType&) -> std::string { return "ChandleType"; },
             [](const ClassHandleType& c) -> std::string {
               return std::format(
-                  "ClassHandleType(class=Class[{}])", c.class_id.value);
+                  "ClassHandleType(class={})", FormatClassRef(c.class_ref));
             },
             [](const ImportedClassHandleType& c) -> std::string {
               return std::format(
@@ -412,12 +469,11 @@ class HirDumper {
             },
             [](const ClassPropertyRef& r) -> std::string {
               return std::format(
-                  "ClassProperty[Class[{}].{}]", r.owner.value,
-                  r.field_index.value);
+                  "ClassProperty[{}]", FormatClassPropertyTarget(r.target));
             },
             [](const StaticPropertyRef& r) -> std::string {
               return std::format(
-                  "StaticProperty[Class[{}].{}]", r.owner.value, r.prop.value);
+                  "StaticProperty[{}]", FormatStaticPropertyTarget(r.target));
             },
             [](const RoutedRef& r) -> std::string {
               return std::format("RoutedRef[{}]", r.id.value);
@@ -577,13 +633,12 @@ class HirDumper {
                       }},
                   m.receiver);
               return std::format(
-                  "Method class=Class[{}] index={} recv={}", m.class_id.value,
-                  m.method.value, recv);
+                  "Method target={} recv={}", FormatClassMethodTarget(m.target),
+                  recv);
             },
             [](const StaticMethodCallRef& s) -> std::string {
               return std::format(
-                  "StaticMethod class=Class[{}] index={}", s.class_id.value,
-                  s.method.value);
+                  "StaticMethod target={}", FormatClassMethodTarget(s.target));
             },
             [](const SystemSubroutineRef& s) -> std::string {
               const auto& desc = support::LookupSystemSubroutine(s.id);
@@ -766,9 +821,8 @@ class HirDumper {
             },
             [](const ClassPropertyAccessExpr& sel) -> std::string {
               return std::format(
-                  "ClassPropertyAccessExpr base=Expr[{}] owner=Class[{}] "
-                  "field={}",
-                  sel.base_value.value, sel.owner.value, sel.field_index.value);
+                  "ClassPropertyAccessExpr base=Expr[{}] target={}",
+                  sel.base_value.value, FormatClassPropertyTarget(sel.target));
             },
             [](const ConcatExpr& c) -> std::string {
               std::string operands;
@@ -824,8 +878,8 @@ class HirDumper {
                 args += std::format("Expr[{}]", n.arguments[i].value);
               }
               return std::format(
-                  "ClassNewExpr class=Class[{}] args=[{}]", n.class_id.value,
-                  args);
+                  "ClassNewExpr class={} args=[{}]",
+                  FormatClassRef(n.class_ref), args);
             },
             [](const AssociativeAssignmentPatternExpr& a) -> std::string {
               std::string entries;
@@ -1033,9 +1087,8 @@ class HirDumper {
     if (d.is_virtual) flags += " virtual";
     if (d.is_prototype) flags += " prototype";
     if (d.overrides.has_value()) {
-      flags += std::format(
-          " overrides=Class[{}].Method[{}]", d.overrides->class_id.value,
-          d.overrides->method.value);
+      flags +=
+          std::format(" overrides={}", FormatClassMethodTarget(*d.overrides));
     }
     Line(
         std::format(

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -229,15 +229,16 @@ auto LowerNewClassExpr(
     }
   }
   const auto& cls = nc.type->getCanonicalType().as<slang::ast::ClassType>();
-  auto class_id = unit_lowerer.InternClass(cls, span);
-  if (!class_id) return std::unexpected(std::move(class_id.error()));
+  auto class_ref = unit_lowerer.ResolveClassRef(cls, span);
+  if (!class_ref) return std::unexpected(std::move(class_ref.error()));
   auto type_id = unit_lowerer.InternType(*nc.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
       .data =
           hir::ClassNewExpr{
-              .class_id = *class_id, .arguments = std::move(arguments)},
+              .class_ref = *std::move(class_ref),
+              .arguments = std::move(arguments)},
       .span = span,
   };
 }

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -595,8 +595,8 @@ auto LowerCallExpr(
     }
     const auto& declaring_class =
         sym->getParentScope()->asSymbol().as<slang::ast::ClassType>();
-    auto class_id = unit_lowerer.InternClass(declaring_class, span);
-    if (!class_id) return std::unexpected(std::move(class_id.error()));
+    auto class_ref = unit_lowerer.ResolveClassRef(declaring_class, span);
+    if (!class_ref) return std::unexpected(std::move(class_ref.error()));
     auto static_result_type = unit_lowerer.InternType(*call.type, span);
     if (!static_result_type) {
       return std::unexpected(std::move(static_result_type.error()));
@@ -607,8 +607,8 @@ auto LowerCallExpr(
             hir::CallExpr{
                 .callee =
                     hir::StaticMethodCallRef{
-                        .class_id = *class_id,
-                        .method = unit_lowerer.LookupMethodId(*sym)},
+                        .target = unit_lowerer.MakeClassMethodTarget(
+                            *class_ref, *sym)},
                 .arguments = std::move(arg_ids),
             },
         .span = span,
@@ -634,8 +634,8 @@ auto LowerCallExpr(
     if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
     const auto& declaring_class =
         sym->getParentScope()->asSymbol().as<slang::ast::ClassType>();
-    auto class_id = unit_lowerer.InternClass(declaring_class, span);
-    if (!class_id) return std::unexpected(std::move(class_id.error()));
+    auto class_ref = unit_lowerer.ResolveClassRef(declaring_class, span);
+    if (!class_ref) return std::unexpected(std::move(class_ref.error()));
     auto method_result_type = unit_lowerer.InternType(*call.type, span);
     if (!method_result_type) {
       return std::unexpected(std::move(method_result_type.error()));
@@ -647,8 +647,8 @@ auto LowerCallExpr(
                 .callee =
                     hir::MethodCallRef{
                         .receiver = *std::move(receiver_or),
-                        .class_id = *class_id,
-                        .method = unit_lowerer.LookupMethodId(*sym)},
+                        .target = unit_lowerer.MakeClassMethodTarget(
+                            *class_ref, *sym)},
                 .arguments = std::move(arg_ids),
             },
         .span = span,

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -224,8 +224,8 @@ auto MakeClassPropertyRefExpr(
   const auto& prop = sym.as<slang::ast::ClassPropertySymbol>();
   const auto& owner_class =
       sym.getParentScope()->asSymbol().as<slang::ast::ClassType>();
-  auto owner_id = unit_lowerer.InternClass(owner_class, span);
-  if (!owner_id) return std::unexpected(std::move(owner_id.error()));
+  auto owner_ref = unit_lowerer.ResolveClassRef(owner_class, span);
+  if (!owner_ref) return std::unexpected(std::move(owner_ref.error()));
   // LRM 8.9: a static-lifetime property is one cell owned by the class, so
   // its reference form carries neither the enclosing method's receiver nor
   // a fabricated stand-in -- a type-associated cell has no per-instance
@@ -234,14 +234,12 @@ auto MakeClassPropertyRefExpr(
   if (prop.lifetime == slang::ast::VariableLifetime::Static) {
     return hir::MakeRefExpr(
         hir::StaticPropertyRef{
-            .owner = *owner_id,
-            .prop = unit_lowerer.LookupClassPropertyStaticId(prop)},
+            .target = unit_lowerer.MakeStaticPropertyTarget(*owner_ref, prop)},
         *type_id, span);
   }
   return hir::MakeRefExpr(
       hir::ClassPropertyRef{
-          .owner = *owner_id,
-          .field_index = unit_lowerer.LookupClassPropertyFieldId(prop)},
+          .target = unit_lowerer.MakeClassPropertyTarget(*owner_ref, prop)},
       *type_id, span);
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -190,8 +190,8 @@ auto LowerMemberAccessExpr(
     const auto& prop = sel.member.as<slang::ast::ClassPropertySymbol>();
     const auto& declaring_class =
         prop.getParentScope()->asSymbol().as<slang::ast::ClassType>();
-    auto owner_id = lowerer.Owner().InternClass(declaring_class, span);
-    if (!owner_id) return std::unexpected(std::move(owner_id.error()));
+    auto owner_ref = lowerer.Owner().ResolveClassRef(declaring_class, span);
+    if (!owner_ref) return std::unexpected(std::move(owner_ref.error()));
     // LRM 8.9 permits reaching a static property through a handle
     // (`p.static_prop`), and LRM 8.3 says accessing a static member through a
     // null handle is legal because no per-instance dereference is required.
@@ -203,8 +203,8 @@ auto LowerMemberAccessExpr(
     if (prop.lifetime == slang::ast::VariableLifetime::Static) {
       return hir::MakeRefExpr(
           hir::StaticPropertyRef{
-              .owner = *owner_id,
-              .prop = lowerer.Owner().LookupClassPropertyStaticId(prop)},
+              .target =
+                  lowerer.Owner().MakeStaticPropertyTarget(*owner_ref, prop)},
           *type_id, span);
     }
     return hir::Expr{
@@ -212,8 +212,8 @@ auto LowerMemberAccessExpr(
         .data =
             hir::ClassPropertyAccessExpr{
                 .base_value = base_id,
-                .owner = *owner_id,
-                .field_index = lowerer.Owner().LookupClassPropertyFieldId(prop),
+                .target =
+                    lowerer.Owner().MakeClassPropertyTarget(*owner_ref, prop),
             },
         .span = span,
     };

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -386,11 +386,12 @@ auto TranslateTypeData(
       if (const auto imported = DetectImportedRuntimeClass(class_type)) {
         return hir::TypeData{hir::ImportedClassHandleType{.klass = *imported}};
       }
-      auto class_id_or = unit_lowerer.InternClass(class_type, decl_span);
-      if (!class_id_or) {
-        return std::unexpected(std::move(class_id_or.error()));
+      auto class_ref_or = unit_lowerer.ResolveClassRef(class_type, decl_span);
+      if (!class_ref_or) {
+        return std::unexpected(std::move(class_ref_or.error()));
       }
-      return hir::TypeData{hir::ClassHandleType{.class_id = *class_id_or}};
+      return hir::TypeData{
+          hir::ClassHandleType{.class_ref = *std::move(class_ref_or)}};
     }
     case slang::ast::SymbolKind::VoidType:
       return hir::TypeData{hir::VoidType{}};
@@ -556,25 +557,145 @@ auto SynthesizeDefaultConstructor(hir::TypeId void_type, diag::SourceSpan span)
       .overrides = std::nullopt};
 }
 
+// Walks a class's parent-scope chain to find the compilation-unit-level
+// symbol that owns its declaration -- a package (LRM 26), a module body
+// (LRM 23.2), or an interface body (LRM 25). A class nested in another
+// class or in a generate block still hits the enclosing module or package
+// body first, which is the ownership boundary. Returns null when the class
+// has no such ancestor (only expected for imported runtime-library classes,
+// which never reach this helper).
+auto DeclaringCompilationUnit(const slang::ast::ClassType& cls)
+    -> const slang::ast::Symbol* {
+  const slang::ast::Scope* scope = cls.getParentScope();
+  while (scope != nullptr) {
+    const slang::ast::Symbol& owner = scope->asSymbol();
+    if (owner.kind == slang::ast::SymbolKind::Package ||
+        owner.kind == slang::ast::SymbolKind::InstanceBody) {
+      return &owner;
+    }
+    scope = owner.getParentScope();
+  }
+  return nullptr;
+}
+
+// The name a compilation unit publishes for itself: a package's declared
+// name, or a module body's specialization name (the same name that unit
+// registers its own artifact under). A consumer reaching a class of this
+// unit by name uses this name for the unit component of the reference; the
+// class component is `SpecializationName(cls)`, computed on both sides
+// deterministically without a shared table.
+auto CompilationUnitName(const slang::ast::Symbol& unit) -> std::string {
+  if (unit.kind == slang::ast::SymbolKind::Package) {
+    return std::string(unit.name);
+  }
+  if (unit.kind == slang::ast::SymbolKind::InstanceBody) {
+    return SpecializationName(unit.as<slang::ast::InstanceBodySymbol>());
+  }
+  throw InternalError(
+      "CompilationUnitName: symbol is not a package or module body");
+}
+
 }  // namespace
 
-auto UnitLowerer::InternClass(
+auto UnitLowerer::MakeClassMethodTarget(
+    const hir::ClassRef& class_ref,
+    const slang::ast::SubroutineSymbol& method) const
+    -> hir::ClassMethodTarget {
+  if (const auto* local = std::get_if<hir::LocalClassRef>(&class_ref)) {
+    return hir::LocalClassMethodTarget{
+        .owner = local->class_id, .method = LookupMethodId(method)};
+  }
+  const auto& ext = std::get<hir::ExternalClassRef>(class_ref);
+  return hir::ExternalClassMethodTarget{
+      .unit_name = ext.unit_name,
+      .class_name = ext.class_name,
+      .method_name = std::string(method.name)};
+}
+
+auto UnitLowerer::MakeClassPropertyTarget(
+    const hir::ClassRef& class_ref,
+    const slang::ast::ClassPropertySymbol& prop) const
+    -> hir::ClassPropertyTarget {
+  if (const auto* local = std::get_if<hir::LocalClassRef>(&class_ref)) {
+    return hir::LocalClassPropertyTarget{
+        .owner = local->class_id, .field = LookupClassPropertyFieldId(prop)};
+  }
+  const auto& ext = std::get<hir::ExternalClassRef>(class_ref);
+  return hir::ExternalClassPropertyTarget{
+      .unit_name = ext.unit_name,
+      .class_name = ext.class_name,
+      .property_name = std::string(prop.name)};
+}
+
+auto UnitLowerer::MakeStaticPropertyTarget(
+    const hir::ClassRef& class_ref,
+    const slang::ast::ClassPropertySymbol& prop) const
+    -> hir::StaticPropertyTarget {
+  if (const auto* local = std::get_if<hir::LocalClassRef>(&class_ref)) {
+    return hir::LocalStaticPropertyTarget{
+        .owner = local->class_id, .prop = LookupClassPropertyStaticId(prop)};
+  }
+  const auto& ext = std::get<hir::ExternalClassRef>(class_ref);
+  return hir::ExternalStaticPropertyTarget{
+      .unit_name = ext.unit_name,
+      .class_name = ext.class_name,
+      .property_name = std::string(prop.name)};
+}
+
+auto UnitLowerer::ResolveClassRef(
     const slang::ast::ClassType& cls, diag::SourceSpan span)
-    -> diag::Result<hir::ClassId> {
+    -> diag::Result<hir::ClassRef> {
+  // A class this unit has already classified reads its `ClassRef` straight
+  // from the cache. Only the first reference to a class runs the boundary
+  // walk that answers "which CU declares it?" and stores the result.
   if (const auto it = class_cache_.find(&cls); it != class_cache_.end()) {
     return it->second;
   }
+  const slang::ast::Symbol* decl_unit = DeclaringCompilationUnit(cls);
+  if (decl_unit == nullptr) {
+    throw InternalError(
+        "UnitLowerer::ResolveClassRef: class has no compilation-unit-level "
+        "declaring scope");
+  }
+  if (decl_unit != &scope_->asSymbol()) {
+    const auto [it, _] = class_cache_.emplace(
+        &cls, hir::ClassRef{hir::ExternalClassRef{
+                  .unit_name = CompilationUnitName(*decl_unit),
+                  .class_name = SpecializationName(cls)}});
+    return it->second;
+  }
+  // A local class not yet minted (e.g. a class nested inside a generate
+  // block, which the top-level scope walk does not reach): mint it lazily
+  // now, so a reference and the pre-pass both converge on the same identity
+  // regardless of which route saw the class first.
+  auto id_or = InternLocalClass(cls, span);
+  if (!id_or) return std::unexpected(std::move(id_or.error()));
+  return hir::ClassRef{hir::LocalClassRef{.class_id = *id_or}};
+}
+
+auto UnitLowerer::InternLocalClass(
+    const slang::ast::ClassType& cls, diag::SourceSpan span)
+    -> diag::Result<hir::ClassId> {
+  // Idempotent: a repeat call for the same class returns the id the first
+  // mint installed. The cache entry is populated before body population, so a
+  // cyclic reference during that population -- a class that names itself in
+  // one of its member types, or a mutually-referential pair -- resolves
+  // against a stable id already visible to peer lookups.
+  if (const auto it = class_cache_.find(&cls); it != class_cache_.end()) {
+    return std::get<hir::LocalClassRef>(it->second).class_id;
+  }
   const hir::ClassId id = unit_.classes.Declare();
-  class_cache_.emplace(&cls, id);
+  class_cache_.emplace(&cls, hir::ClassRef{hir::LocalClassRef{.class_id = id}});
 
   hir::ClassDecl decl;
   decl.name = SpecializationName(cls);
 
   // Base class (LRM 8.13). Slang exposes the base as a `ClassType*` on the
   // derived class and flattens inherited members into the derived's member
-  // list; the base is registered here to reach it by identity, and each
-  // member iteration below filters by parent scope so only members declared
-  // on this class enter its arena.
+  // list; the base is reached through the class-reference translator because
+  // it may live in another compilation unit, and each member iteration below
+  // filters by parent scope so only members declared on this class enter
+  // its arena.
   if (const auto* base_type = cls.getBaseClass()) {
     const auto& base_class =
         base_type->getCanonicalType().as<slang::ast::ClassType>();
@@ -583,9 +704,9 @@ auto UnitLowerer::InternClass(
           span, diag::DiagCode::kUnsupportedClassFeature,
           "interface class conformance is not yet supported");
     }
-    auto base_id = InternClass(base_class, span);
-    if (!base_id) return std::unexpected(std::move(base_id.error()));
-    decl.base = *base_id;
+    auto base_ref = ResolveClassRef(base_class, span);
+    if (!base_ref) return std::unexpected(std::move(base_ref.error()));
+    decl.base = *std::move(base_ref);
   }
 
   for (const auto& prop :
@@ -662,19 +783,18 @@ auto UnitLowerer::InternClass(
       // The frontend has already matched signature, direction, return type,
       // and any other LRM 8.20 override compatibility rule when it resolved
       // this reference; the HIR consumes it as an already-resolved identity.
-      // Its base's methods were interned earlier by the recursive
-      // `InternClass` above, so their HIR identities are already in the
-      // cache the lookup reads.
+      // The base link the class shape carries has resolved a `LocalClassRef`
+      // for a same-unit base or an `ExternalClassRef` for a cross-unit base;
+      // the override target follows the same axis, owner-qualified in either
+      // case.
       if (const auto* overridden = method.getOverride();
           overridden != nullptr) {
         const auto& base_class = overridden->getParentScope()
                                      ->asSymbol()
                                      .as<slang::ast::ClassType>();
-        auto base_class_id = InternClass(base_class, span);
-        if (!base_class_id)
-          return std::unexpected(std::move(base_class_id.error()));
-        method_decl->overrides = hir::MethodRef{
-            .class_id = *base_class_id, .method = LookupMethodId(*overridden)};
+        auto base_ref = ResolveClassRef(base_class, span);
+        if (!base_ref) return std::unexpected(std::move(base_ref.error()));
+        method_decl->overrides = MakeClassMethodTarget(*base_ref, *overridden);
       } else if (const auto* pure_base =
                      FindOverriddenPureInBaseChain(cls, method.name);
                  pure_base != nullptr) {
@@ -684,17 +804,15 @@ auto UnitLowerer::InternClass(
         // this method as a fresh introducer.
         const auto& base_class =
             pure_base->getParentScope()->asSymbol().as<slang::ast::ClassType>();
-        auto base_class_id = InternClass(base_class, span);
-        if (!base_class_id)
-          return std::unexpected(std::move(base_class_id.error()));
+        auto base_ref = ResolveClassRef(base_class, span);
+        if (!base_ref) return std::unexpected(std::move(base_ref.error()));
         const auto* proto_stub = pure_base->getSubroutine();
         if (proto_stub == nullptr) {
           throw InternalError(
-              "UnitLowerer::InternClass: pure virtual prototype has no stub "
-              "subroutine slang normally materializes");
+              "UnitLowerer::InternLocalClass: pure virtual prototype has no "
+              "stub subroutine slang normally materializes");
         }
-        method_decl->overrides = hir::MethodRef{
-            .class_id = *base_class_id, .method = LookupMethodId(*proto_stub)};
+        method_decl->overrides = MakeClassMethodTarget(*base_ref, *proto_stub);
         // An override of a base virtual method is itself virtual (LRM 8.20),
         // even when the derived declaration omits the `virtual` keyword.
         method_decl->is_virtual = true;
@@ -746,12 +864,10 @@ auto UnitLowerer::InternClass(
         const auto& base_class = overridden_sub->getParentScope()
                                      ->asSymbol()
                                      .as<slang::ast::ClassType>();
-        auto base_class_id = InternClass(base_class, span);
-        if (!base_class_id)
-          return std::unexpected(std::move(base_class_id.error()));
-        proto_decl->overrides = hir::MethodRef{
-            .class_id = *base_class_id,
-            .method = LookupMethodId(*overridden_sub)};
+        auto base_ref = ResolveClassRef(base_class, span);
+        if (!base_ref) return std::unexpected(std::move(base_ref.error()));
+        proto_decl->overrides =
+            MakeClassMethodTarget(*base_ref, *overridden_sub);
       }
     }
     const hir::MethodId method_id = decl.methods.Add(*std::move(proto_decl));

--- a/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
@@ -15,6 +15,7 @@
 #include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
+#include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
@@ -47,6 +48,9 @@ UnitLowerer::UnitLowerer(
 auto UnitLowerer::Run() -> diag::Result<hir::CompilationUnit> {
   WalkFrame frame;
   DeclareStructuralIdentities(*scope_);
+  if (auto r = InternOwnClassDeclarations(); !r) {
+    return std::unexpected(std::move(r.error()));
+  }
   StructuralScopeLowerer root(*this, *scope_);
   auto root_scope_or = root.Run(frame);
   if (!root_scope_or) {
@@ -54,6 +58,37 @@ auto UnitLowerer::Run() -> diag::Result<hir::CompilationUnit> {
   }
   unit_.root_scope = *std::move(root_scope_or);
   return std::move(unit_);
+}
+
+auto UnitLowerer::InternOwnClassDeclarations() -> diag::Result<void> {
+  // A class is owned by the compilation unit that declares it. Slang exposes
+  // this unit's class declarations at scope level as one of two kinds: a
+  // `ClassType` for a non-parameterized declaration (LRM 8.3), or a
+  // `GenericClassDefSymbol` for a parameterized one (LRM 8.25), which carries
+  // one `ClassType` per live specialization slang deduplicated during
+  // elaboration. Minting them here before any body lowers keeps class
+  // identity queryable through the unit's registry from the moment any body
+  // resolves a reference, and gives a specialization reached only from
+  // another unit its home in the declaring unit.
+  for (const auto& member : scope_->members()) {
+    if (member.kind == slang::ast::SymbolKind::ClassType) {
+      const auto& cls = member.as<slang::ast::ClassType>();
+      const diag::SourceSpan span = SourceMapper().PointSpanOf(cls.location);
+      if (auto r = InternLocalClass(cls, span); !r) {
+        return std::unexpected(std::move(r.error()));
+      }
+    } else if (member.kind == slang::ast::SymbolKind::GenericClassDef) {
+      const auto& def = member.as<slang::ast::GenericClassDefSymbol>();
+      const diag::SourceSpan span = SourceMapper().PointSpanOf(def.location);
+      for (const auto& spec : def.specializations()) {
+        const auto& cls = spec.getCanonicalType().as<slang::ast::ClassType>();
+        if (auto r = InternLocalClass(cls, span); !r) {
+          return std::unexpected(std::move(r.error()));
+        }
+      }
+    }
+  }
+  return {};
 }
 
 auto UnitLowerer::NextScopeFrameId() -> ScopeFrameId {

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -46,13 +46,23 @@ namespace {
 // method (both facts absent). Depth is bounded by inheritance depth; the
 // frontend guarantees the chain is acyclic (LRM 8.13).
 auto CanonicalizeVirtualDispatch(
-    const UnitLowerer& unit_lowerer, const hir::SubroutineDecl& method)
+    UnitLowerer& unit_lowerer, const hir::SubroutineDecl& method)
     -> std::optional<mir::VirtualDispatchRole> {
   if (method.overrides.has_value()) {
-    const hir::MethodRef& base_ref = *method.overrides;
+    if (const auto* ext =
+            std::get_if<hir::ExternalClassMethodTarget>(&*method.overrides)) {
+      // A slot introduced in another unit is canonically owned there; this
+      // unit records the override by the (unit, class, method) name triple
+      // and reaches the base's dispatch machinery through the link-time
+      // include of the declaring unit.
+      return mir::VirtualDispatchRole{
+          unit_lowerer.MakeExternalMethodOverride(*ext)};
+    }
+    const auto& local_ref =
+        std::get<hir::LocalClassMethodTarget>(*method.overrides);
     const hir::SubroutineDecl& base_method = unit_lowerer.Hir()
-                                                 .classes.Get(base_ref.class_id)
-                                                 .methods.Get(base_ref.method);
+                                                 .classes.Get(local_ref.owner)
+                                                 .methods.Get(local_ref.method);
     const auto base_role =
         CanonicalizeVirtualDispatch(unit_lowerer, base_method);
     if (!base_role.has_value()) {
@@ -61,8 +71,8 @@ auto CanonicalizeVirtualDispatch(
           "method the frontend did not classify as virtual");
     }
     const mir::ClassId base_mir_class =
-        unit_lowerer.TranslateClass(base_ref.class_id);
-    const mir::CallableId base_mir_slot{base_ref.method.value};
+        unit_lowerer.TranslateClass(local_ref.owner);
+    const mir::CallableId base_mir_slot{local_ref.method.value};
     return std::visit(
         Overloaded{
             [&](const mir::IntroducesVirtualSlot&) -> mir::VirtualDispatchRole {
@@ -70,7 +80,9 @@ auto CanonicalizeVirtualDispatch(
                   .slot_owner = base_mir_class, .slot_id = base_mir_slot};
             },
             [](const mir::OverridesIntraUnitSlot& s)
-                -> mir::VirtualDispatchRole { return s; }},
+                -> mir::VirtualDispatchRole { return s; },
+            [](const mir::OverridesExternalSlot& e)
+                -> mir::VirtualDispatchRole { return e; }},
         *base_role);
   }
   if (method.is_virtual) {
@@ -164,8 +176,14 @@ auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
 
   std::optional<mir::ClassRef> base_ref;
   if (hir_class.base.has_value()) {
-    base_ref = mir::ClassRef{mir::IntraUnitClassRef{
-        .class_id = unit_lowerer.TranslateClass(*hir_class.base)}};
+    if (const auto* local_base =
+            std::get_if<hir::LocalClassRef>(&*hir_class.base)) {
+      base_ref = mir::ClassRef{mir::IntraUnitClassRef{
+          .class_id = unit_lowerer.TranslateClass(local_base->class_id)}};
+    } else {
+      base_ref = unit_lowerer.MakeExternalClassBaseRef(
+          std::get<hir::ExternalClassRef>(*hir_class.base));
+    }
   }
 
   mir::ClassShape shape{

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -545,6 +545,12 @@ auto CanonicalIntraUnitSlot(
           [](const mir::OverridesIntraUnitSlot& s)
               -> std::pair<mir::ClassId, mir::CallableId> {
             return {s.slot_owner, s.slot_id};
+          },
+          [](const mir::OverridesExternalSlot&)
+              -> std::pair<mir::ClassId, mir::CallableId> {
+            throw InternalError(
+                "CanonicalIntraUnitSlot: expected an intra-unit slot, but the "
+                "method's role names a cross-unit slot introducer");
           }},
       role);
 }
@@ -563,13 +569,6 @@ auto LowerMethodCall(
     -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
   auto& types = lowerer.Owner().Unit().types;
-
-  // The method's declaring class is stated on the HIR node; the receiver's
-  // runtime class is only used to type the self parameter (which pairs with
-  // the target's own arena entry through C++ member lookup). For a super
-  // call HIR already sets `class_id` to the base's identity.
-  const mir::ClassId owner_class = lowerer.Owner().TranslateClass(m.class_id);
-  const mir::CallableId method_slot{m.method.value};
 
   // The receiver pointer origin depends only on whether the source supplied
   // an explicit handle. A `HandleReceiver` evaluates the handle expression
@@ -608,6 +607,41 @@ auto LowerMethodCall(
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     user_args.push_back(block.exprs.Add(*std::move(arg_or)));
   }
+
+  // Cross-unit instance method: no local shape store to query for the
+  // callee's dispatch role, so this site always lowers to a direct call
+  // naming the method by (unit, class, method) name. Virtual resolution
+  // rides on the target-language include of the declaring unit's header --
+  // the callee's own virtual machinery dispatches at the receiver's runtime
+  // class -- and a super qualifier crosses the boundary the same way, as
+  // an owner-scoped call the backend renders when the qualification arm
+  // is set.
+  if (const auto* ext_target =
+          std::get_if<hir::ExternalClassMethodTarget>(&m.target)) {
+    std::vector<mir::ExprId> direct_args;
+    direct_args.reserve(user_args.size() + 1);
+    direct_args.push_back(receiver_ptr);
+    for (const mir::ExprId a : user_args) direct_args.push_back(a);
+    return mir::Expr{
+        .data =
+            mir::CallExpr{
+                .callee =
+                    mir::Direct{
+                        .target = lowerer.Owner().MakeExternalMethodTarget(
+                            *ext_target),
+                        .qualification = std::nullopt},
+                .arguments = std::move(direct_args)},
+        .type = result_type};
+  }
+
+  // The method's declaring class is stated on the HIR node; the receiver's
+  // runtime class is only used to type the self parameter (which pairs with
+  // the target's own arena entry through C++ member lookup). For a super
+  // call HIR already sets the target to the base's identity.
+  const auto& local_target = std::get<hir::LocalClassMethodTarget>(m.target);
+  const mir::ClassId owner_class =
+      lowerer.Owner().TranslateClass(local_target.owner);
+  const mir::CallableId method_slot{local_target.method.value};
 
   // A super call (LRM 8.15) is a dispatch fact independent of the callee's
   // virtual role: the source demands the base's implementation regardless
@@ -665,8 +699,37 @@ auto LowerStaticMethodCall(
     const hir::StaticMethodCallRef& m, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
-  const mir::ClassId owner_class = lowerer.Owner().TranslateClass(m.class_id);
-  const mir::CallableId method_slot{m.method.value};
+  const auto* local_target =
+      std::get_if<hir::LocalClassMethodTarget>(&m.target);
+  if (local_target == nullptr) {
+    // Cross-unit static method: no receiver, rendered by the backend as the
+    // free qualified `unit::Class::method(args)` after the declaring unit's
+    // header is included.
+    const auto& ext_target = std::get<hir::ExternalClassMethodTarget>(m.target);
+    std::vector<mir::ExprId> args;
+    args.reserve(c.arguments.size());
+    for (const auto& arg : c.arguments) {
+      if (!arg.has_value()) {
+        throw InternalError("LowerStaticMethodCall: argument elided");
+      }
+      auto arg_or = lowerer.LowerExpr(lowerer.HirExprs().Get(*arg), frame);
+      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+      args.push_back(block.exprs.Add(*std::move(arg_or)));
+    }
+    return mir::Expr{
+        .data =
+            mir::CallExpr{
+                .callee =
+                    mir::Direct{
+                        .target = lowerer.Owner().MakeExternalMethodTarget(
+                            ext_target),
+                        .qualification = std::nullopt},
+                .arguments = std::move(args)},
+        .type = result_type};
+  }
+  const mir::ClassId owner_class =
+      lowerer.Owner().TranslateClass(local_target->owner);
+  const mir::CallableId method_slot{local_target->method.value};
 
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size());
@@ -1269,7 +1332,6 @@ auto LowerExternalUnitSubroutineCall(
     -> diag::Result<mir::Expr> {
   const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  lowerer.Owner().Unit().AddExternalReferencedUnit(ref.unit_name);
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size());
   for (const auto& argument : c.arguments) {
@@ -1286,9 +1348,7 @@ auto LowerExternalUnitSubroutineCall(
               .callee =
                   mir::Direct{
                       .target =
-                          mir::ExternalUnitCallableTarget{
-                              .unit_name = ref.unit_name,
-                              .callable_name = ref.subroutine_name}},
+                          lowerer.Owner().MakeExternalCallableTarget(ref)},
               .arguments = std::move(args)},
       .type = result_type};
 }

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -272,20 +272,36 @@ auto LowerHirPrimaryExprProc(
                 frame.current_class->self_pointer_type;
             const mir::ExprId self_ref = frame.current_block->exprs.Add(
                 MakeSelfRefExpr(frame, self_type));
+            if (const auto* local =
+                    std::get_if<hir::LocalClassPropertyTarget>(&r.target)) {
+              return mir::MakeFieldAccessExpr(
+                  self_ref,
+                  mir::FieldTarget{
+                      .owner = process.Owner().TranslateClass(local->owner),
+                      .slot = UnitLowerer::TranslateField(local->field)},
+                  result_type);
+            }
             return mir::MakeFieldAccessExpr(
                 self_ref,
-                mir::FieldTarget{
-                    .owner = process.Owner().TranslateClass(r.owner),
-                    .slot = UnitLowerer::TranslateField(r.field_index)},
+                process.Owner().MakeExternalFieldTarget(
+                    std::get<hir::ExternalClassPropertyTarget>(r.target)),
                 result_type);
           },
           [&](const hir::StaticPropertyRef& r) -> mir::Expr {
+            if (const auto* local =
+                    std::get_if<hir::LocalStaticPropertyTarget>(&r.target)) {
+              return mir::Expr{
+                  .data =
+                      mir::StaticPropertyRef{
+                          .owner = process.Owner().TranslateClass(local->owner),
+                          .prop =
+                              UnitLowerer::TranslateStaticProperty(local->prop),
+                      },
+                  .type = result_type};
+            }
             return mir::Expr{
-                .data =
-                    mir::StaticPropertyRef{
-                        .owner = process.Owner().TranslateClass(r.owner),
-                        .prop = UnitLowerer::TranslateStaticProperty(r.prop),
-                    },
+                .data = process.Owner().MakeExternalStaticPropertyRef(
+                    std::get<hir::ExternalStaticPropertyTarget>(r.target)),
                 .type = result_type};
           },
           [&](const hir::RoutedRef& c) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -452,11 +452,19 @@ auto LowerHirClassPropertyAccessExpr(
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
+  if (const auto* local =
+          std::get_if<hir::LocalClassPropertyTarget>(&sel.target)) {
+    return mir::MakeFieldAccessExpr(
+        base_id,
+        mir::FieldTarget{
+            .owner = unit_lowerer.TranslateClass(local->owner),
+            .slot = UnitLowerer::TranslateField(local->field)},
+        result_type);
+  }
   return mir::MakeFieldAccessExpr(
       base_id,
-      mir::FieldTarget{
-          .owner = unit_lowerer.TranslateClass(sel.owner),
-          .slot = UnitLowerer::TranslateField(sel.field_index)},
+      unit_lowerer.MakeExternalFieldTarget(
+          std::get<hir::ExternalClassPropertyTarget>(sel.target)),
       result_type);
 }
 
@@ -584,11 +592,19 @@ auto LowerHirClassPropertyAccessExprLhs(
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
+  if (const auto* local =
+          std::get_if<hir::LocalClassPropertyTarget>(&sel.target)) {
+    return mir::MakeFieldAccessExpr(
+        base_id,
+        mir::FieldTarget{
+            .owner = unit_lowerer.TranslateClass(local->owner),
+            .slot = UnitLowerer::TranslateField(local->field)},
+        result_type);
+  }
   return mir::MakeFieldAccessExpr(
       base_id,
-      mir::FieldTarget{
-          .owner = unit_lowerer.TranslateClass(sel.owner),
-          .slot = UnitLowerer::TranslateField(sel.field_index)},
+      unit_lowerer.MakeExternalFieldTarget(
+          std::get<hir::ExternalClassPropertyTarget>(sel.target)),
       result_type);
 }
 

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -100,7 +100,7 @@ auto FlattenPackedAggregate(
 
 }  // namespace
 
-auto UnitLowerer::TranslateTypeData(const hir::TypeData& data) const
+auto UnitLowerer::TranslateTypeData(const hir::TypeData& data)
     -> mir::TypeData {
   return std::visit(
       Overloaded{
@@ -237,10 +237,19 @@ auto UnitLowerer::TranslateTypeData(const hir::TypeData& data) const
           },
           [&](const hir::ClassHandleType& src) -> mir::TypeData {
             // A class handle is a managed reference to the class object: the
-            // pointee is the object type naming the class's registry identity,
-            // pre-interned when the class id was minted.
+            // pointee is the object type naming the class's registry identity
+            // (local) or the class's fully qualified name (external). The
+            // external arm routes through the unit-lowerer's builder so the
+            // cross-unit dependency is recorded in the same step as the type
+            // intern.
+            if (const auto* local =
+                    std::get_if<hir::LocalClassRef>(&src.class_ref)) {
+              return mir::ManagedRefType{
+                  .pointee = ClassObjectType(local->class_id)};
+            }
             return mir::ManagedRefType{
-                .pointee = ClassObjectType(src.class_id)};
+                .pointee = MakeExternalClassPointee(
+                    std::get<hir::ExternalClassRef>(src.class_ref))};
           },
           [&](const hir::ImportedClassHandleType& src) -> mir::TypeData {
             // A handle to an imported runtime-library class is the same managed

--- a/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
@@ -311,4 +311,68 @@ auto UnitLowerer::NextGenerateScopeName(std::string_view arm_tag)
   return std::format("gen{}_{}", next_generate_scope_name_++, arm_tag);
 }
 
+auto UnitLowerer::MakeExternalClassPointee(const hir::ExternalClassRef& ref)
+    -> mir::TypeId {
+  unit_.AddExternalClassUnit(ref.unit_name);
+  return unit_.types.Intern(
+      mir::ExternalClassType{
+          .qualified_name =
+              std::format("{}::{}", ref.unit_name, ref.class_name)});
+}
+
+auto UnitLowerer::MakeExternalClassBaseRef(const hir::ExternalClassRef& ref)
+    -> mir::ClassRef {
+  unit_.AddExternalClassUnit(ref.unit_name);
+  return mir::ClassRef{mir::ExternalClassRef{
+      .qualified_name = std::format("{}::{}", ref.unit_name, ref.class_name)}};
+}
+
+auto UnitLowerer::MakeExternalFieldTarget(
+    const hir::ExternalClassPropertyTarget& target)
+    -> mir::ExternalFieldTarget {
+  unit_.AddExternalClassUnit(target.unit_name);
+  return mir::ExternalFieldTarget{
+      .unit_name = target.unit_name,
+      .class_name = target.class_name,
+      .field_name = target.property_name};
+}
+
+auto UnitLowerer::MakeExternalStaticPropertyRef(
+    const hir::ExternalStaticPropertyTarget& target)
+    -> mir::ExternalStaticPropertyRef {
+  unit_.AddExternalClassUnit(target.unit_name);
+  return mir::ExternalStaticPropertyRef{
+      .unit_name = target.unit_name,
+      .class_name = target.class_name,
+      .property_name = target.property_name};
+}
+
+auto UnitLowerer::MakeExternalMethodTarget(
+    const hir::ExternalClassMethodTarget& target)
+    -> mir::ExternalUnitClassMethodTarget {
+  unit_.AddExternalClassUnit(target.unit_name);
+  return mir::ExternalUnitClassMethodTarget{
+      .unit_name = target.unit_name,
+      .class_name = target.class_name,
+      .method_name = target.method_name};
+}
+
+auto UnitLowerer::MakeExternalMethodOverride(
+    const hir::ExternalClassMethodTarget& target)
+    -> mir::OverridesExternalSlot {
+  unit_.AddExternalClassUnit(target.unit_name);
+  return mir::OverridesExternalSlot{
+      .unit_name = target.unit_name,
+      .class_name = target.class_name,
+      .method_name = target.method_name};
+}
+
+auto UnitLowerer::MakeExternalCallableTarget(
+    const hir::ExternalUnitSubroutineRef& ref)
+    -> mir::ExternalUnitCallableTarget {
+  unit_.AddExternalReferencedUnit(ref.unit_name);
+  return mir::ExternalUnitCallableTarget{
+      .unit_name = ref.unit_name, .callable_name = ref.subroutine_name};
+}
+
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -217,6 +217,12 @@ auto LowerCallTarget(
                           "mir_to_lir: a cross-unit package subroutine call is "
                           "not yet lowerable to LIR");
                     },
+                    [&](const mir::ExternalUnitClassMethodTarget&)
+                        -> diag::Result<lir::CallTarget> {
+                      return Unsupported(
+                          "mir_to_lir: a cross-unit class method call is not "
+                          "yet lowerable to LIR");
+                    },
                     [&](const mir::ImportedRuntimeCallTarget&)
                         -> diag::Result<lir::CallTarget> {
                       return Unsupported(
@@ -789,7 +795,13 @@ auto FunctionLowerer::LowerPlace(const mir::Block& block, mir::ExprId id)
             const std::uint32_t slot = std::visit(
                 Overloaded{
                     [](const mir::FieldTarget& t) { return t.slot.value; },
-                    [](const mir::FieldId& id) { return id.value; }},
+                    [](const mir::FieldId& id) { return id.value; },
+                    [](const mir::ExternalFieldTarget&) -> std::uint32_t {
+                      throw InternalError(
+                          "mir_to_lir: cross-unit field access is not "
+                          "supported by the LIR path (LIR is not the target "
+                          "backend for cross-unit class references today)");
+                    }},
                 field.field);
             return lir::Place{
                 .base = *std::move(receiver),

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -502,6 +502,11 @@ class MirDumper {
               return std::format(
                   "OverridesIntraUnitSlot[Class[{}].{}(Callable[{}])]",
                   o.slot_owner.value, callable.name, o.slot_id.value);
+            },
+            [](const OverridesExternalSlot& e) -> std::string {
+              return std::format(
+                  "OverridesExternalSlot[{}::{}::{}]", e.unit_name,
+                  e.class_name, e.method_name);
             }},
         role);
   }
@@ -528,6 +533,11 @@ class MirDumper {
             [](const ExternalUnitCallableTarget& e) -> std::string {
               return std::format(
                   R"(external_unit={}::{})", e.unit_name, e.callable_name);
+            },
+            [](const ExternalUnitClassMethodTarget& e) -> std::string {
+              return std::format(
+                  "external_class_method={}::{}::{}", e.unit_name, e.class_name,
+                  e.method_name);
             }},
         target);
   }
@@ -711,6 +721,11 @@ class MirDumper {
                           },
                           [](const FieldId& id) -> std::string {
                             return std::format("Field[{}]", id.value);
+                          },
+                          [](const ExternalFieldTarget& t) -> std::string {
+                            return std::format(
+                                "External[{}::{}::{}]", t.unit_name,
+                                t.class_name, t.field_name);
                           }},
                       m.field));
             },
@@ -740,6 +755,11 @@ class MirDumper {
               return std::format(
                   "ExternalUnitVariableRef unit={} variable={}", r.unit_name,
                   r.variable_name);
+            },
+            [](const ExternalStaticPropertyRef& r) -> std::string {
+              return std::format(
+                  "ExternalStaticPropertyRef external={}::{}::{}", r.unit_name,
+                  r.class_name, r.property_name);
             },
             [](const ClosureExpr& cl) -> std::string {
               return std::format(

--- a/tests/cases/cpp/class_cross_unit/case.yaml
+++ b/tests/cases/cpp/class_cross_unit/case.yaml
@@ -1,0 +1,19 @@
+id: cpp.class_cross_unit
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    c1_value: 3
+    c2_value: 1
+    counter_made: 2
+    box_int_payload: 42
+    box_byte_payload: 7
+    box_int_count: 1
+    box_byte_count: 1
+    derived_x: 5
+    derived_y: 6

--- a/tests/cases/cpp/class_cross_unit/main.sv
+++ b/tests/cases/cpp/class_cross_unit/main.sv
@@ -1,0 +1,92 @@
+// A class is owned by the compilation unit that declares it. A reference from
+// another unit reaches it by name -- the same by-name resolution package
+// callables (LRM 26.3) already use. Covers: non-parameterized package class,
+// parameterized package class specialization (default + explicit binding),
+// cross-package static property (LRM 8.10 -- one cell owned by the type,
+// shared across every referrer), and cross-unit inheritance (LRM 8.13
+// extends across the package boundary). The parameterized-base case rides on
+// LRM 8.25's rule that matching specializations of a package generic class
+// denote one type throughout the system.
+package pkg;
+
+  class Counter;
+    int value = 0;
+    static int made = 0;
+    function new();
+      made = made + 1;
+    endfunction
+    function void incr();
+      value = value + 1;
+    endfunction
+  endclass
+
+  class Box #(type T = int);
+    T payload;
+    static int count = 0;
+    function new(T seed);
+      payload = seed;
+      count = count + 1;
+    endfunction
+  endclass
+
+  class Base #(type T = int);
+    T x;
+    function new(T seed);
+      x = seed;
+    endfunction
+  endclass
+
+endpackage
+
+module Top;
+
+  class Derived extends pkg::Base #(byte);
+    byte y;
+    function new(byte x0, byte y0);
+      super.new(x0);
+      y = y0;
+    endfunction
+  endclass
+
+  int c1_value;
+  int c2_value;
+  int counter_made;
+
+  int box_int_payload;
+  byte box_byte_payload;
+  int box_int_count;
+  int box_byte_count;
+
+  byte derived_x;
+  byte derived_y;
+
+  initial begin
+    pkg::Counter c1;
+    pkg::Counter c2;
+    pkg::Box b_int;
+    pkg::Box #(byte) b_byte;
+    Derived d;
+
+    c1 = new;
+    c1.incr();
+    c1.incr();
+    c1.incr();
+    c2 = new;
+    c2.incr();
+
+    c1_value = c1.value;
+    c2_value = c2.value;
+    counter_made = pkg::Counter::made;
+
+    b_int = new(42);
+    b_byte = new(8'sd7);
+    box_int_payload = b_int.payload;
+    box_byte_payload = b_byte.payload;
+    box_int_count = pkg::Box #()::count;
+    box_byte_count = pkg::Box #(byte)::count;
+
+    d = new(8'sd5, 8'sd6);
+    derived_x = d.x;
+    derived_y = d.y;
+  end
+endmodule


### PR DESCRIPTION
## Summary

A SystemVerilog class is now owned by the compilation unit that declares it, and a reference from another unit reaches it by name -- the same by-name resolution package callables already use. Before this change, every unit that referenced a package class copied the class body into its own HIR / MIR / emitted artifact, so the same package specialization existed in duplicate per referring unit and matching specializations across CUs were different types. LRM 8.25's package-scope rule ("matching specializations of a package generic class are one type throughout the system") now holds across compilation units, and the fix applies uniformly to non-parameterized and parameterized classes.

## Design

**HIR and MIR carry the Local / External split as first-class variants.** `hir::ClassRef` is `variant<LocalClassRef, ExternalClassRef>` and every class-reference site (handle type, `new`, base extension, property / method / static access, virtual override) carries an owner-qualified target that splits the same way. MIR's peer variants (`ExternalFieldTarget`, `ExternalUnitClassMethodTarget`, `ExternalStaticPropertyRef`, `OverridesExternalSlot`) name the target by (declaring unit, class canonical name, member name); intra-unit references keep their unit-local ids.

**AST-to-HIR splits into a top-down mint and a boundary translator.** The pre-pass walks this unit's own scope and calls `InternLocalClass`, which never queries slang's parent chain because context guarantees local ownership. Every expression site and recursive base link calls `ResolveClassRef`, which is the sole location where AST-to-HIR walks the slang parent chain to decide "which CU declares this class?"; classification caches for the whole unit, so an external reference at N call sites walks once. See `docs/decisions/cross-unit-class-translation.md`.

**HIR-to-MIR routes external references through structural builders.** `MakeExternalClassPointee`, `MakeExternalFieldTarget`, `MakeExternalMethodTarget`, and their peers each produce the MIR value AND record the referenced unit on the dependency list in one operation, so a caller cannot mint a cross-unit MIR reference without also declaring the include the backend needs.

**The C++ backend emits each unit's classes into its own artifact.** A package header renders every class the package declares (parameterized specializations included); a referring unit `#include`s the package header and uses the qualified name. Instance calls render as `receiver->method(args)`; static calls and property accesses as `unit::Class::name`. LIR / JIT paths raise Unsupported for cross-unit class references today; the C++ backend is the target.

## Testing

New end-to-end case `tests/cases/cpp/class_cross_unit`: a package declares a non-parameterized class (`Counter`), a parameterized class (`Box #(T)`), and a parameterized base (`Base #(T)`); the module holds handles to each, calls their instance methods, reads static properties, and declares `class Derived extends pkg::Base #(byte)` with a super-forwarding constructor. Covers cross-unit handle types, `new`, instance method calls, static property reads across default and explicit specializations, and cross-unit inheritance with super. Existing suite (`bazel test //...`) passes; no other tests changed behaviour.