### PR TITLE
Build default and replicated arrays by tiling

### DIFF
--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -24,10 +25,9 @@ namespace lyra::lowering::hir_to_mir {
 
 // Builds a primitive MIR expression evaluating to the LRM Table 6-7 default
 // value of `type`, returning the top node detached for the caller to intern.
-// Composite types (UnpackedArray, DynamicArray, Queue) recurse and register
-// each element default into `frame.current_block` as children before
-// returning the outer composite, so interning the result yields a
-// self-contained subtree of arena entries.
+// A composite default registers the child expressions it references into
+// `frame.current_block` before returning the outer node, so interning the
+// result yields a self-contained subtree of arena entries.
 //
 // `int x;` and `int x = 0;` are different in SV source -- HIR preserves that
 // distinction via `optional<initializer>`. By MIR every variable has an
@@ -49,6 +49,11 @@ namespace lyra::lowering::hir_to_mir {
     const UnitLowerer& unit_lowerer, WalkFrame frame, hir::TypeId hir_type)
     -> mir::Expr;
 
+// The element type of an array container type (unpacked, dynamic, or queue).
+// Throws `InternalError` if `array_type` is not one of those.
+[[nodiscard]] auto ArrayContainerElementType(
+    const mir::CompilationUnit& unit, mir::TypeId array_type) -> mir::TypeId;
+
 // Wraps a list of element ExprIds destined for an array container constructor
 // (`UnpackedArrayType` or `DynamicArrayType`) in a construction call whose
 // arguments are `[element_default, ArrayLiteralExpr{elements}]`. This is the
@@ -60,6 +65,20 @@ namespace lyra::lowering::hir_to_mir {
 [[nodiscard]] auto BuildArrayConstructionCall(
     const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
     std::vector<mir::ExprId> elements) -> mir::Expr;
+
+// Builds the construction call for a uniform array-container value: `count`
+// tilings of the repeat unit `unit`, seeded with `element_default` (the
+// wrapper's OOB / discard source). The unit rides in an `ArrayLiteralExpr` and
+// the count in a `MachineIntLiteral`, so the constructor arguments are
+// `[element_default, ArrayLiteralExpr{unit}, count]` (plus the LRM 7.10.5 bound
+// for a bounded queue). This is the shape every site that produces an
+// all-default or `'{count{...}}` array value must use, so the value's MIR and
+// emitted text stay O(unit) rather than O(unit * count). A distinct-element
+// list uses `BuildArrayConstructionCall` instead.
+[[nodiscard]] auto BuildArrayRepeatCall(
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
+    mir::ExprId element_default, std::vector<mir::ExprId> unit,
+    std::uint64_t count) -> mir::Expr;
 
 // Builds the construction call for an associative-array literal (LRM 7.9.11).
 // Each (key, value) entry becomes a `TupleExpr`; the entries ride in an

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -78,6 +78,17 @@ class DynamicArray {
       : shield_(std::move(element_default)), data_(init.begin(), init.end()) {
   }
 
+  // LRM 10.9.1 `'{count{...}}` replicated pattern: `count` tilings of `unit`.
+  // Built from the repeat unit and a count so the value costs O(unit), not
+  // O(unit * count); mirrors `UnpackedArray`'s tiling ctor.
+  DynamicArray(T element_default, std::span<const T> unit, std::size_t count)
+      : shield_(std::move(element_default)) {
+    data_.reserve(unit.size() * count);
+    for (std::size_t i = 0; i < count; ++i) {
+      data_.insert(data_.end(), unit.begin(), unit.end());
+    }
+  }
+
   DynamicArray(const DynamicArray&) = default;
   DynamicArray(DynamicArray&&) noexcept = default;
   auto operator=(const DynamicArray&) -> DynamicArray& = default;

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -54,6 +54,16 @@ class Queue {
       : shield_(std::move(element_default)), data_(init.begin(), init.end()) {
   }
 
+  // LRM 10.9.1 `'{count{...}}` replicated pattern: `count` tilings of `unit`.
+  // Built from the repeat unit and a count so the value costs O(unit), not
+  // O(unit * count); mirrors `UnpackedArray`'s tiling ctor.
+  Queue(T element_default, std::span<const T> unit, std::size_t count)
+      : shield_(std::move(element_default)) {
+    for (std::size_t i = 0; i < count; ++i) {
+      data_.insert(data_.end(), unit.begin(), unit.end());
+    }
+  }
+
   // LRM 7.10.5 bounded queue `int q[$:N]`: the empty start is unchanged, but
   // the maximum index N is recorded so growth past N+1 elements is discarded
   // with a warning. The bound arrives as a PackedArray construction argument.
@@ -69,6 +79,20 @@ class Queue {
       : shield_(std::move(element_default)),
         data_(init.begin(), init.end()),
         max_bound_(static_cast<std::uint64_t>(max_bound.ToInt64())) {
+    EnforceBound();
+  }
+
+  // LRM 7.10.5 bounded queue initialized by a replicated pattern: tile `unit`
+  // `count` times, record the bound, and trim any overflow on entry. The
+  // tiling counterpart of the `(element_default, init, max_bound)` ctor.
+  Queue(
+      T element_default, std::span<const T> unit, std::size_t count,
+      const PackedArray& max_bound)
+      : shield_(std::move(element_default)),
+        max_bound_(static_cast<std::uint64_t>(max_bound.ToInt64())) {
+    for (std::size_t i = 0; i < count; ++i) {
+      data_.insert(data_.end(), unit.begin(), unit.end());
+    }
     EnforceBound();
   }
 

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -89,6 +89,22 @@ class UnpackedArray {
       : shield_(std::move(element_default)), data_(init.begin(), init.end()) {
   }
 
+  // LRM 10.9.1 / Table 7-1: a uniform array value built as `count` tilings of
+  // `unit`. Covers both a fixed array's all-default state (`unit` is one
+  // element default) and an `'{count{...}}` replicated pattern (`unit` is the
+  // replicated items) -- the two arise from the same repeat-unit-plus-count
+  // shape, so they construct through one path. Building from (unit, count)
+  // keeps a uniform array O(unit) to construct where an enumerated element
+  // list would be O(unit * count); the seeded shield is the OOB / discard
+  // source, the payload is `unit` laid down `count` times.
+  UnpackedArray(T element_default, std::span<const T> unit, std::size_t count)
+      : shield_(std::move(element_default)) {
+    data_.reserve(unit.size() * count);
+    for (std::size_t i = 0; i < count; ++i) {
+      data_.insert(data_.end(), unit.begin(), unit.end());
+    }
+  }
+
   // LRM 5.9 / 21.3.3: a string value assigned to an unpacked array of bytes is
   // left-justified -- the first character lands at the array's left bound and
   // runs toward the right bound, an element past the end of the text keeps the

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -51,9 +51,27 @@ auto DefaultIntegralConstant(const mir::PackedArrayType& pa)
 
 namespace {
 
+// LRM 7.10.5: a bounded queue carries its max index as a trailing construction
+// argument so the runtime trims an over-long initializer. Appends it when
+// `array_type` is a bounded queue; a no-op for every other array container.
+auto AppendBoundedQueueMax(
+    const UnitLowerer& unit_lowerer, mir::Block& block,
+    std::vector<mir::ExprId>& args, mir::TypeId array_type) -> void {
+  const auto& ty = unit_lowerer.Unit().types.Get(array_type);
+  if (const auto* q = std::get_if<mir::QueueType>(&ty.data);
+      q != nullptr && q->max_bound.has_value()) {
+    args.push_back(block.exprs.Add(
+        mir::MakeIntLiteral(
+            unit_lowerer.Unit().builtins.int_type,
+            static_cast<std::int64_t>(*q->max_bound))));
+  }
+}
+
 // Wrap element exprs into an unpacked-array construction: the element type's
 // default prototype (honoring its own member inits) plus the element list.
-// Shared by the type-default array path and the explicit-constant array path.
+// Serves a folded-constant array (LRM 7.2.2), whose elements are materialized
+// individually because a constant fixes each element's own value; a uniform
+// or replicated value builds through `BuildArrayRepeatCall` instead.
 auto BuildUnpackedArrayValue(
     const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
     hir::TypeId element_type, std::vector<mir::ExprId> element_ids)
@@ -188,15 +206,17 @@ auto BuildDefaultValueExpr(
             return mir::Expr{
                 .data = mir::RealLiteral{.value = 0.0}, .type = type};
           },
+          // LRM Table 7-1: a fixed unpacked array defaults to every element at
+          // the element type's default. That uniform value is one tiling of the
+          // element default across the array's size, so it builds through the
+          // repeat call and stays O(1) in the array's element count. The shield
+          // seed and the repeat unit are the same element default.
           [&](const mir::UnpackedArrayType& ua) -> mir::Expr {
-            std::vector<mir::ExprId> elements;
-            elements.reserve(ua.Size());
-            for (std::uint64_t i = 0; i < ua.Size(); ++i) {
-              elements.push_back(block.exprs.Add(
-                  BuildDefaultValueExpr(unit_lowerer, frame, ua.element_type)));
-            }
-            return BuildArrayConstructionCall(
-                unit_lowerer, frame, type, std::move(elements));
+            const mir::ExprId element_default = block.exprs.Add(
+                BuildDefaultValueExpr(unit_lowerer, frame, ua.element_type));
+            return BuildArrayRepeatCall(
+                unit_lowerer, frame, type, element_default, {element_default},
+                ua.Size());
           },
           // LRM Table 7-1: an unpacked struct defaults member-wise -- each
           // component takes its own type's default, recursively. Synthesized as
@@ -356,25 +376,19 @@ auto BuildDefaultValueFromHir(
                                   ? (ua->dim.left - ua->dim.right)
                                   : (ua->dim.right - ua->dim.left);
     const auto size = static_cast<std::uint64_t>(span) + 1U;
-    std::vector<mir::ExprId> elements;
-    elements.reserve(size);
-    for (std::uint64_t i = 0; i < size; ++i) {
-      elements.push_back(block.exprs.Add(
-          BuildDefaultValueFromHir(unit_lowerer, frame, ua->element_type)));
-    }
-    return BuildUnpackedArrayValue(
-        unit_lowerer, frame, mir_type, ua->element_type, std::move(elements));
+    const mir::ExprId element_default = block.exprs.Add(
+        BuildDefaultValueFromHir(unit_lowerer, frame, ua->element_type));
+    return BuildArrayRepeatCall(
+        unit_lowerer, frame, mir_type, element_default, {element_default},
+        size);
   }
 
   return BuildDefaultValueExpr(unit_lowerer, frame, mir_type);
 }
 
-auto BuildArrayConstructionCall(
-    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
-    std::vector<mir::ExprId> elements) -> mir::Expr {
-  auto& block = *frame.current_block;
-  const auto& ty = unit_lowerer.Unit().types.Get(array_type);
-  const mir::TypeId element_type = std::visit(
+auto ArrayContainerElementType(
+    const mir::CompilationUnit& unit, mir::TypeId array_type) -> mir::TypeId {
+  return std::visit(
       [](const auto& t) -> mir::TypeId {
         using TyT = std::decay_t<decltype(t)>;
         if constexpr (
@@ -384,11 +398,18 @@ auto BuildArrayConstructionCall(
           return t.element_type;
         } else {
           throw InternalError(
-              "BuildArrayConstructionCall: type is not UnpackedArrayType, "
-              "DynamicArrayType, or QueueType");
+              "ArrayContainerElementType: type is not an array container");
         }
       },
-      ty.data);
+      unit.types.Get(array_type).data);
+}
+
+auto BuildArrayConstructionCall(
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
+    std::vector<mir::ExprId> elements) -> mir::Expr {
+  auto& block = *frame.current_block;
+  const mir::TypeId element_type =
+      ArrayContainerElementType(unit_lowerer.Unit(), array_type);
   const mir::ExprId element_default =
       block.exprs.Add(BuildDefaultValueExpr(unit_lowerer, frame, element_type));
   const mir::ExprId list_id = block.exprs.Add(
@@ -396,16 +417,30 @@ auto BuildArrayConstructionCall(
           .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
           .type = array_type});
   std::vector<mir::ExprId> args = {element_default, list_id};
-  // LRM 7.10.5: a bounded queue initialized by an assignment pattern still
-  // carries its max index, so the bound rides as a third construction argument
-  // and the runtime trims an over-long initializer.
-  if (const auto* q = std::get_if<mir::QueueType>(&ty.data);
-      q != nullptr && q->max_bound.has_value()) {
-    args.push_back(block.exprs.Add(
-        mir::MakeIntLiteral(
-            unit_lowerer.Unit().builtins.int_type,
-            static_cast<std::int64_t>(*q->max_bound))));
-  }
+  AppendBoundedQueueMax(unit_lowerer, block, args, array_type);
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee = mir::Construct{}, .arguments = std::move(args)},
+      .type = array_type};
+}
+
+auto BuildArrayRepeatCall(
+    const UnitLowerer& unit_lowerer, WalkFrame frame, mir::TypeId array_type,
+    mir::ExprId element_default, std::vector<mir::ExprId> unit,
+    std::uint64_t count) -> mir::Expr {
+  auto& block = *frame.current_block;
+  const mir::ExprId unit_id = block.exprs.Add(
+      mir::Expr{
+          .data = mir::ArrayLiteralExpr{.elements = std::move(unit)},
+          .type = array_type});
+  const mir::ExprId count_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::MachineIntLiteral{.value = static_cast<std::int64_t>(count)},
+          .type = unit_lowerer.Unit().builtins.machine_int64});
+  std::vector<mir::ExprId> args = {element_default, unit_id, count_id};
+  AppendBoundedQueueMax(unit_lowerer, block, args, array_type);
   return mir::Expr{
       .data =
           mir::CallExpr{

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <expected>
 #include <optional>
-#include <span>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -27,10 +26,9 @@ namespace lyra::lowering::hir_to_mir {
 namespace {
 
 // LRM 10.9.1: the replication count of an assignment pattern is a constant
-// expression; slang has already evaluated it to an integer literal. The
-// unpacked-target path uses this value to materialize the element list at
-// compile time (no runtime replication primitive exists for unpacked
-// aggregates).
+// expression; slang has already evaluated it to an integer literal. The array
+// path carries this count into the container's tiling construction, and the
+// packed path folds it into the flat replication width.
 auto ExtractHirLiteralUint64(const hir::Expr& expr) -> std::uint64_t {
   const auto* primary = std::get_if<hir::PrimaryExpr>(&expr.data);
   if (primary == nullptr) {
@@ -44,19 +42,6 @@ auto ExtractHirLiteralUint64(const hir::Expr& expr) -> std::uint64_t {
   const auto& c = lit->value;
   if (c.value_words.empty()) return 0;
   return c.value_words[0];
-}
-
-auto BuildArrayReplicationFlatList(
-    const UnitLowerer& unit_lowerer, WalkFrame frame,
-    std::span<const mir::ExprId> items_ids, std::uint64_t count,
-    mir::TypeId result_type) -> mir::Expr {
-  std::vector<mir::ExprId> flat;
-  flat.reserve(items_ids.size() * count);
-  for (std::uint64_t i = 0; i < count; ++i) {
-    flat.insert(flat.end(), items_ids.begin(), items_ids.end());
-  }
-  return BuildArrayConstructionCall(
-      unit_lowerer, frame, result_type, std::move(flat));
 }
 
 // A packed assignment pattern folds its members into one flat bit plane (LRM
@@ -207,8 +192,13 @@ auto LowerHirAssignmentPatternReplicationExpr(
   if (IsArrayContainerType(result_ty)) {
     const std::uint64_t count =
         ExtractHirLiteralUint64(lowerer.HirExprs().Get(a.count));
-    return BuildArrayReplicationFlatList(
-        lowerer.Owner(), frame, item_ids, count, result_type);
+    const mir::TypeId element_type =
+        ArrayContainerElementType(lowerer.Owner().Unit(), result_type);
+    const mir::ExprId element_default = block.exprs.Add(
+        BuildDefaultValueExpr(lowerer.Owner(), frame, element_type));
+    return BuildArrayRepeatCall(
+        lowerer.Owner(), frame, result_type, element_default,
+        std::move(item_ids), count);
   }
   if (std::holds_alternative<mir::TupleType>(result_ty.data)) {
     const std::uint64_t count =

--- a/tests/cases/cpp/queue_bounded/case.yaml
+++ b/tests/cases/cpp/queue_bounded/case.yaml
@@ -12,6 +12,8 @@ expect:
     s_grow: 4
     init_big: [1, 2, 3]
     s_init: 3
+    rep_init: [7, 7, 7]
+    s_rep: 3
     assigned: [1, 2, 3]
     s_assigned: 3
     retained: [1, 2, 3, 4]

--- a/tests/cases/cpp/queue_bounded/main.sv
+++ b/tests/cases/cpp/queue_bounded/main.sv
@@ -6,11 +6,13 @@
 module Top;
   bit [7:0] grow [$:3];
   bit [7:0] init_big [$:2] = '{1, 2, 3, 4, 5};
+  bit [7:0] rep_init [$:2] = '{5{8'd7}};
   bit [7:0] assigned [$:2];
   bit [7:0] retained [$:3] = '{1, 2};
 
   int s_grow;
   int s_init;
+  int s_rep;
   int s_assigned;
   int s_retained;
 
@@ -23,6 +25,8 @@ module Top;
     s_grow = grow.size();
 
     s_init = init_big.size();
+
+    s_rep = rep_init.size();
 
     assigned = {8'd1, 8'd2, 8'd3, 8'd4};
     s_assigned = assigned.size();


### PR DESCRIPTION
## Summary

A default or replicated unpacked-array value was materialized at HIR-to-MIR as an `ArrayLiteralExpr` enumerating every element, so the MIR and the emitted construction scaled with the array's element count. A large fixed array (an ibex RAM's ~256Ki-deep memory, default all-X) became a single translation unit too big to compile, inflating the C++ build stage against North Star's primary target of end-to-end iteration time. This change gives each array container (`UnpackedArray`, `DynamicArray`, `Queue`) a tiling constructor `(element_default, unit, count)` and routes both the Table 7-1 all-default value and the `'{N{...}}` replicated assignment pattern through it, so the value's MIR and generated code stay O(unit) while the runtime still materializes the N elements at construction time (the LRM-mandated runtime cost, unchanged).

## Design

No new MIR node is introduced. `mir.md` invariant 10 and `backend_contract.md` forbid growing a node kind for a fact already expressible by combining existing primitives, so the count rides as a `Construct` argument (a `MachineIntLiteral`), exactly as the LRM 7.10.5 queue bound already does. Both the C++ backend and a future LIR/LLVM backend realize this mechanically by calling the container's runtime constructor, and both funnel aggregate construction through the same runtime library (per `jit-aggregate-realization.md`), so the tiling lives in the runtime value model, not in either backend's generated code. The count is a machine scalar for the ctor's `std::size_t`, realized as an immediate on both backends rather than a runtime value handle. A genuinely distinct `'{e1, ..., eN}` element list is irreducible and stays on the enumerated `BuildArrayConstructionCall` path.

## Testing

The existing array-default and replication cases exercise the tiling path. A bounded-queue replicated-pattern facet (`'{5{...}}` trimmed to the bound) was added to `queue_bounded`, the one path with no prior coverage.

`'{default: v}` on a large fixed array remains out of scope: slang pre-flattens it to N positional elements before HIR, so it still enumerates. Recovering it needs a separate all-elements-equal peephole after the frontend flattening.