### PR TITLE
Support multi-condition &&& predicates in if and ternary

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -91,9 +91,9 @@ complete.
 ### Expressions
 
 - [x] C14 -- Ternary `cond ? a : b`, including an `&&&` multi-condition predicate (LRM 12.4) that
-      desugars to the same chained logical-AND the `if` statement uses. The `matches` pattern form is
-      rejected as unsupported. 4-state X/Z propagation on the condition rides on the broader 4-state
-      work in `operators.md`.
+      desugars to the same chained logical-AND the `if` statement uses. The `matches` pattern form
+      is rejected as unsupported. 4-state X/Z propagation on the condition rides on the broader
+      4-state work in `operators.md`.
 
 ## Out of Scope
 

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -21,10 +21,11 @@ complete.
 
 ### Statements
 
-- [x] C1 -- `if` / `else` (procedural conditional). Multi-condition lists, pattern forms, and
-      `unique` / `priority` qualifiers are rejected as unsupported; the qualifier work is C13.
-  - [ ] A multi-condition `if` (`if (a &&& b)` / comma list, LRM 12.4) is rejected; only a single
-        condition expression is accepted.
+- [x] C1 -- `if` / `else` (procedural conditional). Pattern forms and `unique` / `priority`
+      qualifiers are rejected as unsupported; the qualifier work is C13.
+  - [x] A multi-condition `if` (`if (a &&& b)`, LRM 12.4): the `&&&`-separated conditions form a
+        conjunction, so the branch is taken iff every condition is true (X / Z counting as false).
+        It desugars to a chained logical-AND, so no multi-condition form reaches a lower layer.
   - [ ] Pattern matching in an `if` condition (`if (e matches p)`, LRM 12.6) is rejected.
 - [x] C2 -- `for` (procedural for-loop). Includes inline and external init, multi-init / multi-step,
       countdown, zero-iteration, and `if`-in-body composition. `break` / `continue` are C7.
@@ -89,7 +90,8 @@ complete.
 
 ### Expressions
 
-- [x] C14 -- Ternary `cond ? a : b`. Multi-condition (`&&&`) and `matches` pattern forms are
+- [x] C14 -- Ternary `cond ? a : b`, including an `&&&` multi-condition predicate (LRM 12.4) that
+      desugars to the same chained logical-AND the `if` statement uses. The `matches` pattern form is
       rejected as unsupported. 4-state X/Z propagation on the condition rides on the broader 4-state
       work in `operators.md`.
 

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -33,8 +33,11 @@ The numeric IDs (W1..W14) imply execution order; where a cut is independent the 
       items use `==?` so wildcard items in `inside` work.
 - [x] W3 -- Case equality `===` / `!==` (LRM 11.4.5). Bit-exact 4-state compare (X matches X, Z
       matches Z, X does not match Z); deterministic bool.
-  - [ ] The conditional operator's `&&&` multi-condition form and its `matches` pattern form (LRM
-        11.4.11 / 12.6) are rejected; the plain `c ? a : b` ternary is supported.
+  - [x] The conditional operator's `&&&` multi-condition form (LRM 12.4): the `&&&`-separated
+        conditions form a conjunction, taken iff every condition is true, desugared to the same
+        chained logical-AND the `if`-statement predicate uses.
+  - [ ] The conditional operator's `matches` pattern form (LRM 11.4.11 / 12.6) is rejected; the
+        plain `c ? a : b` ternary and its `&&&` predicate are supported.
   - [ ] An array query (`$size` / `$left` / `$right` / `$low` / `$high`, LRM 20.7) whose dimension
         index is a run-time value over an array with a run-time dimension is rejected; a constant
         dimension index over a fixed-size operand folds at elaboration.

--- a/include/lyra/lowering/ast_to_hir/expression/operators.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/operators.hpp
@@ -3,6 +3,9 @@
 // Lowering of unary, binary, conditional, and conversion expressions
 // (LRM 11.4 operators).
 
