### PR TITLE
Cover package import forms and shadowing

### DIFF
--- a/docs/progress/packages.md
+++ b/docs/progress/packages.md
@@ -20,12 +20,14 @@ inside a package ride on the class workstream and are out of scope here.
 
 ## Actionable
 
-PK1 (compile-time contents), PK2 (the package as a first-class unit, carrying functions), and PK3
-(package variables) are done on the C++ backend: a package variable is declared with an initializer,
-initialized once at time zero before the top modules, and read and written from another unit by
-name, including from a package function or task and including waking a process on its change. A
-package task enabled from another unit suspends its caller until it completes. PK4 (the import forms
-and the LRM 26.3 name-search rules) is the next actionable step.
+PK1 (compile-time contents), PK2 (the package as a first-class unit, carrying functions), PK3
+(package variables), and PK4 (the import forms and the LRM 26.3 name-search rules) are done on the
+C++ backend: a package variable is declared with an initializer, initialized once at time zero
+before the top modules, and read and written from another unit by name, including from a package
+function or task, by explicit `pkg::item` or by a bare name brought into scope by import, and
+including waking a process on its change. A package task enabled from another unit suspends its
+caller until it completes. PK5 (`$unit`-scope declarations) is the next actionable step. The
+remaining PK2 and PK3 increments (checkboxes below) are independent follow-ups.
 
 ## Sub-Steps
 
@@ -47,9 +49,11 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
       namespace of free functions, and a package function whose signature or body names a
       package-declared enum or typedef resolves it against the namespace's own type declarations,
       emitted into the namespace. Input arguments and the return value work, and one package
-      function calls a sibling in the same package. Remaining increments: a package function with an
-      output / inout / ref argument; and a DPI-C import declared inside a package (LRM 35.4), which
-      is rejected with a diagnostic rather than mis-emitted.
+      function calls a sibling in the same package.
+  - [ ] A package subroutine with an output / inout / ref argument, whose by-reference formal is
+        marshalled across the unit boundary.
+  - [ ] A DPI-C import declared inside a package (LRM 35.4), which is rejected with a diagnostic
+        rather than mis-emitted.
 - [x] PK3 -- Package variables. A package variable is static storage owned by the namespace -- one
       program-global cell, shared, not a member of any instance -- read and written from other units
       by name. It is the same type-associated storage a class static property uses, not a
@@ -64,16 +68,22 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
       relative order of initializers is unspecified by the LRM; the design root picks a stable,
       best-effort order (a dependency before its dependent where a direct read makes it known) as a
       quality-of-implementation choice, and an unknown or cyclic dependency degrades to reading a
-      default, never a crash. Remaining increments: an initializer read reached through a called
-      function does not yet contribute to the preferred order; and two packages that reference each
-      other's symbols still produce circular emitted headers (a header-only emission limit, shared
-      with cross-package subroutine calls, not specific to variables).
-- [ ] PK4 -- The `import` forms for the remaining item kinds and the LRM 26.3 name-search and
+      default, never a crash.
+  - [ ] An initializer read reached through a called function contributes to the preferred
+        initialization order.
+  - [ ] Two packages that reference each other's symbols emit non-circular headers (a header-only
+        emission limit, shared with cross-package subroutine calls, not specific to variables).
+- [x] PK4 -- The `import` forms for the remaining item kinds and the LRM 26.3 name-search and
       shadowing rules. An import brings a name into a scope's lookup; it does not create a new kind
       of reference, so a name resolved through an import lowers identically to the explicit
       `pkg::item` form. Import of compile-time contents is covered by PK1; this item covers import
-      of the callable and variable entities once PK2 and PK3 exist, plus the search-order and
-      shadowing rules.
+      of the callable and variable entities. A package variable (read and write), a package
+      function, and a package task reached by a bare name after explicit `import pkg::item` or
+      wildcard `import pkg::*` behave exactly as under explicit scope resolution. A local
+      declaration shadows a wildcard-imported name, and a package imports another package's symbols
+      the same way a module does. The frontend resolves every import and enforces the search-order,
+      shadowing, and collision rules before lowering, so a bare imported name arrives already bound
+      to its package member.
 - [ ] PK5 -- `$unit`-scope declarations (LRM 3.12.1): declarations outside any design element,
       visible across the compilation-unit file set. Modeled as an implicit anonymous package so they
       ride the same unit, by-name reference, storage, and callable mechanisms as a named package; no
@@ -81,7 +91,7 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
 
 ## Blocked
 
-Nothing blocked. PK4 is actionable now.
+Nothing blocked. PK5 is actionable now.
 
 ## Out of Scope
 

