### PR TITLE
Add DPI-C svdpi context surface

### DIFF
--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -39,13 +39,17 @@ exported subroutine's single top-level instance from the running design -- and t
 runs in both directions: the import task (D5) has SV call a foreign C task, and the export task (D6)
 has foreign C call back an SV task, both under the uniform task protocol. A foreign task also
 consumes simulation time (D6b): its call runs on a fiber, so an exported task it reaches suspends on
-a delay across the boundary and resumes when time advances. What remains is instance-bound export
-dispatch beyond that single instance via `svSetScope` and receiver-less package / `$unit` scope
-(D4a), the generated ABI header and export linkage (D9), and the disable protocol across the
-boundary (D6c). On the execution backend scalar import (D10) is in: a foreign call lowers to an
-external-linkage symbol and the by-value carriers marshal. The rest of the import surface (D11) is
-blocked, and not by anything DPI owns: by-pointer marshaling is expressed as a closure, which that
-backend does not yet lower at all (`architecture-reset.md`).
+a delay across the boundary and resumes when time advances. The `svdpi` context surface (D7) runs: a
+`context` import observes the fully qualified scope of its declaration, foreign code sets and gets
+the current scope and resolves a scope to and from its name, stores per-scope user data, and reads
+the scope's effective time unit and precision and the current time scaled to it -- the current scope
+riding the calling process so concurrent time-consuming imports never cross. What remains is
+instance-bound export dispatch beyond that single instance via `svSetScope` and receiver-less
+package / `$unit` scope (D4a), the generated ABI header and export linkage (D9), and the disable
+protocol across the boundary (D6c). On the execution backend scalar import (D10) is in: a foreign
+call lowers to an external-linkage symbol and the by-value carriers marshal. The rest of the import
+surface (D11) is blocked, and not by anything DPI owns: by-pointer marshaling is expressed as a
+closure, which that backend does not yet lower at all (`architecture-reset.md`).
 
 ## Sub-Steps
 
@@ -132,9 +136,13 @@ protocol on top of it.
 
 ### Context and the svdpi surface
 
-- [ ] D7 -- `context` imports and exports and the `svdpi` runtime surface: DPI scope handles, set /
-      get scope, the scope registry, and time queries. A context import observes the scope of its
-      call site.
+- [x] D7 -- `context` imports and the `svdpi` runtime surface (LRM 35.5.3, Annex H): DPI scope
+      handles, set / get scope, resolve a scope to and from its fully qualified name, per-scope user
+      data, and time queries (a scope's effective unit and precision, and the current time scaled to
+      it). A context import observes the instantiated scope of its declaration, established for the
+      duration of its foreign call; the current scope rides the calling process, so two
+      time-consuming context imports suspended concurrently never observe each other's scope. Every
+      export is a context function reached through the same run context (LRM 35.7).
 
 ### Open arrays
 