+#include <span>
+
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
@@ -17,6 +20,20 @@ class UnaryExpression;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
+
+// Lowers a `cond_predicate` (LRM 12.4): a `&&&`-separated list of conditions,
+// as it appears in an `if` statement and the conditional `?:` operator. Without
+// a `matches` pattern the predicate is the conjunction of its expressions, so
+// the conditions fold into one HIR logical-AND returned as the single boolean
+// expression the caller uses as its condition; the sugar reaches no lower
+// layer. A `matches` pattern (LRM 12.6) is rejected with `pattern_code`, the
+// caller's context-appropriate diagnostic. `Condition` is duck-typed over the
+// statement's and the expression's structurally identical condition record.
+template <ExprLowerer Lowerer, typename Condition>
+auto LowerCondPredicate(
+    Lowerer& lowerer, WalkFrame frame, std::span<const Condition> conditions,
+    diag::DiagCode pattern_code, diag::SourceSpan span)
+    -> diag::Result<hir::Expr>;
 
 // An operator's meaning is independent of the enclosing scope, so one template
 // over the pass class serves both the procedural and structural contexts. The

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -1,19 +1,23 @@
 #include "lyra/lowering/ast_to_hir/expression/operators.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <expected>
+#include <span>
 #include <utility>
 
+#include <slang/ast/Compilation.h>
 #include <slang/ast/Expression.h>
+#include <slang/ast/Scope.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/expressions/ConversionExpression.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
+#include <slang/ast/statements/ConditionalStatements.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
 #include <slang/ast/types/Type.h>
 
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
@@ -140,23 +144,70 @@ auto LowerBinaryExpr(
   };
 }
 
+template <ExprLowerer Lowerer, typename Condition>
+auto LowerCondPredicate(
+    Lowerer& lowerer, WalkFrame frame, std::span<const Condition> conditions,
+    diag::DiagCode pattern_code, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  bool any_four_state = false;
+  for (const auto& condition : conditions) {
+    if (condition.pattern != nullptr) {
+      return diag::Fail(
+          span, pattern_code,
+          "pattern matching in a condition is not yet supported");
+    }
+    any_four_state = any_four_state || condition.expr->type->isFourState();
+  }
+
+  auto first_or = lowerer.LowerExpr(*conditions.front().expr, frame);
+  if (!first_or) return std::unexpected(std::move(first_or.error()));
+  if (conditions.size() == 1) {
+    return *std::move(first_or);
+  }
+
+  // A synthesized `&&` carries slang's own logical-result type: a 1-bit `bit`,
+  // or `logic` when any operand is four-state so an X / Z operand still
+  // propagates before the condition reduces it to false.
+  const slang::ast::Compilation& compilation =
+      lowerer.Owner().SourceScope().getCompilation();
+  auto bit1_or = lowerer.Owner().InternType(
+      any_four_state ? compilation.getLogicType() : compilation.getBitType(),
+      span);
+  if (!bit1_or) return std::unexpected(std::move(bit1_or.error()));
+
+  const auto make_and = [&](hir::ExprId lhs, hir::ExprId rhs) -> hir::Expr {
+    return hir::Expr{
+        .type = *bit1_or,
+        .data =
+            hir::BinaryExpr{
+                .op = hir::BinaryOp::kLogicalAnd, .lhs = lhs, .rhs = rhs},
+        .span = span};
+  };
+
+  // Fold every condition but the last into the accumulator, interning each
+  // intermediate so the next `&&` can name it; the last condition forms the
+  // returned expression as data, which the caller interns.
+  hir::ExprId acc = frame.Exprs().Add(*std::move(first_or));
+  for (std::size_t i = 1; i + 1 < conditions.size(); ++i) {
+    auto rhs_or = lowerer.LowerExpr(*conditions[i].expr, frame);
+    if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+    const hir::ExprId rhs = frame.Exprs().Add(*std::move(rhs_or));
+    acc = frame.Exprs().Add(make_and(acc, rhs));
+  }
+  auto last_or = lowerer.LowerExpr(*conditions.back().expr, frame);
+  if (!last_or) return std::unexpected(std::move(last_or.error()));
+  const hir::ExprId last = frame.Exprs().Add(*std::move(last_or));
+  return make_and(acc, last);
+}
+
 template <ExprLowerer Lowerer>
 auto LowerConditionalExpr(
     Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConditionalExpression& cond, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  if (cond.conditions.size() != 1) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "conditional operator with `&&&` multi-condition is not yet "
-        "supported");
-  }
-  if (cond.conditions[0].pattern != nullptr) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "conditional operator with `matches` pattern is not yet supported");
-  }
-  auto cond_or = lowerer.LowerExpr(*cond.conditions[0].expr, frame);
+  auto cond_or = LowerCondPredicate(
+      lowerer, frame, cond.conditions,
+      diag::DiagCode::kUnsupportedExpressionForm, span);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
   auto then_or = lowerer.LowerExpr(cond.left(), frame);
