### PR TITLE
Support $unit-scope declarations as an anonymous namespace unit

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -137,6 +137,10 @@ the detail lives in the entry itself.
   interning into a top-down `InternLocalClass` (never asks "which CU?") and a boundary
   `ResolveClassRef` (walks slang's parent chain only when a class is not already cached);
   design-wide precomputed maps and single-conflated interning are rejected.
+- [unit-scope-naming](unit-scope-naming.md) -- the anonymous `$unit` scope (LRM 3.12.1) is a
+  namespace unit named by its compilation-unit input identity, recomputed table-free by producer and
+  consumer; a design-wide unit id, a fixed name, a collection ordinal, and a content digest are all
+  rejected.
 - [generated-behavior-boundary](generated-behavior-boundary.md) -- generated behavior reaches the
   runtime through an explicit, backend-neutral per-specialization unit definition (native lifecycle
   entries + a method dispatch table + constant metadata), not a backend-language object ABI; the C++

--- a/docs/decisions/unit-scope-naming.md
+++ b/docs/decisions/unit-scope-naming.md
@@ -1,0 +1,109 @@
+# Anonymous `$unit`-scope unit naming
+
+## Date
+
+2026-07-20
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+The `$unit` compilation-unit scope (LRM 3.12.1) holds declarations that lie outside any design
+element. Lyra models that scope as an ordinary namespace unit -- the same rootless unit a package
+is, with no source name of its own. Every other unit publishes a name a referrer recomputes from the
+same slang facts with no shared table: a package its declared name, a module its specialization name
+(`specialization-identity.md`). The anonymous unit has neither a declared name nor parameters, so it
+needs its own naming rule. This entry pins that rule and records why the tempting alternative --
+give the unit a design-wide id -- is the forbidden shape, not the fix, so the question does not get
+re-litigated at the next cross-unit-identity site.
+
+## The tension this addresses
+
+Two `$unit` scopes must be distinguishable in the linked program (their namespaces and emitted
+headers must not collide), yet a cross-unit name must be recomputed identically by the producer (the
+unit emitting the declaration) and every consumer (a design element reaching a `$unit` member by
+name) with no shared table -- `compilation_unit_model.md` invariant 8 and `north_star.md` invariant
+5 forbid any design-wide identifier space two units both depend on.
+
+The anonymous unit exposes no intrinsic naming property except one: the compilation-unit input it
+belongs to. slang assigns it an empty name and gives its symbol no source location; only its members
+carry a location, and they all share the one source buffer of their input. That input grouping is
+not an incidental packaging fact for this unit the way a file is incidental to a module (a module
+`M` is `M` in any file): LRM 3.12.1 _defines_ the `$unit` scope boundary _by_ the compilation-unit
+input. The input grouping is the anonymous unit's identity.
+
+## The decision
+
+### D1. The anonymous `$unit` scope is a namespace unit named by its compilation-unit input identity
+
+At AST-to-HIR, each slang `CompilationUnitSymbol` that declares namespace-level content is collected
+as an anonymous namespace unit, lowered through the same rootless-unit path a package uses. Its
+published name is a pure function of the unit's own source-input identity: the resolved path of the
+source buffer its declarations live in, folded to a stable digest. One naming function serves every
+unit kind -- a package's declared name, a module's specialization name, and the anonymous unit's
+input-derived name -- so the producer and every consumer compute the same name from the same slang
+unit symbol with no shared table. This holds whether the file set compiles as one unit (a single
+`$unit` visible across every file) or per file (each file its own `$unit`); the count of anonymous
+units is just N, handled uniformly, with the single-unit case as N = 1.
+
+### D2. The name derives from the input identity, never from a design-wide unit id
+
+There is no design-wide unit identity in Lyra: a unit's cross-boundary handle is its name string,
+and cross-unit references carry that name, not an id. The anonymous unit's name is therefore derived
+from an intrinsic, table-free property of its own compilation-unit input (its source buffer), the
+same way a module's specialization name is derived from its own definition name and bindings.
+Deriving from the input keeps the name stable across edits to the scope's body (the property a
+module's name has), which is what incremental compilation (`north_star.md` invariant 4) requires.
+
+## Rejected alternatives
+
+- **A single fixed name for every anonymous unit.** Correct only when at most one anonymous unit has
+  content. Two files each declaring `$unit`-scope content would emit the same namespace and the same
+  header filename, colliding at link time. Rejected: it special-cases N = 1 and breaks at N > 1.
+
+- **A design-wide unit id (a `CompilationUnitSymbol -> id`, or `-> name`, registry the producer and
+  every consumer consult).** This is the same design-wide precomputed map
+  `cross-unit-class-translation.md` already rejected for classes: it violates
+  `compilation_unit_model.md` invariant 8 (units share no identifier space) even when the key is
+  slang-side, because it introduces a design-wide shared table where independent per-unit
+  compilation was the target, and it forecloses compiling one unit without a global pass that sees
+  the others. A cross-unit reference is a name resolved against an interface, never a shared
+  position in a global table. Lyra has no unit id for any unit kind for exactly this reason; the
+  anonymous unit does not get a special one.
+
+- **A name derived from the unit's position in the design-wide compilation-unit list.** A
+  design-wide ordinal two units both depend on -- the forbidden shape named directly in
+  `compilation_unit_model.md`. It also renames a unit when another is added, breaking incremental
+  stability.
+
+- **A name derived from the scope's content (a digest of its members).** Table-free and intrinsic,
+  but it renames the unit on every edit to its body, breaking the incremental stability D2 requires.
+  The input identity is stable across body edits; the content is not.
+
+## Consequences
+
+- The anonymous `$unit` scope rides every mechanism a named package already has -- rootless-unit
+  lowering, by-name cross-unit value and callable references, one-program-global storage, and the
+  two design-wide initialization passes -- with no second scope system and no new IR vocabulary.
+- The naming function is the single source of truth for a unit's published name across all unit
+  kinds; the producer's collection and every consumer's boundary classifier call it, so they cannot
+  disagree.
+- A class declared at `$unit` scope is not covered here; like a class declared in a package, it
+  rides the class workstream.
+
+## Relation to existing decisions
+
+- `cross-unit-class-translation.md` -- the class-side companion. It rejects the design-wide
+  `slang -> name` map for class references; this entry applies the same rejection to the anonymous
+  unit's own name and records why the input-derived name is the table-free analogue of a module's
+  specialization name.
+- `front-end-semantic-boundary.md` -- slang owns resolution, Lyra owns translation. The anonymous
+  unit's owner is read from slang's already-resolved scope, never re-derived.
+- `specialization-identity.md` -- a module's specialization name is likewise a pure function both
+  the producer and the consumer compute from the same bindings with no shared table; the anonymous
+  unit's name is the same shape keyed on the compilation-unit input.
+- `../architecture/compilation_unit_model.md` -- the term "compilation unit" here is Lyra's (a
+  namespace unit); the LRM's `$unit` file-set scope is what this unit models. That doc's Notes warn
+  the two concepts are unrelated; this entry is where they meet.

