### PR TITLE
Support inherited interface-class satisfaction

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -141,6 +141,10 @@ the detail lives in the entry itself.
   namespace unit named by its compilation-unit input identity, recomputed table-free by producer and
   consumer; a design-wide unit id, a fixed name, a collection ordinal, and a content digest are all
   rejected.
+- [interface-conformance-realization](interface-conformance-realization.md) -- inherited interface
+  satisfaction (LRM 8.26.2) is resolved at AST-to-HIR and realized as a synthesized forwarding
+  method (backend renders, never fabricates); the full method-to-slots dispatch representation is
+  deferred until a physical-vtable backend reads it.
 - [generated-behavior-boundary](generated-behavior-boundary.md) -- generated behavior reaches the
   runtime through an explicit, backend-neutral per-specialization unit definition (native lifecycle
   entries + a method dispatch table + constant metadata), not a backend-language object ABI; the C++

--- a/docs/decisions/interface-conformance-realization.md
+++ b/docs/decisions/interface-conformance-realization.md
@@ -1,0 +1,128 @@
+# Interface-class conformance realization
+
+## Date
+
+2026-07-20
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+SystemVerilog interface classes (LRM 8.26) reach the object model as one concrete base plus a set of
+interface conformances (`object_model.md` invariant 3). The C++ backend renders a conformance as
+public inheritance of an abstract type, and relies on the target language's own virtual dispatch to
+route each contract slot to the implementation the class provides.
+
+That works when the class provides the implementation locally. It breaks for LRM 8.26.2 _inherited
+satisfaction_ -- a class implements an interface whose pure-virtual method is satisfied by a method
+inherited from its concrete base, with no local redeclaration. The interface's abstract type and the
+inherited implementation land in sibling base subobjects, and the target language does not let one
+sibling base override another's virtual, so the class stays abstract and a call through it is
+ambiguous. A realization is required.
+
+This entry pins two things: how inherited satisfaction is realized, and how much of the "which
+method fills which dispatch slot" relation the IR states now versus later. The second was contested
+and is the load-bearing part.
+
+## Findings that shaped the decision
+
+- **The frontend resolves conformance; it does not persist a satisfier map.** Slang's conformance
+  check locates each interface method's implementation by name over the flattened base chain and
+  validates the signature, but for a regular class it uses the result only for diagnostics and keeps
+  no queryable interface-slot-to-implementation mapping. The resolution -- including the inherited
+  case -- is available by re-running slang's own by-name lookup at translation time; the class it
+  returns is already conformance-validated.
+- **The backend renders; it does not fabricate.** A backend render entry is a fixed function of one
+  IR node and never invents an expression from IR data (`backend_contract.md`). A forwarding call
+  must therefore exist as a real IR expression produced during lowering, not be synthesized by the
+  backend from a bare relation.
+- **A synthesized method override is an established mechanism.** The post-construction lifecycle
+  bodies are already synthesized overrides with no source form, rendered like any method
+  (`object_model.md`). A synthesized realization method is not a special case.
+- **The full slot-to-implementation table is layout, and no backend reads it today.** Which slot an
+  implementation fills is class-type layout; the physical dispatch table is LIR/runtime
+  (`object_model.md`, `unified-callable-model.md`). The C++ backend never builds a dispatch table --
+  it recovers a method name and lets the target language dispatch -- so it never reads "which slots
+  does this method fill." The one place the IR states a method's participation is its single-slot
+  resolved dispatch role.
+
+## The decision
+
+**D1. Inherited satisfaction is resolved at AST-to-HIR and realized as a synthesized forwarding
+method.** For each directly-declared interface, for each contract method a class does not satisfy
+locally but does satisfy through an inherited concrete-base method, translation synthesizes an
+ordinary method on the class that forwards to the inherited implementation, using slang's own
+by-name resolution (the class it returns is already conformance-validated) to find that
+implementation. The forwarding method's dispatch role names the interface slot it fills, and its
+body forwards to the inherited implementation. The backend renders it as an ordinary method; it does
+not fabricate the forwarding expression. Forwarding methods are deduplicated by (implementation,
+signature): one inherited implementation satisfying several same-signature interface slots yields
+one method, not one per interface. There is no distinct "adapter" entity, marker, or type -- the
+forwarding method is an ordinary synthesized method, the same mechanism a lifecycle body uses.
+
+**D2. The forwarding body is a qualified, non-virtual base call, a general primitive.** The
+forwarding body is a direct, vtable-bypassing call to the inherited base method, qualified by the
+base type -- possibly cross-unit. This is a general IR call form and the same primitive a
+source-level cross-unit `super` call needs; it is built as a general capability, not a bridge-only
+special case.
+
+**D3. A method's dispatch participation stays the single-slot resolved role; the full "one method
+fills these N slots" representation is deferred until a backend reads it.** The IR continues to
+state a method's participation as its single resolved dispatch role, and interface-slot filling
+continues to rely on the target language's implicit override across sibling bases. The richer
+representation -- a method naming every concrete and interface slot it fills -- is deferred. Its
+trigger is the physical-vtable backend (a backend that builds the dispatch table from the IR): at
+that point `backend_contract.md`'s mechanical-backend cross-check forces the full relation, and a
+consumer exists to exercise and test it. Until then, materializing it is write-only state no backend
+reads and no test validates. This keeps inherited satisfaction symmetric with local multi-interface
+satisfaction, which already ships and records the same single-slot role.
+
+## Rejected alternatives
+
+- **A bare conformance binding the backend realizes.** The IR carries only a contract-slot to
+  implementation relation, and the backend emits the forwarding override from it. Rejected: the
+  backend would fabricate the forwarding expression from IR data, the forbidden shape in
+  `backend_contract.md`. The forwarding call belongs to lowering, not render.
+
+- **A separate conformance record parallel to the satisfying method.** Rejected as asymmetric: local
+  satisfaction (a class that defines the method) already carries the relation on the satisfying
+  method's dispatch role, with no separate record. A parallel structure only for the inherited case
+  splits one concept across two homes; the synthesized forwarding method carries the relation the
+  same way a local satisfier does.
+
+- **An origin marker distinguishing a synthesized forwarding method from a source method.**
+  Rejected: it contradicts the one-callable model (`unified-callable-model.md`). A synthesized
+  lifecycle body is already an unmarked ordinary callable; the forwarding method is another. No
+  consumer needs to treat it differently.
+
+- **Building the full method-to-slots representation now.** Rejected as unexercised state: no
+  backend reads slot filling today (the C++ backend defers dispatch to the target language; the
+  physical table is LIR/runtime), so the representation would be write-only and untestable until the
+  physical-vtable backend exists. The shape is anticipated; only its timing is deferred, keyed to
+  the backend that consumes it.
+
+## Consequences
+
+- Inherited satisfaction compiles and dispatches correctly, symmetric with local satisfaction; a
+  further-derived class that overrides the satisfied method dispatches to its own override through
+  every handle type.
+- A general qualified, vtable-bypassing base-call primitive lands, also enabling source-level
+  cross-unit `super`.
+- The full method-to-slots dispatch representation remains an open, deliberately-deferred gap, keyed
+  to the physical-vtable backend.
+
+## Relation to existing decisions
+
+- `object-model.md` -- interface conformance is a relation distinct from the concrete base, and an
+  override is a resolved relation a backend never re-derives by name. The synthesized forwarding
+  method's resolved dispatch role is that relation.
+- `generated-behavior-boundary.md` -- lifecycle and SV-virtual dispatch share a representation but
+  are separate concepts; the synthesized-override mechanism this reuses is the same one lifecycle
+  bodies use.
+- `cross-unit-class-translation.md` -- the cross-unit base the forwarding method calls is resolved
+  by the boundary translator this decision's forwarding call names.
+- `unified-callable-model.md` -- the vtable slot-to-implementation mapping is class-type layout, not
+  callable identity; the single-callable concept is why the forwarding method carries no origin
+  marker.

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -535,12 +535,16 @@ auto RenderDirectExternalUnitCall(const mir::ExternalUnitCallableTarget& target)
 // compilation unit (LRM 8.6 / 8.10 across the unit boundary). Instance
 // method: the receiver arrives as `arguments[0]` (a pointer to the object)
 // and the callee is `(receiver)->method`, so target-language name-lookup
