### PR TITLE
Support $readmemh and $readmemb memory load

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -204,9 +204,11 @@ Tracked in `processes.md`.
 
 - [ ] System tasks -- the `$display` / `$write` / `$strobe` / `$monitor` family, file IO,
       `$sformat`, `$time` / `$timeformat`, `$random`, `$readmem*`. Formatting is tracked in
-      `display.md` and RNG in `simulation-rng.md`; most land in the runtime call registry. Known
-      gaps: `$monitor`, `$random`, `$readmem*`. (The archive effect / pure / state classification is
-      retired -- see below.)
+      `display.md`, memory load in `readmem.md`, and RNG in `simulation-rng.md`; most land in the
+      runtime call registry. `$readmemh` / `$readmemb` load a one-dimensional memory of packed
+      elements today; multidimensional and associative / dynamic memories are the remaining
+      `$readmem*` gap (`readmem.md`). Other known gaps: `$monitor`, `$random`. (The archive effect /
+      pure / state classification is retired -- see below.)
 
 ### trace
 

--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -164,12 +164,25 @@ sanctions; the runtime-parsed path continues silently.
       bounded for free. The same per-channel signal will carry future `$fmonitor` cancellation when
       that lands.
 
+## File read family follow-ups
+
+- [ ] Expression-position use of the output-argument reads `$fgets` / `$fread` / `$ferror` (LRM
+      21.3.4). Each returns a value that LRM permits in any expression position
+      (`if ($fgets(s, fd))`, a blocking-assign condition), but Lyra supports them only in statement
+      position (a bare call or the right-hand side of a blocking assignment), where the LRM 13.5
+      output-argument copy-out has a statement boundary to desugar into; a nested-expression call is
+      rejected with a diagnostic. Closing this needs the copy-out to run inside an
+      immediately-invoked closure, the same shape the scan family already uses for its
+      expression-position support. `$readmemh` / `$readmemb` do not share this gap: they are void
+      tasks, so they never appear in expression position.
+
 ## Out of Scope
 
 - Format-string parse diagnostics (trailing `%`, missing specifier, width overflow, unknown
   specifier) -- already implemented, not gaps.
 - `$monitor` / `$fmonitor`. Not modelled today; add an entry when a concrete consumer needs it.
-- Other file read tasks (`$fgetc` / `$ungetc` / `$fgets` / `$fread` / `$fseek` / `$rewind` /
-  `$ftell` / `$feof` / `$ferror` / `$fflush`) are implemented per LRM 21.3.4..21.3.8.
+- File read / positioning tasks (`$fgetc` / `$ungetc` / `$fseek` / `$rewind` / `$ftell` / `$feof` /
+  `$fflush`) are implemented per LRM 21.3.4..21.3.8. The output-argument reads `$fgets` / `$fread` /
+  `$ferror` are implemented in statement position; their expression-position gap is tracked above.
 - `%u` / `%z` (binary-packed unsigned / signed) and `%v` (strength). Not on the immediate roadmap;
   add entries when concrete consumers appear.

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -106,18 +106,22 @@ full support.
       case (`dpi.md` D4, D4b, D6, D6b, all landed). The multi-instance dispatch (D4a) is not needed
       for either `ibex_top` or `ibex_simple_system_tb`, which each carry a single top-level
       exporting instance.
-- [ ] **`$readmemh`** -- memory backdoor load from a hex file (LRM 21.4.1). The `ibex_simple_system`
-      SRAM model calls `$readmemh(MemInitFile, mem)` in an `initial` block through the vendor helper
-      `prim_util_memload.svh` (included from `prim_ram_1p` / `prim_ram_2p`), which is how the
-      testbench boots a program image into RAM under the `SRAMInitFile` parameter. Not yet
-      supported. Current top-level frontier for `ibex_simple_system_tb`.
-- [ ] **Hierarchical reference reaching a module instance from a nested generate scope** -- a dotted
+- [x] **`$readmemh` / `$readmemb`** -- memory load from a hex / binary text file (LRM 21.4). The
+      `ibex_simple_system` SRAM model calls `$readmemh(MemInitFile, mem)` in an `initial` block
+      through the vendor helper `prim_util_memload.svh` (included from `prim_ram_1p` /
+      `prim_ram_2p`), which is how the testbench boots a program image into RAM under the
+      `SRAMInitFile` parameter. Now supported for a one-dimensional memory of packed elements:
+      `@address` directives, `//` and `/* */` comments, per-digit x / z, an explicit start / finish
+      range (descending when start > finish), and unaddressed words left unchanged.
+      Multidimensional, associative, and dynamic-array memories (LRM 21.4.1 / 21.4.3) are not yet
+      covered; Ibex needs only the 1-D form.
+- [x] **Hierarchical reference reaching a module instance from a nested generate scope** -- a dotted
       reference, written inside a conditional or loop generate block, that descends into a module
-      instance owned by an enclosing scope (the RVFI trap logic in `ibex_core`,
-      `id_stage_i.controller_i.exc_req_d` inside `gen_rvfi_no_wb_stage`; `ibex_ex_block` reaches its
-      generate-instantiated multiplier and divider the same way). Status un-reverified since it was
-      last observed; hidden behind `$readmemh` on the full top and out of the path for `ibex_top`
-      standalone. Recheck once `$readmemh` lowers.
+      instance owned by an enclosing scope (the RVFI trap logic in `ibex_core`, and `ibex_ex_block`
+      reaching its generate-instantiated multiplier and divider the same way). No longer a lowering
+      blocker: with `$readmemh` cleared, the whole `ibex_simple_system_tb` now lowers to MIR with no
+      diagnostics, so this form lowers as part of the full design. C++ emit / build / run of the
+      full top is the next thing to verify and is not yet re-checked.
 - [x] **`$value$plusargs` / `$test$plusargs`** -- runtime plusarg query (LRM 21.6). The full surface
       is live: `$test$plusargs` probes for a prefix, `$value$plusargs` parses the matched plusarg's
       remainder under `%d` / `%o` / `%h` / `%x` / `%b` / `%s`, and the host command line populates

