### PR TITLE
Support interface class conformance (LRM 8.26)

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -93,7 +93,7 @@ each stage establishes, not how.
       to whether the source separately wrote an empty body -- the two forms are semantically
       distinct and remain distinct end-to-end.
 
-- [ ] Interface-class conformance (LRM 8.26): a class may conform to several interfaces, a relation
+- [x] Interface-class conformance (LRM 8.26): a class may conform to several interfaces, a relation
       distinct from its single concrete base and carrying no second instance storage. Each
       conformance is a pure-virtual method contract the class must satisfy; a shared behaviour among
       unrelated concrete hierarchies is expressed as conformance to one interface class, not as a

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -81,14 +81,38 @@ struct BaseCall {
 // position of its own. Each method (LRM 8.6) is a subroutine reached through
 // the instance, reading the receiver and the class's properties through it.
 //
+// `is_interface_class` marks an `interface class` declaration (LRM 8.26): a
+// class whose body carries only pure virtual method contracts -- no
+// instance storage, no constructor, no static storage. Interface classes
+// and regular classes share this one declaration form because their
+// object-model shape coincides: an interface class is a regular class
+// whose non-contract slots are empty by LRM 8.26 syntax. The bit is what
+// consumers read to route emission and dispatch; the "which slots are
+// empty" facts hold because the frontend admits only the LRM 8.26 syntax
+// for a class flagged interface.
+//
 // `base` names the class this one extends (LRM 8.13), absent when the class
 // extends no other. Only own members appear in `fields` / `methods`;
-// inherited members are reached through the base's registry entry.
+// inherited members are reached through the base's registry entry. An
+// interface class carries no concrete base -- its parent interface classes
+// live in `implements`.
 //
-// `constructor` is the class's `new` (LRM 8.7). Every class has one: the
-// user-written `function new` when the source declares it, otherwise a
-// synthesized empty constructor, matching the implicit `new` the LRM
-// provides when the source omits one.
+// `implements` names the interface classes this one commits to satisfying
+// (LRM 8.26.2): for a regular class, the source `implements` clause; for
+// an interface class, the source `extends` clause, which aggregates parent
+// interface class contracts into this one's requirement set. The two
+// source keywords land in one field because at the object-model layer
+// they name the same relation -- aggregate these interface classes' pure
+// virtual method contracts. Multiple entries are allowed (multiple
+// inheritance among interface class contracts is legal, LRM 8.26.2); the
+// concrete-base single-value rule stays with `base`.
+//
+// `constructor` is the class's `new` (LRM 8.7). Every regular class has
+// one: the user-written `function new` when the source declares it,
+// otherwise a synthesized empty constructor, matching the implicit `new`
+// the LRM provides when the source omits one. An interface class carries
+// a synthesized stub that no consumer invokes -- an interface class
+// object cannot be constructed (LRM 8.26.5).
 //
 // `base_call` peers with `constructor` because base-constructor forwarding
 // is a class-level construction fact, not a statement inside the ctor body
@@ -119,7 +143,9 @@ struct BaseCall {
 // its type's Table 7-1 default and does not appear here.
 struct ClassDecl {
   std::string name;
+  bool is_interface_class = false;
   std::optional<ClassRef> base;
+  std::vector<ClassRef> implements;
   base::Arena<ClassField, FieldId> fields;
   base::Arena<ClassStaticProperty, StaticPropertyId> static_properties;
   base::Arena<SubroutineDecl, MethodId> methods;

--- a/include/lyra/hir/class_ref.hpp
+++ b/include/lyra/hir/class_ref.hpp
@@ -104,11 +104,18 @@ struct LocalClassMethodTarget {
 
 // A reference to a class method (LRM 8.6 / 8.10) declared by another
 // compilation unit: the declaring unit, the class's canonical name, and the
-// method's source name.
+// method's source name. `is_virtual` records whether the callee is virtual
+// (LRM 8.20) -- a fact the referring unit needs to route the call site
+// between static and virtual dispatch, but which it cannot recover from its
+// own class registry because the declaring class lives in another unit.
+// The producer (the unit intake that mints this target) reads the fact from
+// its frontend view of the callee; the consumer (the referring unit's call
+// lowering) reads it here.
 struct ExternalClassMethodTarget {
   std::string unit_name;
   std::string class_name;
   std::string method_name;
+  bool is_virtual = false;
 
   auto operator==(const ExternalClassMethodTarget&) const -> bool = default;
 };

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -177,11 +177,27 @@ class UnitLowerer {
   auto MakeExternalClassPointee(const hir::ExternalClassRef& ref)
       -> mir::TypeId;
 
-  auto MakeExternalClassBaseRef(const hir::ExternalClassRef& ref)
-      -> mir::ClassRef;
+  auto MakeExternalClassRef(const hir::ExternalClassRef& ref) -> mir::ClassRef;
+
+  // Convenience that dispatches a HIR class reference to its MIR peer: an
+  // intra-unit reference translates through the class registry, and a cross-
+  // unit one runs through `MakeExternalClassRef` so the external dependency
+  // is recorded in the same call. A caller that needs to name a class in any
+  // position (base, interface contract, receiver type) reads one entry point
+  // instead of visiting the variant itself.
+  auto TranslateClassRef(const hir::ClassRef& ref) -> mir::ClassRef;
 
   auto MakeExternalFieldTarget(const hir::ExternalClassPropertyTarget& target)
       -> mir::ExternalFieldTarget;
+
+  // Convenience that dispatches a HIR class property reference to its MIR
+  // `FieldRef` peer: the intra-unit arm translates the owner class and the
+  // field slot through the class registry, the cross-unit arm runs through
+  // `MakeExternalFieldTarget` so the external dependency is recorded in the
+  // same call. A caller reading a class property reaches for one entry
+  // point instead of visiting the variant at each access site.
+  auto TranslateClassPropertyTarget(const hir::ClassPropertyTarget& target)
+      -> mir::FieldRef;
 
   auto MakeExternalStaticPropertyRef(
       const hir::ExternalStaticPropertyTarget& target)
@@ -192,6 +208,14 @@ class UnitLowerer {
 
   auto MakeExternalMethodOverride(const hir::ExternalClassMethodTarget& target)
       -> mir::OverridesExternalSlot;
+
+  // The virtual-call-site counterpart of `MakeExternalMethodTarget`: the
+  // referring unit reaches a slot introduced by a class in another
+  // compilation unit and dispatches through the target language's own
+  // virtual-call machinery reached by including the declaring unit's
+  // header. Records the class dependency so the header include is emitted.
+  auto MakeExternalVirtualSlot(const hir::ExternalClassMethodTarget& target)
+      -> mir::ExternalVirtualSlot;
 
   // Receiver-less callable of another compilation unit (LRM 26.3 package
   // function or task). Recorded on the callable dependency list, not the

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -94,6 +94,14 @@ struct CallableSignature {
 struct ClassShape {
   std::string name;
   std::optional<ClassRef> base;
+  // Interface class contracts (LRM 8.26) this class commits to satisfying.
+  // Populated from the source `implements` clause of a regular class or
+  // the `extends` clause of an interface class; both source keywords name
+  // the same object-model relation -- aggregate these interface classes'
+  // pure virtual method contracts. Multiple entries are legal; the
+  // concrete-base single-value rule stays on `base`, and interface
+  // conformance introduces no instance storage.
+  std::vector<ClassRef> implements;
   TypeId self_pointer_type;
   TimeResolution time_resolution;
   base::Arena<ParamDecl, ParamId> ctor_prefix_params;
@@ -109,13 +117,21 @@ struct ClassShape {
   // Whether the class is final (LRM 8.13). A structural class always is; an
   // SV class carries the source-declared value.
   bool is_final = false;
+  // Whether this class is an `interface class` declaration (LRM 8.26): its
+  // body carries only pure virtual method contracts, no instance storage
+  // and no constructor. Consumers read the bit to render the class as an
+  // abstract target-language type and to route inheritance through the
+  // multi-base mechanism `implements` names.
+  bool is_interface_class = false;
 };
 
 struct Class {
   std::string name;
   std::optional<ClassRef> base;
+  std::vector<ClassRef> implements;
   bool is_scope_tree_node = false;
   bool is_final = false;
+  bool is_interface_class = false;
   TypeId self_pointer_type;
   // The class's resolved time unit and precision (LRM 3.14.2). The emitted
   // class exposes the precision so the engine can take the design-global

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -228,19 +228,46 @@ struct Indirect {
   ExprId closure;
 };
 
-// A virtually-dispatched call: the receiver is evaluated once and then the
-// implementation of the named slot on that receiver's dynamic type runs
-// (LRM 8.20). `owner_class` and `slot` name the slot as it appears in the
-// class arena that introduced it -- the canonical logical identity a
-// backend uses to reach the method's name and signature; the receiver's
-// dynamic type is what decides which implementation runs. The receiver
-// rides here, distinct from user-supplied `CallExpr::arguments`, so the
-// call carries exactly the arguments the SV source wrote and the receiver
-// is not conflated with them.
-struct Virtual {
-  ExprId receiver;
+// Identity of a virtual dispatch slot introduced by a class in this
+// compilation unit: the introducing class and the callable arena position
+// where the slot was first declared. The receiver's dynamic type is what
+// decides which implementation runs; the slot is the canonical logical
+// identity a backend reads to reach the method's name and signature.
+struct LocalVirtualSlot {
   ClassId owner_class;
   CallableId slot;
+
+  auto operator==(const LocalVirtualSlot&) const -> bool = default;
+};
+
+// Identity of a virtual dispatch slot introduced by a class in another
+// compilation unit. The introducing class carries no unit-local id here, so
+// the slot is named by (declaring unit, class canonical name, method source
+// name) -- the same triple the cross-unit override relation uses. A backend
+// renders the dispatch through the target language's own virtual-call
+// machinery reached by including the declaring unit's header.
+struct ExternalVirtualSlot {
+  std::string unit_name;
+  std::string class_name;
+  std::string method_name;
+
+  auto operator==(const ExternalVirtualSlot&) const -> bool = default;
+};
+
+// The slot a virtual call names -- an intra-unit position or a cross-unit
+// by-name identity. Peer of `DirectTarget`'s local / external variant
+// structure: identity representation follows the compilation-unit boundary,
+// never split across two dispatch node kinds.
+using VirtualSlot = std::variant<LocalVirtualSlot, ExternalVirtualSlot>;
+
+// A virtually-dispatched call: the receiver is evaluated once and then the
+// implementation of the named slot on that receiver's dynamic type runs
+// (LRM 8.20). The receiver rides here, distinct from user-supplied
+// `CallExpr::arguments`, so the call carries exactly the arguments the SV
+// source wrote and the receiver is not conflated with them.
+struct Virtual {
+  ExprId receiver;
+  VirtualSlot slot;
 };
 
 // Constructs a value of the call's result data type from the positional

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -400,8 +400,23 @@ auto RenderScopeAsClass(
   if (s.is_final) {
     out += " final";
   }
+  // Concrete base class first (LRM 8.13), then each interface contract
+  // (LRM 8.26). C++ handles the multi-base combination natively: an
+  // interface class carries no instance storage, so the multiple-inheritance
+  // does not introduce diamond storage; the target-language virtual-call
+  // machinery routes each vtable slot to the one implementation the class
+  // provides.
+  bool base_emitted = false;
+  const auto append_base = [&](const std::string& rendered) {
+    out += base_emitted ? ", public " : " : public ";
+    out += rendered;
+    base_emitted = true;
+  };
   if (s.base.has_value()) {
-    out += " : public " + RenderClassRefAsCpp(unit, *s.base);
+    append_base(RenderClassRefAsCpp(unit, *s.base));
+  }
+  for (const mir::ClassRef& iface : s.implements) {
+    append_base(RenderClassRefAsCpp(unit, iface));
   }
   out += " {\n";
   out += Indent(indent) + " public:\n";
@@ -421,7 +436,13 @@ auto RenderScopeAsClass(
     out += "\n";
   }
 
-  out += RenderConstructor(this_anchor, s, indent + 1);
+  // An interface class carries only pure virtual method contracts and no
+  // instance storage (LRM 8.26), so it has no constructor to emit; C++
+  // makes the class implicitly abstract by virtue of the pure virtual
+  // methods and forbids `new` on it.
+  if (!s.is_interface_class) {
+    out += RenderConstructor(this_anchor, s, indent + 1);
+  }
 
   // Members follow the constructor and methods. They are public so cross-unit
   // references can reach them directly.

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -604,11 +604,22 @@ auto RenderCalleePart(
                 .leading_arg_count = 0};
           },
           [&](const mir::Virtual& v) -> CalleeRender {
-            const auto& cls = view.Unit().GetClass(v.owner_class);
+            const std::string method_name = std::visit(
+                Overloaded{
+                    [&](const mir::LocalVirtualSlot& l) -> std::string {
+                      return view.Unit()
+                          .GetClass(l.owner_class)
+                          .callables.Get(l.slot)
+                          .name;
+                    },
+                    [](const mir::ExternalVirtualSlot& e) -> std::string {
+                      return e.method_name;
+                    }},
+                v.slot);
             return {
                 .expr = std::format(
                     "({})->{}", RenderExpr(view, view.Expr(v.receiver)),
-                    cls.callables.Get(v.slot).name),
+                    method_name),
                 .leading_arg_count = 0};
           },
           [&](const mir::Construct&) -> CalleeRender {

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -953,8 +953,15 @@ class HirDumper {
   }
 
   void DumpClass(std::size_t index, const ClassDecl& c) {
-    Line(std::format("[{}] class \"{}\"", index, c.name));
+    const std::string kind = c.is_interface_class ? "interface class" : "class";
+    Line(std::format("[{}] {} \"{}\"", index, kind, c.name));
     Indent();
+    if (c.base.has_value()) {
+      Line(std::format("Extends: {}", FormatClassRef(*c.base)));
+    }
+    for (const auto& impl : c.implements) {
+      Line(std::format("Implements: {}", FormatClassRef(impl)));
+    }
     for (const auto& field : c.fields) {
       Line(std::format("{}:Type[{}]", field.name, field.type.value));
     }

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -538,6 +538,32 @@ auto FindOverriddenPureInBaseChain(
   return &proto;
 }
 
+// Locates the pure virtual method prototype (LRM 8.26 / 8.21) an interface
+// class this class directly implements declares, matched by name.
+// Complements the base-chain finder for the case a class reaches an
+// interface only through its own declared implements list -- typically a
+// class with no concrete base at all, where the base-chain walk has nothing
+// to walk. Interfaces are consulted in declaration order, and the first
+// match wins (LRM 8.26.6.1 name conflict resolution: one implementation
+// satisfies every same-name interface slot).
+auto FindOverriddenPureInImplementsChain(
+    const slang::ast::ClassType& cls, std::string_view method_name)
+    -> const slang::ast::MethodPrototypeSymbol* {
+  for (const auto* iface : cls.getDeclaredInterfaces()) {
+    const auto& iface_cls =
+        iface->getCanonicalType().as<slang::ast::ClassType>();
+    const auto* found = iface_cls.find(method_name);
+    if (found == nullptr ||
+        found->kind != slang::ast::SymbolKind::MethodPrototype) {
+      continue;
+    }
+    const auto& proto = found->as<slang::ast::MethodPrototypeSymbol>();
+    if (!proto.flags.has(slang::ast::MethodFlags::Pure)) continue;
+    return &proto;
+  }
+  return nullptr;
+}
+
 auto SynthesizeDefaultConstructor(hir::TypeId void_type, diag::SourceSpan span)
     -> hir::SubroutineDecl {
   hir::ProceduralBody body;
@@ -609,7 +635,8 @@ auto UnitLowerer::MakeClassMethodTarget(
   return hir::ExternalClassMethodTarget{
       .unit_name = ext.unit_name,
       .class_name = ext.class_name,
-      .method_name = std::string(method.name)};
+      .method_name = std::string(method.name),
+      .is_virtual = method.isVirtual()};
 }
 
 auto UnitLowerer::MakeClassPropertyTarget(
@@ -689,24 +716,39 @@ auto UnitLowerer::InternLocalClass(
 
   hir::ClassDecl decl;
   decl.name = SpecializationName(cls);
+  decl.is_interface_class = cls.isInterface;
 
-  // Base class (LRM 8.13). Slang exposes the base as a `ClassType*` on the
-  // derived class and flattens inherited members into the derived's member
-  // list; the base is reached through the class-reference translator because
-  // it may live in another compilation unit, and each member iteration below
-  // filters by parent scope so only members declared on this class enter
-  // its arena.
+  // Concrete base class (LRM 8.13). Only a regular class may extend a
+  // concrete base; an interface class carries no concrete base and reaches
+  // its parent interface classes through `implements` instead. Slang
+  // exposes the concrete base as a `ClassType*` on the derived class and
+  // flattens inherited members into the derived's member list; the base is
+  // reached through the class-reference translator because it may live in
+  // another compilation unit, and each member iteration below filters by
+  // parent scope so only members declared on this class enter its arena.
   if (const auto* base_type = cls.getBaseClass()) {
     const auto& base_class =
         base_type->getCanonicalType().as<slang::ast::ClassType>();
-    if (base_class.isInterface) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedClassFeature,
-          "interface class conformance is not yet supported");
-    }
     auto base_ref = ResolveClassRef(base_class, span);
     if (!base_ref) return std::unexpected(std::move(base_ref.error()));
     decl.base = *std::move(base_ref);
+  }
+
+  // Interface class contracts (LRM 8.26.2). Slang's `getDeclaredInterfaces`
+  // returns the source-declared list: for a regular class it is the
+  // `implements` clause; for an interface class it is the `extends` clause
+  // parents. Both source keywords land in the same field because at the
+  // object model layer they name the same relation -- aggregate these
+  // interface classes' pure virtual method contracts. The implicit-inherit
+  // rule ("a subclass implicitly implements every interface its superclass
+  // implements") is walked through the base chain at consumption time, not
+  // duplicated into this list, so this stays a source-declared shape.
+  for (const auto* iface_type : cls.getDeclaredInterfaces()) {
+    const auto& iface_class =
+        iface_type->getCanonicalType().as<slang::ast::ClassType>();
+    auto iface_ref = ResolveClassRef(iface_class, span);
+    if (!iface_ref) return std::unexpected(std::move(iface_ref.error()));
+    decl.implements.push_back(*std::move(iface_ref));
   }
 
   for (const auto& prop :
@@ -815,6 +857,29 @@ auto UnitLowerer::InternLocalClass(
         method_decl->overrides = MakeClassMethodTarget(*base_ref, *proto_stub);
         // An override of a base virtual method is itself virtual (LRM 8.20),
         // even when the derived declaration omits the `virtual` keyword.
+        method_decl->is_virtual = true;
+      } else if (const auto* pure_iface =
+                     FindOverriddenPureInImplementsChain(cls, method.name);
+                 pure_iface != nullptr) {
+        // The method satisfies an interface class's pure virtual contract
+        // (LRM 8.26). Slang validates the satisfaction but leaves the
+        // override link unset on the concrete method; wire it so downstream
+        // dispatch canonicalizes to the interface's slot instead of
+        // treating this method as a fresh introducer.
+        const auto& iface_class = pure_iface->getParentScope()
+                                      ->asSymbol()
+                                      .as<slang::ast::ClassType>();
+        auto iface_ref = ResolveClassRef(iface_class, span);
+        if (!iface_ref) return std::unexpected(std::move(iface_ref.error()));
+        const auto* proto_stub = pure_iface->getSubroutine();
+        if (proto_stub == nullptr) {
+          throw InternalError(
+              "UnitLowerer::InternLocalClass: interface pure virtual "
+              "prototype has no stub subroutine slang normally materializes");
+        }
+        method_decl->overrides = MakeClassMethodTarget(*iface_ref, *proto_stub);
+        // A method satisfying an interface pure virtual is itself virtual
+        // (LRM 8.26.2 requires the implementation carry `virtual`).
         method_decl->is_virtual = true;
       }
     }

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -176,19 +176,18 @@ auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
 
   std::optional<mir::ClassRef> base_ref;
   if (hir_class.base.has_value()) {
-    if (const auto* local_base =
-            std::get_if<hir::LocalClassRef>(&*hir_class.base)) {
-      base_ref = mir::ClassRef{mir::IntraUnitClassRef{
-          .class_id = unit_lowerer.TranslateClass(local_base->class_id)}};
-    } else {
-      base_ref = unit_lowerer.MakeExternalClassBaseRef(
-          std::get<hir::ExternalClassRef>(*hir_class.base));
-    }
+    base_ref = unit_lowerer.TranslateClassRef(*hir_class.base);
+  }
+  std::vector<mir::ClassRef> implements;
+  implements.reserve(hir_class.implements.size());
+  for (const hir::ClassRef& iface : hir_class.implements) {
+    implements.push_back(unit_lowerer.TranslateClassRef(iface));
   }
 
   mir::ClassShape shape{
       .name = hir_class.name,
       .base = base_ref,
+      .implements = std::move(implements),
       .self_pointer_type = self_pointer_type,
       .time_resolution = {},
       .ctor_prefix_params = {},
@@ -197,7 +196,8 @@ auto ClassDeclLowerer::DeclareShape() -> diag::Result<void> {
       .callable_signatures = {},
       .contained = {},
       .is_scope_tree_node = false,
-      .is_final = false};
+      .is_final = false,
+      .is_interface_class = hir_class.is_interface_class};
 
   // Property fields come first in declaration order (LRM 8.4), so an SV
   // reference to a property by its declaration index reaches the same shape
@@ -256,8 +256,10 @@ auto ClassDeclLowerer::PopulateBodies() -> diag::Result<void> {
   mir::Class mir_class{
       .name = shape.name,
       .base = shape.base,
+      .implements = shape.implements,
       .is_scope_tree_node = shape.is_scope_tree_node,
       .is_final = shape.is_final,
+      .is_interface_class = shape.is_interface_class,
       .self_pointer_type = shape.self_pointer_type,
       .time_resolution = shape.time_resolution,
       .fields = shape.fields,

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -609,15 +609,28 @@ auto LowerMethodCall(
   }
 
   // Cross-unit instance method: no local shape store to query for the
-  // callee's dispatch role, so this site always lowers to a direct call
-  // naming the method by (unit, class, method) name. Virtual resolution
-  // rides on the target-language include of the declaring unit's header --
-  // the callee's own virtual machinery dispatches at the receiver's runtime
-  // class -- and a super qualifier crosses the boundary the same way, as
-  // an owner-scoped call the backend renders when the qualification arm
-  // is set.
+  // callee's dispatch role, so the HIR target's `is_virtual` fact -- read
+  // from the callee's frontend view when the target was minted -- decides
+  // between virtual dispatch (LRM 8.20) and static dispatch. A super
+  // qualifier always demands the base's implementation regardless of the
+  // callee's virtuality, so it lowers as a direct owner-qualified call
+  // even when the target is virtual.
   if (const auto* ext_target =
           std::get_if<hir::ExternalClassMethodTarget>(&m.target)) {
+    const bool through_super_ext =
+        std::holds_alternative<hir::SuperReceiver>(m.receiver);
+    if (!through_super_ext && ext_target->is_virtual) {
+      return mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::Virtual{
+                          .receiver = receiver_ptr,
+                          .slot = lowerer.Owner().MakeExternalVirtualSlot(
+                              *ext_target)},
+                  .arguments = std::move(user_args)},
+          .type = result_type};
+    }
     std::vector<mir::ExprId> direct_args;
     direct_args.reserve(user_args.size() + 1);
     direct_args.push_back(receiver_ptr);
@@ -667,8 +680,10 @@ auto LowerMethodCall(
                 .callee =
                     mir::Virtual{
                         .receiver = receiver_ptr,
-                        .owner_class = canonical_owner,
-                        .slot = canonical_slot},
+                        .slot =
+                            mir::LocalVirtualSlot{
+                                .owner_class = canonical_owner,
+                                .slot = canonical_slot}},
                 .arguments = std::move(user_args)},
         .type = result_type};
   }

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -272,19 +272,9 @@ auto LowerHirPrimaryExprProc(
                 frame.current_class->self_pointer_type;
             const mir::ExprId self_ref = frame.current_block->exprs.Add(
                 MakeSelfRefExpr(frame, self_type));
-            if (const auto* local =
-                    std::get_if<hir::LocalClassPropertyTarget>(&r.target)) {
-              return mir::MakeFieldAccessExpr(
-                  self_ref,
-                  mir::FieldTarget{
-                      .owner = process.Owner().TranslateClass(local->owner),
-                      .slot = UnitLowerer::TranslateField(local->field)},
-                  result_type);
-            }
             return mir::MakeFieldAccessExpr(
                 self_ref,
-                process.Owner().MakeExternalFieldTarget(
-                    std::get<hir::ExternalClassPropertyTarget>(r.target)),
+                process.Owner().TranslateClassPropertyTarget(r.target),
                 result_type);
           },
           [&](const hir::StaticPropertyRef& r) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -452,19 +452,8 @@ auto LowerHirClassPropertyAccessExpr(
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-  if (const auto* local =
-          std::get_if<hir::LocalClassPropertyTarget>(&sel.target)) {
-    return mir::MakeFieldAccessExpr(
-        base_id,
-        mir::FieldTarget{
-            .owner = unit_lowerer.TranslateClass(local->owner),
-            .slot = UnitLowerer::TranslateField(local->field)},
-        result_type);
-  }
   return mir::MakeFieldAccessExpr(
-      base_id,
-      unit_lowerer.MakeExternalFieldTarget(
-          std::get<hir::ExternalClassPropertyTarget>(sel.target)),
+      base_id, unit_lowerer.TranslateClassPropertyTarget(sel.target),
       result_type);
 }
 
@@ -592,19 +581,8 @@ auto LowerHirClassPropertyAccessExprLhs(
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-  if (const auto* local =
-          std::get_if<hir::LocalClassPropertyTarget>(&sel.target)) {
-    return mir::MakeFieldAccessExpr(
-        base_id,
-        mir::FieldTarget{
-            .owner = unit_lowerer.TranslateClass(local->owner),
-            .slot = UnitLowerer::TranslateField(local->field)},
-        result_type);
-  }
   return mir::MakeFieldAccessExpr(
-      base_id,
-      unit_lowerer.MakeExternalFieldTarget(
-          std::get<hir::ExternalClassPropertyTarget>(sel.target)),
+      base_id, unit_lowerer.TranslateClassPropertyTarget(sel.target),
       result_type);
 }
 

--- a/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
@@ -320,11 +320,19 @@ auto UnitLowerer::MakeExternalClassPointee(const hir::ExternalClassRef& ref)
               std::format("{}::{}", ref.unit_name, ref.class_name)});
 }
 
-auto UnitLowerer::MakeExternalClassBaseRef(const hir::ExternalClassRef& ref)
+auto UnitLowerer::MakeExternalClassRef(const hir::ExternalClassRef& ref)
     -> mir::ClassRef {
   unit_.AddExternalClassUnit(ref.unit_name);
   return mir::ClassRef{mir::ExternalClassRef{
       .qualified_name = std::format("{}::{}", ref.unit_name, ref.class_name)}};
+}
+
+auto UnitLowerer::TranslateClassRef(const hir::ClassRef& ref) -> mir::ClassRef {
+  if (const auto* local = std::get_if<hir::LocalClassRef>(&ref)) {
+    return mir::ClassRef{
+        mir::IntraUnitClassRef{.class_id = TranslateClass(local->class_id)}};
+  }
+  return MakeExternalClassRef(std::get<hir::ExternalClassRef>(ref));
 }
 
 auto UnitLowerer::MakeExternalFieldTarget(
@@ -335,6 +343,17 @@ auto UnitLowerer::MakeExternalFieldTarget(
       .unit_name = target.unit_name,
       .class_name = target.class_name,
       .field_name = target.property_name};
+}
+
+auto UnitLowerer::TranslateClassPropertyTarget(
+    const hir::ClassPropertyTarget& target) -> mir::FieldRef {
+  if (const auto* local = std::get_if<hir::LocalClassPropertyTarget>(&target)) {
+    return mir::FieldRef{mir::FieldTarget{
+        .owner = TranslateClass(local->owner),
+        .slot = TranslateField(local->field)}};
+  }
+  return mir::FieldRef{MakeExternalFieldTarget(
+      std::get<hir::ExternalClassPropertyTarget>(target))};
 }
 
 auto UnitLowerer::MakeExternalStaticPropertyRef(
@@ -362,6 +381,15 @@ auto UnitLowerer::MakeExternalMethodOverride(
     -> mir::OverridesExternalSlot {
   unit_.AddExternalClassUnit(target.unit_name);
   return mir::OverridesExternalSlot{
+      .unit_name = target.unit_name,
+      .class_name = target.class_name,
+      .method_name = target.method_name};
+}
+
+auto UnitLowerer::MakeExternalVirtualSlot(
+    const hir::ExternalClassMethodTarget& target) -> mir::ExternalVirtualSlot {
+  unit_.AddExternalClassUnit(target.unit_name);
+  return mir::ExternalVirtualSlot{
       .unit_name = target.unit_name,
       .class_name = target.class_name,
       .method_name = target.method_name};

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -185,6 +185,25 @@ class MirDumper {
         ref);
   }
 
+  [[nodiscard]] auto FormatVirtualSlot(const VirtualSlot& s) const
+      -> std::string {
+    return std::visit(
+        Overloaded{
+            [this](const LocalVirtualSlot& l) -> std::string {
+              const auto& owner = unit_->GetClass(l.owner_class);
+              const auto& callable = owner.callables.Get(l.slot);
+              return std::format(
+                  "Class[{}].{}(Callable[{}])", l.owner_class.value,
+                  callable.name, l.slot.value);
+            },
+            [](const ExternalVirtualSlot& e) -> std::string {
+              return std::format(
+                  "External({}::{}::{})", e.unit_name, e.class_name,
+                  e.method_name);
+            }},
+        s);
+  }
+
   static auto FormatType(const Type& t) -> std::string {
     return std::visit(
         Overloaded{
@@ -567,12 +586,9 @@ class MirDumper {
             },
             [](const Construct&) -> std::string { return "Construct"; },
             [this](const Virtual& v) -> std::string {
-              const auto& owner = unit_->GetClass(v.owner_class);
-              const auto& callable = owner.callables.Get(v.slot);
               return std::format(
-                  "Virtual[recv=Expr[{}] slot=Class[{}].{}(Callable[{}])]",
-                  v.receiver.value, v.owner_class.value, callable.name,
-                  v.slot.value);
+                  "Virtual[recv=Expr[{}] slot={}]", v.receiver.value,
+                  FormatVirtualSlot(v.slot));
             },
         },
         callee);
@@ -835,11 +851,16 @@ class MirDumper {
 
   void DumpClass(ClassId id, const Class& s) {
     scope_stack_.push_back(&s);
-    Line(std::format("Class \"{}\" (#{})", s.name, id.value));
+    const std::string kind = s.is_interface_class ? "InterfaceClass" : "Class";
+    Line(std::format("{} \"{}\" (#{})", kind, s.name, id.value));
     Indent();
 
     if (s.base.has_value()) {
       Line(std::format("Base: {}", FormatClassRef(*s.base)));
+    }
+
+    for (const auto& impl : s.implements) {
+      Line(std::format("Implements: {}", FormatClassRef(impl)));
     }
 
     Line("Contained:");

--- a/tests/cases/cpp/class_interface_conformance/case.yaml
+++ b/tests/cases/cpp/class_interface_conformance/case.yaml
@@ -1,0 +1,19 @@
+id: cpp.class_interface_conformance
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    cell_direct_get: 42
+    cell_via_putter: 51
+    cell_via_getter: 51
+    cell_via_putget: 201
+    cell_tag_direct: 7
+    cell_tag_via_named: 7
+    byte_get_value: 12
+    derived_tag_direct: 100
+    derived_tag_via_named: 100

--- a/tests/cases/cpp/class_interface_conformance/main.sv
+++ b/tests/cases/cpp/class_interface_conformance/main.sv
@@ -1,0 +1,126 @@
+// LRM 8.26 interface classes. A set of related classes shares a common set
+// of behaviors through interface class contracts: only pure virtual method
+// prototypes and type-level declarations, no instance storage, not itself
+// constructible. Non-interface classes commit to satisfying an interface
+// through `implements`; an interface class extends other interface classes
+// through `extends`. Both keywords name the same relation at the object
+// model layer (aggregate these contracts) and land in one HIR / MIR field.
+// Covers:
+//   - Interface class in a package, reached from a module class (cross-unit).
+//   - Regular class implementing multiple interface classes.
+//   - Interface class extending multiple interface classes (LRM 8.26.2).
+//   - Parameterized interface class specialization (LRM 8.25 + 8.26).
+//   - Handle upcast to an interface class handle (LRM 8.26.5).
+//   - Virtual dispatch through an interface class handle (LRM 8.20 + 8.26).
+//   - One method satisfying multiple same-name pure virtual slots (LRM
+//     8.26.6.1 name conflict resolution).
+//   - Inherited satisfaction: the concrete base provides the implementation
+//     (LRM 8.26.2 -- `virtual` on the base method carries through).
+package pkg;
+
+  interface class Putter #(type T = int);
+    pure virtual function void put(T a);
+  endclass
+
+  interface class Getter #(type T = int);
+    pure virtual function T get();
+  endclass
+
+  interface class PutGet #(type T = int) extends Putter #(T), Getter #(T);
+  endclass
+
+  interface class Named;
+    pure virtual function int tag();
+  endclass
+
+  class Base;
+    virtual function int tag();
+      return 100;
+    endfunction
+  endclass
+
+endpackage
+
+module Top;
+
+  class Cell implements pkg::PutGet #(int), pkg::Named;
+    int value = 0;
+    virtual function void put(int a);
+      value = a;
+    endfunction
+    virtual function int get();
+      return value + 1;
+    endfunction
+    virtual function int tag();
+      return 7;
+    endfunction
+  endclass
+
+  class ByteCell implements pkg::Putter #(byte), pkg::Getter #(byte);
+    byte b = 0;
+    virtual function void put(byte a);
+      b = a;
+    endfunction
+    virtual function byte get();
+      return b;
+    endfunction
+  endclass
+
+  // Inherited satisfaction (LRM 8.26.2): Base has `virtual function int
+  // tag()`, and `pkg::Named` requires `pure virtual function int tag()`. The
+  // implementation is inherited from Base; Derived does not need to redefine
+  // it.
+  class Derived extends pkg::Base implements pkg::Named;
+  endclass
+
+  int cell_direct_get;
+  int cell_via_putter;
+  int cell_via_getter;
+  int cell_via_putget;
+  int cell_tag_direct;
+  int cell_tag_via_named;
+
+  int byte_get_value;
+  int derived_tag_direct;
+  int derived_tag_via_named;
+
+  initial begin
+    Cell c;
+    ByteCell bc;
+    Derived d;
+    pkg::Putter #(int) put_ref;
+    pkg::Getter #(int) get_ref;
+    pkg::PutGet #(int) putget_ref;
+    pkg::Named named_ref;
+    pkg::Getter #(byte) byte_get_ref;
+
+    c = new;
+    c.put(41);
+    cell_direct_get = c.get();
+
+    put_ref = c;
+    put_ref.put(50);
+    cell_via_putter = c.get();
+
+    get_ref = c;
+    cell_via_getter = get_ref.get();
+
+    putget_ref = c;
+    putget_ref.put(200);
+    cell_via_putget = putget_ref.get();
+
+    named_ref = c;
+    cell_tag_direct = c.tag();
+    cell_tag_via_named = named_ref.tag();
+
+    bc = new;
+    bc.put(8'sd12);
+    byte_get_ref = bc;
+    byte_get_value = byte_get_ref.get();
+
+    d = new;
+    derived_tag_direct = d.tag();
+    named_ref = d;
+    derived_tag_via_named = named_ref.tag();
+  end
+endmodule


### PR DESCRIPTION
## Summary

An SV class can now conform to interface classes (LRM 8.26): the concrete class extends at most one base and implements zero or more interface class contracts, each contract a set of pure virtual methods the class must satisfy. Interface classes themselves may extend other interface classes (multiple inheritance among contracts). Parameterized interface classes and cross-unit interface conformance both ride existing machinery.

## Design

Interface class is the same `hir::ClassDecl` / `mir::ClassShape` shape as a regular class, distinguished by an `is_interface_class` bit and by having its non-contract slots empty (no fields, no static properties, no constructor, only pure virtual methods). The object model already commits to "one nominal object type" (invariant 1) and to a two-relation split between concrete inheritance and interface conformance (invariant 3); a second declaration kind or a base list mixing concrete + interface entries would violate both.

`implements: vector<ClassRef>` on the class declaration is where both SV keywords land: a regular class's `implements` clause and an interface class's `extends` clause populate the same field because at the object-model layer they name the same relation -- aggregate these interface classes' pure virtual method contracts. The frontend has already resolved LRM 8.26.3's rule (`extends` inherits typedefs and parameters, `implements` does not) into the resolved references we intake.

`mir::Virtual.slot` becomes a `VirtualSlot` variant (`LocalVirtualSlot` / `ExternalVirtualSlot`), peer to `Direct.target`'s local / external variant. This closes a gap left by the cross-unit class ownership work where a cross-unit virtual call slipped through as `mir::Direct` and relied on the C++ backend's vtable to recover virtuality; MIR now states the fact so a future LLVM backend has what it needs. `hir::ExternalClassMethodTarget` carries the callee's `is_virtual` fact from the AST-to-HIR intake so the call lowering can pick between `Virtual` and `Direct` without querying another unit's shape store.

For one method that satisfies multiple same-name pure virtual slots (LRM 8.26.6.1), the MIR override target picks the first match in `implements` declaration order as canonical; the C++ backend's virtual-override machinery routes every same-name vtable slot to that one implementation.

The C++ backend renders an interface class as an abstract class with pure virtual methods and no fields / constructor; a class implementing interfaces emits with each interface class as an additional public base after the concrete base. `GcRef<T>`'s existing converting constructor handles handle upcast to an interface class handle for free.

While the audit surfaced it, `TranslateClassPropertyTarget` factors the same variant-dispatch pattern the new `TranslateClassRef` uses, replacing three inline dispatches in `references.cpp` and `selects.cpp` with a single call.

## Testing

`tests/cases/cpp/class_interface_conformance/main.sv` covers interface class in a package reached from a module class, a regular class implementing multiple interface classes, an interface class extending multiple interface classes, parameterized interface class specialization, handle upcast to an interface handle, virtual dispatch through an interface handle, and inherited satisfaction where a concrete base's `virtual` method provides the interface's pure virtual implementation.