--- a/docs/progress/packages.md
+++ b/docs/progress/packages.md
@@ -21,13 +21,14 @@ inside a package ride on the class workstream and are out of scope here.
 ## Actionable
 
 PK1 (compile-time contents), PK2 (the package as a first-class unit, carrying functions), PK3
-(package variables), and PK4 (the import forms and the LRM 26.3 name-search rules) are done on the
-C++ backend: a package variable is declared with an initializer, initialized once at time zero
-before the top modules, and read and written from another unit by name, including from a package
-function or task, by explicit `pkg::item` or by a bare name brought into scope by import, and
-including waking a process on its change. A package task enabled from another unit suspends its
-caller until it completes. PK5 (`$unit`-scope declarations) is the next actionable step. The
-remaining PK2 and PK3 increments (checkboxes below) are independent follow-ups.
+(package variables), PK4 (the import forms and the LRM 26.3 name-search rules), and PK5
+(`$unit`-scope declarations) are done on the C++ backend: a package or `$unit`-scope variable is
+declared with an initializer, initialized once at time zero before the top modules, and read and
+written from another unit by name, including from a package function or task, by explicit
+`pkg::item` or by a bare name (brought into scope by import, or lying at `$unit` scope), and
+including waking a process on its change. A package or `$unit` task enabled from another unit
+suspends its caller until it completes. The remaining PK2 and PK3 increments (checkboxes below) are
+the independent follow-ups.
 
 ## Sub-Steps
 