--- a/docs/progress/readmem.md
+++ b/docs/progress/readmem.md
@@ -1,0 +1,49 @@
+# Memory load ($readmemh / $readmemb)
+
+Tracks LRM 21.4 memory-array load from a text file. `$readmemh` reads hexadecimal words, `$readmemb`
+binary; both fill an unpacked memory from a file of whitespace-separated words with optional
+`@address` directives, comments, and a supplied address range. This is the running inventory of what
+is supported and what remains.
+
+## Done
+
+- [x] One-dimensional unpacked memory of packed integral elements, for both radixes. File format:
+      whitespace- and newline-separated words, `@hex` address directives, `//` line and `/* */`
+      block comments, per-digit `x` / `z` / `?`, and `_` digit separators. Elements of any width
+      (including wider than 64 bits) and any declared range (non-zero-based or descending) load by
+      declared index.
+- [x] Addressing (LRM 21.4). With no range the load fills from the lowest declared index upward; a
+      `start`-only call fills upward from `start`; a `start` / `finish` call fills from `start`
+      toward `finish`, descending when `start > finish`. An `@address` in the file repositions the
+      write cursor. Words the file never addresses keep their prior value. A 2-state element
+      collapses `x` / `z` to 0 (LRM 21.4.2).
+- [x] Statement-position use in any procedural context (an `initial` / `always` / `final` block, a
+      task, or a function). The task carries an output argument and has no value, so the frontend
+      rejects it in a continuous assignment or any other expression position -- that is the language
+      rule, not a gap.
+- [x] Error / warning behaviour. A missing file, an `@address` outside the active range, and a
+      malformed word or address each stop the load and report an error; the simulation continues (a
+      failed load is not fatal). A `start` / `finish` range whose word count does not match the
+      file, with no in-file `@address`, reports a warning. A missing file is reported as an error
+      (LRM 21.4 does not fix the severity; treating a silently-uninitialized memory as an error is
+      the deliberate choice here).
+
+## Not yet supported
+
+Each form below is rejected today with a clear diagnostic (never silently mis-loaded), and stands
+open until the corresponding behaviour lands.
+
+- [ ] Multidimensional unpacked memory (LRM 21.4.3). The file is organized row-major with the lowest
+      dimension varying fastest; a memory whose element is itself an unpacked array is rejected
+      today.
+- [ ] Associative-array memory (LRM 21.4.1). Loading an address creates the entry, and indices must
+      be integral (an enumerated index maps by ordinal value). Rejected today.
+- [ ] Dynamic-array and queue memory (LRM 21.4.1). The container's current size is fixed and is not
+      resized by the load. Rejected today.
+- [ ] A packed struct / union element (LRM 21.4.1: each packed element is loaded as its vector
+      equivalent). Only bit-vector elements load today.
+
+## Related
+
+- `$writememh` / `$writememb` (LRM 21.5), the dump counterpart, is not modelled.
+- The Ibex bring-up consumer that first drove this feature is tracked in `ibex.md`.

