### PR TITLE
Add the dynamic array to the execution backend

### DIFF
--- a/docs/architecture/lir.md
+++ b/docs/architecture/lir.md
@@ -256,7 +256,13 @@ value-aggregate family: a packed slice, a container element, and a union member 
 sub-accesses, so a sub-write is a functional whole-value update, never a store into an independently
 addressable sub-place -- a static, structural selector (a struct component) may ride a dedicated
 value instruction, a dynamic, runtime-indexed one (a container element) a runtime-library call, but
-the principle that a value sub-write produces a new whole value is the same.
+the principle that a value sub-write produces a new whole value is the same. A whole-value mutating
+method on a value receiver -- a container's `delete`, a queue's `push` -- follows the same rule: it
+is realized as a functional operation whose result is stored back through the receiver's owner, not
+an in-place mutation of the value. How a target keeps value semantics for such a store is below LIR:
+a target with language-level value copies may fulfill it by mutating a private copy in place, while
+one whose container value is reached through a shared handle must produce a new value, so the model
+LIR states -- a new whole value written back to the owner -- holds for both.
 
 LIR carries the fact that a packed value is two-state or four-state; it does not carry how a
 four-state value is stored. The canonical encoding of a four-state value -- value bits plus a state

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -350,3 +350,16 @@ already says `wrapper.<read>(...)` or `wrapper.<write>(...)`; the backend reads 
 it the same way it emits any other call. The wrapper type's target-language spelling and the method
 spellings are backend-internal -- `backend_contract.md` owns the rules that keep those out of
 value-emission sites.
+
+An assignment whose target is a place-producing access -- a container element, a struct component, a
+union member -- states an abstract update of the owning value: which owner, which selector, how many
+times the selector evaluates, the value written and its coercion, and that the owning value is the
+value updated. A place names where the write lands; it does not assert that the interior is
+independently addressable storage, an alias with its own identity, or a reference that outlives the
+owner. How that update keeps value semantics is a lower layer's concern: MIR-to-LIR legalizes a
+value-owned projection into explicit whole-value operations -- an extract and an insert, or a
+container primitive -- where the target's representation requires it (`lir.md`), and a backend may
+instead realize the same semantics by mutating private storage in place. A write-side selector whose
+name carries `Ref` marks the write side of the access, not a first-class interior reference; a
+reference that could escape the owner or alias it would be a distinct concept, not this target
+place.

--- a/docs/decisions/jit-value-realization.md
+++ b/docs/decisions/jit-value-realization.md
@@ -75,6 +75,18 @@ The accurate framing, which documentation must not overstate into a final value 
    Native lowering of small scalars or simple packed values is a future option, not a split to make
    now.
 
+6. **A runtime value handle is immutable from the generated side's view; every apparent mutation is
+   functional.** A whole-value assignment carries a handle, which a copy may alias, so the runtime
+   value object behind it is never mutated in place through a possibly-shared handle. An operation
+   that appears to mutate a value -- a scalar compound-assign, a container element write, a
+   receiver-mutating container method (`delete`) -- produces a _new_ value handle, which is stored
+   back through the value's owner (its place, activation cell, or observable cell). This is what
+   makes handle aliasing safe: `b = a; a[i] = x;` leaves `b` intact because the element write
+   rebuilds `a`'s value and restores it to `a`'s storage, never touching the object `b` still holds.
+   The C++ backend reaches the same value semantics through the language's own value copies, so it
+   may mutate a local value object in place; the generated side, holding only handles, may not, and
+   never copies that in-place realization.
+
 ## Separate from the generated-behavior descriptor
 
 Value lifetime and ABI realization is one axis; the ownership of the generated-behavior record

--- a/docs/progress/execution-backend.md
+++ b/docs/progress/execution-backend.md
@@ -22,9 +22,9 @@ the stretch that made it.
       activation frame, storage the running activation owns for its whole life and reaches through a
       handle the generated frame holds. A store copies into it; a load copies out; the store
       decision is made where storage placement belongs and the backend realizes it as an ordinary
-      call, so it stays mechanical. Complete for the value domains the backend realizes today
-      (packed, string, and the real family -- real, shortreal, realtime). Contracts and rationale:
-      `../decisions/cross-suspension-value-storage.md`,
+      call, so it stays mechanical. Complete for every non-managed value domain the backend realizes
+      today, aggregates included -- a struct or dynamic-array local crosses as one activation-frame
+      value. Contracts and rationale: `../decisions/cross-suspension-value-storage.md`,
       `../decisions/activation-frame-and-transient-scope.md`.
 
 - [x] **The storage lifetimes are named and separated.** The per-stretch transient scope, the
@@ -61,19 +61,58 @@ ownership, or native in-frame layout) for every value.
       A component write is a whole-value rebuild stored back through the value's owner, so an
       observable partial write never bypasses the cell's update semantics -- the aggregate
       partial-update protocol a container reuses later.
-- [ ] **The remaining value domains** (unpacked array, dynamic array, queue, associative array) --
-      not realized on the execution backend yet. Each is a homogeneous or keyed collection whose
-      element count is a runtime quantity, so unlike the fixed-arity struct its element operations
-      are runtime loops rather than generated-code expansions.
+- [x] **The dynamic array** (LRM 7.5) -- realized on the execution backend as a run-time-sized
+      container value domain, the first variable-size aggregate. It defaults to empty, builds from
+      `new[N]` / `new[N](src)` and an assignment pattern, copies with value semantics, takes the
+      equality and case-equality families, reports its size, reads and writes an element (an
+      out-of-range read yields the element default and an out-of-range write is discarded, LRM 7.4.5
+      / 7.4.6), empties under `delete`, lives in a member slot as a whole-cell observable signal
+      whose element write fires subscribers, and crosses a suspension as an activation-frame value.
+      An element write and `delete` are functional whole-value updates stored back through the owner
+      -- never an in-place mutation of a value reached through a possibly-shared handle -- so value
+      semantics hold across a copy; this is the mutating-container protocol the queue and
+      associative array reuse.
+- [ ] **The remaining collection domains** (unpacked array, queue, associative array) -- not
+      realized on the execution backend yet. Each is a homogeneous or keyed collection whose element
+      count is a runtime quantity; the dynamic array established the erased-container and
+      functional-update shape they follow.
 - [ ] **A managed value (class handle) across a suspension.** A traceable frame and precise
       reclamation, none of which is implemented: the managed reference is realized as a
       reference-counted handle that does not reclaim cycles, and only in the C++ backend. Contract:
       `../architecture/object_lifetime.md`.
 - [ ] **A reference, `output`, or `inout` argument aliasing a procedural local.** Taking the address
       of a suspending body's value local is not yet lowered.
-- [ ] **Native in-frame layout for value members** -- the baseline keeps runtime-owned cells; a
-      value's bytes in the generated frame is the deferred optimization
-      (`../decisions/jit-value-realization.md`).
+
+## Value realization: two tracks today, one native model deferred
+
+The value layer is realized two ways, and the breadth work above runs against this split:
+
+- The transitional C++ backend realizes each value type as a monomorphized target type -- the host
+  C++ compiler expands one concrete type per element type, and an aggregate interior is written in
+  place because that type owns real storage.
+- The execution backend realizes each value as an opaque handle into a runtime-owned, type-erased
+  object (`../decisions/jit-value-realization.md`, `../decisions/jit-aggregate-realization.md`): it
+  emits generated code with no host compiler to expand a template, so an aggregate is one erased
+  object and an interior write is a functional whole-value update.
+
+Both are correct and agree per source (the backend-agreement tests check this), but they are two
+implementations of the same value semantics. Every value domain added to the execution backend is a
+second implementation beside the C++ one, so the two-track maintenance grows as the breadth fills.
+This is deliberate, not overlooked: erasure is the uniform, correct baseline chosen so the
+value-domain breadth can be filled first, and the C++ backend is transitional.
+
+- [ ] **One native value model (physical value monomorphization).** The convergence that ends the
+      two-track split: the execution backend generates specialized native code per concrete type --
+      doing the type expansion itself, the way the host C++ compiler does it for the C++ backend --
+      so a value's bytes live inline and its operations are native, reproducing the value layer's
+      physical layout in generated code (`../decisions/jit-aggregate-realization.md` physical value
+      monomorphization; `../decisions/jit-value-realization.md` native in-frame layout, member
+      storage included). It is a deferred, value-model-wide endpoint gated behind the value-domain
+      breadth being broad, never a per-domain step; once it lands the value model is native on both
+      sides and the second implementation is no longer a separate track. A run-time-sized container
+      keeps runtime-owned storage regardless -- its element count is a runtime quantity -- so this
+      makes the fixed-arity aggregates and the element bytes native, not the container's own
+      storage.
 
 ## Deferred effects and concurrency
 