@@ -207,5 +258,17 @@ template auto LowerConditionalExpr(
     StructuralScopeLowerer&, WalkFrame,
     const slang::ast::ConditionalExpression&, diag::SourceSpan)
     -> diag::Result<hir::Expr>;
+template auto LowerCondPredicate(
+    ProcessLowerer&, WalkFrame,
+    std::span<const slang::ast::ConditionalStatement::Condition>,
+    diag::DiagCode, diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerCondPredicate(
+    ProcessLowerer&, WalkFrame,
+    std::span<const slang::ast::ConditionalExpression::Condition>,
+    diag::DiagCode, diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerCondPredicate(
+    StructuralScopeLowerer&, WalkFrame,
+    std::span<const slang::ast::ConditionalExpression::Condition>,
+    diag::DiagCode, diag::SourceSpan) -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/statement/branches.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/branches.cpp
@@ -10,7 +10,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
+#include "lyra/lowering/ast_to_hir/expression/operators.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -141,20 +141,11 @@ auto LowerConditionalStmt(
     const slang::ast::ConditionalStatement& cs, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
   const auto if_check = LowerUniquePriorityCheck(cs.check);
-  if (cs.conditions.size() != 1) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedStatementForm,
-        "multi-condition if expressions are not yet supported");
-  }
-  const auto& cond = cs.conditions.front();
-  if (cond.pattern != nullptr) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedStatementForm,
-        "pattern matching in if conditions is not yet supported");
-  }
-  auto cond_expr = proc.LowerExpr(*cond.expr, frame);
-  if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_expr));
+  auto cond_or = LowerCondPredicate(
+      proc, frame, cs.conditions, diag::DiagCode::kUnsupportedStatementForm,
+      span);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
   auto then_stmt = proc.LowerStmt(cs.ifTrue, frame);
   if (!then_stmt) return std::unexpected(std::move(then_stmt.error()));
   const hir::StmtId then_id =

--- a/tests/cases/cpp/conditional_runtime/case.yaml
+++ b/tests/cases/cpp/conditional_runtime/case.yaml
@@ -10,3 +10,5 @@ expect:
   variables:
     a: 1
     b: 2
+    c_all: 1
+    d_one: 2

--- a/tests/cases/cpp/conditional_runtime/main.sv
+++ b/tests/cases/cpp/conditional_runtime/main.sv
@@ -1,14 +1,29 @@
 module Top;
   int a;
   int b;
+  int c_all;
+  int d_one;
   initial begin
     int yes;
     int no_;
+    int t1;
+    int t2;
+    int t3;
     yes = 5;
     no_ = 0;
     if (yes) a = 1;
     else     a = 2;
     if (no_) b = 1;
     else     b = 2;
+
+    // Multi-condition if (LRM 12.4): the `&&&`-separated conditions form a
+    // conjunction, so the branch is taken iff every condition is true.
+    t1 = 3;
+    t2 = 7;
+    t3 = 9;
+    if (t1 &&& t2 &&& t3) c_all = 1;
+    else                  c_all = 2;
+    if (t1 &&& no_ &&& t3) d_one = 1;
+    else                   d_one = 2;
   end
 endmodule