--- a/include/lyra/lowering/hir_to_mir/expression/system/readmem.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/readmem.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// LRM 21.4 `$readmemh` / `$readmemb`. A void task that loads a memory from a
+// named text file; it appears only in statement position. The output memory is
+// an unpacked-array lvalue, so the call round-trips through a copy-out temp
+// (LRM 13.5): the temp is copy-in initialized from the memory's current value
+// so words the file does not address survive, the runtime ReadMem entry fills
+// the temp, and the writeback commits it. The declared bounds and the digit
+// radix ride as ordinary operands.
+auto LowerReadMemSystemSubroutineCallStmt(
+    ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
+    const hir::CallExpr& call, const support::ReadMemSystemSubroutineInfo& info)
+    -> diag::Result<mir::Stmt>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/runtime/readmem.hpp
+++ b/include/lyra/runtime/readmem.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+#include "lyra/value/unpacked_array.hpp"
+
+namespace lyra::runtime {
+
+class RuntimeEffects;
+
+// LRM 21.4 $readmemh / $readmemb. Loads the memory `dest` from the text file
+// named `filename`: whitespace-separated radix-`base` words (base 16 for
+// $readmemh, 2 for $readmemb), optional `@hex` address directives, `//` and
+// `/* */` comments, and per-digit x / z / ?. `declared_left` / `declared_right`
+// are dest's declared index bounds; each word is written by declared index, so
+// a descending or non-zero-based memory resolves correctly. Words the file does
+// not address keep their prior value. `dest` is the lowering's copy-out temp,
+// committed to the SV memory after the call returns.
+//
+// Addressing (LRM 21.4): the no-range form fills from the lowest declared index
+// upward; the `start`-only form fills upward from `start`; the `start`/`finish`
+// form fills from `start` toward `finish`, descending when `start > finish`. An
+// `@address` in the file repositions the write cursor and must fall inside the
+// active range, else the load stops with an error.
+void ReadMem(
+    RuntimeEffects& runtime, value::UnpackedArray<value::PackedArray>& dest,
+    const value::String& filename, const value::PackedArray& declared_left,
+    const value::PackedArray& declared_right, const value::PackedArray& base);
+void ReadMem(
+    RuntimeEffects& runtime, value::UnpackedArray<value::PackedArray>& dest,
+    const value::String& filename, const value::PackedArray& declared_left,
+    const value::PackedArray& declared_right, const value::PackedArray& base,
+    const value::PackedArray& start);
+void ReadMem(
+    RuntimeEffects& runtime, value::UnpackedArray<value::PackedArray>& dest,
+    const value::String& filename, const value::PackedArray& declared_left,
+    const value::PackedArray& declared_right, const value::PackedArray& base,
+    const value::PackedArray& start, const value::PackedArray& finish);
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime.hpp
+++ b/include/lyra/runtime/runtime.hpp
@@ -14,6 +14,7 @@
 #include "lyra/runtime/diagnostic.hpp"
 #include "lyra/runtime/file_table.hpp"
 #include "lyra/runtime/plusargs.hpp"
+#include "lyra/runtime/readmem.hpp"
 #include "lyra/runtime/registration.hpp"
 #include "lyra/runtime/runtime_effects.hpp"
 #include "lyra/runtime/stream_dispatcher.hpp"

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -231,6 +231,13 @@ enum class BuiltinFn : std::uint16_t {
   // return an SV `int` (1 on prefix match, 0 otherwise).
   kTestPlusargs,
   kValuePlusargs,
+  // LRM 21.4 $readmemh / $readmemb. A free function on `lyra::runtime` taking
+  // the runtime handle, the output memory by reference, the file name, the
+  // memory's declared bounds, the digit radix (16 / 2), and the optional start
+  // / finish addresses. It opens and parses the named text file and fills the
+  // memory in place; the SV task's void result means the caller never awaits
+  // it.
+  kReadMem,
   // LRM 9.4.1 `#N`. The runtime free function the scheduler suspends on.
   // The call takes the runtime handle, the duration in the calling scope's
   // precision steps, and the calling scope's precision power; the runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -157,12 +157,21 @@ struct PlusargsSystemSubroutineInfo {
   PlusargsKind kind;
 };
 
+// LRM 21.4 memory-load tasks. `base` is the digit radix -- 16 for $readmemh,
+// 2 for $readmemb -- which the lowering emits as a literal operand of the
+// runtime ReadMem call so the parser reads each file word at that radix. The
+// two tasks share one runtime entry and differ only in this value.
+struct ReadMemSystemSubroutineInfo {
+  unsigned base;
+};
+
 using SystemSubroutineSemantic = std::variant<
     PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo,
     DiagnosticSystemSubroutineInfo, FileIOSystemSubroutineInfo,
     ScanSystemSubroutineInfo, SFormatSystemSubroutineInfo,
     TimeSystemSubroutineInfo, TimeFormatSystemSubroutineInfo,
-    PrintTimescaleSystemSubroutineInfo, PlusargsSystemSubroutineInfo>;
+    PrintTimescaleSystemSubroutineInfo, PlusargsSystemSubroutineInfo,
+    ReadMemSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -855,6 +864,24 @@ inline constexpr std::array kSystemSubroutines = {
         .result_conv = ReturnConvention::kInt32,
         .arg_policy = ArgCountPolicy{.min_args = 2, .max_args = 2},
         .semantic = PlusargsSystemSubroutineInfo{.kind = PlusargsKind::kValue},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{56},
+        .name = "$readmemh",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 2, .max_args = 4},
+        .semantic = ReadMemSystemSubroutineInfo{.base = 16},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{57},
+        .name = "$readmemb",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 2, .max_args = 4},
+        .semantic = ReadMemSystemSubroutineInfo{.base = 2},
     },
 };
 

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -3,7 +3,9 @@
 #include <array>
 #include <concepts>
 #include <cstdint>
+#include <optional>
 #include <span>
+#include <string_view>
 #include <type_traits>
 #include <variant>
 #include <vector>
@@ -139,6 +141,18 @@ class PackedArray {
   // applies the justification rule. An empty string yields zero.
   [[nodiscard]] static auto FromString(
       const String& text, const PackedArray& prototype) -> PackedArray;
+
+  // LRM 21.4 memory-load digit parse: builds a value of the given shape from a
+  // radix-`base` digit string (base 2 / 8 / 16). Each digit contributes
+  // log2(base) bits MSB-first, so the string is right-justified into the target
+  // -- a shorter string zero-fills the leading bits and a longer one drops
+  // them. An `x` / `X` digit contributes that many x bits and a `z` / `Z` / `?`
+  // digit that many z bits; a 2-state target collapses both to 0. `_`
+  // separators are ignored. Returns nullopt if `digits` (after removing `_`)
+  // is empty or holds a character that is not a base-`base` digit, x, z, or ?.
+  [[nodiscard]] static auto FromDigits(
+      std::string_view digits, unsigned base, std::uint64_t bit_width,
+      bool is_signed, bool is_four_state) -> std::optional<PackedArray>;
 
   // LRM 11.4.12: `{a, b, c, ...}`. First operand occupies the result's MSBs,
   // last occupies the LSBs. Total bit width is the sum of operand widths.

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -87,6 +87,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "TestPlusargs";
     case support::BuiltinFn::kValuePlusargs:
       return "ValuePlusargs";
+    case support::BuiltinFn::kReadMem:
+      return "ReadMem";
     case support::BuiltinFn::kTrigger:
       return "Trigger";
     case support::BuiltinFn::kAwait:
@@ -415,6 +417,7 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
     case support::BuiltinFn::kDisableFork:
     case support::BuiltinFn::kTestPlusargs:
     case support::BuiltinFn::kValuePlusargs:
+    case support::BuiltinFn::kReadMem:
     case support::BuiltinFn::kRunExportedTaskToCompletion:
     case support::BuiltinFn::kCurrentExportScope:
       return "lyra::runtime";

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -368,6 +368,17 @@ auto LowerSystemSubroutineCall(
             return LowerPlusargsSystemSubroutineCall(
                 lowerer, frame, call, plusargs);
           },
+          [&](const support::ReadMemSystemSubroutineInfo&)
+              -> diag::Result<mir::Expr> {
+            // A void task (LRM 21.4) has no value, so the frontend rejects it
+            // in any value position; a statement-position call is intercepted
+            // by the statement-form dispatch and never falls through here.
+            // Reaching this arm is therefore a frontend / lowering invariant
+            // violation, not an unsupported source form.
+            throw InternalError(
+                "$readmemh / $readmemb reached expression lowering; a void "
+                "task only lowers through the statement-form dispatch");
+          },
       },
       desc.semantic);
 }