--- a/tests/cases/cpp/package_import/case.yaml
+++ b/tests/cases/cpp/package_import/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.package_import
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    var_read: 5
+    fn_read: 10
+    after_write: 8
+    after_task: 20

--- a/tests/cases/cpp/package_import/main.sv
+++ b/tests/cases/cpp/package_import/main.sv
@@ -1,0 +1,41 @@
+// An `import` brings a package's names into a scope's lookup (LRM 26.3); it does
+// not create a new kind of reference. A name reached by a bare identifier after
+// import resolves to the same cross-unit package entity as the explicit
+// `pkg::item` form, so it lowers identically. This exercises both import forms
+// against the entities that are real cross-unit symbols -- a package variable
+// (read and write), a package function, and a package task -- since compile-time
+// contents (parameters, typedefs, enums) fold or intern in place and are covered
+// elsewhere. The explicit import of a name coexists with a wildcard import of the
+// package: the explicit import takes precedence and is not a collision.
+package pkg;
+  int cnt = 5;
+
+  function automatic int doubled();
+    return cnt * 2;
+  endfunction
+
+  task automatic set_cnt(int v);
+    #1;
+    cnt = v;
+  endtask
+endpackage
+
+module Top;
+  import pkg::cnt;
+  import pkg::set_cnt;
+  import pkg::*;
+
+  int var_read;
+  int fn_read;
+  int after_write;
+  int after_task;
+
+  initial begin
+    var_read = cnt;
+    fn_read = doubled();
+    cnt = 8;
+    after_write = cnt;
+    set_cnt(20);
+    after_task = cnt;
+  end
+endmodule

--- a/tests/cases/cpp/package_import_shadowing/case.yaml
+++ b/tests/cases/cpp/package_import_shadowing/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.package_import_shadowing
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    local_val: 3
+    pkg_shared_after: 5
+    wildcard_val: 9
+    cross_pkg: 10

--- a/tests/cases/cpp/package_import_shadowing/main.sv
+++ b/tests/cases/cpp/package_import_shadowing/main.sv
@@ -1,0 +1,35 @@
+// The LRM 26.3 name-search rules for a wildcard import. A wildcard `import pkg::*`
+// makes a name a candidate only when the scope does not otherwise declare it: a
+// local declaration of the same name shadows the import, and a reference to the
+// shadowed name reaches the local, leaving the package's own cell untouched. A
+// name the scope does not declare resolves through the wildcard to the package
+// member. An import is also a package-to-package reference: a package that
+// imports another package's variable and reads it in an initializer reaches the
+// imported cell by name, the same cross-unit form a module uses.
+package pkg;
+  int shared = 5;
+  int other = 9;
+endpackage
+
+package mid;
+  import pkg::other;
+  int derived = other + 1;
+endpackage
+
+module Top;
+  import pkg::*;
+  int shared;
+
+  int local_val;
+  int pkg_shared_after;
+  int wildcard_val;
+  int cross_pkg;
+
+  initial begin
+    shared = 3;
+    local_val = shared;
+    pkg_shared_after = pkg::shared;
+    wildcard_val = other;
+    cross_pkg = mid::derived;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Locks in the `import` half of SystemVerilog packages (LRM 26.3): a package variable, function, or task reached by a bare name after an explicit `import pkg::item` or a wildcard `import pkg::*` behaves exactly as under explicit `pkg::item` scope resolution, a local declaration shadows a wildcard-imported name, and a package imports another package's symbols the same way a module does. This is PK4 in `docs/progress/packages.md`.

## Design

PK4 needs no new lowering mechanism, and the change is test-only. The frontend fully resolves every import before AST-to-HIR: a bare imported name arrives already bound to the same package member symbol that an explicit `pkg::item` reference produces (confirmed by identical symbol identity across explicit-reference, explicit-import, and wildcard-import forms), and the frontend enforces the LRM 26.3 search-order, shadowing, and collision rules during elaboration. Lyra classifies a reference as cross-unit by the resolved symbol's owning scope, never by the `pkg::` syntax, so an imported name routes through the exact same cross-unit by-name reference as explicit scope resolution. This is by design: the cross-unit reference translator deliberately walks up to the owning unit rather than threading source qualifiers, precisely because a wildcard-imported name carries no qualifier at the reference site.

## Testing

Two cpp_run cases. `package_import` mixes an explicit import of a variable and a task with a wildcard import supplying a function, exercising a read, a write, a call, and a task enable by bare name. `package_import_shadowing` covers a local declaration shadowing a wildcard import while leaving the package cell untouched, an un-shadowed wildcard name resolving to the package member, and a package that imports another package's variable and reads it in an initializer.

The progress doc also promotes the previously prose-only remaining PK2 and PK3 increments to checkboxes, and records PK5 (`$unit`-scope declarations) as the next actionable step.