-// resolves the method through the receiver's static type after the
-// declaring unit's header is included, and any virtual dispatch happens
-// through the target language's own vtable. Static method: no receiver in
-// the argument list, and the callee is the free qualified form
-// `unit::Class::method`. The two shapes are told apart by the receiver
-// argument -- an instance call always prepends a pointer-typed receiver.
+// resolves the method through the receiver's static type after the declaring
+// unit's header is included. A `Direct` call is non-virtual by construction
+// (LRM 8.15 super, or a non-virtual callee), so the instance form is
+// owner-qualified `(receiver)->unit::Class::method` -- the same shape the
+// intra-unit owner-qualified render uses -- which bypasses the target
+// language's vtable exactly as super demands and is equivalent to an
+// unqualified call for a non-virtual callee. Static method: no receiver in the
+// argument list, and the callee is the free qualified form
+// `unit::Class::method`. The two shapes are told apart by the receiver argument
+// -- an instance call always prepends a pointer-typed receiver.
 auto RenderDirectExternalUnitClassMethodCall(
     const ScopeView& view, const mir::CallExpr& call,
     const mir::ExternalUnitClassMethodTarget& target) -> CalleeRender {
@@ -557,7 +561,8 @@ auto RenderDirectExternalUnitClassMethodCall(
   }
   return {
       .expr = std::format(
-          "({})->{}", RenderExpr(view, view.Expr(call.arguments[0])),
+          "({})->{}::{}::{}", RenderExpr(view, view.Expr(call.arguments[0])),
+          ToCppName(target.unit_name), ToCppName(target.class_name),
           target.method_name),
       .leading_arg_count = 1};
 }

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
 #include <utility>