--- a/src/lyra/lowering/hir_to_mir/expression/system/readmem.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/readmem.cpp
@@ -1,0 +1,109 @@
+#include "lyra/lowering/hir_to_mir/expression/system/readmem.hpp"
+
+#include <cstddef>
+#include <expected>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/type.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
+#include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
+#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/runtime_call.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/type.hpp"
+#include "lyra/support/builtin_fn.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto LowerReadMemSystemSubroutineCallStmt(
+    ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
+    const hir::CallExpr& call, const support::ReadMemSystemSubroutineInfo& info)
+    -> diag::Result<mir::Stmt> {
+  const auto& unit_lowerer = process.Owner();
+  const auto& hir_proc = process.HirBody();
+  const auto& builtins = unit_lowerer.Unit().builtins;
+
+  // LRM 21.4: arg[0] is the file name, arg[1] the memory, arg[2] / arg[3] the
+  // optional start / finish addresses.
+  const auto& mem_hir = hir_proc.exprs.Get(*call.arguments[1]);
+  const auto& mem_hir_ty = unit_lowerer.Hir().types.Get(mem_hir.type);
+  const auto* unpacked = std::get_if<hir::UnpackedArrayType>(&mem_hir_ty.data);
+  if (unpacked == nullptr) {
+    return diag::Fail(
+        diag::DiagCode::kUnsupportedSubroutineArgument,
+        "$readmemh / $readmemb target must be an unpacked memory (LRM 21.4)");
+  }
+  const auto& elem_ty = unit_lowerer.Hir().types.Get(unpacked->element_type);
+  if (!elem_ty.IsBitVector()) {
+    return diag::Fail(
+        diag::DiagCode::kUnsupportedSubroutineArgument,
+        "$readmemh / $readmemb memory: only a 1-D unpacked array of integral "
+        "packed elements is supported (LRM 21.4)");
+  }
+
+  mir::Block wrapper;
+  const WalkFrame wrapper_frame = frame.WithBlock(&wrapper);
+
+  auto name_or =
+      process.LowerExpr(hir_proc.exprs.Get(*call.arguments[0]), wrapper_frame);
+  if (!name_or) return std::unexpected(std::move(name_or.error()));
+  // The file name is an SV string; a string literal reaches here as a packed
+  // value, so route it to the runtime's String type (LRM 21.4).
+  const mir::ExprId name_id = ConvertToType(
+      unit_lowerer.Unit(), wrapper, wrapper.exprs.Add(*std::move(name_or)),
+      builtins.string);
+
+  auto slot_or = BuildOutputArgSlot(
+      process, wrapper_frame, *call.arguments[1], "_lyra_readmem_dest");
+  if (!slot_or) return std::unexpected(std::move(slot_or.error()));
+  const OutputArgSlot slot = *slot_or;
+
+  std::vector<mir::ExprId> operands;
+  operands.push_back(
+      wrapper.exprs.Add(BuildCurrentRuntimeCallExpr(unit_lowerer)));
+  operands.push_back(
+      wrapper.exprs.Add(mir::MakeLocalRefExpr(slot.temp, slot.type)));
+  operands.push_back(name_id);
+  operands.push_back(wrapper.exprs.Add(
+      mir::MakeIntLiteral(builtins.int_type, unpacked->dim.left)));
+  operands.push_back(wrapper.exprs.Add(
+      mir::MakeIntLiteral(builtins.int_type, unpacked->dim.right)));
+  operands.push_back(wrapper.exprs.Add(
+      mir::MakeIntLiteral(
+          builtins.int_type, static_cast<std::int64_t>(info.base))));
+  for (std::size_t i = 2; i < call.arguments.size(); ++i) {
+    if (!call.arguments[i].has_value()) {
+      return diag::Fail(
+          diag::DiagCode::kUnsupportedSubroutineArgument,
+          "$readmemh / $readmemb: an elided start / finish argument is not "
+          "supported (LRM 21.4)");
+    }
+    auto arg_or = process.LowerExpr(
+        hir_proc.exprs.Get(*call.arguments[i]), wrapper_frame);
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    operands.push_back(wrapper.exprs.Add(*std::move(arg_or)));
+  }
+
+  mir::Expr call_expr{
+      .data =
+          mir::CallExpr{
+              .callee = mir::Direct{.target = support::BuiltinFn::kReadMem},
+              .arguments = std::move(operands)},
+      .type = builtins.void_type};
+
+  const mir::ExprId runtime_id =
+      wrapper.exprs.Add(BuildCurrentRuntimeCallExpr(unit_lowerer));
+  return BuildCopyOutBlock(
+      unit_lowerer.Unit(), runtime_id, frame, std::move(wrapper),
+      std::move(label), builtins.void_type, std::move(call_expr), false,
+      std::nullopt, std::vector<OutputArgSlot>{slot});
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -20,6 +20,7 @@
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/assignment.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/file_io.hpp"
+#include "lyra/lowering/hir_to_mir/expression/system/readmem.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/sformat.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
@@ -314,6 +315,13 @@ auto LowerSystemSubroutineCallStmtForm(
           [](const support::PlusargsSystemSubroutineInfo&)
               -> std::optional<diag::Result<mir::Stmt>> {
             return std::nullopt;
+          },
+          [&](const support::ReadMemSystemSubroutineInfo& readmem)
+              -> std::optional<diag::Result<mir::Stmt>> {
+            // A void task (LRM 21.4): its only form is a statement, so it never
+            // feeds an assignment target.
+            return LowerReadMemSystemSubroutineCallStmt(
+                process, frame, std::move(label), call, readmem);
           },
       },
       desc.semantic);