--- a/tests/cases/cpp/continuous_assign_ternary/case.yaml
+++ b/tests/cases/cpp/continuous_assign_ternary/case.yaml
@@ -9,3 +9,4 @@ expect:
   exit: 0
   variables:
     y: 7
+    g: 9

--- a/tests/cases/cpp/continuous_assign_ternary/main.sv
+++ b/tests/cases/cpp/continuous_assign_ternary/main.sv
@@ -1,6 +1,6 @@
 module Top;
   bit sel;
-  int a, b, y;
+  int a, b, y, g;
 
   initial begin
     sel = 1;
@@ -11,4 +11,10 @@ module Top;
   // RHS read set covers all three operands (sel, a, b); change on any of
   // them re-evaluates the assignment.
   assign y = sel ? a : b;
+
+  // Conditional operator with an `&&&` multi-condition predicate (LRM 12.4) in
+  // a continuous assignment. `sel` is true but `a > b` is false, so the
+  // conjunction is false and the `:` branch is taken -- proving the predicate
+  // ANDs its conditions in the structural path, not just reads the first.
+  assign g = sel &&& (a > b) ? a : b;
 endmodule

--- a/tests/cases/cpp/ternary_basic/case.yaml
+++ b/tests/cases/cpp/ternary_basic/case.yaml
@@ -11,3 +11,5 @@ expect:
     a: 7
     b: 3
     larger: 7
+    guarded_hit: 7
+    guarded_miss: 3

--- a/tests/cases/cpp/ternary_basic/main.sv
+++ b/tests/cases/cpp/ternary_basic/main.sv
@@ -2,9 +2,18 @@ module Top;
   int a;
   int b;
   int larger;
+  int guarded_hit;
+  int guarded_miss;
   initial begin
     a = 7;
     b = 3;
     larger = (a > b) ? a : b;
+
+    // Conditional operator with an `&&&` multi-condition predicate (LRM 12.4):
+    // the `?` branch is chosen iff every condition is true. `&&&` is a
+    // cond_predicate separator, legal only at the predicate's top level (not
+    // inside a parenthesized expression).
+    guarded_hit  = (a > b) &&& (b > 0) ? a : b;
+    guarded_miss = (a > b) &&& (b > 5) ? a : b;
   end
 endmodule


### PR DESCRIPTION
## Summary

SystemVerilog lets an `if` statement and the conditional `?:` operator take a `cond_predicate` (LRM 12.4): one or more conditions joined by `&&&`. Lyra previously accepted only a single condition and rejected any `&&&` form in both constructs. This adds the multi-condition form: without a `matches` pattern the predicate is simply the conjunction of its expressions, taken iff every condition is true (X / Z counting as false), so it desugars to a chained logical-AND at AST-to-HIR and reaches no lower layer.

## Design

The `&&&` conjunction is source-level sugar, so it collapses to primitives at the AST-to-HIR boundary rather than becoming a node any later layer carries -- `mir.md` invariant 10 and the backend contract keep multi-condition forms out of MIR and out of render. Both call sites (the `if` statement and the ternary) share one `LowerCondPredicate` helper that folds the `&&&`-separated conditions into a left-associative logical-AND and returns the resulting expression as data; a single condition passes through unchanged, and a `matches` pattern (LRM 12.6) is still rejected with the caller's context-appropriate diagnostic. The synthesized `&&` carries slang's own logical-result type (a 1-bit `bit`, or `logic` when any operand is four-state), matching how slang types a real `&&`. The helper is duck-typed over the statement's and the expression's structurally identical condition records, and covers all three lowering paths -- the `if` statement, the procedural ternary, and the structural (continuous-assign) ternary.

## Testing

Extended three existing cases in place -- one per lowering path -- rather than adding new ones: `conditional_runtime` (multi-condition `if`, including a three-condition chain and a one-false case), `ternary_basic` (procedural ternary `&&&`), and `continuous_assign_ternary` (structural ternary `&&&`, where a true-then-false predicate proves the conjunction actually ANDs rather than reading only the first condition).