@@ -84,14 +85,22 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
       the same way a module does. The frontend resolves every import and enforces the search-order,
       shadowing, and collision rules before lowering, so a bare imported name arrives already bound
       to its package member.
-- [ ] PK5 -- `$unit`-scope declarations (LRM 3.12.1): declarations outside any design element,
-      visible across the compilation-unit file set. Modeled as an implicit anonymous package so they
-      ride the same unit, by-name reference, storage, and callable mechanisms as a named package; no
-      second scope system.
+- [x] PK5 -- `$unit`-scope declarations (LRM 3.12.1): declarations outside any design element. A
+      `$unit`-scope variable (read and write), function, and task reached from a design element by a
+      bare name behave exactly as their package-scoped counterparts, including waking a process on
+      the variable's change and suspending a caller across a `$unit` task. They are modeled as an
+      anonymous namespace unit -- the same rootless unit a package is, with no source name of its
+      own -- so the by-name reference, storage, callable, and two-pass initialization mechanisms are
+      shared with a named package; there is no second scope system. The unit publishes a name
+      derived from its compilation-unit input identity, so the referrer and the emitted definition
+      agree with no shared table, whether the file set compiles as one unit (a single `$unit`
+      visible across every file) or per file (each file its own `$unit`). A class declared at
+      `$unit` scope rides the class workstream and is out of scope here, as its package-scoped
+      counterpart is.
 
 ## Blocked
 
-Nothing blocked. PK5 is actionable now.
+Nothing blocked. The remaining PK2 and PK3 increment checkboxes are the actionable follow-ups.
 
 ## Out of Scope
 