--- a/src/lyra/runtime/readmem.cpp
+++ b/src/lyra/runtime/readmem.cpp
@@ -1,0 +1,210 @@
+#include "lyra/runtime/readmem.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <format>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "lyra/runtime/diagnostic.hpp"
+#include "lyra/runtime/runtime_effects.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+#include "lyra/value/unpacked_array.hpp"
+
+namespace lyra::runtime {
+
+namespace {
+
+auto TaskName(unsigned base) -> value::String {
+  return value::String(base == 2U ? "$readmemb" : "$readmemh");
+}
+
+void Warn(RuntimeEffects& runtime, unsigned base, const std::string& text) {
+  runtime.Diagnostic().EmitWarning(TaskName(base), value::String(text));
+}
+
+void Error(RuntimeEffects& runtime, unsigned base, const std::string& text) {
+  runtime.Diagnostic().EmitError(TaskName(base), value::String(text));
+}
+
+// Splits the file text into tokens, dropping `//`-to-end-of-line and `/* */`
+// comments and any whitespace between tokens. A token is a maximal run of
+// non-whitespace, non-comment characters -- either an `@address` directive or a
+// data word.
+auto Tokenize(std::string_view text) -> std::vector<std::string> {
+  std::vector<std::string> tokens;
+  std::string current;
+  const auto flush = [&] {
+    if (!current.empty()) {
+      tokens.push_back(current);
+      current.clear();
+    }
+  };
+  std::size_t i = 0;
+  while (i < text.size()) {
+    const char c = text[i];
+    if (c == '/' && i + 1 < text.size() && text[i + 1] == '/') {
+      flush();
+      i += 2;
+      while (i < text.size() && text[i] != '\n') ++i;
+      continue;
+    }
+    if (c == '/' && i + 1 < text.size() && text[i + 1] == '*') {
+      flush();
+      i += 2;
+      while (i + 1 < text.size()) {
+        if (text[i] == '*' && text[i + 1] == '/') break;
+        ++i;
+      }
+      i += 2;
+      continue;
+    }
+    if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+        c == '\v') {
+      flush();
+      ++i;
+      continue;
+    }
+    current.push_back(c);
+    ++i;
+  }
+  flush();
+  return tokens;
+}
+
+void ReadMemImpl(
+    RuntimeEffects& runtime, value::UnpackedArray<value::PackedArray>& dest,
+    const value::String& filename, std::int64_t declared_left,
+    std::int64_t declared_right, unsigned base,
+    std::optional<std::int64_t> start, std::optional<std::int64_t> finish) {
+  if (dest.RawSize() == 0U) return;
+
+  std::ifstream in{std::string{filename.View()}};
+  if (!in.is_open()) {
+    Error(
+        runtime, base,
+        std::format("cannot open file '{}'", std::string{filename.View()}));
+    return;
+  }
+  std::ostringstream contents;
+  contents << in.rdbuf();
+  const std::string text = contents.str();
+
+  const std::int64_t lowest = std::min(declared_left, declared_right);
+  const std::int64_t highest = std::max(declared_left, declared_right);
+
+  // The active window and fill direction follow LRM 21.4 from which optional
+  // addresses the call supplied.
+  std::int64_t active_lo = lowest;
+  std::int64_t active_hi = highest;
+  std::int64_t cursor = lowest;
+  std::int64_t step = 1;
+  if (start.has_value() && finish.has_value()) {
+    cursor = *start;
+    step = (*start <= *finish) ? 1 : -1;
+    active_lo = std::min(*start, *finish);
+    active_hi = std::max(*start, *finish);
+  } else if (start.has_value()) {
+    cursor = *start;
+    active_lo = *start;
+  }
+
+  const auto& shape = dest.RawAt(0);
+  const std::uint64_t width = shape.BitWidth();
+  const bool is_signed = shape.IsSigned();
+  const bool is_four_state = shape.IsFourState();
+
+  bool saw_address = false;
+  std::int64_t words_written = 0;
+  const std::vector<std::string> tokens = Tokenize(text);
+  for (const std::string& token : tokens) {
+    if (token.front() == '@') {
+      const auto addr = value::PackedArray::FromDigits(
+          std::string_view{token}.substr(1), 16U, 64U, true, false);
+      if (!addr) {
+        Error(runtime, base, std::format("malformed address '{}'", token));
+        return;
+      }
+      const std::int64_t a = addr->ToInt64();
+      if (a < active_lo || a > active_hi) {
+        Error(
+            runtime, base,
+            std::format("address {} is outside the load range", a));
+        return;
+      }
+      cursor = a;
+      saw_address = true;
+      continue;
+    }
+
+    if (cursor < active_lo || cursor > active_hi) break;
+
+    const auto elem = value::PackedArray::FromDigits(
+        token, base, width, is_signed, is_four_state);
+    if (!elem) {
+      Error(runtime, base, std::format("malformed data word '{}'", token));
+      return;
+    }
+    dest.ElementRef(
+        value::PackedArray::Int(static_cast<std::int32_t>(cursor)),
+        value::PackedArray::Int(static_cast<std::int32_t>(declared_left)),
+        value::PackedArray::Int(static_cast<std::int32_t>(declared_right))) =
+        *elem;
+    ++words_written;
+    cursor += step;
+  }
+
+  // LRM 21.4: a start/finish range with no in-file addresses must be filled
+  // exactly; a word-count mismatch is a warning, not an error.
+  if (start.has_value() && finish.has_value() && !saw_address) {
+    const std::int64_t expected = active_hi - active_lo + 1;
+    if (words_written != expected) {
+      Warn(
+          runtime, base,
+          std::format(
+              "file holds {} words but the address range spans {}",
+              words_written, expected));
+    }
+  }
+}
+
+}  // namespace
+
+void ReadMem(
+    RuntimeEffects& runtime, value::UnpackedArray<value::PackedArray>& dest,
+    const value::String& filename, const value::PackedArray& declared_left,
+    const value::PackedArray& declared_right, const value::PackedArray& base) {
+  ReadMemImpl(
+      runtime, dest, filename, declared_left.ToInt64(),
+      declared_right.ToInt64(), static_cast<unsigned>(base.ToInt64()),
+      std::nullopt, std::nullopt);
+}
+
+void ReadMem(
+    RuntimeEffects& runtime, value::UnpackedArray<value::PackedArray>& dest,
+    const value::String& filename, const value::PackedArray& declared_left,
+    const value::PackedArray& declared_right, const value::PackedArray& base,
+    const value::PackedArray& start) {
+  ReadMemImpl(
+      runtime, dest, filename, declared_left.ToInt64(),
+      declared_right.ToInt64(), static_cast<unsigned>(base.ToInt64()),
+      start.ToInt64(), std::nullopt);
+}
+
+void ReadMem(
+    RuntimeEffects& runtime, value::UnpackedArray<value::PackedArray>& dest,
+    const value::String& filename, const value::PackedArray& declared_left,
+    const value::PackedArray& declared_right, const value::PackedArray& base,
+    const value::PackedArray& start, const value::PackedArray& finish) {
+  ReadMemImpl(
+      runtime, dest, filename, declared_left.ToInt64(),
+      declared_right.ToInt64(), static_cast<unsigned>(base.ToInt64()),
+      start.ToInt64(), finish.ToInt64());
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -298,6 +298,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "test_plusargs";
     case BuiltinFn::kValuePlusargs:
       return "value_plusargs";
+    case BuiltinFn::kReadMem:
+      return "read_mem";
     case BuiltinFn::kDelay:
       return "delay";
     case BuiltinFn::kWaitAny:

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <bit>
 #include <cstdint>
+#include <optional>
 #include <ranges>
 #include <span>
 #include <string>
@@ -259,6 +260,105 @@ auto PackedArray::FromBytes(
       std::span<const std::uint64_t>{}, bit_width, is_signed, is_four_state);
 }
 