--- a/include/lyra/hir/foreign_import.hpp
+++ b/include/lyra/hir/foreign_import.hpp
@@ -22,15 +22,17 @@ struct DpiParamAbi {
 // A subroutine declared `import "DPI-C"` (LRM 35.4). It has no SV body, so it
 // is a bodyless external callable, not a body-bearing structural subroutine.
 // The foreign linkage name, the pure property, whether it is a task or a
-// function (LRM 35.5), and the ABI projection of the signature are resolved
-// once here (where slang types are available) and are the sole downstream
-// source for the import; no layer below reads slang.
+// function (LRM 35.5), whether it is a context import (LRM 35.5.3), and the ABI
+// projection of the signature are resolved once here (where slang types are
+// available) and are the sole downstream source for the import; no layer below
+// reads slang.
 // Lowered to a MIR static external callable at HIR-to-MIR.
 struct ForeignImportDecl {
   std::string name;
   std::string foreign_name;
   bool is_pure = false;
   bool is_task = false;
+  bool is_context = false;
   support::DpiScalarAbi ret_abi = support::DpiScalarAbi::kVoid;
   TypeId ret_sv_type{};
   std::vector<DpiParamAbi> params;

--- a/include/lyra/mir/callable.hpp
+++ b/include/lyra/mir/callable.hpp
@@ -36,14 +36,18 @@ struct ForeignParam {
 };
 
 // The external implementation form of a callable: a foreign linkage name plus
-// the pure property, with no SV body. A DPI-C import is realized as one
-// (LRM 35.4). `is_pure` marks an import the LRM lets the simulator treat as
-// side-effect-free (LRM 35.5.4). The source language and calling convention are
-// implicitly C, the only foreign linkage today; a second linkage adds them
-// here.
+// the pure and context properties, with no SV body. A DPI-C import is realized
+// as one (LRM 35.4). `is_pure` marks an import the LRM lets the simulator treat
+// as side-effect-free (LRM 35.5.4). `is_context` marks an import that observes
+// the instantiated scope of its declaration and may reach SV state or call an
+// exported subroutine back (LRM 35.5.3); the call site establishes that scope
+// for the duration of the foreign call. The source language and calling
+// convention are implicitly C, the only foreign linkage today; a second linkage
+// adds them here.
 struct ExternalSymbol {
   std::string foreign_name;
   bool is_pure;
+  bool is_context;
 };
 
 // A callable realized as a foreign symbol (LRM 35.4): a DPI-C import. The

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -369,6 +369,13 @@ enum class RuntimeLibraryKind : std::uint8_t {
   // layout-equivalent word / record.
   kDpiBitChunk,
   kDpiLogicChunk,
+  // The RAII bracket a `context` DPI import's marshaling body opens over its
+  // declaration scope (LRM 35.5.3): `lyra::runtime::DpiScopeGuard`, constructed
+  // from the run services and the declaration scope, pushing that scope on the
+  // calling process's DPI scope chain for the foreign call's duration and
+  // popping it when the body's scope exits. An inert scoped value MIR never
+  // inspects; its lifetime -- not its contents -- is the effect.
+  kDpiScopeGuard,
 };
 
 struct RuntimeLibraryType {

--- a/include/lyra/runtime/ambient_run_context.hpp
+++ b/include/lyra/runtime/ambient_run_context.hpp
@@ -1,17 +1,21 @@
 #pragma once
 
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/dpi_scope_registry.hpp"
 #include "lyra/runtime/foreign_execution.hpp"
 
 namespace lyra::runtime {
 
 class Scope;
+class RuntimeServices;
 
 // The design context in effect for the duration of a running simulation. A
-// foreign C function that calls back an exported SV subroutine (LRM 35.5)
-// reaches the wrapper with plain C arguments and no design pointer, so the
-// wrapper has nothing to reach the design from unless the runtime anchors it
-// ambiently. This holds the design root for that recovery.
+// foreign C function that calls back an exported SV subroutine (LRM 35.5), or
+// that queries the DPI scope surface (LRM 35.5.3, Annex H), reaches the runtime
+// with plain C arguments and no design pointer, so it has nothing to reach the
+// run from unless the runtime anchors it ambiently. This holds the design root
+// for export-instance recovery, the run's services facade for the executing
+// process and time queries, and the DPI scope directory.
 //
 // It is an RAII stack guard over a thread-local slot: installed once around the
 // simulation run at the single run entry, and torn down when the run returns.
@@ -21,7 +25,7 @@ class Scope;
 // different thread must install its own.
 class AmbientRunContext {
  public:
-  explicit AmbientRunContext(Scope* root);
+  AmbientRunContext(Scope* root, RuntimeServices& services);
   ~AmbientRunContext();
   AmbientRunContext(const AmbientRunContext&) = delete;
   auto operator=(const AmbientRunContext&) -> AmbientRunContext& = delete;
@@ -32,10 +36,20 @@ class AmbientRunContext {
     return root_;
   }
 
+  [[nodiscard]] auto Services() const -> RuntimeServices& {
+    return *services_;
+  }
+
+  [[nodiscard]] auto ScopeRegistry() -> DpiScopeRegistry& {
+    return scope_registry_;
+  }
+
   static auto Current() -> AmbientRunContext&;
 
  private:
   Scope* root_;
+  RuntimeServices* services_;
+  DpiScopeRegistry scope_registry_;
   AmbientRunContext* previous_;
 };
 

--- a/include/lyra/runtime/dpi_context.hpp
+++ b/include/lyra/runtime/dpi_context.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace lyra::runtime {
+
+class RuntimeServices;
+class RuntimeProcess;
+class Scope;
+
+// Brackets a `context` DPI import's foreign call (LRM 35.5.3) with the scope of
+// the import's declaration on the calling process's DPI scope chain. Emitted as
+// the first local of the import's marshaling body, it pushes the scope on
+// construction and pops it when that body's scope exits -- on a normal return
+// or on an unwind, because it is an ordinary scoped local whose destructor the
+// C++ (and any future) backend runs at scope end. The chain lives on the
+// process, so the push survives a suspension of a time-consuming context import
+// and never leaks into another process's chain.
+class DpiScopeGuard {
+ public:
+  DpiScopeGuard(RuntimeServices& services, Scope* decl_scope);
+  ~DpiScopeGuard();
+  DpiScopeGuard(const DpiScopeGuard&) = delete;
+  auto operator=(const DpiScopeGuard&) -> DpiScopeGuard& = delete;
+  DpiScopeGuard(DpiScopeGuard&&) = delete;
+  auto operator=(DpiScopeGuard&&) -> DpiScopeGuard& = delete;
+
+ private:
+  RuntimeProcess* process_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/dpi_scope_registry.hpp
+++ b/include/lyra/runtime/dpi_scope_registry.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace lyra::runtime {
+
+class Scope;
+
+// The DPI scope directory for a running simulation (LRM 35.5.3, Annex H). Every
+// instance / generate scope addressable by a fully qualified name is a valid
+// `svScope` handle; the directory keys that relation both ways so
+// `svGetScopeFromName` resolves a name and `svGetNameFromScope` recovers a
+// stable name. It also holds the per-scope user-data store
+// (`svPutUserData` / `svGetUserData`). The hierarchy is built once from the
+// design root and read-only after; the user-data store is mutable across the
+// run. A handle is valid iff it is a registered scope.
+class DpiScopeRegistry {
+ public:
+  explicit DpiScopeRegistry(Scope* root);
+
+  [[nodiscard]] auto IsValidHandle(const Scope* scope) const -> bool;
+
+  // The fully qualified name of a valid handle (the `%m` form, LRM 21.2.1.1),
+  // owned by the directory and stable for the run; null for an unregistered
+  // handle.
+  [[nodiscard]] auto NameOf(const Scope* scope) const -> const char*;
+
+  // The scope registered under a fully qualified name; null if no scope carries
+  // that name. Non-const because the result is an opaque `svScope` handle the
+  // foreign side holds, not a read-only view.
+  [[nodiscard]] auto ScopeOfName(std::string_view name) const -> Scope*;
+
+  // `svPutUserData` (Annex H): store `data` under `key` for `scope`. Returns 0
+  // on success, -1 for an invalid scope or a null key.
+  auto PutUserData(const Scope* scope, void* key, void* data) -> int;
+
+  // `svGetUserData` (Annex H): the pointer previously stored under `key` for
+  // `scope`, or null for an invalid scope, a null key, or an absent entry.
+  [[nodiscard]] auto GetUserData(const Scope* scope, void* key) const -> void*;
+
+ private:
+  void RegisterSubtree(Scope& scope);
+
+  std::unordered_map<const Scope*, std::string> scope_to_path_;
+  std::unordered_map<std::string_view, Scope*> path_to_scope_;
+  std::unordered_map<const Scope*, std::unordered_map<void*, void*>> user_data_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -115,6 +115,10 @@ class Engine {
   // The process whose body is executing right now (LRM 9.5): what a fork spawn
   // parents its branch to, and what `wait fork` observes.
   [[nodiscard]] auto CurrentProcess() -> RuntimeProcess&;
+  // The executing process, or null when none is executing (non-throwing).
+  [[nodiscard]] auto TryCurrentProcess() -> RuntimeProcess* {
+    return execution_context_.TryCurrentProcess();
+  }
   [[nodiscard]] auto Now() const -> SimTime {
     return now_;
   }

--- a/include/lyra/runtime/execution_context.hpp
+++ b/include/lyra/runtime/execution_context.hpp
@@ -15,6 +15,17 @@ class RuntimeProcess;
 // time.
 class ExecutionContext {
  public:
+  // The base read of the current-process state: the executing process, or null
+  // when none is executing. Absence is a legal result the caller handles -- a
+  // DPI query reachable from foreign C (`svGetScope`) reads this form because
+  // "no imported function is executing" is a state it must report, not fault.
+  [[nodiscard]] auto TryCurrentProcess() const -> RuntimeProcess* {
+    return current_;
+  }
+
+  // The same state read under the invariant that a process is executing (LRM
+  // 9.5): a fork spawn or a process-control statement runs inside a process, so
+  // absence is a compiler-invariant violation, not a case to handle.
   [[nodiscard]] auto CurrentProcess() const -> RuntimeProcess&;
 
  private:

--- a/include/lyra/runtime/prelude.hpp
+++ b/include/lyra/runtime/prelude.hpp
@@ -23,6 +23,7 @@
 #include "lyra/runtime/coroutine.hpp"          // IWYU pragma: keep
 #include "lyra/runtime/delay.hpp"              // IWYU pragma: keep
 #include "lyra/runtime/diagnostic.hpp"         // IWYU pragma: keep
+#include "lyra/runtime/dpi_context.hpp"        // IWYU pragma: keep
 #include "lyra/runtime/engine.hpp"             // IWYU pragma: keep
 #include "lyra/runtime/event.hpp"              // IWYU pragma: keep
 #include "lyra/runtime/file_table.hpp"         // IWYU pragma: keep

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -14,6 +14,7 @@ namespace lyra::runtime {
 class ExecutionContext;
 class ForeignExecution;
 class ForeignExecutionGuard;
+class Scope;
 
 enum class ProcessExecutionState : std::uint8_t {
   kCreated,
@@ -178,6 +179,35 @@ class RuntimeProcess : public std::enable_shared_from_this<RuntimeProcess> {
   auto EnterForeignExecution(CoroutineHandle continuation, ForeignExecution& fe)
       -> bool;
 
+  // The DPI current-scope chain (LRM 35.5.3). A `context` import brackets its
+  // foreign call by pushing the scope of its declaration and popping on return;
+  // `svGetScope` reads the top, `svSetScope` replaces it. The chain lives on
+  // the process, not a thread-global, so two foreign calls suspended on
+  // different processes never share one -- the invariant a shared thread-local
+  // would break once time-consuming foreign calls interleave. It is non-empty
+  // only inside a context import's foreign call.
+  void PushDpiScope(Scope* scope) {
+    dpi_scope_chain_.push_back(scope);
+  }
+  void PopDpiScope() {
+    dpi_scope_chain_.pop_back();
+  }
+  [[nodiscard]] auto CurrentDpiScope() const -> Scope* {
+    return dpi_scope_chain_.empty() ? nullptr : dpi_scope_chain_.back();
+  }
+  // `svSetScope` (LRM 35.5.3): retarget the current chain's scope, reporting
+  // the previous one. Outside any context import the chain is empty and there
+  // is no chain to retarget, so it is a no-op reporting null rather than
+  // fabricating a frame with no lifetime boundary to pop it.
+  auto ReplaceDpiScope(Scope* scope) -> Scope* {
+    if (dpi_scope_chain_.empty()) {
+      return nullptr;
+    }
+    Scope* previous = dpi_scope_chain_.back();
+    dpi_scope_chain_.back() = scope;
+    return previous;
+  }
+
   // LRM 9.7 `suspend`: revoke the active leaf's scheduler participation -- a
   // detach, no scheduler verb -- and record the suspended state. The leaf's
   // pending wait is kept if it was blocked (resume re-establishes it) and
@@ -327,6 +357,10 @@ class RuntimeProcess : public std::enable_shared_from_this<RuntimeProcess> {
   // internally to the fiber, so its completion is not what continues the
   // process; this frame is. Null when no foreign call is outstanding.
   CoroutineHandle foreign_continuation_ = nullptr;
+  // The DPI current-scope chain (LRM 35.5.3), one frame per active context
+  // import in this process's foreign call chain. Empty outside any context
+  // import.
+  std::vector<Scope*> dpi_scope_chain_;
   ProcessExecutionState execution_state_ = ProcessExecutionState::kCreated;
   ProcessTerminationCause termination_cause_ =
       ProcessTerminationCause::kCompleted;

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -94,6 +94,8 @@ class RuntimeServices {
   // The process whose body is executing right now (LRM 9.5); the observation
   // target `wait fork` reads and a fork spawn parents its branch to.
   [[nodiscard]] auto CurrentProcess() -> RuntimeProcess&;
+  // The executing process, or null when none is executing (non-throwing).
+  [[nodiscard]] auto TryCurrentProcess() -> RuntimeProcess*;
   [[nodiscard]] auto Now() const -> SimTime;
 
   // The design-global time precision (LRM 3.14.3) the delay awaitable scales a

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -131,6 +131,15 @@ class Scope {
     return program_->metadata.time_precision_power;
   }
 
+  // The scope's time unit as a power of ten (LRM Table 20-2), read from its
+  // metadata: an addressable scope reports its own or inherited timescale, a
+  // scope with none of its own the unspecified sentinel. Read by the DPI
+  // `svGetTimeUnit` query and to scale `svGetTime` to the scope (LRM 35.5.3,
+  // Annex H).
+  [[nodiscard]] auto TimeUnitPower() const -> std::int8_t {
+    return program_->metadata.time_unit_power;
+  }
+
   // The post-construction elaboration phases, each a top-down walk over the
   // whole subtree. Services and structure are already wired in the
   // constructor; these install behavior that needs the whole tree to exist.

--- a/include/lyra/runtime/scope_program.hpp
+++ b/include/lyra/runtime/scope_program.hpp
@@ -7,10 +7,11 @@ namespace lyra::runtime {
 
 class Scope;
 
-// Returned by a scope that declares no timescale of its own (the synthetic
-// `$root`). The engine's design-global precision minimum ignores it, so a
-// purely structural node does not pull the simulation tick finer.
-inline constexpr std::int8_t kUnspecifiedTimePrecisionPower = 127;
+// The time unit or precision power a scope reports when it declares no
+// timescale of its own (the synthetic `$root`). The engine's design-global
+// precision minimum ignores it, so a purely structural node does not pull the
+// simulation tick finer.
+inline constexpr std::int8_t kUnspecifiedTimePower = 127;
 
 // The backend-neutral entry a generated body is reached through: a native
 // function over the generic scope receiver. A backend realizes it as a thunk
@@ -39,17 +40,22 @@ struct AbiStringRef {
 
 // A scope's immutable constant properties, known when its definition is built
 // and never computed by running generated code: its def name (LRM 23.8; empty
-// for a generate scope or `$root`) and its declared time precision as a power
-// of ten (LRM Table 20-2). These are data, not entries -- a backend supplies
+// for a generate scope or `$root`) and its effective time unit and precision as
+// powers of ten (LRM Table 20-2), each the scope's own timescale or the one it
+// inherits (LRM 3.14.2.3). These are data, not entries -- a backend supplies
 // the values, it does not supply a function that returns them.
 struct ScopeMetadata {
   AbiStringRef def_name;
-  std::int8_t time_precision_power = kUnspecifiedTimePrecisionPower;
+  std::int8_t time_unit_power = kUnspecifiedTimePower;
+  std::int8_t time_precision_power = kUnspecifiedTimePower;
 
   constexpr ScopeMetadata() = default;
   constexpr ScopeMetadata(
-      AbiStringRef def_name, std::int8_t time_precision_power)
-      : def_name(def_name), time_precision_power(time_precision_power) {
+      AbiStringRef def_name, std::int8_t time_unit_power,
+      std::int8_t time_precision_power)
+      : def_name(def_name),
+        time_unit_power(time_unit_power),
+        time_precision_power(time_precision_power) {
   }
 };
 

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -674,12 +674,13 @@ auto RenderUnitIncludes(const mir::CompilationUnit& unit) -> std::string {
   out += "#include <stdexcept>\n";
   out += "#include <string>\n";
   out += "#include <vector>\n";
+  out += "#include \"lyra/runtime/ambient_run_context.hpp\"\n";
   out += "#include \"lyra/runtime/coroutine.hpp\"\n";
   out += "#include \"lyra/runtime/delay.hpp\"\n";
+  out += "#include \"lyra/runtime/dpi_context.hpp\"\n";
   out += "#include \"lyra/runtime/file_table.hpp\"\n";
   out += "#include \"lyra/runtime/finish.hpp\"\n";
   out += "#include \"lyra/runtime/fork.hpp\"\n";
-  out += "#include \"lyra/runtime/ambient_run_context.hpp\"\n";
   out += "#include \"lyra/runtime/gc_ref.hpp\"\n";
   out += "#include \"lyra/runtime/named_event.hpp\"\n";
   out += "#include \"lyra/runtime/net.hpp\"\n";

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -212,6 +212,8 @@ auto RenderTypeAsCpp(const mir::CompilationUnit& unit, mir::TypeId type_id)
                 return std::string{"svBitVecVal"};
               case mir::RuntimeLibraryKind::kDpiLogicChunk:
                 return std::string{"svLogicVecVal"};
+              case mir::RuntimeLibraryKind::kDpiScopeGuard:
+                return std::string{"lyra::runtime::DpiScopeGuard"};
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -399,18 +399,13 @@ auto ClassifyDpiParams(
 // classification and the foreign name are resolved once here and never
 // re-derived downstream. A function or a task is accepted; a task carries no
 // return, so its `void` return classifies as `kVoid` through the same path. A
-// `context` import remains a located diagnostic, its scope surface a separate
-// concern.
+// `context` import (LRM 35.5.3) carries its context property forward; the call
+// site establishes the declaration scope around the foreign call.
 auto LowerForeignImport(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
     -> diag::Result<hir::ForeignImportDecl> {
   const auto& mapper = unit_lowerer.SourceMapper();
   const auto loc = mapper.PointSpanOf(sym.location);
-  if (sym.flags.has(slang::ast::MethodFlags::DPIContext)) {
-    return diag::Fail(
-        loc, diag::DiagCode::kUnsupportedDpi,
-        "DPI-C context import is not yet supported");
-  }
   const bool is_task = sym.subroutineKind == slang::ast::SubroutineKind::Task;
   auto ret_abi = ClassifyDpiScalarResult(sym.getReturnType(), loc);
   if (!ret_abi) return std::unexpected(std::move(ret_abi.error()));
@@ -425,6 +420,7 @@ auto LowerForeignImport(
       .foreign_name = ResolveImportCName(sym),
       .is_pure = sym.flags.has(slang::ast::MethodFlags::Pure),
       .is_task = is_task,
+      .is_context = sym.flags.has(slang::ast::MethodFlags::DPIContext),
       .ret_abi = *ret_abi,
       .ret_sv_type = *ret_type,
       .params = std::move(*abi_params)};

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -1060,8 +1060,8 @@ auto LowerForeignImportInputsOnly(
 template <ExprLowerer Lowerer>
 auto PopulateForeignImportBoundary(
     Lowerer& lowerer, ClosureBuilder& closure, const hir::CallExpr& c,
-    const mir::ExternalCallable& decl, mir::CallableTarget target)
-    -> diag::Result<std::optional<mir::LocalId>> {
+    const mir::ExternalCallable& decl, mir::CallableTarget target,
+    mir::EnclosingHops hops) -> diag::Result<std::optional<mir::LocalId>> {
   auto& unit_lowerer = lowerer.Owner();
   auto& unit = unit_lowerer.Unit();
   const auto& hir_exprs = lowerer.HirExprs();
@@ -1069,6 +1069,34 @@ auto PopulateForeignImportBoundary(
 
   mir::Block& body = closure.Body();
   const WalkFrame& cframe = closure.Frame();
+
+  // A context import (LRM 35.5.3) observes the scope of its declaration and may
+  // call an exported subroutine back, so the boundary opens with an RAII guard
+  // that pushes the declaration scope (the enclosing instance `hops` levels up)
+  // on the calling process's DPI scope chain for the foreign call's duration.
+  // Declared first so its scope-exit pop is the last effect, on a normal return
+  // or an unwind.
+  if (decl.external.is_context) {
+    const mir::TypeId guard_type = unit.types.Intern(
+        mir::RuntimeLibraryType{
+            .kind = mir::RuntimeLibraryKind::kDpiScopeGuard});
+    const mir::LocalId guard = closure.Bindings().DeclareAnonymous(
+        mir::LocalDecl{.name = "_lyra_dpi_scope", .type = guard_type});
+    const mir::ExprId services_id =
+        body.exprs.Add(BuildServicesCallExpr(unit_lowerer, cframe));
+    const mir::ExprId decl_scope_id =
+        BuildEnclosingScopeReceiver(cframe, unit, hops);
+    body.AppendStmt(
+        mir::LocalDeclStmt{
+            .target = guard,
+            .init = body.exprs.Add(
+                mir::Expr{
+                    .data =
+                        mir::CallExpr{
+                            .callee = mir::Construct{},
+                            .arguments = {services_id, decl_scope_id}},
+                    .type = guard_type})});
+  }
 
   // One output / inout argument to copy back after the call.
   struct Writeback {
@@ -1234,13 +1262,14 @@ template <ExprLowerer Lowerer>
 auto LowerForeignImportSequenced(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     const mir::ExternalCallable& decl, mir::CallableTarget target,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+    mir::EnclosingHops hops, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
   auto& unit_lowerer = lowerer.Owner();
   auto& unit = unit_lowerer.Unit();
 
   ClosureBuilder closure(unit, frame);
   auto ret_temp =
-      PopulateForeignImportBoundary(lowerer, closure, c, decl, target);
+      PopulateForeignImportBoundary(lowerer, closure, c, decl, target, hops);
   if (!ret_temp) return std::unexpected(std::move(ret_temp.error()));
 
   if (!ret_temp->has_value()) {
@@ -1271,12 +1300,12 @@ auto LowerForeignImportSequenced(
 template <ExprLowerer Lowerer>
 auto LowerForeignImportTask(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const mir::ExternalCallable& decl, mir::CallableTarget target)
-    -> diag::Result<mir::Expr> {
+    const mir::ExternalCallable& decl, mir::CallableTarget target,
+    mir::EnclosingHops hops) -> diag::Result<mir::Expr> {
   auto& unit = lowerer.Owner().Unit();
   ClosureBuilder closure(unit, frame);
   auto ret_temp =
-      PopulateForeignImportBoundary(lowerer, closure, c, decl, target);
+      PopulateForeignImportBoundary(lowerer, closure, c, decl, target, hops);
   if (!ret_temp) return std::unexpected(std::move(ret_temp.error()));
   return closure.BuildCoroutine();
 }
@@ -1325,12 +1354,15 @@ auto LowerForeignImportCall(
   const auto& decl = std::get<mir::ExternalCallable>(callable.impl);
 
   if (decl.is_task) {
-    return LowerForeignImportTask(lowerer, frame, c, decl, target);
+    return LowerForeignImportTask(lowerer, frame, c, decl, target, hops);
   }
+  // A context import sequences through a closure even when every actual is a
+  // by-value input, because its scope guard is a scoped body local the plain
+  // single-expression form has no room for.
   const bool needs_temp = std::ranges::any_of(decl.params, NeedsBoundaryTemp);
-  if (needs_temp) {
+  if (needs_temp || decl.external.is_context) {
     return LowerForeignImportSequenced(
-        lowerer, frame, c, decl, target, result_type);
+        lowerer, frame, c, decl, target, hops, result_type);
   }
   return LowerForeignImportInputsOnly(
       lowerer, frame, c, decl, target, result_type);

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -1444,7 +1444,8 @@ auto InstallGeneratedDefinition(
       {name_lit, machine_int(static_cast<std::int64_t>(def_name.size()))});
   const mir::ExprId metadata = construct(
       mir::RuntimeLibraryKind::kScopeMetadata,
-      {def_name_ref, machine_int(cls.time_resolution.precision_power)});
+      {def_name_ref, machine_int(cls.time_resolution.unit_power),
+       machine_int(cls.time_resolution.precision_power)});
   const mir::ExprId program = construct(
       mir::RuntimeLibraryKind::kScopeProgram,
       {metadata, func_ref(resolve_abi), func_ref(init_abi),
@@ -1559,7 +1560,8 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
                     .external =
                         mir::ExternalSymbol{
                             .foreign_name = imp.foreign_name,
-                            .is_pure = imp.is_pure}},
+                            .is_pure = imp.is_pure,
+                            .is_context = imp.is_context}},
             .virtual_dispatch = std::nullopt,
             .visibility = mir::CallableVisibility::kInternal});
   }

--- a/src/lyra/lowering/mir_to_lir/translate_type.cpp
+++ b/src/lyra/lowering/mir_to_lir/translate_type.cpp
@@ -109,6 +109,11 @@ auto TranslateRuntimeLibraryKind(mir::RuntimeLibraryKind k)
           "TranslateRuntimeLibraryKind: a unit-definition record type is a "
           "compile-time constant consumed by the backend directly and does not "
           "flow through MIR-to-LIR");
+    case mir::RuntimeLibraryKind::kDpiScopeGuard:
+      throw InternalError(
+          "TranslateRuntimeLibraryKind: the DPI context scope guard is a "
+          "C++-backend marshaling artifact; the execution backend does not "
+          "consume the DPI context surface");
   }
   throw InternalError(
       "TranslateRuntimeLibraryKind: unknown RuntimeLibraryKind");

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -322,6 +322,8 @@ class MirDumper {
                   return "RuntimeLibrary(DpiBitChunk)";
                 case RuntimeLibraryKind::kDpiLogicChunk:
                   return "RuntimeLibrary(DpiLogicChunk)";
+                case RuntimeLibraryKind::kDpiScopeGuard:
+                  return "RuntimeLibrary(DpiScopeGuard)";
               }
               throw InternalError("dump: unknown RuntimeLibraryKind");
             },

--- a/src/lyra/runtime/ambient_run_context.cpp
+++ b/src/lyra/runtime/ambient_run_context.cpp
@@ -14,8 +14,11 @@ auto CurrentSlot() -> AmbientRunContext*& {
 
 }  // namespace
 
-AmbientRunContext::AmbientRunContext(Scope* root)
-    : root_(root), previous_(CurrentSlot()) {
+AmbientRunContext::AmbientRunContext(Scope* root, RuntimeServices& services)
+    : root_(root),
+      services_(&services),
+      scope_registry_(root),
+      previous_(CurrentSlot()) {
   CurrentSlot() = this;
 }
 

--- a/src/lyra/runtime/dpi_context.cpp
+++ b/src/lyra/runtime/dpi_context.cpp
@@ -1,0 +1,167 @@
+#include "lyra/runtime/dpi_context.hpp"
+
+#include <cstdint>
+
+#include "lyra/runtime/ambient_run_context.hpp"
+#include "lyra/runtime/dpi_scope_registry.hpp"
+#include "lyra/runtime/runtime_process.hpp"
+#include "lyra/runtime/runtime_services.hpp"
+#include "lyra/runtime/scope.hpp"
+#include "lyra/runtime/sim_time.hpp"
+
+namespace lyra::runtime {
+
+DpiScopeGuard::DpiScopeGuard(RuntimeServices& services, Scope* decl_scope)
+    : process_(&services.CurrentProcess()) {
+  process_->PushDpiScope(decl_scope);
+}
+
+DpiScopeGuard::~DpiScopeGuard() {
+  process_->PopDpiScope();
+}
+
+}  // namespace lyra::runtime
+
+namespace {
+
+// The svdpi time value (Annex H `svTimeVal` == `s_vpi_time`), laid out here so
+// the runtime need not include the vendored header. `svGetTime` fills the
+// integer simulation-time form.
+struct SvTimeVal {
+  std::int32_t type;
+  std::uint32_t high;
+  std::uint32_t low;
+  double real;
+};
+constexpr std::int32_t kVpiSimTime = 2;
+
+// The scope directory answering the name and user-data queries.
+auto Directory() -> lyra::runtime::DpiScopeRegistry& {
+  return lyra::runtime::AmbientRunContext::Current().ScopeRegistry();
+}
+
+// The process whose foreign call is running, or null when none is executing --
+// a query from C that is not an imported function, which svGetScope reports as
+// a null scope rather than a fault.
+auto ForeignProcess() -> lyra::runtime::RuntimeProcess* {
+  return lyra::runtime::AmbientRunContext::Current()
+      .Services()
+      .TryCurrentProcess();
+}
+
+// Resolves a time-query scope handle: a null handle is legal (the query is at
+// the simulation level), a non-null handle must be registered. Returns false
+// for an unregistered non-null handle, which the query reports as an error.
+auto ResolveTimeScope(void* scope, const lyra::runtime::Scope** resolved)
+    -> bool {
+  if (scope == nullptr) {
+    *resolved = nullptr;
+    return true;
+  }
+  const auto* handle = static_cast<const lyra::runtime::Scope*>(scope);
+  if (!Directory().IsValidHandle(handle)) {
+    return false;
+  }
+  *resolved = handle;
+  return true;
+}
+
+}  // namespace
+
+// The Annex H context and time surface, linked into the simulation binary and
+// resolved against the user's C by name. `svScope` is `void*`; a handle is a
+// `runtime::Scope*`. The current scope is the top of the executing process's
+// DPI scope chain; the directory answers the name and user-data queries; a time
+// query reports the scope's effective unit or precision, or the
+// simulation-level value for a null scope. Errors follow the svdpi contract --
+// a null handle, null out slot, or invalid handle yields the documented null /
+// -1 -- and never throw across the C boundary.
+extern "C" {
+
+auto svGetScope() -> void* {
+  lyra::runtime::RuntimeProcess* process = ForeignProcess();
+  return process == nullptr ? nullptr : process->CurrentDpiScope();
+}
+
+auto svSetScope(void* scope) -> void* {
+  lyra::runtime::RuntimeProcess* process = ForeignProcess();
+  return process == nullptr ? nullptr
+                            : process->ReplaceDpiScope(
+                                  static_cast<lyra::runtime::Scope*>(scope));
+}
+
+auto svGetNameFromScope(void* scope) -> const char* {
+  return Directory().NameOf(static_cast<const lyra::runtime::Scope*>(scope));
+}
+
+auto svGetScopeFromName(const char* name) -> void* {
+  return name == nullptr ? nullptr : Directory().ScopeOfName(name);
+}
+
+auto svPutUserData(void* scope, void* key, void* data) -> int {
+  return Directory().PutUserData(
+      static_cast<const lyra::runtime::Scope*>(scope), key, data);
+}
+
+auto svGetUserData(void* scope, void* key) -> void* {
+  return Directory().GetUserData(
+      static_cast<const lyra::runtime::Scope*>(scope), key);
+}
+
+auto svGetTime(void* scope, void* time) -> int {
+  if (time == nullptr) {
+    return -1;
+  }
+  const lyra::runtime::Scope* resolved = nullptr;
+  if (!ResolveTimeScope(scope, &resolved)) {
+    return -1;
+  }
+  lyra::runtime::RuntimeServices& services =
+      lyra::runtime::AmbientRunContext::Current().Services();
+  const std::int8_t unit = resolved != nullptr
+                               ? resolved->TimeUnitPower()
+                               : services.GlobalPrecisionPower();
+  const lyra::SimDuration divisor =
+      lyra::runtime::TimeUnitDivisor(unit, services.GlobalPrecisionPower());
+  const std::uint64_t scaled = services.Now() / divisor;
+  auto* out = static_cast<SvTimeVal*>(time);
+  out->type = kVpiSimTime;
+  out->high = static_cast<std::uint32_t>(scaled >> 32U);
+  out->low = static_cast<std::uint32_t>(scaled & 0xFFFFFFFFU);
+  out->real = 0.0;
+  return 0;
+}
+
+auto svGetTimeUnit(void* scope, void* time_unit) -> int {
+  if (time_unit == nullptr) {
+    return -1;
+  }
+  const lyra::runtime::Scope* resolved = nullptr;
+  if (!ResolveTimeScope(scope, &resolved)) {
+    return -1;
+  }
+  lyra::runtime::RuntimeServices& services =
+      lyra::runtime::AmbientRunContext::Current().Services();
+  *static_cast<std::int32_t*>(time_unit) =
+      resolved != nullptr ? resolved->TimeUnitPower()
+                          : services.GlobalPrecisionPower();
+  return 0;
+}
+
+auto svGetTimePrecision(void* scope, void* time_precision) -> int {
+  if (time_precision == nullptr) {
+    return -1;
+  }
+  const lyra::runtime::Scope* resolved = nullptr;
+  if (!ResolveTimeScope(scope, &resolved)) {
+    return -1;
+  }
+  lyra::runtime::RuntimeServices& services =
+      lyra::runtime::AmbientRunContext::Current().Services();
+  *static_cast<std::int32_t*>(time_precision) =
+      resolved != nullptr ? resolved->TimePrecisionPower()
+                          : services.GlobalPrecisionPower();
+  return 0;
+}
+
+}  // extern "C"

--- a/src/lyra/runtime/dpi_scope_registry.cpp
+++ b/src/lyra/runtime/dpi_scope_registry.cpp
@@ -1,0 +1,70 @@
+#include "lyra/runtime/dpi_scope_registry.hpp"
+
+#include <string>
+#include <utility>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/scope.hpp"
+
+namespace lyra::runtime {
+
+DpiScopeRegistry::DpiScopeRegistry(Scope* root) {
+  if (root != nullptr) {
+    RegisterSubtree(*root);
+  }
+}
+
+void DpiScopeRegistry::RegisterSubtree(Scope& scope) {
+  // `$root` and synthetic anonymous begin/end scopes carry no source-visible
+  // name, so they are not addressable svScope handles; their named descendants
+  // still are, so the walk always recurses.
+  if (scope.IsAddressable()) {
+    std::string path{scope.HierarchicalPath().View()};
+    auto [it, inserted] = scope_to_path_.try_emplace(&scope, std::move(path));
+    if (!inserted) {
+      throw InternalError("DPI scope registry: scope registered twice");
+    }
+    if (!path_to_scope_.try_emplace(it->second, &scope).second) {
+      throw InternalError("DPI scope registry: duplicate hierarchical path");
+    }
+  }
+  scope.ForEachChild([this](Scope& child) { RegisterSubtree(child); });
+}
+
+auto DpiScopeRegistry::IsValidHandle(const Scope* scope) const -> bool {
+  return scope != nullptr && scope_to_path_.contains(scope);
+}
+
+auto DpiScopeRegistry::NameOf(const Scope* scope) const -> const char* {
+  const auto it = scope_to_path_.find(scope);
+  return it == scope_to_path_.end() ? nullptr : it->second.c_str();
+}
+
+auto DpiScopeRegistry::ScopeOfName(std::string_view name) const -> Scope* {
+  const auto it = path_to_scope_.find(name);
+  return it == path_to_scope_.end() ? nullptr : it->second;
+}
+
+auto DpiScopeRegistry::PutUserData(const Scope* scope, void* key, void* data)
+    -> int {
+  if (!IsValidHandle(scope) || key == nullptr) {
+    return -1;
+  }
+  user_data_[scope][key] = data;
+  return 0;
+}
+
+auto DpiScopeRegistry::GetUserData(const Scope* scope, void* key) const
+    -> void* {
+  if (!IsValidHandle(scope) || key == nullptr) {
+    return nullptr;
+  }
+  const auto scope_it = user_data_.find(scope);
+  if (scope_it == user_data_.end()) {
+    return nullptr;
+  }
+  const auto key_it = scope_it->second.find(key);
+  return key_it == scope_it->second.end() ? nullptr : key_it->second;
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -95,7 +95,7 @@ void Engine::ResolveGlobalTimePrecision() {
   std::int8_t min_power = kDefaultTimePrecisionPower;
   WalkScopePreOrder(*root_, [&](Scope& scope) {
     const std::int8_t power = scope.TimePrecisionPower();
-    if (power == kUnspecifiedTimePrecisionPower) {
+    if (power == kUnspecifiedTimePower) {
       return;
     }
     min_power = found ? std::min(min_power, power) : power;

--- a/src/lyra/runtime/execution_context.cpp
+++ b/src/lyra/runtime/execution_context.cpp
@@ -6,10 +6,11 @@
 namespace lyra::runtime {
 
 auto ExecutionContext::CurrentProcess() const -> RuntimeProcess& {
-  if (current_ == nullptr) {
+  RuntimeProcess* process = TryCurrentProcess();
+  if (process == nullptr) {
     throw InternalError("ExecutionContext: no process is executing");
   }
-  return *current_;
+  return *process;
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -75,6 +75,13 @@ auto RuntimeServices::CurrentProcess() -> RuntimeProcess& {
   return engine_->CurrentProcess();
 }
 
+auto RuntimeServices::TryCurrentProcess() -> RuntimeProcess* {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::TryCurrentProcess: no Engine bound");
+  }
+  return engine_->TryCurrentProcess();
+}
+
 auto RuntimeServices::Now() const -> SimTime {
   if (engine_ == nullptr) {
     throw InternalError("RuntimeServices::Now: no Engine bound");

--- a/src/lyra/runtime/simulation_entry.cpp
+++ b/src/lyra/runtime/simulation_entry.cpp
@@ -35,7 +35,7 @@ auto RunDesignHost(int argc, char** argv, RootBuilder builder) -> int {
   auto root = builder(engine.Services());
   Scope* root_scope = root.get();
   engine.BindDesign(std::move(root));
-  AmbientRunContext run_context{root_scope};
+  AmbientRunContext run_context{root_scope, engine.Services()};
   return RunSimulation(engine);
 }
 

--- a/tests/cases/cpp/dpi_context_scope/case.yaml
+++ b/tests/cases/cpp/dpi_context_scope/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.dpi_context_scope
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      observe=1
+      setscope=1
+      userdata=1
+      time=1
+      nested=1

--- a/tests/cases/cpp/dpi_context_scope/dpi.c
+++ b/tests/cases/cpp/dpi_context_scope/dpi.c
@@ -1,0 +1,91 @@
+#include <string.h>
+
+/* Context DPI-C surface (LRM 35.5.3, Annex H). Declared here rather than via
+   svdpi.h so the link input needs no extra include path; the runtime provides
+   the definitions. */
+typedef void* svScope;
+extern svScope svGetScope(void);
+extern const char* svGetNameFromScope(svScope scope);
+extern svScope svGetScopeFromName(const char* name);
+extern svScope svSetScope(svScope scope);
+extern int svPutUserData(svScope scope, void* key, void* data);
+extern void* svGetUserData(svScope scope, void* key);
+
+typedef struct {
+  int type;
+  unsigned int high;
+  unsigned int low;
+  double real;
+} svTimeVal;
+extern int svGetTime(svScope scope, svTimeVal* t);
+extern int svGetTimeUnit(svScope scope, int* time_unit);
+extern int svGetTimePrecision(svScope scope, int* time_precision);
+
+/* A context import observes the instantiated scope of its declaration. */
+int scope_ends_with(const char* suffix) {
+  const char* name = svGetNameFromScope(svGetScope());
+  if (name == 0) {
+    return 0;
+  }
+  size_t name_len = strlen(name);
+  size_t suffix_len = strlen(suffix);
+  return name_len >= suffix_len &&
+                 strcmp(name + (name_len - suffix_len), suffix) == 0
+             ? 1
+             : 0;
+}
+
+/* svGetScopeFromName round-trips the current scope, and svSetScope reports the
+   previous scope and installs the new one. */
+int setscope_roundtrip(void) {
+  svScope orig = svGetScope();
+  svScope by_name = svGetScopeFromName(svGetNameFromScope(orig));
+  if (by_name != orig) {
+    return 0;
+  }
+  svScope prev = svSetScope(by_name);
+  if (prev != orig) {
+    return 0;
+  }
+  if (svGetScope() != by_name) {
+    return 0;
+  }
+  svSetScope(orig);
+  return 1;
+}
+
+/* svdpi convention: a unique userKey is the address of a user C object. */
+static const int udata_key = 0;
+
+int userdata_roundtrip(void) {
+  svScope s = svGetScope();
+  void* key = (void*)&udata_key;
+  if (svPutUserData(s, key, (void*)0x1234) != 0) {
+    return 0;
+  }
+  return svGetUserData(s, key) == (void*)0x1234 ? 1 : 0;
+}
+
+/* The `1ns / 1ps` timescale gives unit -9 and precision -12. At time #5 the
+   current time is 5 ns: scaled to the scope's ns unit it is 5, and to the
+   simulation-level ps precision (null scope) it is 5000. */
+int check_time(void) {
+  svScope s = svGetScope();
+  int unit = 0;
+  int precision = 0;
+  if (svGetTimeUnit(s, &unit) != 0 || unit != -9) {
+    return 0;
+  }
+  if (svGetTimePrecision(s, &precision) != 0 || precision != -12) {
+    return 0;
+  }
+  svTimeVal scoped;
+  if (svGetTime(s, &scoped) != 0 || scoped.low != 5 || scoped.high != 0) {
+    return 0;
+  }
+  svTimeVal sim;
+  if (svGetTime(0, &sim) != 0 || sim.low != 5000) {
+    return 0;
+  }
+  return 1;
+}

--- a/tests/cases/cpp/dpi_context_scope/main.sv
+++ b/tests/cases/cpp/dpi_context_scope/main.sv
@@ -1,0 +1,25 @@
+`timescale 1ns / 1ps
+module Top;
+  import "DPI-C" context function int scope_ends_with(input string suffix);
+  import "DPI-C" context function int setscope_roundtrip();
+  import "DPI-C" context function int userdata_roundtrip();
+  import "DPI-C" context function int check_time();
+
+  initial begin
+    $display("observe=%0d", scope_ends_with("Top"));
+    $display("setscope=%0d", setscope_roundtrip());
+    $display("userdata=%0d", userdata_roundtrip());
+    #5;
+    $display("time=%0d", check_time());
+  end
+
+  // A context import observes the scope of its declaration, not of its call
+  // site: called from the generate block, `scope_ends_with` still declared at
+  // module scope observes `Top`, not `Top.g`.
+  if (1) begin : g
+    initial begin
+      #6;
+      $display("nested=%0d", scope_ends_with("Top"));
+    end
+  end
+endmodule

--- a/tests/cases/cpp/dpi_context_task_interleave/case.yaml
+++ b/tests/cases/cpp/dpi_context_task_interleave/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.dpi_context_task_interleave
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      g2=1
+      g1=1

--- a/tests/cases/cpp/dpi_context_task_interleave/dpi.c
+++ b/tests/cases/cpp/dpi_context_task_interleave/dpi.c
@@ -1,0 +1,38 @@
+#include <string.h>
+
+typedef void* svScope;
+extern svScope svGetScope(void);
+extern const char* svGetNameFromScope(svScope scope);
+
+/* Exported SV tasks that consume time, driven across the boundary so the calling
+   import task suspends. The long one outlives the short one, so the two imports
+   are suspended concurrently. */
+extern int nap_long(void);
+extern int nap_short(void);
+
+/* Reads the observing scope, suspends inside the exported task, then confirms
+   the scope observed after the suspension is the same one -- its own
+   declaration scope -- not the other concurrent import's. */
+static void observe(int (*nap)(void), int* ok) {
+  char before[64];
+  const char* first = svGetNameFromScope(svGetScope());
+  if (first == 0) {
+    *ok = 0;
+    return;
+  }
+  strncpy(before, first, sizeof(before) - 1);
+  before[sizeof(before) - 1] = 0;
+
+  nap();
+
+  const char* after = svGetNameFromScope(svGetScope());
+  *ok = (after != 0 && strcmp(before, after) == 0) ? 1 : 0;
+}
+
+void observe_long(int* ok) {
+  observe(nap_long, ok);
+}
+
+void observe_short(int* ok) {
+  observe(nap_short, ok);
+}

--- a/tests/cases/cpp/dpi_context_task_interleave/main.sv
+++ b/tests/cases/cpp/dpi_context_task_interleave/main.sv
@@ -1,0 +1,35 @@
+`timescale 1ns / 1ps
+// Two context task imports run concurrently in different scopes, each suspending
+// across the foreign boundary. A context import observes the scope of its own
+// declaration; because the DPI scope chain lives on the process, the scope each
+// import observes survives its suspension unchanged even while the other import
+// is pushing its own scope on another process. A shared thread-global chain
+// would let the later import's scope leak into the earlier one on resume.
+module Top;
+  export "DPI-C" task nap_long;
+  export "DPI-C" task nap_short;
+  task nap_long();
+    #10;
+  endtask
+  task nap_short();
+    #5;
+  endtask
+
+  if (1) begin : g1
+    import "DPI-C" context task observe_long(output int ok);
+    initial begin
+      int ok;
+      observe_long(ok);
+      $display("g1=%0d", ok);
+    end
+  end
+
+  if (1) begin : g2
+    import "DPI-C" context task observe_short(output int ok);
+    initial begin
+      int ok;
+      observe_short(ok);
+      $display("g2=%0d", ok);
+    end
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements the DPI-C `svdpi` context surface (LRM 35.5.3, Annex H): a `context` import observes the fully qualified instantiated scope of its declaration for the duration of its foreign call, and foreign code queries and manipulates that scope through the `svdpi` functions. Foreign C can get and set the current scope (`svGetScope` / `svSetScope`), resolve a scope to and from its fully qualified name (`svGetNameFromScope` / `svGetScopeFromName`), store and retrieve per-scope user data (`svPutUserData` / `svGetUserData`), and read a scope's effective time unit and precision and the current time scaled to it (`svGetTimeUnit` / `svGetTimePrecision` / `svGetTime`). Every export is a context function reached through the same run context (LRM 35.7).

## Design

The current scope is the top of a DPI scope chain that lives on the calling process, not a thread-global, so two time-consuming context imports suspended concurrently across the foreign boundary never observe each other's scope. A context import's marshaling body opens with an RAII scope guard as its first local: it pushes the declaration scope (resolved through the enclosing-scope receiver at the import's lexical hop distance) and pops it when the body's scope exits, on a normal return or an unwind, so the bracket needs no cooperation from the termination path. The scope directory (name-to-scope, scope-to-name, and the user-data store) is a run-owned service built once from the design root and exposed through the ambient run context. A scope now carries its effective time unit alongside its precision in its metadata. The svdpi entry points reach the executing process through the ambient run context and follow the svdpi error contract -- a null or invalid handle yields the documented null / -1 -- never throwing across the C boundary.

## Testing

`bazel test //...` passes. New end-to-end cases cover the synchronous context surface and time queries, a context import observing its declaration scope from a nested generate block (a non-zero hop distance), and two concurrent time-consuming context task imports that keep separate scopes across suspension.