@@ -14,6 +15,7 @@
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
+#include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -583,6 +585,165 @@ auto SynthesizeDefaultConstructor(hir::TypeId void_type, diag::SourceSpan span)
       .overrides = std::nullopt};
 }
 
+// Builds the forwarding method for one interface pure virtual method a class
+// satisfies through an inherited concrete-base method rather than a local
+// definition (LRM 8.26.2). Its dispatch role names the interface slot it fills;
+// its body forwards to the inherited implementation through a `super`-qualified
+// call, so a backend renders it as an ordinary method rather than fabricating
+// the forward.
+auto BuildInterfaceForwardingMethod(
+    UnitLowerer& unit_lowerer, diag::SourceSpan span,
+    const slang::ast::ClassType& iface_cls,
+    const slang::ast::MethodPrototypeSymbol& proto,
+    const slang::ast::SubroutineSymbol& impl)
+    -> diag::Result<hir::SubroutineDecl> {
+  auto result_type_or = unit_lowerer.InternType(impl.getReturnType(), span);
+  if (!result_type_or) {
+    return std::unexpected(std::move(result_type_or.error()));
+  }
+  const hir::TypeId result_type = *result_type_or;
+
+  hir::ProceduralBody body;
+  std::vector<hir::SubroutineParam> params;
+  std::vector<std::optional<hir::ExprId>> args;
+  for (const auto* formal : impl.getArguments()) {
+    if (formal->direction != slang::ast::ArgumentDirection::In) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "an interface method satisfied by an inherited implementation with "
+          "an output / inout / ref argument is not yet supported");
+    }
+    auto param_type_or = unit_lowerer.InternType(formal->getType(), span);
+    if (!param_type_or) {
+      return std::unexpected(std::move(param_type_or.error()));
+    }
+    const hir::ProceduralVarId var = body.procedural_vars.Add(
+        hir::ProceduralVarDecl{
+            .name = std::string{formal->name}, .type = *param_type_or});
+    params.push_back(
+        hir::SubroutineParam{
+            .var = var, .direction = hir::ParamDirection::kInput});
+    args.push_back(body.exprs.Add(
+        hir::Expr{
+            .type = *param_type_or,
+            .data = hir::PrimaryExpr{hir::ProceduralVarRef{.var = var}},
+            .span = span}));
+  }
+
+  std::optional<hir::ProceduralVarId> result_var;
+  if (!impl.getReturnType().isVoid()) {
+    result_var = body.procedural_vars.Add(
+        hir::ProceduralVarDecl{.name = "forward_result", .type = result_type});
+  }
+
+  const auto& impl_class =
+      impl.getParentScope()->asSymbol().as<slang::ast::ClassType>();
+  auto impl_ref = unit_lowerer.ResolveClassRef(impl_class, span);
+  if (!impl_ref) return std::unexpected(std::move(impl_ref.error()));
+  const hir::ExprId call = body.exprs.Add(
+      hir::Expr{
+          .type = result_type,
+          .data =
+              hir::CallExpr{
+                  .callee =
+                      hir::MethodCallRef{
+                          .receiver = hir::SuperReceiver{},
+                          .target = unit_lowerer.MakeClassMethodTarget(
+                              *impl_ref, impl)},
+                  .arguments = std::move(args)},
+          .span = span});
+  const hir::StmtId ret = body.stmts.Add(
+      hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::ReturnStmt{.value = call},
+          .span = span});
+  body.root_stmt = body.stmts.Add(
+      hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::BlockStmt{.statements = {ret}, .scope = std::nullopt},
+          .span = span});
+
+  auto iface_ref = unit_lowerer.ResolveClassRef(iface_cls, span);
+  if (!iface_ref) return std::unexpected(std::move(iface_ref.error()));
+  const auto* proto_stub = proto.getSubroutine();
+  if (proto_stub == nullptr) {
+    throw InternalError(
+        "BuildInterfaceForwardingMethod: interface pure virtual prototype "
+        "has no stub subroutine slang normally materializes");
+  }
+
+  return hir::SubroutineDecl{
+      .name = std::string{proto.name},
+      .kind = hir::SubroutineKind::kFunction,
+      .result_type = result_type,
+      .params = std::move(params),
+      .result_var = result_var,
+      .body = std::move(body),
+      .is_virtual = true,
+      .is_prototype = false,
+      .is_static = false,
+      .overrides = unit_lowerer.MakeClassMethodTarget(*iface_ref, *proto_stub)};
+}
+
+// Synthesizes forwarding methods for every interface pure virtual method a
+// class satisfies by inheriting a concrete-base implementation with no local
+// override (LRM 8.26.2). C++ multiple inheritance does not let one sibling
+// base's method override another's, so without the forward the class stays
+// abstract and a call through it is ambiguous. One forwarding method per
+// inherited implementation: a single method satisfying several same-name
+// interface slots (LRM 8.26.6.1) forwards once, and the target language's
+// implicit override fills the remaining slots.
+auto SynthesizeInterfaceForwardingMethods(
+    UnitLowerer& unit_lowerer, const slang::ast::ClassType& cls,
+    diag::SourceSpan span, hir::ClassDecl& decl) -> diag::Result<void> {
+  // An interface class only aggregates contracts (LRM 8.26); it carries no
+  // implementation to forward to, so it never bridges. Its `extends` parents
+  // are pure prototypes, not satisfiers.
+  if (cls.isInterface) return {};
+  std::set<const slang::ast::SubroutineSymbol*> bridged;
+  for (const auto* iface_type : cls.getDeclaredInterfaces()) {
+    const auto& iface_cls =
+        iface_type->getCanonicalType().as<slang::ast::ClassType>();
+    for (const auto& member : iface_cls.members()) {
+      const slang::ast::Symbol* unwrapped = &member;
+      if (member.kind == slang::ast::SymbolKind::TransparentMember) {
+        unwrapped = &member.as<slang::ast::TransparentMemberSymbol>().wrapped;
+      }
+      if (unwrapped->kind != slang::ast::SymbolKind::MethodPrototype) continue;
+      const auto& proto = unwrapped->as<slang::ast::MethodPrototypeSymbol>();
+      if (!proto.flags.has(slang::ast::MethodFlags::Pure)) continue;
+
+      const slang::ast::Symbol* found = cls.find(proto.name);
+      if (found == nullptr ||
+          found->kind != slang::ast::SymbolKind::Subroutine) {
+        continue;
+      }
+      const auto& impl = found->as<slang::ast::SubroutineSymbol>();
+      // A locally-defined satisfier is wired by the class's own method loop;
+      // only an inherited implementation needs a bridge.
+      if (impl.getParentScope() ==
+          static_cast<const slang::ast::Scope*>(&cls)) {
+        continue;
+      }
+      // The satisfier must be a real implementation. A pure prototype declared
+      // in an interface base carries no body to forward to (only reachable for
+      // a still-abstract virtual class); it is not a satisfier.
+      const auto& impl_owner = impl.getParentScope()->asSymbol();
+      if (impl_owner.kind == slang::ast::SymbolKind::ClassType &&
+          impl_owner.as<slang::ast::ClassType>().isInterface) {
+        continue;
+      }
+      if (!bridged.insert(&impl).second) continue;
+
+      auto method_or = BuildInterfaceForwardingMethod(
+          unit_lowerer, span, iface_cls, proto, impl);
+      if (!method_or) return std::unexpected(std::move(method_or.error()));
+      decl.methods.Add(*std::move(method_or));
+    }
+  }
+  return {};
+}
+
 // Walks a class's parent-scope chain to find the compilation-unit-level
 // symbol that owns its declaration -- a package (LRM 26), a module body
 // (LRM 23.2), or an interface body (LRM 25). A class nested in another