+namespace {
+
+// One scanned bit's two-plane encoding: `unk` marks x or z, and for an unknown
+// bit `val` distinguishes x (1) from z (0), matching the 4-state convention
+// (all-x is val1/unk1, all-z is val0/unk1).
+struct DigitBit {
+  bool val;
+  bool unk;
+};
+
+auto HexDigitValue(char c) -> int {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return (c - 'a') + 10;
+  if (c >= 'A' && c <= 'F') return (c - 'A') + 10;
+  return -1;
+}
+
+}  // namespace
+
+auto PackedArray::FromDigits(
+    std::string_view digits, unsigned base, std::uint64_t bit_width,
+    bool is_signed, bool is_four_state) -> std::optional<PackedArray> {
+  unsigned bits_per_digit = 0;
+  switch (base) {
+    case 2:
+      bits_per_digit = 1;
+      break;
+    case 8:
+      bits_per_digit = 3;
+      break;
+    case 16:
+      bits_per_digit = 4;
+      break;
+    default:
+      throw InternalError("PackedArray::FromDigits: base must be 2, 8, or 16");
+  }
+
+  // Each digit expands to `bits_per_digit` bits, MSB-first, so the string is
+  // right-justified into the target below. An x / z / ? digit marks its whole
+  // span unknown (LRM 21.4: an unknown digit covers all the bits it names).
+  std::vector<DigitBit> bits;
+  bits.reserve(digits.size() * bits_per_digit);
+  bool any_digit = false;
+  for (const char c : digits) {
+    if (c == '_') continue;
+    bool unknown = false;
+    bool unknown_val = false;
+    unsigned digit_value = 0;
+    if (c == 'x' || c == 'X') {
+      unknown = true;
+      unknown_val = true;
+    } else if (c == 'z' || c == 'Z' || c == '?') {
+      unknown = true;
+    } else {
+      const int d = HexDigitValue(c);
+      if (d < 0 || static_cast<unsigned>(d) >= base) return std::nullopt;
+      digit_value = static_cast<unsigned>(d);
+    }
+    any_digit = true;
+    for (unsigned b = 0; b < bits_per_digit; ++b) {
+      const unsigned shift = bits_per_digit - 1U - b;
+      if (unknown) {
+        bits.push_back(DigitBit{.val = unknown_val, .unk = true});
+      } else {
+        bits.push_back(
+            DigitBit{.val = ((digit_value >> shift) & 1U) != 0U, .unk = false});
+      }
+    }
+  }
+  if (!any_digit) return std::nullopt;
+
+  const auto word_count = static_cast<std::size_t>((bit_width + 63U) / 64U);
+  std::vector<std::uint64_t> val_words(word_count, 0U);
+  std::vector<std::uint64_t> unk_words(word_count, 0U);
+  const auto bits_to_use =
+      std::min<std::size_t>(bits.size(), static_cast<std::size_t>(bit_width));
+  const std::size_t skip = bits.size() - bits_to_use;
+  for (std::size_t i = 0; i < bits_to_use; ++i) {
+    const std::size_t bit_pos = bits_to_use - 1U - i;
+    const DigitBit b = bits[skip + i];
+    const std::size_t word_ix = bit_pos / 64U;
+    const std::size_t bit_ix = bit_pos % 64U;
+    if (b.val) val_words[word_ix] |= std::uint64_t{1} << bit_ix;
+    if (b.unk) unk_words[word_ix] |= std::uint64_t{1} << bit_ix;
+  }
+
+  if (!is_four_state) {
+    for (std::size_t w = 0; w < word_count; ++w) {
+      val_words[w] &= ~unk_words[w];
+    }
+    return PackedArray::FromWords(
+        std::span<const std::uint64_t>{val_words},
+        std::span<const std::uint64_t>{}, bit_width, is_signed, false);
+  }
+  return PackedArray::FromWords(
+      std::span<const std::uint64_t>{val_words},
+      std::span<const std::uint64_t>{unk_words}, bit_width, is_signed, true);
+}
+
 auto PackedArray::BitWidth() const -> std::uint64_t {
   return type_.bit_width;
 }