--- a/include/lyra/backend/llvm/codegen_function.hpp
+++ b/include/lyra/backend/llvm/codegen_function.hpp
@@ -42,6 +42,9 @@ class CodeGenFunction {
   auto LowerTupleAggregate(
       const lir::AggregateInstr& agg, const lir::TupleType& tuple)
       -> llvm::Value*;
+  auto LowerErasedDynamicArrayConstruct(
+      const lir::CallInstr& call, const lir::DynamicArrayType& type)
+      -> llvm::Value*;
   auto LowerAggregateExtract(const lir::AggregateExtractInstr& extract)
       -> llvm::Value*;
   auto LowerAggregateUpdate(const lir::AggregateUpdateInstr& update)

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -36,6 +36,7 @@ enum class ValueDomain : std::uint8_t {
   kShortReal,
   kChandle,
   kTuple,
+  kDynArray,
 };
 
 auto ValueDomainName(ValueDomain domain) -> std::string_view;
@@ -161,16 +162,30 @@ class RuntimeAbi {
   // Reduces a value to the machine boolean a conditional branch tests.
   auto ToBool(ValueDomain domain) -> llvm::FunctionCallee;
 
-  // The product-value entries. A component crosses as a handle of its own
-  // domain, and boxing one into a product component rides the domain in the
-  // symbol name, as every domain-parametric entry does. Extract and update are
-  // value operations: update yields a new product with one component replaced,
-  // never an in-place write, so value semantics hold even when the product is
-  // shared.
-  auto TupleComponent(ValueDomain domain) -> llvm::FunctionCallee;
+  // Boxes a value-domain handle into a type-erased aggregate element. The
+  // domain rides in the symbol name, as every domain-parametric entry does.
+  // Shared by every aggregate family (a struct component, a dynamic-array
+  // element).
+  auto ValueBox(ValueDomain domain) -> llvm::FunctionCallee;
+
+  // The product-value entries. `Make` collects the boxed components; `Extract`
+  // and `Update` are value operations: update yields a new product with one
+  // component replaced, never an in-place write, so value semantics hold even
+  // when the product is shared.
   auto TupleMake() -> llvm::FunctionCallee;
   auto TupleExtract() -> llvm::FunctionCallee;
   auto TupleUpdate() -> llvm::FunctionCallee;
+
+  // The dynamic-array constructors (LRM 7.5.1 / 10.9.1): the empty array, the
+  // sized array, the sized-from-source array, and the assignment-pattern array.
+  // Each takes the element default as a boxed prototype; `New` / `NewCopy` lead
+  // with the size, `FromLiteral` follows the prototype with the boxed element
+  // span. Element read / functional update / delete / size resolve through the
+  // generic value-builtin path, not a dedicated entry here.
+  auto MakeDynamicArrayDefault() -> llvm::FunctionCallee;
+  auto MakeDynamicArrayNew() -> llvm::FunctionCallee;
+  auto MakeDynamicArrayNewCopy() -> llvm::FunctionCallee;
+  auto MakeDynamicArrayFromLiteral() -> llvm::FunctionCallee;
 
   // Builds the format specification of one conversion, and the print item that
   // pairs a value with it. A specification is written either as a bare

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -13,6 +13,7 @@
 #include "lyra/mir/callable_code.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::mir_to_lir {
 
@@ -99,6 +100,22 @@ class FunctionLowerer {
   // and, when the owner is an observable cell, the whole-cell update fires.
   auto LowerComponentAssign(
       const mir::Block& block, const mir::AssignExpr& assign)
+      -> diag::Result<lir::Operand>;
+  // A write to one element of a value container (`arr[i] = x`). The container
+  // is a value reached by an opaque handle, so the element write is a
+  // functional whole-value update: read the whole container, produce a new one
+  // with the element replaced, store it back through the container's owner --
+  // the runtime-library counterpart of `LowerComponentAssign`'s static value
+  // instructions, for a dynamic, runtime-indexed selector.
+  auto LowerElementAssign(
+      const mir::Block& block, const mir::AssignExpr& assign)
+      -> diag::Result<lir::Operand>;
+  // A receiver-mutating value-container method (`arr.delete()`). The container
+  // value cannot be mutated in place through a shared handle, so the method is
+  // a functional operation whose result is stored back through the receiver's
+  // owner, the same whole-value read / update / write as an element write.
+  auto LowerMutatingCall(
+      const mir::Block& block, const mir::CallExpr& call, support::BuiltinFn fn)
       -> diag::Result<lir::Operand>;
   // Reads / writes the whole value of a product-write chain's root. The root is
   // an ordinary place, or the mutate proxy of an observable cell -- reached by

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -170,6 +170,7 @@ auto lyra_rt_packed_reduction_xor(const void* value) -> void*;
 auto lyra_rt_packed_reduction_nand(const void* value) -> void*;
 auto lyra_rt_packed_reduction_nor(const void* value) -> void*;
 auto lyra_rt_packed_reduction_xnor(const void* value) -> void*;
+auto lyra_rt_packed_to_owned(const void* value) -> void*;
 
 auto lyra_rt_string_from_packed_array(const void* bits) -> void*;
 // The C string a `string` crosses the DPI-C boundary as (LRM 35.5.6). It points
@@ -267,24 +268,27 @@ auto lyra_rt_chandle_ne(void* lhs, void* rhs) -> void*;
 auto lyra_rt_chandle_case_equal(void* lhs, void* rhs) -> void*;
 auto lyra_rt_chandle_to_bool(void* operand) -> bool;
 
+// Boxes a value-domain handle into a type-erased `RuntimeValue`, the element of
+// an aggregate value. An aggregate assembles from these boxed elements; the
+// domain rides in the symbol name, as every other domain-parametric entry does,
+// so the generated side never inspects the element's runtime representation.
+auto lyra_rt_value_box_packed(const void* value) -> void*;
+auto lyra_rt_value_box_string(const void* value) -> void*;
+auto lyra_rt_value_box_real(const void* value) -> void*;
+auto lyra_rt_value_box_shortreal(const void* value) -> void*;
+auto lyra_rt_value_box_chandle(void* value) -> void*;
+auto lyra_rt_value_box_tuple(const void* value) -> void*;
+auto lyra_rt_value_box_dynarray(const void* value) -> void*;
+
 // The unpacked-struct domain (LRM 7.2), MIR's product type. A struct value is a
 // runtime-owned product carried behind an opaque handle. It owns its components
 // by value, so construction copies each component in and access copies out; the
 // generated side only ever holds handles, never the product's internal storage.
 //
-// A component crosses as a handle of its own domain. Assembly first boxes each
-// into a component of the product (the domain rides in the symbol name, as
-// every other domain-parametric entry does), then `make` collects the
-// components into the product value. `extract` copies component `index` back
-// out; `update` returns a copy of the product with component `index` replaced
-// -- a value operation, never an in-place write, so value semantics hold even
-// when the product is shared.
-auto lyra_rt_tuple_component_packed(const void* value) -> void*;
-auto lyra_rt_tuple_component_string(const void* value) -> void*;
-auto lyra_rt_tuple_component_real(const void* value) -> void*;
-auto lyra_rt_tuple_component_shortreal(const void* value) -> void*;
-auto lyra_rt_tuple_component_chandle(void* value) -> void*;
-auto lyra_rt_tuple_component_tuple(const void* value) -> void*;
+// `make` collects the boxed components into the product value. `extract` copies
+// component `index` back out; `update` returns a copy of the product with
+// component `index` replaced -- a value operation, never an in-place write, so
+// value semantics hold even when the product is shared.
 auto lyra_rt_tuple_make(LyraSpan components) -> void*;
 auto lyra_rt_tuple_extract(const void* tuple, std::int64_t index) -> void*;
 auto lyra_rt_tuple_update(const void* tuple, std::int64_t index, void* value)
@@ -298,6 +302,37 @@ void lyra_rt_cell_tuple_set(void* cell, void* services, const void* value);
 auto lyra_rt_activation_frame_alloc_tuple() -> void*;
 void lyra_rt_activation_frame_store_tuple(void* cell, const void* value);
 auto lyra_rt_activation_frame_load_tuple(const void* cell) -> void*;
+
+// The dynamic-array domain (LRM 7.5), MIR's `DynamicArrayType`. A
+// run-time-sized homogeneous container carried behind an opaque handle, owning
+// its elements by value. `default` / `new` / `new_copy` are the LRM 7.5.1
+// constructors (empty, sized, sized-from-source); `from_literal` collects boxed
+// elements from an assignment pattern. The element default rides every
+// constructor as a boxed prototype -- the shape source for out-of-range reads
+// (LRM 7.4.5) and resize fills. `element` copies an element out; `with_element`
+// returns a copy of the array with one element replaced (LRM 7.4.6), and
+// `delete` a copy emptied (LRM 7.5.3) -- value operations, never in-place
+// writes, so value semantics hold even when the array is shared.
+auto lyra_rt_dynarray_default(const void* prototype) -> void*;
+auto lyra_rt_dynarray_new(const void* size, const void* prototype) -> void*;
+auto lyra_rt_dynarray_new_copy(
+    const void* size, const void* prototype, const void* src) -> void*;
+auto lyra_rt_dynarray_from_literal(const void* prototype, LyraSpan elements)
+    -> void*;
+auto lyra_rt_dynarray_element(const void* array, const void* index) -> void*;
+auto lyra_rt_dynarray_with_element(
+    const void* array, const void* index, void* value) -> void*;
+auto lyra_rt_dynarray_delete(const void* array) -> void*;
+auto lyra_rt_dynarray_size(const void* array) -> void*;
+auto lyra_rt_dynarray_eq(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_dynarray_ne(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_dynarray_case_equal(const void* lhs, const void* rhs) -> void*;
+auto lyra_rt_cell_dynarray_get(void* cell) -> const void*;
+void lyra_rt_cell_dynarray_initialize(void* cell, const void* prototype);
+void lyra_rt_cell_dynarray_set(void* cell, void* services, const void* value);
+auto lyra_rt_activation_frame_alloc_dynarray() -> void*;
+void lyra_rt_activation_frame_store_dynarray(void* cell, const void* value);
+auto lyra_rt_activation_frame_load_dynarray(const void* cell) -> void*;
 
 // Builds one conversion's format specification, and the print item that pairs a
 // value with it. Each field arrives as a packed value, as the value model

--- a/include/lyra/runtime/member_storage.hpp
+++ b/include/lyra/runtime/member_storage.hpp
@@ -7,6 +7,7 @@
 #include "lyra/value/chandle.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
+#include "lyra/value/runtime_dynamic_array.hpp"
 #include "lyra/value/runtime_tuple.hpp"
 #include "lyra/value/string.hpp"
 
@@ -34,7 +35,8 @@ class MemberStorage {
  private:
   std::variant<
       void*, Var<value::PackedArray>, Var<value::String>, Var<value::Real>,
-      Var<value::ShortReal>, value::Chandle, Var<value::RuntimeTuple>>
+      Var<value::ShortReal>, value::Chandle, Var<value::RuntimeTuple>,
+      Var<value::RuntimeDynamicArray>>
       object_;
 };
 

--- a/include/lyra/runtime/scope_program.hpp
+++ b/include/lyra/runtime/scope_program.hpp
@@ -87,6 +87,7 @@ enum class ValueDomain : std::uint8_t {
   kShortReal,
   kChandle,
   kTuple,
+  kDynArray,
 };
 
 // How a member's storage is realized. A borrowed handle is a box holding a

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -19,6 +19,13 @@ enum class BuiltinFn : std::uint16_t {
   kElementRef,
   kSlice,
   kSliceRef,
+  // The functional element write for a value-container: yields a new container
+  // equal to the receiver with one element replaced (LRM 7.4.6). It is the
+  // value-model counterpart of the in-place `kElementRef` write, synthesized at
+  // MIR-to-LIR for a backend whose container value is reached by an opaque
+  // handle and so cannot write an element in place; it never arises from
+  // source.
+  kWithElement,
   // LRM 7.4.3 / 7.5 / 7.9 / 7.10.2. AA's `num` is an alias of `size`;
   // String's LRM 6.16.1 `len` is its own mandated spelling.
   kSize,

--- a/include/lyra/value/runtime_dynamic_array.hpp
+++ b/include/lyra/value/runtime_dynamic_array.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+struct RuntimeValue;
+
+// The runtime-owned realization of a SystemVerilog dynamic array (LRM 7.5),
+// MIR's `DynamicArrayType`. A run-time-sized homogeneous container that owns
+// its elements by value: copy is an element-wise deep copy, destruction is C++
+// RAII, so an element never borrows caller storage.
+//
+// This is the execution backend's type-erased counterpart of the C++ backend's
+// monomorphized `DynamicArray<T>`, the aggregate-family peer of `RuntimeTuple`.
+// One `RuntimeDynamicArray` holds a vector of type-erased `RuntimeValue`
+// elements and an element-default prototype, and composes the value contract by
+// visiting them.
+//
+// Value semantics are preserved by immutability: every apparent mutation is a
+// functional operation returning a new array (`WithElement`, `Delete`), never
+// an in-place write, so an array whose handle is shared by a copy is never
+// disturbed by a write through another copy.
+class RuntimeDynamicArray {
+ public:
+  // The uninitialized sentinel form -- the empty array before its declared
+  // element shape is known. It is the declared default state of a
+  // `Var<RuntimeDynamicArray>` cell; the cell's first initialization overwrites
+  // it with the real element default.
+  RuntimeDynamicArray();
+
+  // LRM Table 6-7: the default dynamic array is empty. `element_default` is the
+  // shape source for out-of-range reads (LRM 7.4.5) and resize fills; it
+  // carries the exact element representation, so a nested struct or packed
+  // element keeps its member initializers and width.
+  explicit RuntimeDynamicArray(RuntimeValue element_default);
+
+  // LRM 7.5.1 `new[N]`: `n` elements, each a copy of the element default.
+  RuntimeDynamicArray(const PackedArray& n, RuntimeValue element_default);
+
+  // LRM 7.5.1 `new[N](src)`: copy `src`, then resize to `n`, truncating when
+  // smaller and padding with the element default when larger.
+  RuntimeDynamicArray(
+      const PackedArray& n, RuntimeValue element_default,
+      const RuntimeDynamicArray& src);
+
+  // LRM 10.9.1 assignment-pattern construction: the element list, with the
+  // element default seeded for later out-of-range reads.
+  RuntimeDynamicArray(
+      RuntimeValue element_default, std::vector<RuntimeValue> elements);
+
+  RuntimeDynamicArray(const RuntimeDynamicArray&);
+  RuntimeDynamicArray(RuntimeDynamicArray&&) noexcept;
+  auto operator=(const RuntimeDynamicArray&) -> RuntimeDynamicArray&;
+  auto operator=(RuntimeDynamicArray&&) noexcept -> RuntimeDynamicArray&;
+  ~RuntimeDynamicArray();
+
+  // LRM 7.5.1: the current element count as an SV `int`.
+  [[nodiscard]] auto Size() const -> PackedArray;
+
+  // The element-default prototype. Its runtime domain is the array's element
+  // domain, so a caller boxing an incoming element value into the erased
+  // representation reads the target domain from here.
+  [[nodiscard]] auto ElementDefault() const -> const RuntimeValue&;
+
+  // LRM 7.4.5 / 7.4.6: reads element `index` by reference. An out-of-range or
+  // x / z index reads the element default. The caller copies the result out
+  // across the opaque-handle boundary rather than aliasing it.
+  [[nodiscard]] auto Element(const PackedArray& index) const
+      -> const RuntimeValue&;
+
+  // A functional element write: yields a new array equal to this one with
+  // element `index` replaced by `value`. LRM 7.4.6: an out-of-range or x / z
+  // index leaves the array unchanged (the write is discarded).
+  [[nodiscard]] auto WithElement(const PackedArray& index, RuntimeValue value)
+      const -> RuntimeDynamicArray;
+
+  // LRM 7.5.3 `delete`: a functional clear -- yields the empty array with the
+  // same element default.
+  [[nodiscard]] auto Delete() const -> RuntimeDynamicArray;
+
+  // LRM 11.4.5 `==` / `!=` (Any data type): a size check then an element-wise
+  // reduction that propagates X / Z through each element's own equality.
+  [[nodiscard]] auto operator==(const RuntimeDynamicArray& other) const
+      -> PackedArray;
+  [[nodiscard]] auto operator!=(const RuntimeDynamicArray& other) const
+      -> PackedArray;
+
+  // LRM 11.4.5 `===` / `!==`: element-wise case equality, deterministic in
+  // X / Z.
+  [[nodiscard]] auto CaseEqual(const RuntimeDynamicArray& other) const
+      -> PackedArray;
+
+  // LRM 9.4.2 update-event predicate (engine change-detection hook).
+  [[nodiscard]] auto IsBitIdentical(const RuntimeDynamicArray& other) const
+      -> bool;
+
+  // LRM 20.9: any element carrying an unknown bit propagates up.
+  [[nodiscard]] auto HasUnknown() const -> bool;
+  [[nodiscard]] auto IsUnknown() const -> PackedArray;
+
+ private:
+  // A negative, out-of-range, or x / z index (LRM 7.4.5). A valid index is
+  // returned as its storage ordinal.
+  [[nodiscard]] auto IsInvalidIndex(const PackedArray& index) const -> bool;
+
+  // Indirect because `RuntimeValue` closes over this type: a by-value member
+  // would need `RuntimeValue` complete here, which it is not.
+  std::unique_ptr<RuntimeValue> element_default_;
+  std::vector<RuntimeValue> data_;
+};
+
+}  // namespace lyra::value

--- a/include/lyra/value/runtime_tuple.hpp
+++ b/include/lyra/value/runtime_tuple.hpp
@@ -1,14 +1,10 @@
 #pragma once
 
 #include <cstddef>
-#include <variant>
 #include <vector>
 
-#include "lyra/value/chandle.hpp"
 #include "lyra/value/concepts.hpp"
 #include "lyra/value/packed_array.hpp"
-#include "lyra/value/real.hpp"
-#include "lyra/value/string.hpp"
 
 namespace lyra::value {
 
@@ -66,16 +62,6 @@ class RuntimeTuple {
 
  private:
   std::vector<RuntimeValue> components_;
-};
-
-// A type-erased runtime value: the payload one opaque JIT handle refers to. The
-// active alternative is the value's current runtime domain. This is a runtime
-// representation, not a compiler-IR value -- it is neither an MIR nor a LIR
-// value type. It closes over `RuntimeTuple`, so a struct component may itself
-// be a struct.
-struct RuntimeValue {
-  std::variant<PackedArray, String, Real, ShortReal, Chandle, RuntimeTuple>
-      value;
 };
 
 static_assert(LyraValue<RuntimeTuple>);

--- a/include/lyra/value/runtime_value.hpp
+++ b/include/lyra/value/runtime_value.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <variant>
+
+#include "lyra/value/chandle.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/real.hpp"
+#include "lyra/value/runtime_dynamic_array.hpp"
+#include "lyra/value/runtime_tuple.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::value {
+
+// A type-erased runtime value: the payload one opaque JIT handle refers to. The
+// active alternative is the value's current runtime domain. This is a runtime
+// representation, not a compiler-IR value -- it is neither an MIR nor a LIR
+// value type. It closes over the aggregate realizations (`RuntimeTuple`,
+// `RuntimeDynamicArray`), so a struct component or an array element may itself
+// be an aggregate.
+struct RuntimeValue {
+  std::variant<
+      PackedArray, String, Real, ShortReal, Chandle, RuntimeTuple,
+      RuntimeDynamicArray>
+      value;
+};
+
+// The shared element-wise relations over two runtime values of the same domain.
+// The aggregate realizations reduce their whole-value equality / change
+// predicates over these, so a component or element that is itself an aggregate
+// recurses through the same operations.
+
+// LRM 11.4.5 `==`: each domain's own equality, propagating X / Z.
+[[nodiscard]] auto RuntimeValueEqual(
+    const RuntimeValue& a, const RuntimeValue& b) -> PackedArray;
+
+// LRM 11.4.5 `===`: each domain's own case equality, deterministic in X / Z. A
+// real / shortreal element makes the source-level `===` an error, rejected
+// before lowering, so it never reaches this function.
+[[nodiscard]] auto RuntimeValueCaseEqual(
+    const RuntimeValue& a, const RuntimeValue& b) -> PackedArray;
+
+// LRM 9.4.2 update-event predicate (engine change-detection hook).
+[[nodiscard]] auto RuntimeValueBitIdentical(
+    const RuntimeValue& a, const RuntimeValue& b) -> bool;
+
+// LRM 20.9: whether the value carries any unknown bit.
+[[nodiscard]] auto RuntimeValueHasUnknown(const RuntimeValue& value) -> bool;
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -149,6 +149,13 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Element";
     case support::BuiltinFn::kElementRef:
       return "ElementRef";
+    case support::BuiltinFn::kWithElement:
+      // The functional element write is synthesized only at MIR-to-LIR for the
+      // execution backend; the C++ backend writes an element in place through
+      // `ElementRef`, so it never renders this entry.
+      throw InternalError(
+          "BuiltinFnCppName: with_element is an execution-backend synthesis "
+          "entry, never rendered by the C++ backend");
     case support::BuiltinFn::kSlice:
       return "Slice";
     case support::BuiltinFn::kSliceRef:

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -205,6 +205,10 @@ auto CodeGenFunction::LowerCall(
   // A construct that builds a child unit leads with the child's definition
   // reference, which the result type names rather than the operand list.
   if (const auto* construct = std::get_if<lir::ConstructTarget>(&call.target)) {
+    if (const auto* dynamic_array = std::get_if<lir::DynamicArrayType>(
+            &module_->Unit().types.Get(construct->result).data)) {
+      return LowerErasedDynamicArrayConstruct(call, *dynamic_array);
+    }
     if (llvm::Value* definition = ConstructDefinitionArg(construct->result)) {
       args.push_back(definition);
     }
@@ -274,25 +278,44 @@ auto CodeGenFunction::ForeignCallee(
 }
 
 // An array literal is a value built in place, not a runtime call: its elements
-// are stored into contiguous storage and named by a {pointer, length} span.
+// are stored into contiguous storage and named by a {pointer, length} span. A
+// dynamic array is a type-erased value, so its literal boxes each element into
+// the erased representation first; a fixed unpacked array carries its elements'
+// own handles directly.
 auto CodeGenFunction::LowerAggregate(
     const lir::AggregateInstr& agg, lir::TypeId result_type) -> llvm::Value* {
   const auto& result_data = module_->Unit().types.Get(result_type).data;
   if (const auto* tuple = std::get_if<lir::TupleType>(&result_data)) {
     return LowerTupleAggregate(agg, *tuple);
   }
-  const auto* array = std::get_if<lir::UnpackedArrayType>(&result_data);
-  if (array == nullptr) {
+  lir::TypeId element_type{};
+  bool box_elements = false;
+  if (const auto* dynamic_array =
+          std::get_if<lir::DynamicArrayType>(&result_data)) {
+    element_type = dynamic_array->element_type;
+    box_elements = true;
+  } else if (
+      const auto* array = std::get_if<lir::UnpackedArrayType>(&result_data)) {
+    element_type = array->element_type;
+  } else {
     throw InternalError(
-        "llvm codegen: aggregate result is not an unpacked array or tuple");
+        "llvm codegen: aggregate result is not an unpacked array, dynamic "
+        "array, or tuple");
   }
   auto* storage_ty = llvm::ArrayType::get(
-      module_->Types().Map(array->element_type), agg.elements.size());
+      box_elements ? module_->Types().Ptr()
+                   : module_->Types().Map(element_type),
+      agg.elements.size());
   llvm::Value* storage = builder_.CreateAlloca(storage_ty);
   for (std::uint32_t i = 0; i < agg.elements.size(); ++i) {
+    llvm::Value* element = LowerOperand(agg.elements[i]);
+    if (box_elements) {
+      element = builder_.CreateCall(
+          module_->Runtime().ValueBox(DomainOf(element_type)), {element});
+    }
     llvm::Value* slot =
         builder_.CreateConstInBoundsGEP2_64(storage_ty, storage, 0, i);
-    builder_.CreateStore(LowerOperand(agg.elements[i]), slot);
+    builder_.CreateStore(element, slot);
   }
   llvm::Value* span = llvm::UndefValue::get(module_->Types().Span());
   span = builder_.CreateInsertValue(span, storage, {0});
@@ -302,6 +325,45 @@ auto CodeGenFunction::LowerAggregate(
           llvm::Type::getInt64Ty(module_->Context()), agg.elements.size()),
       {1});
   return span;
+}
+
+// Realizes the construction of a dynamic-array runtime value: it selects the
+// runtime-ABI constructor from the operand shape, boxes the element prototype
+// into the erased representation, and emits the call. This is representation
+// lowering, not source semantics -- the container's value semantics, its
+// out-of-range behavior, and its element-write model belong to the runtime
+// object and the MIR-to-LIR lowering, never here. The four shapes are the
+// runtime constructors' operand lists: `[proto]` empty, `[size, proto]` sized,
+// `[size, proto, src]` sized-from-source, `[proto, literal]` assignment pattern
+// -- the literal's span is the one operand whose own type is the array type,
+// which separates it from the sized form's leading size.
+auto CodeGenFunction::LowerErasedDynamicArrayConstruct(
+    const lir::CallInstr& call, const lir::DynamicArrayType& type)
+    -> llvm::Value* {
+  const ValueDomain element_domain = DomainOf(type.element_type);
+  auto box = [&](const lir::Operand& operand) -> llvm::Value* {
+    return builder_.CreateCall(
+        module_->Runtime().ValueBox(element_domain), {LowerOperand(operand)});
+  };
+  const std::vector<lir::Operand>& args = call.args;
+  if (args.size() == 1) {
+    return builder_.CreateCall(
+        module_->Runtime().MakeDynamicArrayDefault(), {box(args[0])});
+  }
+  if (args.size() == 3) {
+    return builder_.CreateCall(
+        module_->Runtime().MakeDynamicArrayNewCopy(),
+        {LowerOperand(args[0]), box(args[1]), LowerOperand(args[2])});
+  }
+  const lir::TypeId result = std::get<lir::ConstructTarget>(call.target).result;
+  if (OperandType(args[1]) == result) {
+    return builder_.CreateCall(
+        module_->Runtime().MakeDynamicArrayFromLiteral(),
+        {box(args[0]), LowerOperand(args[1])});
+  }
+  return builder_.CreateCall(
+      module_->Runtime().MakeDynamicArrayNew(),
+      {LowerOperand(args[0]), box(args[1])});
 }
 
 // A product value is assembled by boxing each component into a product
@@ -319,8 +381,7 @@ auto CodeGenFunction::LowerTupleAggregate(
     const ValueDomain domain =
         ValueDomainOf(module_->Unit(), tuple.elements[i]);
     llvm::Value* boxed = builder_.CreateCall(
-        module_->Runtime().TupleComponent(domain),
-        {LowerOperand(agg.elements[i])});
+        module_->Runtime().ValueBox(domain), {LowerOperand(agg.elements[i])});
     llvm::Value* slot =
         builder_.CreateConstInBoundsGEP2_64(storage_ty, storage, 0, i);
     builder_.CreateStore(boxed, slot);

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -32,6 +32,8 @@ auto ValueDomainName(ValueDomain domain) -> std::string_view {
       return "chandle";
     case ValueDomain::kTuple:
       return "tuple";
+    case ValueDomain::kDynArray:
+      return "dynarray";
   }
   throw InternalError("llvm codegen: unknown value domain");
 }
@@ -58,6 +60,10 @@ auto ValueDomainOf(const lir::CompilationUnit& unit, lir::TypeId type)
           // realization is a type-erased product value carried inline behind an
           // opaque handle, like every other value domain.
           [](const lir::TupleType&) { return ValueDomain::kTuple; },
+          // A dynamic array (LRM 7.5) is MIR's `DynamicArrayType`; its runtime
+          // realization is a type-erased container carried behind an opaque
+          // handle, like every other value domain.
+          [](const lir::DynamicArrayType&) { return ValueDomain::kDynArray; },
           [](const auto&) -> ValueDomain {
             throw InternalError(
                 "llvm codegen: value type has no runtime library domain");
@@ -281,9 +287,9 @@ auto RuntimeAbi::ToBool(ValueDomain domain) -> llvm::FunctionCallee {
       llvm::Type::getInt1Ty(*ctx_), {types_->Ptr()});
 }
 
-auto RuntimeAbi::TupleComponent(ValueDomain domain) -> llvm::FunctionCallee {
+auto RuntimeAbi::ValueBox(ValueDomain domain) -> llvm::FunctionCallee {
   return Get(
-      std::format("lyra_rt_tuple_component_{}", ValueDomainName(domain)),
+      std::format("lyra_rt_value_box_{}", ValueDomainName(domain)),
       types_->Ptr(), {types_->Ptr()});
 }
 
@@ -301,6 +307,27 @@ auto RuntimeAbi::TupleUpdate() -> llvm::FunctionCallee {
   return Get(
       "lyra_rt_tuple_update", types_->Ptr(),
       {types_->Ptr(), llvm::Type::getInt64Ty(*ctx_), types_->Ptr()});
+}
+
+auto RuntimeAbi::MakeDynamicArrayDefault() -> llvm::FunctionCallee {
+  return Get("lyra_rt_dynarray_default", types_->Ptr(), {types_->Ptr()});
+}
+
+auto RuntimeAbi::MakeDynamicArrayNew() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_dynarray_new", types_->Ptr(), {types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::MakeDynamicArrayNewCopy() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_dynarray_new_copy", types_->Ptr(),
+      {types_->Ptr(), types_->Ptr(), types_->Ptr()});
+}
+
+auto RuntimeAbi::MakeDynamicArrayFromLiteral() -> llvm::FunctionCallee {
+  return Get(
+      "lyra_rt_dynarray_from_literal", types_->Ptr(),
+      {types_->Ptr(), types_->Span()});
 }
 
 auto RuntimeAbi::MakeFormatSpec(std::size_t field_count)

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -207,6 +207,7 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_packed_reduction_nand", &lyra_rt_packed_reduction_nand);
   add("lyra_rt_packed_reduction_nor", &lyra_rt_packed_reduction_nor);
   add("lyra_rt_packed_reduction_xnor", &lyra_rt_packed_reduction_xnor);
+  add("lyra_rt_packed_to_owned", &lyra_rt_packed_to_owned);
   add("lyra_rt_string_from_packed_array", &lyra_rt_string_from_packed_array);
   add("lyra_rt_string_string_cstr", &lyra_rt_string_string_cstr);
   add("lyra_rt_string_len", &lyra_rt_string_len);
@@ -292,12 +293,13 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_chandle_ne", &lyra_rt_chandle_ne);
   add("lyra_rt_chandle_case_equal", &lyra_rt_chandle_case_equal);
   add("lyra_rt_chandle_to_bool", &lyra_rt_chandle_to_bool);
-  add("lyra_rt_tuple_component_packed", &lyra_rt_tuple_component_packed);
-  add("lyra_rt_tuple_component_string", &lyra_rt_tuple_component_string);
-  add("lyra_rt_tuple_component_real", &lyra_rt_tuple_component_real);
-  add("lyra_rt_tuple_component_shortreal", &lyra_rt_tuple_component_shortreal);
-  add("lyra_rt_tuple_component_chandle", &lyra_rt_tuple_component_chandle);
-  add("lyra_rt_tuple_component_tuple", &lyra_rt_tuple_component_tuple);
+  add("lyra_rt_value_box_packed", &lyra_rt_value_box_packed);
+  add("lyra_rt_value_box_string", &lyra_rt_value_box_string);
+  add("lyra_rt_value_box_real", &lyra_rt_value_box_real);
+  add("lyra_rt_value_box_shortreal", &lyra_rt_value_box_shortreal);
+  add("lyra_rt_value_box_chandle", &lyra_rt_value_box_chandle);
+  add("lyra_rt_value_box_tuple", &lyra_rt_value_box_tuple);
+  add("lyra_rt_value_box_dynarray", &lyra_rt_value_box_dynarray);
   add("lyra_rt_tuple_make", &lyra_rt_tuple_make);
   add("lyra_rt_tuple_extract", &lyra_rt_tuple_extract);
   add("lyra_rt_tuple_update", &lyra_rt_tuple_update);
@@ -313,6 +315,26 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
       &lyra_rt_activation_frame_store_tuple);
   add("lyra_rt_activation_frame_load_tuple",
       &lyra_rt_activation_frame_load_tuple);
+  add("lyra_rt_dynarray_default", &lyra_rt_dynarray_default);
+  add("lyra_rt_dynarray_new", &lyra_rt_dynarray_new);
+  add("lyra_rt_dynarray_new_copy", &lyra_rt_dynarray_new_copy);
+  add("lyra_rt_dynarray_from_literal", &lyra_rt_dynarray_from_literal);
+  add("lyra_rt_dynarray_element", &lyra_rt_dynarray_element);
+  add("lyra_rt_dynarray_with_element", &lyra_rt_dynarray_with_element);
+  add("lyra_rt_dynarray_delete", &lyra_rt_dynarray_delete);
+  add("lyra_rt_dynarray_size", &lyra_rt_dynarray_size);
+  add("lyra_rt_dynarray_eq", &lyra_rt_dynarray_eq);
+  add("lyra_rt_dynarray_ne", &lyra_rt_dynarray_ne);
+  add("lyra_rt_dynarray_case_equal", &lyra_rt_dynarray_case_equal);
+  add("lyra_rt_cell_dynarray_get", &lyra_rt_cell_dynarray_get);
+  add("lyra_rt_cell_dynarray_initialize", &lyra_rt_cell_dynarray_initialize);
+  add("lyra_rt_cell_dynarray_set", &lyra_rt_cell_dynarray_set);
+  add("lyra_rt_activation_frame_alloc_dynarray",
+      &lyra_rt_activation_frame_alloc_dynarray);
+  add("lyra_rt_activation_frame_store_dynarray",
+      &lyra_rt_activation_frame_store_dynarray);
+  add("lyra_rt_activation_frame_load_dynarray",
+      &lyra_rt_activation_frame_load_dynarray);
   Check(
       jit.getMainJITDylib().define(
           llvm::orc::absoluteSymbols(std::move(symbols))),
@@ -356,6 +378,8 @@ auto AbiDomain(backend::llvm_backend::ValueDomain domain)
       return runtime::ValueDomain::kChandle;
     case backend::llvm_backend::ValueDomain::kTuple:
       return runtime::ValueDomain::kTuple;
+    case backend::llvm_backend::ValueDomain::kDynArray:
+      return runtime::ValueDomain::kDynArray;
   }
   throw InternalError("jit executor: unknown value domain");
 }

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -38,6 +38,20 @@ auto Unsupported(std::string message) -> std::unexpected<diag::Diagnostic> {
       diag::DiagCode::kUnsupportedExpressionForm, std::move(message));
 }
 
+// The builtin entry a call names directly, if any.
+auto DirectBuiltinFn(const mir::CallExpr& call)
+    -> std::optional<support::BuiltinFn> {
+  const auto* direct = std::get_if<mir::Direct>(&call.callee);
+  if (direct == nullptr) {
+    return std::nullopt;
+  }
+  const auto* fn = std::get_if<support::BuiltinFn>(&direct->target);
+  if (fn == nullptr) {
+    return std::nullopt;
+  }
+  return *fn;
+}
+
 // The place a place local names: its own storage, with nothing projected off
 // it.
 auto LocalPlace(lir::ValueId local) -> lir::Place {
@@ -123,17 +137,29 @@ auto PlacedLocal(const mir::Block& block, mir::ExprId id)
 // A value type whose runtime realization is an opaque handle into transient
 // storage the boundary releases at each suspension: a packed value (or the
 // enumeration and packed struct/union projections that share its shape), a
-// string, a real-family value (real / shortreal / realtime), or an unpacked
-// struct product value. A local of such a type that a suspending body reads
-// across a suspension needs activation-stable storage, because its handle
-// cannot outlive the stretch that produced it. A pointer, a reference, an
-// object handle, or a machine scalar is not one of these -- it is stable across
-// a suspension on its own -- so it is unaffected.
+// string, a real-family value (real / shortreal / realtime), an unpacked struct
+// product value, or a dynamic array. A local of such a type that a suspending
+// body reads across a suspension needs activation-stable storage, because its
+// handle cannot outlive the stretch that produced it. A pointer, a reference,
+// an object handle, or a machine scalar is not one of these -- it is stable
+// across a suspension on its own -- so it is unaffected.
 auto IsActivationValueType(const mir::Type& type) -> bool {
   const mir::TypeKind kind = type.Kind();
   return type.IsIntegralPacked() || kind == mir::TypeKind::kString ||
          kind == mir::TypeKind::kReal || kind == mir::TypeKind::kShortReal ||
-         kind == mir::TypeKind::kRealTime || kind == mir::TypeKind::kTuple;
+         kind == mir::TypeKind::kRealTime || kind == mir::TypeKind::kTuple ||
+         kind == mir::TypeKind::kDynamicArray;
+}
+
+// Whether mutating a value of this type -- writing one element, or a
+// receiver-mutating method -- must be a functional whole-value update stored
+// back through the owner rather than an in-place store. True for a value
+// container reached by an opaque handle (a dynamic array today, a queue and an
+// associative array later): its whole value crosses as a handle a copy may
+// share, so an in-place mutation would corrupt the copy. This is what routes
+// such a write off the place-store path.
+auto RequiresFunctionalMutation(const mir::Type& type) -> bool {
+  return type.Kind() == mir::TypeKind::kDynamicArray;
 }
 
 // Marks every local the canonical lowering needs an address for: one that is
@@ -847,6 +873,17 @@ auto FunctionLowerer::LowerArgument(const mir::Block& block, mir::ExprId id)
 auto FunctionLowerer::LowerCall(
     const mir::Block& block, const mir::CallExpr& call, mir::TypeId type)
     -> diag::Result<lir::Operand> {
+  // A receiver-mutating method on a value container is not an in-place call:
+  // the container is an opaque handle, so it is a functional operation whose
+  // result is stored back through the receiver's owner.
+  if (const auto fn = DirectBuiltinFn(call);
+      fn.has_value() && support::IsMutatingBuiltinFn(*fn) &&
+      !call.arguments.empty() &&
+      RequiresFunctionalMutation(
+          unit_->Mir().types.Get(block.exprs.Get(call.arguments[0]).type))) {
+    return LowerMutatingCall(block, call, *fn);
+  }
+
   std::vector<lir::Operand> args;
   args.reserve(call.arguments.size());
   for (const mir::ExprId arg : call.arguments) {
@@ -906,6 +943,19 @@ auto FunctionLowerer::LowerAssign(
   if (std::holds_alternative<mir::TupleGetExpr>(
           block.exprs.Get(assign.target).data)) {
     return LowerComponentAssign(block, assign);
+  }
+
+  // A write to a value-container element (`arr[i] = x`) targets the container-
+  // access write reference. The container is likewise an opaque value, so the
+  // write is a functional whole-value update stored back through its owner.
+  if (const auto* call =
+          std::get_if<mir::CallExpr>(&block.exprs.Get(assign.target).data)) {
+    if (const auto fn = DirectBuiltinFn(*call);
+        fn == support::BuiltinFn::kElementRef &&
+        RequiresFunctionalMutation(
+            unit_->Mir().types.Get(block.exprs.Get(call->arguments[0]).type))) {
+      return LowerElementAssign(block, assign);
+    }
   }
 
   const lir::TypeId type =
@@ -1133,6 +1183,95 @@ auto FunctionLowerer::LowerComponentAssign(
   }
 
   return WriteWholeValue(block, root, std::move(rebuilt));
+}
+
+auto FunctionLowerer::LowerElementAssign(
+    const mir::Block& block, const mir::AssignExpr& assign)
+    -> diag::Result<lir::Operand> {
+  const auto& target =
+      std::get<mir::CallExpr>(block.exprs.Get(assign.target).data);
+  const mir::ExprId container = target.arguments[0];
+  const mir::ExprId index = target.arguments[1];
+  const lir::TypeId container_type =
+      unit_->TranslateType(block.exprs.Get(container).type);
+  const lir::TypeId element_type =
+      unit_->TranslateType(block.exprs.Get(assign.target).type);
+
+  auto array = ReadWholeValue(block, container);
+  if (!array) {
+    return std::unexpected(std::move(array.error()));
+  }
+  const lir::Operand array_value = *std::move(array);
+  auto index_value = LowerExpr(block, index);
+  if (!index_value) {
+    return std::unexpected(std::move(index_value.error()));
+  }
+  auto rhs = LowerExpr(block, assign.value);
+  if (!rhs) {
+    return std::unexpected(std::move(rhs.error()));
+  }
+
+  lir::Operand replacement = *std::move(rhs);
+  if (assign.compound_op.has_value()) {
+    const std::optional<lir::BinaryOp> op =
+        TranslateBinaryOp(*assign.compound_op);
+    if (!op) {
+      return Unsupported(
+          "mir_to_lir: compound assignment operator has no direct realization");
+    }
+    lir::Operand old = Emit(
+        element_type, lir::CallInstr{
+                          .target =
+                              lir::BuiltinTarget{
+                                  .fn = support::BuiltinFn::kElement,
+                                  .qualifier = std::nullopt},
+                          .args = {array_value, *index_value}});
+    replacement = Emit(
+        element_type,
+        lir::BinaryInstr{
+            .op = *op, .lhs = std::move(old), .rhs = std::move(replacement)});
+  }
+
+  lir::Operand updated = Emit(
+      container_type,
+      lir::CallInstr{
+          .target =
+              lir::BuiltinTarget{
+                  .fn = support::BuiltinFn::kWithElement,
+                  .qualifier = std::nullopt},
+          .args = {
+              array_value, *std::move(index_value), std::move(replacement)}});
+  return WriteWholeValue(block, container, std::move(updated));
+}
+
+auto FunctionLowerer::LowerMutatingCall(
+    const mir::Block& block, const mir::CallExpr& call, support::BuiltinFn fn)
+    -> diag::Result<lir::Operand> {
+  const mir::ExprId receiver = call.arguments[0];
+  const lir::TypeId container_type =
+      unit_->TranslateType(block.exprs.Get(receiver).type);
+
+  auto value = ReadWholeValue(block, receiver);
+  if (!value) {
+    return std::unexpected(std::move(value.error()));
+  }
+  std::vector<lir::Operand> args;
+  args.reserve(call.arguments.size());
+  args.push_back(*std::move(value));
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg = LowerArgument(block, call.arguments[i]);
+    if (!arg) {
+      return std::unexpected(std::move(arg.error()));
+    }
+    args.push_back(*std::move(arg));
+  }
+
+  lir::Operand updated = Emit(
+      container_type,
+      lir::CallInstr{
+          .target = lir::BuiltinTarget{.fn = fn, .qualifier = std::nullopt},
+          .args = std::move(args)});
+  return WriteWholeValue(block, receiver, std::move(updated));
 }
 
 auto FunctionLowerer::LowerIncDec(

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -27,7 +27,9 @@
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
+#include "lyra/value/runtime_dynamic_array.hpp"
 #include "lyra/value/runtime_tuple.hpp"
+#include "lyra/value/runtime_value.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
@@ -158,6 +160,7 @@ using lyra::value::PrintItem;
 using lyra::value::PrintLiteralItem;
 using lyra::value::PrintValueItem;
 using lyra::value::Real;
+using lyra::value::RuntimeDynamicArray;
 using lyra::value::RuntimeTuple;
 using lyra::value::RuntimeValue;
 using lyra::value::ShortReal;
@@ -592,6 +595,14 @@ auto lyra_rt_packed_reduction_xnor(const void* value) -> void* {
   return Own(Read<PackedArray>(value).ReductionXnor());
 }
 
+// Materializes a borrowed packed view (a container element or slice read) into
+// an owning value. On the execution backend a container access already copies
+// the element out, so this is an idempotent copy that keeps the ownership shape
+// the source-level `to_owned` names.
+auto lyra_rt_packed_to_owned(const void* value) -> void* {
+  return Own(Read<PackedArray>(value).ToOwned());
+}
+
 auto lyra_rt_string_from_packed_array(const void* bits) -> void* {
   return Own(String::FromPackedArray(Read<PackedArray>(bits)));
 }
@@ -922,31 +933,39 @@ auto lyra_rt_chandle_to_bool(void* operand) -> bool {
   return static_cast<bool>(Chandle{operand});
 }
 
-auto lyra_rt_tuple_component_packed(const void* value) -> void* {
+// Boxes a value-domain handle into a type-erased `RuntimeValue`, the element of
+// an aggregate (an unpacked struct component, a dynamic-array element). The
+// domain rides in the symbol name, so the generated side never inspects the
+// value's runtime representation.
+auto lyra_rt_value_box_packed(const void* value) -> void* {
   return Own(RuntimeValue{Read<PackedArray>(value)});
 }
 
-auto lyra_rt_tuple_component_string(const void* value) -> void* {
+auto lyra_rt_value_box_string(const void* value) -> void* {
   return Own(RuntimeValue{Read<String>(value)});
 }
 
-auto lyra_rt_tuple_component_real(const void* value) -> void* {
+auto lyra_rt_value_box_real(const void* value) -> void* {
   return Own(RuntimeValue{Read<Real>(value)});
 }
 
-auto lyra_rt_tuple_component_shortreal(const void* value) -> void* {
+auto lyra_rt_value_box_shortreal(const void* value) -> void* {
   return Own(RuntimeValue{Read<ShortReal>(value)});
 }
 
 // A chandle's handle is the pointer it carries, not a pointer to a runtime
-// object, so its component boxes the pointer directly rather than reading a
-// value object out of it.
-auto lyra_rt_tuple_component_chandle(void* value) -> void* {
+// object, so its box wraps the pointer directly rather than reading a value
+// object out of it.
+auto lyra_rt_value_box_chandle(void* value) -> void* {
   return Own(RuntimeValue{Chandle{value}});
 }
 
-auto lyra_rt_tuple_component_tuple(const void* value) -> void* {
+auto lyra_rt_value_box_tuple(const void* value) -> void* {
   return Own(RuntimeValue{Read<RuntimeTuple>(value)});
+}
+
+auto lyra_rt_value_box_dynarray(const void* value) -> void* {
+  return Own(RuntimeValue{Read<RuntimeDynamicArray>(value)});
 }
 
 auto lyra_rt_tuple_make(LyraSpan components) -> void* {
@@ -1033,5 +1052,127 @@ void lyra_rt_activation_frame_store_tuple(void* cell, const void* value) {
 auto lyra_rt_activation_frame_load_tuple(const void* cell) -> void* {
   return Own(
       static_cast<const ActivationValueCell<RuntimeTuple>*>(cell)->Get());
+}
+
+auto lyra_rt_dynarray_default(const void* prototype) -> void* {
+  return Own(RuntimeDynamicArray(Read<RuntimeValue>(prototype)));
+}
+
+auto lyra_rt_dynarray_new(const void* size, const void* prototype) -> void* {
+  return Own(RuntimeDynamicArray(
+      Read<PackedArray>(size), Read<RuntimeValue>(prototype)));
+}
+
+auto lyra_rt_dynarray_new_copy(
+    const void* size, const void* prototype, const void* src) -> void* {
+  return Own(RuntimeDynamicArray(
+      Read<PackedArray>(size), Read<RuntimeValue>(prototype),
+      Read<RuntimeDynamicArray>(src)));
+}
+
+// The literal's elements arrive already boxed into `RuntimeValue`s (the domain
+// rode the boxing entry's name at the assembly site), so the array collects
+// them directly -- the same shape as `lyra_rt_tuple_make`.
+auto lyra_rt_dynarray_from_literal(const void* prototype, LyraSpan elements)
+    -> void* {
+  std::span<RuntimeValue*> handles(
+      static_cast<RuntimeValue**>(elements.data), elements.count);
+  std::vector<RuntimeValue> collected;
+  collected.reserve(elements.count);
+  for (RuntimeValue* handle : handles) {
+    collected.push_back(std::move(*handle));
+  }
+  return Own(
+      RuntimeDynamicArray(Read<RuntimeValue>(prototype), std::move(collected)));
+}
+
+// Reads element `index`, copying it out across the opaque-handle boundary as a
+// handle of the element's own domain (a chandle's handle is the pointer it
+// carries). An out-of-range index reads the element default (LRM 7.4.5).
+auto lyra_rt_dynarray_element(const void* array, const void* index) -> void* {
+  const RuntimeValue& element =
+      Read<RuntimeDynamicArray>(array).Element(Read<PackedArray>(index));
+  return std::visit(
+      [](const auto& value) -> void* {
+        using T = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<T, Chandle>) {
+          return value.Ptr();
+        } else {
+          return Own(value);
+        }
+      },
+      element.value);
+}
+
+// The functional element write (LRM 7.4.6): yields a new array with element
+// `index` replaced. The incoming value is a handle of the element domain, boxed
+// into the erased representation by the domain the element default names.
+auto lyra_rt_dynarray_with_element(
+    const void* array, const void* index, void* value) -> void* {
+  const auto& source = Read<RuntimeDynamicArray>(array);
+  RuntimeValue boxed = std::visit(
+      [&](const auto& prototype) -> RuntimeValue {
+        using T = std::decay_t<decltype(prototype)>;
+        if constexpr (std::is_same_v<T, Chandle>) {
+          return RuntimeValue{Chandle{value}};
+        } else {
+          return RuntimeValue{Read<T>(value)};
+        }
+      },
+      source.ElementDefault().value);
+  return Own(source.WithElement(Read<PackedArray>(index), std::move(boxed)));
+}
+
+auto lyra_rt_dynarray_delete(const void* array) -> void* {
+  return Own(Read<RuntimeDynamicArray>(array).Delete());
+}
+
+auto lyra_rt_dynarray_size(const void* array) -> void* {
+  return Own(Read<RuntimeDynamicArray>(array).Size());
+}
+
+auto lyra_rt_dynarray_eq(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<RuntimeDynamicArray>(lhs) == Read<RuntimeDynamicArray>(rhs));
+}
+
+auto lyra_rt_dynarray_ne(const void* lhs, const void* rhs) -> void* {
+  return Own(Read<RuntimeDynamicArray>(lhs) != Read<RuntimeDynamicArray>(rhs));
+}
+
+auto lyra_rt_dynarray_case_equal(const void* lhs, const void* rhs) -> void* {
+  return Own(
+      Read<RuntimeDynamicArray>(lhs).CaseEqual(Read<RuntimeDynamicArray>(rhs)));
+}
+
+auto lyra_rt_cell_dynarray_get(void* cell) -> const void* {
+  return &static_cast<Var<RuntimeDynamicArray>*>(cell)->Get();
+}
+
+void lyra_rt_cell_dynarray_initialize(void* cell, const void* prototype) {
+  static_cast<Var<RuntimeDynamicArray>*>(cell)->Initialize(
+      Read<RuntimeDynamicArray>(prototype));
+}
+
+void lyra_rt_cell_dynarray_set(void* cell, void* services, const void* value) {
+  static_cast<Var<RuntimeDynamicArray>*>(cell)->Set(
+      *static_cast<RuntimeServices*>(services),
+      Read<RuntimeDynamicArray>(value));
+}
+
+auto lyra_rt_activation_frame_alloc_dynarray() -> void* {
+  return GeneratedCallScope::Current()
+      .ActivationFrame()
+      .New<ActivationValueCell<RuntimeDynamicArray>>();
+}
+
+void lyra_rt_activation_frame_store_dynarray(void* cell, const void* value) {
+  static_cast<ActivationValueCell<RuntimeDynamicArray>*>(cell)->Store(
+      Read<RuntimeDynamicArray>(value));
+}
+
+auto lyra_rt_activation_frame_load_dynarray(const void* cell) -> void* {
+  return Own(
+      static_cast<const ActivationValueCell<RuntimeDynamicArray>*>(cell)
+          ->Get());
 }
 }

--- a/src/lyra/runtime/member_storage.cpp
+++ b/src/lyra/runtime/member_storage.cpp
@@ -7,6 +7,7 @@
 #include "lyra/runtime/scope_program.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/real.hpp"
+#include "lyra/value/runtime_dynamic_array.hpp"
 #include "lyra/value/runtime_tuple.hpp"
 #include "lyra/value/string.hpp"
 
@@ -33,6 +34,9 @@ MemberStorage::MemberStorage(MemberStorageDescriptor descriptor) {
           return;
         case ValueDomain::kTuple:
           object_.emplace<Var<value::RuntimeTuple>>();
+          return;
+        case ValueDomain::kDynArray:
+          object_.emplace<Var<value::RuntimeDynamicArray>>();
           return;
         case ValueDomain::kChandle:
           throw InternalError(

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -120,6 +120,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "element";
     case BuiltinFn::kElementRef:
       return "element_ref";
+    case BuiltinFn::kWithElement:
+      return "with_element";
     case BuiltinFn::kSlice:
       return "slice";
     case BuiltinFn::kSliceRef:

--- a/src/lyra/value/runtime_dynamic_array.cpp
+++ b/src/lyra/value/runtime_dynamic_array.cpp
@@ -1,0 +1,172 @@
+#include "lyra/value/runtime_dynamic_array.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/runtime_value.hpp"
+
+namespace lyra::value {
+
+RuntimeDynamicArray::RuntimeDynamicArray()
+    : element_default_(std::make_unique<RuntimeValue>()) {
+}
+
+RuntimeDynamicArray::RuntimeDynamicArray(RuntimeValue element_default)
+    : element_default_(
+          std::make_unique<RuntimeValue>(std::move(element_default))) {
+}
+
+RuntimeDynamicArray::RuntimeDynamicArray(
+    const PackedArray& n, RuntimeValue element_default)
+    : element_default_(
+          std::make_unique<RuntimeValue>(std::move(element_default))) {
+  const std::int64_t count = n.ToInt64();
+  if (count < 0) {
+    throw InternalError(
+        "RuntimeDynamicArray::new[N]: size operand is negative (LRM 7.5.1)");
+  }
+  data_.assign(static_cast<std::size_t>(count), *element_default_);
+}
+
+RuntimeDynamicArray::RuntimeDynamicArray(
+    const PackedArray& n, RuntimeValue element_default,
+    const RuntimeDynamicArray& src)
+    : element_default_(
+          std::make_unique<RuntimeValue>(std::move(element_default))),
+      data_(src.data_) {
+  const std::int64_t count = n.ToInt64();
+  if (count < 0) {
+    throw InternalError(
+        "RuntimeDynamicArray::new[N](src): size operand is negative "
+        "(LRM 7.5.1)");
+  }
+  data_.resize(static_cast<std::size_t>(count), *element_default_);
+}
+
+RuntimeDynamicArray::RuntimeDynamicArray(
+    RuntimeValue element_default, std::vector<RuntimeValue> elements)
+    : element_default_(
+          std::make_unique<RuntimeValue>(std::move(element_default))),
+      data_(std::move(elements)) {
+}
+
+RuntimeDynamicArray::RuntimeDynamicArray(const RuntimeDynamicArray& other)
+    : element_default_(std::make_unique<RuntimeValue>(*other.element_default_)),
+      data_(other.data_) {
+}
+
+RuntimeDynamicArray::RuntimeDynamicArray(RuntimeDynamicArray&&) noexcept =
+    default;
+
+auto RuntimeDynamicArray::operator=(const RuntimeDynamicArray& other)
+    -> RuntimeDynamicArray& {
+  if (this != &other) {
+    element_default_ = std::make_unique<RuntimeValue>(*other.element_default_);
+    data_ = other.data_;
+  }
+  return *this;
+}
+
+auto RuntimeDynamicArray::operator=(RuntimeDynamicArray&&) noexcept
+    -> RuntimeDynamicArray& = default;
+
+RuntimeDynamicArray::~RuntimeDynamicArray() = default;
+
+auto RuntimeDynamicArray::Size() const -> PackedArray {
+  return PackedArray::Int(static_cast<std::int32_t>(data_.size()));
+}
+
+auto RuntimeDynamicArray::ElementDefault() const -> const RuntimeValue& {
+  return *element_default_;
+}
+
+auto RuntimeDynamicArray::IsInvalidIndex(const PackedArray& index) const
+    -> bool {
+  if (index.HasUnknown()) {
+    return true;
+  }
+  const std::int64_t value = index.ToInt64();
+  return value < 0 || static_cast<std::uint64_t>(value) >=
+                          static_cast<std::uint64_t>(data_.size());
+}
+
+auto RuntimeDynamicArray::Element(const PackedArray& index) const
+    -> const RuntimeValue& {
+  if (IsInvalidIndex(index)) {
+    return *element_default_;
+  }
+  return data_[static_cast<std::size_t>(index.ToInt64())];
+}
+
+auto RuntimeDynamicArray::WithElement(
+    const PackedArray& index, RuntimeValue value) const -> RuntimeDynamicArray {
+  RuntimeDynamicArray result(*this);
+  if (!IsInvalidIndex(index)) {
+    result.data_[static_cast<std::size_t>(index.ToInt64())] = std::move(value);
+  }
+  return result;
+}
+
+auto RuntimeDynamicArray::Delete() const -> RuntimeDynamicArray {
+  return RuntimeDynamicArray(*element_default_);
+}
+
+auto RuntimeDynamicArray::operator==(const RuntimeDynamicArray& other) const
+    -> PackedArray {
+  if (data_.size() != other.data_.size()) {
+    return PackedArray::Bit(false);
+  }
+  PackedArray result = PackedArray::Bit(true);
+  for (std::size_t i = 0; i < data_.size(); ++i) {
+    result = result && RuntimeValueEqual(data_[i], other.data_[i]);
+  }
+  return result;
+}
+
+auto RuntimeDynamicArray::operator!=(const RuntimeDynamicArray& other) const
+    -> PackedArray {
+  return !(*this == other);
+}
+
+auto RuntimeDynamicArray::CaseEqual(const RuntimeDynamicArray& other) const
+    -> PackedArray {
+  if (data_.size() != other.data_.size()) {
+    return PackedArray::Bit(false);
+  }
+  PackedArray result = PackedArray::Bit(true);
+  for (std::size_t i = 0; i < data_.size(); ++i) {
+    result = result && RuntimeValueCaseEqual(data_[i], other.data_[i]);
+  }
+  return result;
+}
+
+auto RuntimeDynamicArray::IsBitIdentical(const RuntimeDynamicArray& other) const
+    -> bool {
+  if (data_.size() != other.data_.size()) {
+    return false;
+  }
+  for (std::size_t i = 0; i < data_.size(); ++i) {
+    if (!RuntimeValueBitIdentical(data_[i], other.data_[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto RuntimeDynamicArray::HasUnknown() const -> bool {
+  return std::ranges::any_of(data_, [](const RuntimeValue& element) {
+    return RuntimeValueHasUnknown(element);
+  });
+}
+
+auto RuntimeDynamicArray::IsUnknown() const -> PackedArray {
+  return PackedArray::Bit(HasUnknown());
+}
+
+}  // namespace lyra::value

--- a/src/lyra/value/runtime_tuple.cpp
+++ b/src/lyra/value/runtime_tuple.cpp
@@ -1,13 +1,13 @@
 #include "lyra/value/runtime_tuple.hpp"
 
+#include <algorithm>
 #include <cstddef>
-#include <type_traits>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/runtime_value.hpp"
 
 namespace lyra::value {
 
@@ -50,59 +50,13 @@ auto RequireSameCount(std::size_t a_count, std::size_t b_count) -> void {
   }
 }
 
-auto SameDomain(const RuntimeValue& a, const RuntimeValue& b) -> void {
-  if (a.value.index() != b.value.index()) {
-    throw InternalError(
-        "RuntimeTuple: comparing components of different runtime domains");
-  }
-}
-
-auto ComponentEqual(const RuntimeValue& a, const RuntimeValue& b)
-    -> PackedArray {
-  SameDomain(a, b);
-  return std::visit(
-      [&](const auto& lhs) -> PackedArray {
-        using T = std::decay_t<decltype(lhs)>;
-        return lhs == std::get<T>(b.value);
-      },
-      a.value);
-}
-
-auto ComponentCaseEqual(const RuntimeValue& a, const RuntimeValue& b)
-    -> PackedArray {
-  SameDomain(a, b);
-  return std::visit(
-      [&](const auto& lhs) -> PackedArray {
-        using T = std::decay_t<decltype(lhs)>;
-        if constexpr (std::is_same_v<T, Real> || std::is_same_v<T, ShortReal>) {
-          throw InternalError(
-              "RuntimeTuple::CaseEqual: === is not defined on a real component "
-              "(LRM Table 11-1)");
-        } else {
-          return lhs.CaseEqual(std::get<T>(b.value));
-        }
-      },
-      a.value);
-}
-
-auto ComponentBitIdentical(const RuntimeValue& a, const RuntimeValue& b)
-    -> bool {
-  SameDomain(a, b);
-  return std::visit(
-      [&](const auto& lhs) -> bool {
-        using T = std::decay_t<decltype(lhs)>;
-        return lhs.IsBitIdentical(std::get<T>(b.value));
-      },
-      a.value);
-}
-
 }  // namespace
 
 auto RuntimeTuple::operator==(const RuntimeTuple& other) const -> PackedArray {
   RequireSameCount(components_.size(), other.components_.size());
   PackedArray result = PackedArray::Bit(true);
   for (std::size_t i = 0; i < components_.size(); ++i) {
-    result = result && ComponentEqual(components_[i], other.components_[i]);
+    result = result && RuntimeValueEqual(components_[i], other.components_[i]);
   }
   return result;
 }
@@ -115,7 +69,8 @@ auto RuntimeTuple::CaseEqual(const RuntimeTuple& other) const -> PackedArray {
   RequireSameCount(components_.size(), other.components_.size());
   PackedArray result = PackedArray::Bit(true);
   for (std::size_t i = 0; i < components_.size(); ++i) {
-    result = result && ComponentCaseEqual(components_[i], other.components_[i]);
+    result =
+        result && RuntimeValueCaseEqual(components_[i], other.components_[i]);
   }
   return result;
 }
@@ -125,7 +80,7 @@ auto RuntimeTuple::IsBitIdentical(const RuntimeTuple& other) const -> bool {
     return false;
   }
   for (std::size_t i = 0; i < components_.size(); ++i) {
-    if (!ComponentBitIdentical(components_[i], other.components_[i])) {
+    if (!RuntimeValueBitIdentical(components_[i], other.components_[i])) {
       return false;
     }
   }
@@ -133,15 +88,9 @@ auto RuntimeTuple::IsBitIdentical(const RuntimeTuple& other) const -> bool {
 }
 
 auto RuntimeTuple::HasUnknown() const -> bool {
-  for (const RuntimeValue& component : components_) {
-    const bool unknown = std::visit(
-        [](const auto& value) -> bool { return value.HasUnknown(); },
-        component.value);
-    if (unknown) {
-      return true;
-    }
-  }
-  return false;
+  return std::ranges::any_of(components_, [](const RuntimeValue& component) {
+    return RuntimeValueHasUnknown(component);
+  });
 }
 
 auto RuntimeTuple::IsUnknown() const -> PackedArray {

--- a/src/lyra/value/runtime_value.cpp
+++ b/src/lyra/value/runtime_value.cpp
@@ -1,0 +1,66 @@
+#include "lyra/value/runtime_value.hpp"
+
+#include <type_traits>
+#include <variant>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+namespace {
+
+auto SameDomain(const RuntimeValue& a, const RuntimeValue& b) -> void {
+  if (a.value.index() != b.value.index()) {
+    throw InternalError(
+        "RuntimeValue: comparing values of different runtime domains");
+  }
+}
+
+}  // namespace
+
+auto RuntimeValueEqual(const RuntimeValue& a, const RuntimeValue& b)
+    -> PackedArray {
+  SameDomain(a, b);
+  return std::visit(
+      [&](const auto& lhs) -> PackedArray {
+        using T = std::decay_t<decltype(lhs)>;
+        return lhs == std::get<T>(b.value);
+      },
+      a.value);
+}
+
+auto RuntimeValueCaseEqual(const RuntimeValue& a, const RuntimeValue& b)
+    -> PackedArray {
+  SameDomain(a, b);
+  return std::visit(
+      [&](const auto& lhs) -> PackedArray {
+        using T = std::decay_t<decltype(lhs)>;
+        if constexpr (std::is_same_v<T, Real> || std::is_same_v<T, ShortReal>) {
+          throw InternalError(
+              "RuntimeValue::CaseEqual: === is not defined on a real value "
+              "(LRM Table 11-1)");
+        } else {
+          return lhs.CaseEqual(std::get<T>(b.value));
+        }
+      },
+      a.value);
+}
+
+auto RuntimeValueBitIdentical(const RuntimeValue& a, const RuntimeValue& b)
+    -> bool {
+  SameDomain(a, b);
+  return std::visit(
+      [&](const auto& lhs) -> bool {
+        using T = std::decay_t<decltype(lhs)>;
+        return lhs.IsBitIdentical(std::get<T>(b.value));
+      },
+      a.value);
+}
+
+auto RuntimeValueHasUnknown(const RuntimeValue& value) -> bool {
+  return std::visit(
+      [](const auto& v) -> bool { return v.HasUnknown(); }, value.value);
+}
+
+}  // namespace lyra::value

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -316,6 +316,52 @@ auto WriteStructSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+auto WriteDynArraySource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  int arr[];\n"
+      << "  int brr[];\n"
+      << "  int sig[];\n"
+      << "  int mirror = 0;\n"
+      << "  always_comb mirror = sig[0] * 100 + sig[1];\n"
+      << "  initial begin\n"
+      << "    $display(\"def size=%0d\", arr.size());\n"
+      << "    arr = new[3];\n"
+      << "    arr[0] = 5; arr[1] = 6; arr[2] = 7;\n"
+      << "    $display(\"new size=%0d a0=%0d a2=%0d\", arr.size(), arr[0], "
+         "arr[2]);\n"
+      << "    arr[9] = 99;\n"
+      << "    $display(\"oob r=%0d size=%0d\", arr[9], arr.size());\n"
+      << "    brr = arr;\n"
+      << "    arr[0] = 100;\n"
+      << "    $display(\"alias b0=%0d a0=%0d\", brr[0], arr[0]);\n"
+      << "    brr = '{5, 6, 7};\n"
+      << "    arr = '{5, 6, 7};\n"
+      << "    $display(\"eq=%0d ne=%0d ceq=%0d\", arr == brr, arr != brr, "
+         "arr === brr);\n"
+      << "    arr[2] = 8;\n"
+      << "    $display(\"eq2=%0d\", arr == brr);\n"
+      << "    arr = new[2](arr);\n"
+      << "    $display(\"resize size=%0d a0=%0d\", arr.size(), arr[0]);\n"
+      << "    brr = arr;\n"
+      << "    arr.delete();\n"
+      << "    $display(\"del a=%0d b=%0d\", arr.size(), brr.size());\n"
+      << "    begin\n"
+      << "      automatic int loc[] = '{42, 43};\n"
+      << "      #1;\n"
+      << "      $display(\"xsusp l0=%0d l1=%0d\", loc[0], loc[1]);\n"
+      << "    end\n"
+      << "    sig = new[2];\n"
+      << "    sig[0] = 1; sig[1] = 2;\n"
+      << "    #1;\n"
+      << "    $display(\"whole mirror=%0d\", mirror);\n"
+      << "    sig[0] = 7;\n"
+      << "    #1;\n"
+      << "    $display(\"partial mirror=%0d sig0=%0d\", mirror, sig[0]);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -713,6 +759,46 @@ TEST(LyraRun, JitAndCppAgreeOnStruct) {
       "xsusp a=42 b=43\n"
       "whole mirror=102\n"
       "partial mirror=702 sig.a=7\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnDynArray) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteDynArraySource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "def size=0\n"
+      "new size=3 a0=5 a2=7\n"
+      "oob r=0 size=3\n"
+      "alias b0=5 a0=100\n"
+      "eq=1 ne=0 ceq=1\n"
+      "eq2=0\n"
+      "resize size=2 a0=5\n"
+      "del a=0 b=2\n"
+      "xsusp l0=42 l1=43\n"
+      "whole mirror=102\n"
+      "partial mirror=702 sig0=7\n")
       << "stdout: " << jit.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

The execution (JIT/LLVM) backend gains the SystemVerilog dynamic array (LRM 7.5) as a runtime value domain -- the first variable-size aggregate it realizes, at parity with the C++ backend and verified to agree with it per source. A dynamic array defaults to empty, constructs from `new[N]`, `new[N](src)`, and an assignment pattern, copies with value semantics, compares under the equality and case-equality families, reports its size, reads and writes an element (an out-of-range read yields the element default and an out-of-range write is discarded, LRM 7.4.5 / 7.4.6), empties under `delete`, lives in a member slot as a whole-cell observable signal whose element write fires subscribers, and crosses a suspension as an activation-frame value. It establishes the erased-container and functional-update shape the remaining collection domains follow.

## Design

On the execution backend a value crosses as an opaque handle into runtime-owned storage, and an aggregate is realized by erasure -- one runtime-owned, type-erased object rather than a monomorphized template -- because the backend emits generated code with no host compiler to expand a per-element-type template. An element write and `delete` are therefore functional whole-value updates stored back through the value's owner, never an in-place mutation of a value reached through a possibly-shared handle, so value semantics hold across a copy: `b = a` followed by `a[i] = x` leaves `b` intact. This is the mutating-container protocol the queue and associative array reuse, and an observable partial write fires subscribers because the whole updated value is stored back through the cell.

The transitional C++ backend instead monomorphizes each value type and writes an element in place, because that type owns real storage. The two are two implementations of the same value semantics, checked to agree per source; the convergence that ends the split -- physical value monomorphization, where the execution backend generates specialized native code per concrete type -- is a deferred, value-model-wide endpoint recorded in the progress doc, not built here. This PR also records that two-track realization state in the progress doc and clarifies in `mir.md` that a place-producing assignment target names where a write lands, not an independently addressable or escaping interior reference.

## Testing

A backend-agreement test runs one SystemVerilog dynamic-array program through both backends and compares the output per source: construction, value-semantics copy and handle-aliasing, equality and case-equality, size, in-range and out-of-range element read and write, `delete`, a value local carried across a suspension, and observable partial-write notification.