@@ -926,6 +1087,15 @@ auto UnitLowerer::InternLocalClass(
     if (const auto* proto_stub = proto.getSubroutine(); proto_stub != nullptr) {
       RegisterMethodId(*proto_stub, method_id);
     }
+  }
+
+  // Forward every interface pure virtual this class satisfies by inheritance
+  // rather than a local definition (LRM 8.26.2); a locally-satisfied contract
+  // is already wired by the method loop above.
+  if (auto forwards =
+          SynthesizeInterfaceForwardingMethods(*this, cls, span, decl);
+      !forwards) {
+    return std::unexpected(std::move(forwards.error()));
   }
 
   hir::SubroutineDecl constructor =

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -527,30 +527,32 @@ auto LowerBuiltinMethodCall(
       .type = result_type};
 }
 
-// Reads the slot's canonical (owner, id) off a method's stated
-// `virtual_dispatch`. Every participating method already stores this pair --
-// an introducer names itself, an intra-unit override was populated with the
-// canonical id at class lowering -- so this is a one-arm dispatch, never a
-// chain walk.
-auto CanonicalIntraUnitSlot(
+// Reads the virtual slot a method participates in off its stated
+// `virtual_dispatch`. Every participating method already names its slot -- an
+// introducer names its own (owner, id), an intra-unit override was populated
+// with the canonical intra-unit id at class lowering, and a cross-unit
+// override names the introducing (unit, class, method) triple -- so this is a
+// one-arm dispatch, never a chain walk. A method whose slot was introduced in
+// another compilation unit resolves to an `ExternalVirtualSlot`, reached
+// through the declaring unit's header.
+auto CanonicalVirtualSlot(
     mir::ClassId self_owner, mir::CallableId self_slot,
-    const mir::VirtualDispatchRole& role)
-    -> std::pair<mir::ClassId, mir::CallableId> {
+    const mir::VirtualDispatchRole& role) -> mir::VirtualSlot {
   return std::visit(
       Overloaded{
-          [&](const mir::IntroducesVirtualSlot&)
-              -> std::pair<mir::ClassId, mir::CallableId> {
-            return {self_owner, self_slot};
+          [&](const mir::IntroducesVirtualSlot&) -> mir::VirtualSlot {
+            return mir::LocalVirtualSlot{
+                .owner_class = self_owner, .slot = self_slot};
           },
-          [](const mir::OverridesIntraUnitSlot& s)
-              -> std::pair<mir::ClassId, mir::CallableId> {
-            return {s.slot_owner, s.slot_id};
+          [](const mir::OverridesIntraUnitSlot& s) -> mir::VirtualSlot {
+            return mir::LocalVirtualSlot{
+                .owner_class = s.slot_owner, .slot = s.slot_id};
           },
-          [](const mir::OverridesExternalSlot&)
-              -> std::pair<mir::ClassId, mir::CallableId> {
-            throw InternalError(
-                "CanonicalIntraUnitSlot: expected an intra-unit slot, but the "
-                "method's role names a cross-unit slot introducer");
+          [](const mir::OverridesExternalSlot& e) -> mir::VirtualSlot {
+            return mir::ExternalVirtualSlot{
+                .unit_name = e.unit_name,
+                .class_name = e.class_name,
+                .method_name = e.method_name};
           }},
       role);
 }
@@ -672,18 +674,15 @@ auto LowerMethodCall(
                                .GetClassShape(owner_class)
                                .callable_signatures.Get(method_slot);
   if (!through_super && method_sig.virtual_dispatch.has_value()) {
-    const auto [canonical_owner, canonical_slot] = CanonicalIntraUnitSlot(
-        owner_class, method_slot, *method_sig.virtual_dispatch);
     return mir::Expr{
         .data =
             mir::CallExpr{
                 .callee =
                     mir::Virtual{
                         .receiver = receiver_ptr,
-                        .slot =
-                            mir::LocalVirtualSlot{
-                                .owner_class = canonical_owner,
-                                .slot = canonical_slot}},
+                        .slot = CanonicalVirtualSlot(
+                            owner_class, method_slot,
+                            *method_sig.virtual_dispatch)},
                 .arguments = std::move(user_args)},
         .type = result_type};
   }

--- a/tests/cases/cpp/class_interface_conformance/case.yaml
+++ b/tests/cases/cpp/class_interface_conformance/case.yaml
@@ -17,3 +17,7 @@ expect:
     byte_get_value: 12
     derived_tag_direct: 100
     derived_tag_via_named: 100
+    derived_tag_via_tagged: 100
+    mderived_tag_direct: 200
+    mderived_tag_via_named: 200
+    mderived_tag_via_tagged: 200

--- a/tests/cases/cpp/class_interface_conformance/main.sv
+++ b/tests/cases/cpp/class_interface_conformance/main.sv
@@ -33,6 +33,12 @@ package pkg;
     pure virtual function int tag();
   endclass
 
+  // Same-signature contract as Named: one inherited implementation satisfies
+  // both (LRM 8.26.6.1), exercising adapter deduplication by implementation.
+  interface class Tagged;
+    pure virtual function int tag();
+  endclass
+
   class Base;
     virtual function int tag();
       return 100;
@@ -67,10 +73,20 @@ module Top;
   endclass
 
   // Inherited satisfaction (LRM 8.26.2): Base has `virtual function int
-  // tag()`, and `pkg::Named` requires `pure virtual function int tag()`. The
-  // implementation is inherited from Base; Derived does not need to redefine
-  // it.
-  class Derived extends pkg::Base implements pkg::Named;
+  // tag()`, and `pkg::Named` / `pkg::Tagged` each require `pure virtual
+  // function int tag()`. The implementation is inherited from Base; Derived
+  // does not redefine it, and one inherited method satisfies both same-name
+  // contracts (LRM 8.26.6.1).
+  class Derived extends pkg::Base implements pkg::Named, pkg::Tagged;
+  endclass
+
+  // A further-derived class overrides the inherited-satisfied method. Dispatch
+  // through every handle -- the concrete base, each interface, and the
+  // subclass -- must reach the most-derived override.
+  class MoreDerived extends Derived;
+    virtual function int tag();
+      return 200;
+    endfunction
   endclass
 
   int cell_direct_get;
@@ -83,15 +99,21 @@ module Top;
   int byte_get_value;
   int derived_tag_direct;
   int derived_tag_via_named;
+  int derived_tag_via_tagged;
+  int mderived_tag_direct;
+  int mderived_tag_via_named;
+  int mderived_tag_via_tagged;
 
   initial begin
     Cell c;
     ByteCell bc;
     Derived d;
+    MoreDerived md;
     pkg::Putter #(int) put_ref;
     pkg::Getter #(int) get_ref;
     pkg::PutGet #(int) putget_ref;
     pkg::Named named_ref;
+    pkg::Tagged tagged_ref;
     pkg::Getter #(byte) byte_get_ref;
 
     c = new;
@@ -122,5 +144,17 @@ module Top;
     derived_tag_direct = d.tag();
     named_ref = d;
     derived_tag_via_named = named_ref.tag();
+    tagged_ref = d;
+    derived_tag_via_tagged = tagged_ref.tag();
+
+    // A further-derived override dispatches to the most-derived method through
+    // every handle -- direct and each interface (LRM 8.26.2: a subclass of an
+    // implementing class also implements the interface).
+    md = new;
+    mderived_tag_direct = md.tag();
+    named_ref = md;
+    mderived_tag_via_named = named_ref.tag();
+    tagged_ref = md;
+    mderived_tag_via_tagged = tagged_ref.tag();
   end
 endmodule


### PR DESCRIPTION
## Summary

The C++ backend gains SystemVerilog interface-class inherited satisfaction (LRM 8.26.2): a class that implements an interface whose pure-virtual method is satisfied by a method inherited from its concrete base, with no local redeclaration. Previously the emitted C++ did not compile in this case -- the interface's abstract type and the inherited implementation land in sibling base subobjects, and C++ does not let one sibling base override another's virtual, so the class stayed abstract and a call through it was ambiguous. AST-to-HIR now synthesizes an ordinary forwarding method on the class, resolved through slang's own conformance lookup and deduplicated so one inherited implementation satisfying several same-signature interface contracts bridges once, whose body forwards to the inherited implementation through a qualified, vtable-bypassing base call. Two adjacent cross-unit gaps this exposed are fixed in the same change: a local method overriding a cross-unit base virtual now lowers to a cross-unit virtual slot instead of raising an internal error, and a cross-unit direct (super / non-virtual) instance call now renders owner-qualified so it bypasses the vtable as super requires -- which also enables source-level cross-unit super.

## Design

The forwarding method is an ordinary synthesized method -- the same mechanism the post-construction lifecycle bodies use -- not a distinct adapter entity, binding, or origin-marked callable. The backend renders it mechanically and never fabricates the forwarding expression. Interface-slot filling continues to rely on the target language's implicit override across sibling bases, so a method's dispatch participation stays the single-slot resolved role, matching the already-shipped local multi-interface case; the richer "which method fills which dispatch slot" representation is deferred to a physical-vtable backend that would build the dispatch table from the IR, since no backend reads it today. The rationale and rejected alternatives are recorded in docs/decisions/interface-conformance-realization.md.

## Testing

The class_interface_conformance case is extended with a same-signature two-interface contract satisfied by one inherited implementation (exercising deduplication) and a further-derived subclass that overrides the inherited-satisfied method (exercising dispatch through the concrete base and each interface handle). Verified end-to-end -- emit, host-compile, run -- plus the full suite. CI's Test job filters out the host-compile tests, so this cpp_run coverage was validated locally.