@@ -296,7 +396,7 @@ auto PackedArray::HighImpedanceLike(const PackedArray& prototype)
   // unknown 1). Construction masks the bits above the declared width in the top
   // word.
   const std::uint64_t width = prototype.type_.bit_width;
-  const std::size_t words = static_cast<std::size_t>((width + 63) / 64);
+  const auto words = static_cast<std::size_t>((width + 63) / 64);
   const std::vector<std::uint64_t> value_words(words, 0);
   const std::vector<std::uint64_t> unknown_words(words, ~std::uint64_t{0});
   return FromWords(value_words, unknown_words, prototype.type_);

--- a/tests/cases/cpp/readmem/case.yaml
+++ b/tests/cases/cpp/readmem/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.readmem
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    mem: ["32'h0a0b0c0d", "32'h11223344", "32'hDEADBEEF", "32'h00c0ffee"]
+    mem_at: ["16'h0000", "16'h0000", "16'h000a", "16'h000b"]
+    mem_cmt: ["8'h0a", "8'h0b", "8'h0c"]
+    mem_start: ["8'h00", "8'h0a", "8'h0b", "8'h0c"]
+    mem_desc: ["8'h00", "8'h0c", "8'h0b", "8'h0a"]
+    mem_keep: ["8'hFF", "8'h0a", "8'h0b", "8'hFF"]
+    mem_wide: ["40'h0011223344", "40'h5566778899"]
+    mem_x: ["16'h0ax0", "16'hzzzz", "16'h1x2z"]
+    memb: ["8'b10100101", "8'b00001111", "8'b11110000"]
+    memb_x: ["4'b10x1", "4'bz0z0"]

--- a/tests/cases/cpp/readmem/main.sv
+++ b/tests/cases/cpp/readmem/main.sv
@@ -1,0 +1,83 @@
+module Top;
+  // LRM 21.4 $readmemh / $readmemb. One memory per facet: full fill, @address
+  // directive, comments, explicit start, descending start>finish, unaddressed
+  // words preserved (copy-in), a wide element with `_` separators, per-digit
+  // x/z, and the binary radix (full fill plus per-bit x/z). Every image is
+  // written to a text file by the test itself, then loaded back and asserted.
+  bit [31:0]   mem       [0:3];
+  bit [15:0]   mem_at    [0:3];
+  bit [7:0]    mem_cmt   [0:2];
+  bit [7:0]    mem_start [0:3];
+  bit [7:0]    mem_desc  [0:3];
+  bit [7:0]    mem_keep  [0:3];
+  bit [39:0]   mem_wide  [0:1];
+  logic [15:0] mem_x     [0:2];
+  bit [7:0]    memb      [0:2];
+  logic [3:0]  memb_x    [0:1];
+
+  int fd;
+
+  initial begin
+    // Full fill: space- and newline-separated hex words, mixed case.
+    fd = $fopen("full.hex", "w");
+    $fwrite(fd, "0a0b0c0d 11223344\nDEADBEEF 00c0ffee\n");
+    $fclose(fd);
+    $readmemh("full.hex", mem);
+
+    // @address directive: load starts at address 2, leaving 0 and 1 default.
+    fd = $fopen("at.hex", "w");
+    $fwrite(fd, "@2\n000a\n000b\n");
+    $fclose(fd);
+    $readmemh("at.hex", mem_at);
+
+    // Line (//) and block (/* */) comments are skipped.
+    fd = $fopen("cmt.hex", "w");
+    $fwrite(fd, "// header\n0a /* inline */ 0b\n0c // trailing\n");
+    $fclose(fd);
+    $readmemh("cmt.hex", mem_cmt);
+
+    // Explicit start address 1: index 0 stays default.
+    fd = $fopen("start.hex", "w");
+    $fwrite(fd, "0a 0b 0c\n");
+    $fclose(fd);
+    $readmemh("start.hex", mem_start, 1);
+
+    // start > finish: load descends from 3 toward 1; index 0 stays default.
+    fd = $fopen("desc.hex", "w");
+    $fwrite(fd, "0a 0b 0c\n");
+    $fclose(fd);
+    $readmemh("desc.hex", mem_desc, 3, 1);
+
+    // Unaddressed words keep their prior value (copy-in). Preload all to 0xFF,
+    // then load two words at @1.
+    for (int i = 0; i < 4; i++) mem_keep[i] = 8'hFF;
+    fd = $fopen("keep.hex", "w");
+    $fwrite(fd, "@1\n0a\n0b\n");
+    $fclose(fd);
+    $readmemh("keep.hex", mem_keep);
+
+    // Wide element (40 bits) with `_` digit separators.
+    fd = $fopen("wide.hex", "w");
+    $fwrite(fd, "00_11_22_33_44\n55_66_77_88_99\n");
+    $fclose(fd);
+    $readmemh("wide.hex", mem_wide);
+
+    // Per-nibble x/z (4-state element).
+    fd = $fopen("x.hex", "w");
+    $fwrite(fd, "0ax0 zzzz 1x2z\n");
+    $fclose(fd);
+    $readmemh("x.hex", mem_x);
+
+    // Binary radix: full fill with `_` separators.
+    fd = $fopen("full.bin", "w");
+    $fwrite(fd, "10100101 0000_1111\n11110000\n");
+    $fclose(fd);
+    $readmemb("full.bin", memb);
+
+    // Binary per-bit x/z (4-state element).
+    fd = $fopen("x.bin", "w");
+    $fwrite(fd, "10x1 z0z0\n");
+    $fclose(fd);
+    $readmemb("x.bin", memb_x);
+  end
+endmodule