--- a/include/lyra/lowering/ast_to_hir/expression/references.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/references.hpp
@@ -14,19 +14,21 @@
 namespace slang::ast {
 class HierarchicalValueExpression;
 class NamedValueExpression;
-class PackageSymbol;
+class Symbol;
 class ValueSymbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
 
-// A variable declared directly in a package scope (LRM 26.2), or nullptr
-// otherwise. A package variable is reached by name across the unit boundary,
-// the way a package subroutine call is; both the value-reference path and the
-// sensitivity path detect it here so a package variable read and a wait on its
-// change agree on the by-name form.
-auto EnclosingPackageOfValue(const slang::ast::ValueSymbol& value)
-    -> const slang::ast::PackageSymbol*;
+// The compilation unit a value is declared directly in when that unit is
+// reached by name across the boundary -- a package (LRM 26.2) or the anonymous
+// `$unit` scope (LRM 3.12.1) -- or nullptr when the value belongs to this unit
+// and routes locally. Such a value is one program-global cell reached by name;
+// both the value-reference path and the sensitivity path detect it here so a
+// read and a wait on its change agree on the by-name form. The returned symbol
+// is the declaring unit, from which the caller computes its published name.
+auto DeclaringUnitOfValue(const slang::ast::ValueSymbol& value)
+    -> const slang::ast::Symbol*;
 
 auto LowerNamedValueProc(
     ProcessLowerer& proc, WalkFrame frame,

--- a/include/lyra/lowering/ast_to_hir/specialization_name.hpp
+++ b/include/lyra/lowering/ast_to_hir/specialization_name.hpp
@@ -6,6 +6,7 @@ namespace slang::ast {
 class ClassType;
 class InstanceBodySymbol;
 class InstanceSymbol;
+class Symbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
@@ -35,5 +36,16 @@ auto SpecializationName(const slang::ast::InstanceSymbol& inst) -> std::string;
 // names. Bare `C` and empty-override `C #()` resolve to the same slang
 // ClassType and thus name the same specialization.
 auto SpecializationName(const slang::ast::ClassType& cls) -> std::string;
+
+// The name a compilation unit publishes for itself, so a consumer reaching one
+// of its members by name and the unit emitting that member agree with no shared
+// table (LRM 26.3). A package publishes its declared name; a module body its
+// specialization name. An anonymous compilation-unit scope (the LRM 3.12.1
+// `$unit` file-set scope, modeled as a namespace unit with no source name)
+// publishes a name derived from its own source-input identity: the only
+// property distinguishing two such scopes is which compilation-unit input they
+// belong to, which the LRM uses to define the scope boundary itself. Both the
+// producer and every consumer compute this from the same slang unit symbol.
+auto CompilationUnitName(const slang::ast::Symbol& unit) -> std::string;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
@@ -93,16 +93,76 @@ auto LowerPackageUnit(
   return unit;
 }
 
+// Whether a compilation-unit scope declares a member that becomes namespace
+// content -- a variable, net, subroutine, or type alias. A file whose only
+// scope members are design elements (a module or package declaration) and
+// imports manifests no `$unit` unit, so it is not collected.
+auto HasUnitScopeContent(const slang::ast::CompilationUnitSymbol& cu) -> bool {
+  for (const auto& member : cu.members()) {
+    switch (member.kind) {
+      case slang::ast::SymbolKind::Variable:
+      case slang::ast::SymbolKind::Net:
+      case slang::ast::SymbolKind::Subroutine:
+      case slang::ast::SymbolKind::TypeAlias:
+        return true;
+      default:
+        break;
+    }
+  }
+  return false;
+}
+
+auto CollectCompilationUnits(const LowerCompilationFacts& facts)
+    -> std::vector<const slang::ast::CompilationUnitSymbol*> {
+  // The `$unit` file-set scope (LRM 3.12.1) is modeled as an anonymous
+  // namespace unit. slang exposes one `CompilationUnitSymbol` per
+  // compilation-unit input (one per file, or one for all files under
+  // `--single-unit`); only those declaring namespace-level content manifest a
+  // unit, so a file holding only a design element contributes none.
+  std::vector<const slang::ast::CompilationUnitSymbol*> units;
+  for (const auto* cu : facts.Compilation().getRoot().compilationUnits) {
+    if (HasUnitScopeContent(*cu)) {
+      units.push_back(cu);
+    }
+  }
+  return units;
+}
+
+auto LowerCompilationUnitUnit(
+    const LowerCompilationFacts& facts,
+    const slang::ast::CompilationUnitSymbol& cu)
+    -> diag::Result<hir::CompilationUnit> {
+  const LoweringFacts unit_facts(
+      facts.SourceMapper(), facts.Sensitivity(), facts.DisableAssertions());
+  UnitLowerer lowerer(unit_facts, cu, CompilationUnitName(cu));
+  auto unit = lowerer.Run();
+  if (unit) {
+    // A `$unit` scope is lowered, emitted, and initialized exactly as a package
+    // is -- a rootless namespace unit -- so it carries the same unit kind;
+    // nothing downstream distinguishes the two, so there is no separate kind.
+    unit->kind = hir::UnitKind::kPackage;
+  }
+  return unit;
+}
+
 }  // namespace
 
 auto LowerCompilationToHir(const LowerCompilationFacts& facts)
     -> diag::Result<std::vector<hir::CompilationUnit>> {
   std::vector<hir::CompilationUnit> units;
   const auto packages = CollectPackages(facts);
+  const auto compilation_units = CollectCompilationUnits(facts);
   const auto bodies = CollectUnitBodies(facts);
-  units.reserve(packages.size() + bodies.size());
+  units.reserve(packages.size() + compilation_units.size() + bodies.size());
   for (const auto* package : packages) {
     auto unit = LowerPackageUnit(facts, *package);
+    if (!unit) {
+      return std::unexpected(std::move(unit.error()));
+    }
+    units.push_back(*std::move(unit));
+  }
+  for (const auto* cu : compilation_units) {
+    auto unit = LowerCompilationUnitUnit(facts, *cu);
     if (!unit) {
       return std::unexpected(std::move(unit.error()));
     }

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -32,6 +32,7 @@
 #include "lyra/lowering/ast_to_hir/expression/query.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/unit_lowerer.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -167,21 +168,24 @@ auto DetectImportedRuntimeMethod(const slang::ast::SubroutineSymbol& method)
   return std::nullopt;
 }
 
-// The package a subroutine is declared directly in (LRM 26.2), or null when the
-// subroutine belongs to this compilation unit. A package subroutine's target
-// lives across the unit boundary and is reached by name, not through an
-// enclosing-scope binding of this unit.
-auto EnclosingPackage(const slang::ast::SubroutineSymbol& sym)
-    -> const slang::ast::PackageSymbol* {
+// The unit a subroutine is declared directly in when that unit is reached by
+// name across the boundary -- a package (LRM 26.2) or the anonymous `$unit`
+// scope (LRM 3.12.1) -- or null when the subroutine belongs to this compilation
+// unit. Such a target is a receiver-less callable reached by name, not through
+// an enclosing-scope binding of this unit. The returned symbol is the declaring
+// unit, from which the caller computes its published name.
+auto DeclaringUnitOfSubroutine(const slang::ast::SubroutineSymbol& sym)
+    -> const slang::ast::Symbol* {
   const slang::ast::Scope* scope = sym.getParentScope();
   if (scope == nullptr) {
     return nullptr;
   }
   const slang::ast::Symbol& owner = scope->asSymbol();
-  if (owner.kind != slang::ast::SymbolKind::Package) {
+  if (owner.kind != slang::ast::SymbolKind::Package &&
+      owner.kind != slang::ast::SymbolKind::CompilationUnit) {
     return nullptr;
   }
-  return &owner.as<slang::ast::PackageSymbol>();
+  return &owner;
 }
 
 }  // namespace
@@ -684,16 +688,16 @@ auto LowerCallExpr(
     };
   }
 
-  // A subroutine declared in a package belongs to another compilation unit
-  // (LRM 26.3). It is reached by name across the unit boundary rather than
-  // through an enclosing-scope binding of this unit.
-  if (const auto* pkg = EnclosingPackage(*sym)) {
+  // A subroutine declared in a package or the `$unit` scope belongs to another
+  // compilation unit (LRM 26.3 / 3.12.1). It is reached by name across the unit
+  // boundary rather than through an enclosing-scope binding of this unit.
+  if (const auto* unit = DeclaringUnitOfSubroutine(*sym)) {
     for (const auto* formal : sym->getArguments()) {
       if (formal->direction != slang::ast::ArgumentDirection::In) {
         return diag::Fail(
             span, diag::DiagCode::kUnsupportedExpressionForm,
-            "package subroutine with output / inout / ref arguments is not yet "
-            "supported");
+            "a subroutine reached across a unit boundary with an output / "
+            "inout / ref argument is not yet supported");
       }
     }
     auto result_type = unit_lowerer.InternType(*call.type, span);
@@ -704,7 +708,7 @@ auto LowerCallExpr(
             hir::CallExpr{
                 .callee =
                     hir::ExternalUnitSubroutineRef{
-                        .unit_name = std::string{pkg->name},
+                        .unit_name = CompilationUnitName(*unit),
                         .subroutine_name = std::string{sym->name},
                         .kind = ToHirSubroutineKind(sym->subroutineKind)},
                 .arguments = std::move(arg_ids)},

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -25,6 +25,7 @@
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/expression/selects.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -256,19 +257,21 @@ auto RouteRefExpr(
       route);
 }
 
-// Lowers a reference to a package variable as an `ExternalUnitValueRef` naming
-// the package and the variable. The same by-name form serves a referrer in
-// another unit and the package's own callable reading its own variable; neither
-// has a receiver to route through.
+// Lowers a reference to a variable owned by another unit's namespace as an
+// `ExternalUnitValueRef` naming that unit and the variable. The same by-name
+// form serves a referrer in another unit and the owning unit's own callable
+// reading its own variable; neither has a receiver to route through. The unit
+// is a package or the anonymous `$unit` scope, already resolved to its
+// published name by the caller.
 auto LowerExternalUnitValueRef(
-    UnitLowerer& unit_lowerer, const slang::ast::PackageSymbol& pkg,
+    UnitLowerer& unit_lowerer, std::string unit_name,
     const slang::ast::ValueSymbol& value, const slang::ast::Type& type,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::MakeRefExpr(
       hir::ExternalUnitValueRef{
-          .unit_name = std::string{pkg.name},
+          .unit_name = std::move(unit_name),
           .variable_name = std::string{value.name},
           .value_type = *type_id},
       *type_id, span);
@@ -296,13 +299,16 @@ auto LowerStructuralSignalRef(
 
 }  // namespace
 
-auto EnclosingPackageOfValue(const slang::ast::ValueSymbol& value)
-    -> const slang::ast::PackageSymbol* {
+auto DeclaringUnitOfValue(const slang::ast::ValueSymbol& value)
+    -> const slang::ast::Symbol* {
   const slang::ast::Scope* scope = value.getParentScope();
   if (scope == nullptr) return nullptr;
   const slang::ast::Symbol& owner = scope->asSymbol();
-  if (owner.kind != slang::ast::SymbolKind::Package) return nullptr;
-  return &owner.as<slang::ast::PackageSymbol>();
+  if (owner.kind != slang::ast::SymbolKind::Package &&
+      owner.kind != slang::ast::SymbolKind::CompilationUnit) {
+    return nullptr;
+  }
+  return &owner;
 }
 
 auto LowerNamedValueProc(
@@ -341,9 +347,9 @@ auto LowerNamedValueProc(
             hir::ProceduralVarRef{.var = *local}, type, span);
       }
       const auto& value = sym.as<slang::ast::ValueSymbol>();
-      if (const auto* pkg = EnclosingPackageOfValue(value)) {
+      if (const auto* unit = DeclaringUnitOfValue(value)) {
         return LowerExternalUnitValueRef(
-            unit_lowerer, *pkg, value, *named.type, span);
+            unit_lowerer, CompilationUnitName(*unit), value, *named.type, span);
       }
       return LowerStructuralSignalRef(
           unit_lowerer, frame, value, *named.type, span);
@@ -398,9 +404,9 @@ auto LowerHierarchicalValue(
     case Referent::kVariableStorage:
     case Referent::kNetStorage: {
       const auto& value = target.as<slang::ast::ValueSymbol>();
-      if (const auto* pkg = EnclosingPackageOfValue(value)) {
+      if (const auto* unit = DeclaringUnitOfValue(value)) {
         return LowerExternalUnitValueRef(
-            unit_lowerer, *pkg, value, *hve.type, span);
+            unit_lowerer, CompilationUnitName(*unit), value, *hve.type, span);
       }
       auto type_id = unit_lowerer.InternType(*hve.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -434,9 +440,9 @@ auto LowerNamedValueStructural(
     case Referent::kVariableStorage:
     case Referent::kNetStorage: {
       const auto& value = sym.as<slang::ast::ValueSymbol>();
-      if (const auto* pkg = EnclosingPackageOfValue(value)) {
+      if (const auto* unit = DeclaringUnitOfValue(value)) {
         return LowerExternalUnitValueRef(
-            unit_lowerer, *pkg, value, *named.type, span);
+            unit_lowerer, CompilationUnitName(*unit), value, *named.type, span);
       }
       return LowerStructuralSignalRef(
           unit_lowerer, frame, value, *named.type, span);

--- a/src/lyra/lowering/ast_to_hir/specialization_name.cpp
+++ b/src/lyra/lowering/ast_to_hir/specialization_name.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <string_view>
 
+#include <slang/ast/Compilation.h>
+#include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
@@ -13,6 +15,9 @@
 #include <slang/ast/types/DeclaredType.h>
 #include <slang/ast/types/Type.h>
 #include <slang/numeric/ConstantValue.h>
+#include <slang/text/SourceManager.h>
+
+#include "lyra/base/internal_error.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -80,6 +85,44 @@ auto SpecializationName(const slang::ast::ClassType& cls) -> std::string {
     EncodeBinding(*sym, encoding);
   }
   return std::format("{}__{:016x}", name, Fnv1a64(encoding));
+}
+
+auto CompilationUnitName(const slang::ast::Symbol& unit) -> std::string {
+  using slang::ast::SymbolKind;
+  if (unit.kind == SymbolKind::Package) {
+    return std::string(unit.name);
+  }
+  if (unit.kind == SymbolKind::InstanceBody) {
+    return SpecializationName(unit.as<slang::ast::InstanceBodySymbol>());
+  }
+  if (unit.kind == SymbolKind::CompilationUnit) {
+    // The anonymous $unit scope has no source name; its distinguishing identity
+    // is the compilation-unit input it belongs to, named by the source buffer
+    // its declarations live in. Folding the resolved path yields a name stable
+    // across edits to the scope's body (the property a module's specialization
+    // name has) and distinct per input, with no shared table. The scope symbol
+    // itself carries no source location, but every member of one input shares
+    // its buffer, so the first located member names it.
+    const auto& cu = unit.as<slang::ast::CompilationUnitSymbol>();
+    const slang::SourceManager* sources =
+        cu.getCompilation().getSourceManager();
+    if (sources == nullptr) {
+      throw InternalError(
+          "CompilationUnitName: compilation has no source manager");
+    }
+    for (const auto& member : cu.members()) {
+      if (member.location.valid()) {
+        const std::string path =
+            sources->getFullPath(member.location.buffer()).string();
+        return std::format("$unit__{:016x}", Fnv1a64(path));
+      }
+    }
+    throw InternalError(
+        "CompilationUnitName: compilation unit has no located member");
+  }
+  throw InternalError(
+      "CompilationUnitName: symbol is not a package, module body, or "
+      "compilation unit");
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -604,23 +604,6 @@ auto DeclaringCompilationUnit(const slang::ast::ClassType& cls)
   return nullptr;
 }
 
-// The name a compilation unit publishes for itself: a package's declared
-// name, or a module body's specialization name (the same name that unit
-// registers its own artifact under). A consumer reaching a class of this
-// unit by name uses this name for the unit component of the reference; the
-// class component is `SpecializationName(cls)`, computed on both sides
-// deterministically without a shared table.
-auto CompilationUnitName(const slang::ast::Symbol& unit) -> std::string {
-  if (unit.kind == slang::ast::SymbolKind::Package) {
-    return std::string(unit.name);
-  }
-  if (unit.kind == slang::ast::SymbolKind::InstanceBody) {
-    return SpecializationName(unit.as<slang::ast::InstanceBodySymbol>());
-  }
-  throw InternalError(
-      "CompilationUnitName: symbol is not a package or module body");
-}
-
 }  // namespace
 
 auto UnitLowerer::MakeClassMethodTarget(

--- a/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
@@ -34,6 +34,7 @@
 #include "lyra/lowering/ast_to_hir/expression/references.hpp"
 #include "lyra/lowering/ast_to_hir/instance_array_shape.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
@@ -503,10 +504,11 @@ auto UnitLowerer::TranslateSensitivityReads(
     const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
         read_type.isIntegral() && !read_type.isEnum() ? read.footprint
                                                       : std::nullopt;
-    // A package variable is watched the same way, but by name: it has no
-    // reader-relative route, so it wakes the process through a reference to its
-    // one program-global cell (LRM 26.2), the observation dual of reading it.
-    if (const auto* pkg = EnclosingPackageOfValue(*value)) {
+    // A variable owned by another unit's namespace is watched the same way, but
+    // by name: it has no reader-relative route, so it wakes the process through
+    // a reference to its one program-global cell (LRM 26.2 / 3.12.1), the
+    // observation dual of reading it.
+    if (const auto* unit = DeclaringUnitOfValue(*value)) {
       auto value_type =
           InternType(read_type, SourceMapper().PointSpanOf(value->location));
       if (!value_type) continue;
@@ -514,7 +516,7 @@ auto UnitLowerer::TranslateSensitivityReads(
           hir::SensitivityEntry{
               .ref =
                   hir::ExternalUnitValueRef{
-                      .unit_name = std::string{pkg->name},
+                      .unit_name = CompilationUnitName(*unit),
                       .variable_name = std::string{value->name},
                       .value_type = *value_type},
               .footprint = footprint});

--- a/tests/cases/cpp/unit_scope/case.yaml
+++ b/tests/cases/cpp/unit_scope/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.unit_scope
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    var_read: 5
+    fn_read: 10
+    after_write: 8
+    after_task: 20

--- a/tests/cases/cpp/unit_scope/main.sv
+++ b/tests/cases/cpp/unit_scope/main.sv
@@ -1,0 +1,34 @@
+// A $unit-scope declaration (LRM 3.12.1) lies outside any design element and is
+// reached from a design element by a bare name -- the same cross-unit by-name
+// form a package member uses. The $unit scope is modeled as an anonymous
+// compilation unit (a namespace unit with no source name of its own), so a
+// variable (read and write), a function, and a task declared there behave
+// exactly as their package-scoped counterparts. This exercises all three real
+// cross-unit entities; compile-time contents (parameters, typedefs) fold in
+// place and need no unit, covered elsewhere.
+int cnt = 5;
+
+function automatic int doubled();
+  return cnt * 2;
+endfunction
+
+task automatic set_cnt(int v);
+  #1;
+  cnt = v;
+endtask
+
+module Top;
+  int var_read;
+  int fn_read;
+  int after_write;
+  int after_task;
+
+  initial begin
+    var_read = cnt;
+    fn_read = doubled();
+    cnt = 8;
+    after_write = cnt;
+    set_cnt(20);
+    after_task = cnt;
+  end
+endmodule

--- a/tests/cases/cpp/unit_scope_multifile/a.sv
+++ b/tests/cases/cpp/unit_scope_multifile/a.sv
@@ -1,0 +1,10 @@
+// Per-file compilation (the default): each file is its own compilation-unit
+// input, so each file's `$unit` scope (LRM 3.12.1) is separate. This file's
+// `m` is invisible to the other file's `$unit`, and the two same-named `$unit`
+// variables are distinct cells in distinct anonymous units -- they must not
+// collide. `Top` reads its own file's `m`.
+int m = 7;
+
+module Top;
+  initial $display("%0d", m);
+endmodule

--- a/tests/cases/cpp/unit_scope_multifile/b.sv
+++ b/tests/cases/cpp/unit_scope_multifile/b.sv
@@ -1,0 +1,4 @@
+// A second, independent compilation-unit input. Its `$unit`-scope `m` shares a
+// name with the other file's but is a distinct cell in a distinct anonymous
+// unit; it is not visible to the other file and is never read here.
+int m = 100;

--- a/tests/cases/cpp/unit_scope_multifile/case.yaml
+++ b/tests/cases/cpp/unit_scope_multifile/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.unit_scope_multifile
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [a.sv, b.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      7

--- a/tests/cases/cpp/unit_scope_single_unit/a.sv
+++ b/tests/cases/cpp/unit_scope_single_unit/a.sv
@@ -1,0 +1,5 @@
+// Single-unit compilation (`--single-unit`): every file joins one
+// compilation-unit input, so there is one `$unit` scope (LRM 3.12.1) shared
+// across the files. This file's `$unit`-scope `shared` is visible to a design
+// element in the other file, reached there by a bare name.
+int shared = 42;

--- a/tests/cases/cpp/unit_scope_single_unit/b.sv
+++ b/tests/cases/cpp/unit_scope_single_unit/b.sv
@@ -1,0 +1,5 @@
+// Under single-unit compilation this module shares the other file's `$unit`
+// scope, so it reads `shared` declared there by a bare name.
+module Top;
+  initial $display("%0d", shared);
+endmodule

--- a/tests/cases/cpp/unit_scope_single_unit/case.yaml
+++ b/tests/cases/cpp/unit_scope_single_unit/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.unit_scope_single_unit
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [a.sv, b.sv]
+  args: [--single-unit]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      42


### PR DESCRIPTION
## Summary

Lower SystemVerilog `$unit`-scope declarations (LRM 3.12.1) -- variables, functions, and tasks that lie outside any design element -- so they can be read, written, called, and waited on from a design element by a bare name. The `$unit` scope is modeled as an anonymous namespace unit: the same rootless unit a package is, with no source name of its own, so it rides the existing by-name cross-unit reference, one-program-global storage, receiver-less callable, and two-pass initialization mechanisms with no second scope system. The unit lowering body, the design-root initialization, and the namespace emission are all unchanged -- they were already generic over any rootless unit; the change is one boundary classifier that now accepts a compilation-unit owner alongside a package, plus collecting the anonymous units at AST-to-HIR.

## Design

The one new question is how the anonymous unit publishes a name, since a cross-unit reference is resolved by a name that both the producer and every consumer recompute from the same slang facts with no shared table (there is no design-wide unit id in Lyra -- a unit's cross-boundary handle is its name string). The anonymous unit has no declared name and no parameters; its only distinguishing property is the compilation-unit input it belongs to, which LRM 3.12.1 uses to define the scope boundary itself. Its name is therefore derived from that input identity, which is also stable across edits to the scope's body -- the same property a module's specialization name has, and what incremental compilation needs. A design-wide unit id, a fixed name, a collection ordinal, and a content digest are all rejected; the rationale is recorded in `docs/decisions/unit-scope-naming.md`, the companion to the class-side `cross-unit-class-translation.md`.

Because the input grouping is the unit's identity, the same mechanism handles both compilation modes uniformly: per-file (each file its own `$unit`, invisible to the others) and single-unit (one `$unit` visible across every file), with the single-unit case as N = 1 rather than a special case.

## Testing

Three `cpp_run` cases: a single file exercising a `$unit` variable (read and write), function, and task; two independent files proving per-file `$unit` scopes are isolated and their same-named variables occupy distinct anonymous units without colliding; and two files under `--single-unit` proving a `$unit` declaration in one file is visible to a design element in another.