--- a/tests/cases/cpp/readmem_errors/case.yaml
+++ b/tests/cases/cpp/readmem_errors/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.readmem_errors
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    contains:
+      - "cannot open file 'no_such_file.hex'"
+      - "address 9 is outside the load range"
+      - "file holds 2 words but the address range spans 4"
+  variables:
+    mem_miss: ["8'h00", "8'h00", "8'h00", "8'h00"]
+    mem_oor: ["8'h00", "8'h00", "8'h00", "8'h00"]
+    mem_cnt: ["8'h0a", "8'h0b", "8'h00", "8'h00"]

--- a/tests/cases/cpp/readmem_errors/main.sv
+++ b/tests/cases/cpp/readmem_errors/main.sv
@@ -1,0 +1,27 @@
+module Top;
+  // LRM 21.4 error / warning paths. Each case emits a runtime diagnostic and
+  // the simulation continues (a missing or malformed load is not fatal).
+  bit [7:0] mem_miss [0:3];
+  bit [7:0] mem_oor  [0:3];
+  bit [7:0] mem_cnt  [0:3];
+
+  int fd;
+
+  initial begin
+    // Missing file: error, memory left at default.
+    $readmemh("no_such_file.hex", mem_miss);
+
+    // @address outside the memory range: error, load stops before any write.
+    fd = $fopen("oor.hex", "w");
+    $fwrite(fd, "@9\n0a\n");
+    $fclose(fd);
+    $readmemh("oor.hex", mem_oor);
+
+    // Explicit range wider than the file's word count, no in-file @address:
+    // warning. The two words present still load.
+    fd = $fopen("cnt.hex", "w");
+    $fwrite(fd, "0a 0b\n");
+    $fclose(fd);
+    $readmemh("cnt.hex", mem_cnt, 0, 3);
+  end
+endmodule

--- a/tests/cases/errors/system_subroutine_unsupported/case.yaml
+++ b/tests/cases/errors/system_subroutine_unsupported/case.yaml
@@ -11,7 +11,7 @@ expect:
   stderr:
     contains:
       - "unsupported:"
-      - "$readmemh"
+      - "$monitor"
       - "not yet supported"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/system_subroutine_unsupported/main.sv
+++ b/tests/cases/errors/system_subroutine_unsupported/main.sv
@@ -1,4 +1,4 @@
 module Top;
-  logic [7:0] mem [0:3];
-  initial $readmemh("mem.hex", mem);
+  int x;
+  initial $monitor("x=%0d", x);
 endmodule


### PR DESCRIPTION
## Summary

Implements `$readmemh` / `$readmemb` (LRM 21.4), loading a one-dimensional unpacked memory of packed integral elements from a hexadecimal or binary text file. The file format supports whitespace- and newline-separated words, `@address` directives, `//` and `/* */` comments, per-digit `x` / `z` / `?`, and `_` digit separators. Addressing follows LRM 21.4: with no range the load fills from the lowest declared index upward; a `start`-only call fills upward from `start`; a `start` / `finish` call fills from `start` toward `finish`, descending when `start > finish`. Words the file never addresses keep their prior value, and a 2-state element collapses `x` / `z` to 0. Elements of any width (including wider than 64 bits) and any declared range (non-zero-based or descending) load by declared index. This clears the last lowering wall for the full `ibex_simple_system_tb`, which now lowers to MIR with no diagnostics.

## Design

`$readmemh` / `$readmemb` are void tasks, so they only appear in statement position; the lowering follows the existing `$fread` memory-form pattern, round-tripping the output memory through an LRM 13.5 copy-out block (a copy-in temp so unaddressed words survive, the runtime fills it, then a write-back commits it). The runtime entry is a free function on the ambient runtime handle rather than a method on the file-descriptor broker, because the load opens a named file itself and uses none of the descriptor pool's state; its only real dependencies are a filesystem read and the diagnostic sink. Radix-digit parsing (with per-digit x/z) is a new neutral value-layer primitive. A new `ReadMemSystemSubroutineInfo` semantic family forces both the statement and expression dispatch visits to decide explicitly how the task lowers; the expression arm is an invariant guard (a void task the frontend already rejects in value position), not an unsupported diagnostic.

Multidimensional, associative, and dynamic-array memories, and packed struct / union elements (LRM 21.4.1 / 21.4.3), are rejected today with a clear diagnostic and tracked as open items in `readmem.md`.

## Testing

A `readmem` case covers every file-format facet across both radixes (full fill, `@address`, comments, explicit start, descending range, unaddressed-preserved, wide element, per-digit x/z). A `readmem_errors` case covers the diagnostic paths (missing file, `@address` out of range, word-count mismatch warning) via stderr assertion, confirming the simulation continues. The `system_subroutine_unsupported` canary was repointed from `$readmemh` to `$monitor`.