### PR TITLE
State an interior write as an owner-relative value projection

### DIFF
--- a/docs/architecture/lir.md
+++ b/docs/architecture/lir.md
@@ -48,8 +48,10 @@ below LIR, at LIR-to-LLVM.
 - A self-contained type graph: LIR-owned type identities that type every local, value, place
   projection, return, and call argument. Each is translated from a generic-PL type at MIR-to-LIR and
   carries no live reference back to MIR.
-- The place vocabulary: a place is a base local plus a projection chain (member, index, dereference,
-  slice, downcast). Every load, store, and address-of names a place by logical identity.
+- The place vocabulary: a place is a base local plus a projection chain of member and dereference
+  steps. Every load, store, and address-of names a place by logical identity. There is no index or
+  slice step: a value aggregate's interior is not independently addressable, and an array of storage
+  is reached through the indirection its elements already carry.
 - The transient-value vocabulary: a computed value with a pure dataflow origin, not backed by a
   named memory location.
 - Logical storage topology: which local, member, element, or referent a place names, and the logical
@@ -96,8 +98,8 @@ identity is the suspect, not the analysis.
    codegen knows for every value whether it lives in memory or in a register-class temporary; no
    value's storage class must be inferred._
 3. LIR fixes logical storage topology, not physical layout. A place names storage by logical
-   identity -- a base local and a projection chain of member, index, and dereference steps -- never
-   as a byte offset, an address, or pointer arithmetic. The physical realization of that topology is
+   identity -- a base local and a projection chain of member and dereference steps -- never as a
+   byte offset, an address, or pointer arithmetic. The physical realization of that topology is
    derived below LIR. _Machine-execution consequence: one LIR program is valid for every target; the
    target-specific layout is a separate derivation, not a property baked into a place._
 4. LIR identity is self-contained. Every type, class, member, and callable a LIR node names is a

--- a/docs/architecture/lir.md
+++ b/docs/architecture/lir.md
@@ -54,6 +54,9 @@ below LIR, at LIR-to-LLVM.
   is reached through the indirection its elements already carry.
 - The transient-value vocabulary: a computed value with a pure dataflow origin, not backed by a
   named memory location.
+- The value-aggregate selector vocabulary: which subvalue a step names -- a component slot, a
+  runtime coordinate, a fixed-width window. One extract and one update carry every step; the
+  selector never says how the step is realized.
 - Logical storage topology: which local, member, element, or referent a place names, and the logical
   identity of every class member and callable a node refers to.
 - Effect ordering within a block.
@@ -256,15 +259,16 @@ so it is a pair of value operations, an extract and an insert (the aggregate pee
 real, not because one is a special case of the other. The same principle governs the rest of the
 value-aggregate family: a packed slice, a container element, and a union member are value
 sub-accesses, so a sub-write is a functional whole-value update, never a store into an independently
-addressable sub-place -- a static, structural selector (a struct component) may ride a dedicated
-value instruction, a dynamic, runtime-indexed one (a container element) a runtime-library call, but
-the principle that a value sub-write produces a new whole value is the same. A whole-value mutating
-method on a value receiver -- a container's `delete`, a queue's `push` -- follows the same rule: it
-is realized as a functional operation whose result is stored back through the receiver's owner, not
-an in-place mutation of the value. How a target keeps value semantics for such a store is below LIR:
-a target with language-level value copies may fulfill it by mutating a private copy in place, while
-one whose container value is reached through a shared handle must produce a new value, so the model
-LIR states -- a new whole value written back to the owner -- holds for both.
+addressable sub-place. One extract and one update carry every one of them, and the selector says
+only which subvalue is named -- a component slot, a runtime coordinate, a fixed-width window. Which
+library entry realizes a step, and whether it is an instruction or a call at all, is a realization
+question answered below LIR; it never decides which node the step is expressed as. A whole-value
+mutating method on a value receiver -- a container's `delete`, a queue's `push` -- follows the same
+rule: it is realized as a functional operation whose result is stored back through the receiver's
+owner, not an in-place mutation of the value. How a target keeps value semantics for such a store is
+below LIR: a target with language-level value copies may fulfill it by mutating a private copy in
+place, while one whose container value is reached through a shared handle must produce a new value,
+so the model LIR states -- a new whole value written back to the owner -- holds for both.
 
 LIR carries the fact that a packed value is two-state or four-state; it does not carry how a
 four-state value is stored. The canonical encoding of a four-state value -- value bits plus a state

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -70,9 +70,10 @@ what the construct means.
   blocks at this layer.
 - A primitive expression set: literals, references, unary / binary / conditional operators, calls,
   conversions, closures, member access through an explicit receiver expression, access primitives
-  for element and range selection, and value-build primitives for aggregate construction. The set is
-  closed under what a generic programming-language AST needs to express; it does not grow to model a
-  particular backend's storage realization or runtime library shape.
+  for element and range selection, value-build primitives for aggregate construction, and a
+  designator naming a part of a value by the place that owns the whole and the descent that reaches
+  the part. The set is closed under what a generic programming-language AST needs to express; it
+  does not grow to model a particular backend's storage realization or runtime library shape.
 - Action shapes for constructs that bind behavior to schedule events (always blocks, continuous
   assignments, deferred assertions, concurrent assertions).
 - A textual dumper that serializes MIR for inspection, validation, and golden testing. The dumper is
@@ -351,15 +352,15 @@ it the same way it emits any other call. The wrapper type's target-language spel
 spellings are backend-internal -- `backend_contract.md` owns the rules that keep those out of
 value-emission sites.
 
-An assignment whose target is a place-producing access -- a container element, a struct component, a
-union member -- states an abstract update of the owning value: which owner, which selector, how many
-times the selector evaluates, the value written and its coercion, and that the owning value is the
-value updated. A place names where the write lands; it does not assert that the interior is
-independently addressable storage, an alias with its own identity, or a reference that outlives the
-owner. How that update keeps value semantics is a lower layer's concern: MIR-to-LIR legalizes a
-value-owned projection into explicit whole-value operations -- an extract and an insert, or a
-container primitive -- where the target's representation requires it (`lir.md`), and a backend may
-instead realize the same semantics by mutating private storage in place. A write-side selector whose
-name carries `Ref` marks the write side of the access, not a first-class interior reference; a
-reference that could escape the owner or alias it would be a distinct concept, not this target
-place.
+An assignment whose target descends into a value -- a container element, a struct component, a union
+member, a fixed-width range -- states an abstract update of the owning value: which owner, which
+selectors, how many times each evaluates, the value written and its coercion, and that the owning
+value is the value updated. The owner is a place; the descent is not. Nothing about the target
+asserts that the interior is independently addressable storage, an alias with its own identity, or a
+reference that outlives the owner -- a value aggregate has no such interior to name. How that update
+keeps value semantics is a lower layer's concern: MIR-to-LIR legalizes the descent into explicit
+whole-value operations, an extract and an insert (`lir.md`), and a backend may instead realize the
+same semantics by mutating private storage in place. A construct that binds the designated part
+rather than writing it -- a reference actual, an output pack component, a nonblocking update --
+binds the same statement of owner and descent; it is owner-relative, so it names no interior pointer
+and aliases nothing the owner does not already own.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,6 +43,10 @@ the detail lives in the entry itself.
   owner-relative value projection (a functional whole-value update through the owner), not a place
   store; MIR states the place-vs-projection designator, the C++ in-place write is a
   behavior-preserving optimization.
+- [value-projection-designator](value-projection-designator.md) -- the formal shape of that
+  designator: one node whose children are the owner place and a closed selector path, shared by the
+  write path and by the projection reference a `ref`, an `output` / `inout` actual, and a
+  nonblocking assignment bind; the nested-lvalue write encoding is deleted.
 - [queue-operators](queue-operators.md) -- queue access operators lower to built-in method calls;
   read and write are distinct methods chosen at lowering.
 - [array-method-dispatch](array-method-dispatch.md) -- LRM 7.12 array-method runtime semantics;

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,6 +39,10 @@ the detail lives in the entry itself.
   below LIR, and LIR's aggregate operations stay realization-agnostic.
 - [slice-value-semantics](slice-value-semantics.md) -- a slice read materializes an owned value; the
   access model is value, not borrow.
+- [value-projection-write](value-projection-write.md) -- a value-aggregate interior write is an
+  owner-relative value projection (a functional whole-value update through the owner), not a place
+  store; MIR states the place-vs-projection designator, the C++ in-place write is a
+  behavior-preserving optimization.
 - [queue-operators](queue-operators.md) -- queue access operators lower to built-in method calls;
   read and write are distinct methods chosen at lowering.
 - [array-method-dispatch](array-method-dispatch.md) -- LRM 7.12 array-method runtime semantics;

--- a/docs/decisions/compound-assignment-write-location.md
+++ b/docs/decisions/compound-assignment-write-location.md
@@ -1,6 +1,10 @@
 # Compound assignment lowers uniformly; every write target is an op=-able location
 
-Date: 2026-06-28 Status: accepted
+Date: 2026-06-28 Status: accepted; the requirement that every write target be an op=-able location
+is superseded for value interiors by [value-projection-write](value-projection-write.md) (an
+interior write is an owner-relative value projection, not a location). The uniform
+compound-assignment node and the evaluate-once goal remain in force; genuine places keep the store
+model.
 
 ## Context
 

--- a/docs/decisions/slice-value-semantics.md
+++ b/docs/decisions/slice-value-semantics.md
@@ -6,7 +6,10 @@
 
 ## Status
 
-Accepted
+Accepted. The write-side conclusion is reframed for value interiors by
+[value-projection-write](value-projection-write.md) -- a value-aggregate interior write is an
+owner-relative value projection, not an addressable reference or write-back location. The
+slice-read-as-materialized-value model, this document's thesis, remains in force.
 
 ## Context
 

--- a/docs/decisions/value-projection-designator.md
+++ b/docs/decisions/value-projection-designator.md
@@ -1,0 +1,260 @@
+# The value-projection designator: MIR's formal write target and projection reference
+
+## Date
+
+2026-07-24
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+[value-projection-write](value-projection-write.md) settled the model: a write into a value
+aggregate's interior is an owner-relative functional whole-value update, not a place store. It left
+the representation to the last of its staged cuts -- "the canonical decomposition is promoted into
+the formal MIR write-designator node, and the old nested-lvalue write encoding is deleted".
+
+That cut is the one that pays the debt. Until it lands, MIR still encodes an interior write as a
+nested lvalue expression, and both backends recover the owner and the selectors by walking that
+chain and consulting each receiver's type kind. Two backends deriving one semantic fact is the
+`mir.md` Forbidden Shape the model exists to remove; the walking is also what makes each new
+container family arrive as another per-type branch.
+
+This entry fixes the representation: what the node is, what a selector is, how a deferred write and
+a `ref` share it, and what is deleted. It answers the questions the model deliberately left open, so
+the migration that follows is mechanical.
+
+## What the model already fixed
+
+These are not reopened. The designator is designed to satisfy them.
+
+- The owner boundary is structural, never a classification flag over a retained nested lvalue, and
+  never recovered by walking (D1, and its first rejected alternative).
+- Owner and selectors are structural children; a field that restates what the structure already
+  fixes is forbidden (D1's third rejected alternative, and `mir.md`'s node-field rule).
+- The owner and every selector evaluate exactly once, as a stated MIR semantic. Temporaries and the
+  read / update / store sequence belong to MIR-to-LIR (D2, `lowering_boundaries.md`).
+- The C++ in-place write is a behavior-preserving optimization admitted only against an equivalent
+  proxy; MIR never asserts a value interior is addressable (D3).
+- A `ref` bound to an interior is an owner-relative projection reference, never an interior pointer
+  and never an addressable sub-place (D4).
+- The read side keeps its value semantics: a slice read materializes an owned value (D5).
+
+## The decision
+
+### D1. The designator is one expression node whose children are the owner and the selector path
+
+A write target is either a place expression, whose write is a store, or a `ValueProjection` node,
+whose write is a functional whole-value update. The node has exactly two children: an owner
+expression, which must be a place, and a non-empty selector path in owner-to-leaf order. The node's
+type is the type of the part it designates.
+
+The node kind is the classification. There is no place-versus-projection flag, no marker on the
+assignment, and no payload restating what the children already say. A backend reads the boundary by
+reading which node is at the target position; it never inspects a receiver's type kind to classify a
+step, and it never walks a chain to find where the place prefix ends.
+
+`AssignExpr.target` and `IncDecExpr.target` accept either form. Nothing else about those nodes
+changes: the single compound-assignment shape `{target, compound_op, value}` stands
+([compound-assignment-write-location](compound-assignment-write-location.md)).
+
+### D2. The selector set is closed, coordinate-facing, and realized per value domain
+
+A selector names one descent step into a value. The set is:
+
+- **Component** -- a positional part of a product value (an unpacked struct's field).
+- **UnionMember** -- a positional member of a union value. Its update makes the member active; the
+  active-member value model is unchanged
+  ([unpacked-union-representation](unpacked-union-representation.md)).
+- **Element** -- one coordinate into a homogeneous or keyed value: an unpacked-array, dynamic-array,
+  or queue element, an associative-array key, a string character, a packed bit-select.
+- **Slice** -- a fixed-width window: a packed part-select, an unpacked slice, and a packed
+  aggregate's member, which projects to a constant-bounds slice over the base
+  ([packed-array-representation](packed-array-representation.md)).
+
+One selector kind spans several value domains where the descent is the same shape; which runtime
+operation realizes it follows from the type of the value it descends into, through the backend's
+ordinary type-mapping dispatch. That is the same dispatch every value operation already uses; it is
+not a decision in value emission.
+
+Every coordinate is the source-level one. No selector carries a rebased position, a storage offset,
+or a resolved index ([selector-coordinate-resolution](selector-coordinate-resolution.md)). A
+selector whose value domain takes its declared range from its static type carries that range as its
+own operand, materialized at HIR-to-MIR from the statically known type at that position in the path
+([unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md)). Every LRM corner case --
+out-of-range write discard, an x or z coordinate collapsing the write to a no-op, slice window
+normalization, string `putc` rules, queue clamping and append, associative auto-allocation -- stays
+inside the runtime operation that realizes the selector.
+
+### D3. The path never crosses a dereference; reaching the owner is an ordinary read
+
+A designator's owner is a place, and its path descends only through value parts. Where a chain
+re-enters storage -- a class handle held inside a value aggregate, as in `s.h.f = x` -- the
+dereference terminates the path: the owner is the dereferenced referent, and whatever projection was
+needed to read the handle out of `s` appears inside the owner expression as an ordinary read. One
+write is one designator; a chain is never split into several.
+
+This is what makes the owner boundary well-defined without a rule about re-entering place-land: the
+path is the value-aggregate descent, and a dereference is not one.
+
+### D4. A projection reference is the designator's evaluated form, and it serves every deferred write
+
+Evaluating a designator without writing it yields a projection reference: a reference to the owner's
+storage plus the already-evaluated coordinates of its path. Reads go read-owner then select; writes
+go read-owner, update the selected part, write-owner. It is never an interior pointer, and never a
+LIR indexed place.
+
+Three constructs need exactly this, and all three take it:
+
+- A `ref` / `const ref` actual bound to an interior. It stays a live alias: a write lands in the
+  owner immediately, not at completion ([unified-callable-model](unified-callable-model.md)).
+- An `output` / `inout` actual that is an interior. The actual is bound once at call entry and
+  written back after completion; binding once is what the projection reference provides.
+- A nonblocking assignment into an interior. Owner and coordinates are evaluated where the statement
+  executes; the update and the single writeback run in the update region.
+
+The formal's type is unchanged -- a `ref` formal is a reference-typed parameter
+([reference-as-data-type](reference-as-data-type.md)). What is new is that the actual may be a
+designator, and that the reference a designator produces carries selector state. A `ref` port still
+binds to a whole variable and seals to a direct cell; ports are not projections.
+
+A projection reference holds a reference to storage, never a transient value handle, so it never
+installs a per-stretch transient into longer-lived storage
+([activation-frame-and-transient-scope](activation-frame-and-transient-scope.md)). Its coordinates
+are values; one that outlives the stretch that built it is promoted with the reference.
+
+### D5. The write side is a designator and the read side stays a select chain, because they are different operations
+
+A read composes bottom-up: each step is a total function from a value to a part of it, so a nested
+select chain says everything, and both backends already realize it identically. A write cannot
+compose that way. The innermost step must know where the result goes, and a bottom-up value
+composition never names the root place. That is why the write side needs the owner stated and the
+read side does not.
+
+This is the same asymmetry `lir.md` draws between reading a component and writing one, and it is not
+duplicated structure: the read chain and the designator never describe the same access. A statement
+that both reads and writes an interior -- a compound assignment -- has one designator, not a read
+chain beside it.
+
+### D6. Compound assignment and increment read through the same owner read they write back
+
+`target op= value` reads the owner's whole value once, extracts along the path, applies the
+operator, inserts along the path, and stores the whole value back. There is one owner read and one
+writeback, whatever the path's depth. Increment and decrement follow the same shape. The evaluate-
+once obligation of the model is discharged here rather than restated per target family, which is
+what retires the per-target evaluate-once reimplementation the earlier decision was written to stop.
+
+### D7. A projection write into an observable owner is one semantic store through the cell
+
+Whatever the path's depth, the writeback is a single store through the owner's own write protocol --
+for an observable owner, the cell's write, firing subscribers once
+([value-type-concepts](value-type-concepts.md)). It is a semantic store, so it conforms the value to
+the destination's declared type ([value-store-discipline](value-store-discipline.md)). Reactivity
+stays whole-cell; field-granular reactivity is out of scope
+([unpacked-struct-representation](unpacked-struct-representation.md)).
+
+### D8. The C++ in-place recovery is uniform, or it is not taken
+
+A backend may realize a projection write in place only against a proxy equivalent to the functional
+update. The equivalence is not judged per call site: a value domain either has an equivalent proxy
+for a selector kind or it does not, and the answer is a property of the type mapping, not a branch
+in value emission. A backend with a partial proxy set realizes the whole family functionally rather
+than branching between the two shapes.
+
+Equivalence is established by the same backend-agreement tests the migration already uses: a source
+that exercises the family's corner cases, run on both backends, output compared. A new proxy without
+such a case is not admitted.
+
+### D9. What is deleted
+
+- The nested-lvalue write encoding: the write-side `Ref`-suffixed access forms (`element_ref`,
+  `slice_ref`, and the union write form) disappear from MIR, along with the read-versus-write choice
+  a lowering flag makes at a select.
+- The MIR-to-LIR target decomposition and its per-type-kind predicate, which exist only to recover
+  what the designator now states.
+- The functional-write primitives that exist solely for the execution backend, once the designator
+  makes the functional update a stated MIR fact both backends realize.
+- `AddressOfExpr` over a value interior. Its operand must be an addressable place, which a
+  projection is not; the verifier rejects it ([address-of-primitive](address-of-primitive.md)).
+
+### D10. Well-formedness is established at construction, and violated forms fail loudly
+
+A designator is only ever built by the lowering that peels a write target, and that lowering cannot
+build an ill-formed one: it appends exactly one step per descent, so the path is never empty; the
+owner is whatever the recursion reached that was not itself a descent, so it is a place; and each
+step states the type it projects, so the chain types by construction.
+
+The forms that would be ill-formed are rejected where they would be consumed rather than silently
+accepted: a designator under an address-of names no place, and an address-of requires an addressable
+place ([address-of-primitive](address-of-primitive.md)). There is no MIR verifier today -- LIR has
+one and MIR does not -- so these are the checks that exist; when a MIR verifier exists, they are the
+rules it states.
+
+## Decisions this reverses
+
+Each is reversed only for the write side of a value interior, and only in mechanism.
+
+- [unpacked-union-representation](unpacked-union-representation.md) D4 -- "There is no
+  union-specific reference concept: the write form is an ordinary reference into the active member's
+  storage" -- and D5's composition of a nested member write on that reference. A union member
+  becomes a selector; a nested write is a two-step path, not composition on a reference. The
+  active-member value model, member activation as part of the write, and the inactive-read default
+  are unchanged.
+- [unpacked-array-representation](unpacked-array-representation.md) invariant 2 -- the write-side
+  slice proxy "whose destructor scatters back into the receiver's storage", and the out-of-range
+  reference to a shield slot. Both become realizations admitted under D8, not the model; the
+  out-of-range rule is the functional update's no-op.
+- [queue-operators](queue-operators.md) D2 -- "the assignment lowering marks its left-hand side as a
+  write target, and the queue element-select picks the write-side method under that flag". The flag
+  and the write-side method selection go; a queue element is a selector like any other. That an
+  access is a call rather than a select node, and that the store boundary conforms the element
+  shape, are unchanged.
+- [compound-assignment-write-location](compound-assignment-write-location.md) and
+  [slice-value-semantics](slice-value-semantics.md) were already reframed for value interiors by
+  [value-projection-write](value-projection-write.md); this entry is where their write-side
+  mechanism is actually removed.
+
+## Rejected alternatives
+
+- **Self-classifying access nodes in a retained nested chain.** Split each access primitive into a
+  place form and a value-projection form so a backend can classify each step by node kind alone, and
+  keep the chain. Rejected: it is the model's own first rejected alternative. Reading structure is
+  allowed, but the owner boundary would still be recovered by each backend walking a chain, and two
+  backends can walk it to different results. The boundary is stated, not found.
+- **One designator for reads and writes.** Rejected: it would rewrite every read path to gain
+  nothing. A read chain composes bottom-up and is already realized identically by both backends;
+  there is no fact either backend re-derives. D5 gives the standing justification for the asymmetry.
+- **A generic multi-level update entry in the runtime.** Rejected: the per-domain functional update
+  entries already exist and compose one call per level, which is the accepted erased-aggregate cost
+  ([jit-aggregate-realization](jit-aggregate-realization.md)). A generic entry would need to
+  interpret a selector path at runtime -- a second selector vocabulary below LIR.
+- **A distinct MIR reference type for a projection reference.** Rejected: the formal's type already
+  states reference-ness, and a second reference type would split one concept by how its referent is
+  reached. What a projection reference carries beyond a cell reference is its realization, below
+  MIR.
+
+## Consequences
+
+- Every interior write -- struct component, union member, packed slice, packed or unpacked element,
+  queue and associative element, string character -- is one node kind with one realization rule per
+  backend. A new container family adds a value domain and its runtime entries, never a branch at the
+  write path.
+- `ref`, `output`, `inout`, and nonblocking assignment into an interior become expressible on the
+  execution backend through one mechanism rather than four.
+- Both backends lose their target-classification code; the execution backend's per-type-kind
+  predicate and the C++ backend's write-side access forms disappear together.
+- A deep path on a large aggregate costs one owner read, one update call per level, and one
+  writeback. No measurement exists for this in the repository today; the optimization paths are the
+  C++ in-place recovery of D8 and, on the execution backend, the deferred in-frame value layout
+  ([jit-value-realization](jit-value-realization.md)), neither of which changes the model.
+
+## Correction to an architecture document
+
+`lir.md` states the place vocabulary as "a base local plus a projection chain (member, index,
+dereference, slice, downcast)" and, in its invariant on logical storage topology, as "member, index,
+and dereference steps". Neither matches the implementation, which has member and dereference only,
+nor the model, under which a value interior is not an addressable sub-place. An array of storage --
+owned children, for instance -- is reached as a member yielding a vector, an element yielding an
+owning pointer, and a dereference of that pointer, so the place-ness comes from the indirection and
+no index arm is required. The document is corrected to member and dereference as part of this work.

--- a/docs/decisions/value-projection-write.md
+++ b/docs/decisions/value-projection-write.md
@@ -1,0 +1,169 @@
+# A value-aggregate interior write is an owner-relative value projection, not a place store
+
+## Date
+
+2026-07-23
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+A write to the interior of a value aggregate -- a struct component, a container element, a packed
+slice, a union member, a string character -- reaches MIR as an assignment whose target is an lvalue
+expression: a write-through reference the write composes onto. That is the reference / location
+model. The functional whole-value-update model the layer contracts describe (`mir.md`, `lir.md`)
+does not live in MIR; it lives one layer below, synthesized during MIR-to-LIR by the execution
+backend, and only for one container type.
+
+The consequence is that one MIR node is consumed two different ways. The C++ backend renders an
+in-place lvalue mutation; the execution backend rewrites the target back into a read-whole /
+functional-update / write-whole sequence, because its value realization forbids an in-place interior
+write. That divergence is not a backend detail -- it is the shape `mir.md`'s Forbidden Shapes name:
+a semantic fact two backends infer differently belongs in MIR, not in each backend's re-derivation.
+
+This entry pins two things: what MIR states about an interior write, and how each backend realizes
+that statement.
+
+## Findings that shaped the decision
+
+- **The asymmetry is forced by value realization, not an implementation gap.**
+  `jit-value-realization.md` invariant 6: a runtime value handle is immutable from the generated
+  side, so every apparent mutation is functional -- a new whole value stored back through the owner.
+  The execution backend, holding only handles, cannot write an interior in place. The C++ backend,
+  which owns real storage, can. Both realize the same value semantics.
+- **The place-vs-projection fact is currently re-derived, and differently, by each backend.** The
+  execution backend inspects the target expression's kind and walks it back to an owner to classify
+  the write; the C++ backend treats it as an lvalue it may mutate. `mir.md`'s Forbidden Shapes: a
+  fact two backends could infer differently is not yet in MIR and belongs there.
+- **The layer below MIR already states the distinction.** `lir.md` separates a value-functional
+  aggregate selector (extract / update, no addressable interior) from an addressable place
+  projection (whose vocabulary is dereference and member -- it has no index or slice arm). MIR is
+  the one layer still carrying the interior write as a reference.
+- **The C++ in-place path is already proxy-driven and carries the LRM corner cases.** A dynamic
+  array's element reference routes an out-of-range write to a discard target (LRM 7.4.5); a slice
+  reference resolves its window; a string character reference writes through `putc` with its
+  out-of-range / NUL rules (LRM 6.16.2); a union member reference activates the member first. The
+  in-place write is already an optimization over a semantically complete proxy, not a naive store.
+- **The below-MIR functional machinery is the abstraction gap made concrete.** A functional
+  element-write primitive exists solely for the execution backend's rewrite and the C++ backend
+  rejects it outright, and a single-container-type gate limits which interior writes take the
+  functional path at all. Both are symptoms of the model living below MIR rather than in it.
+
+## The decision
+
+**D1. MIR states a write designator that distinguishes a place from a value projection.** A place is
+independently addressable storage -- a whole variable, an object member, a dereferenced referent --
+and its write is a store. A value projection is a selected part of a value aggregate -- a struct
+component, a container element, a packed slice, a union member, a string character -- and its write
+is a functional whole-value update. The boundary between the two -- the longest place prefix of the
+target, with the value-aggregate descent as its suffix -- is stated as structure: the owner is a
+place expression, and the value-projection suffix is a selector chain of ordinary sub-expressions. A
+backend reads the boundary from the structure; it does not walk a nested lvalue expression to
+recover it.
+
+**D2. A value-projection write is a functional whole-value update stored back through the owner.**
+Read the owner's whole value; produce a new whole value equal to the old one with the selected part
+replaced along the selector chain; store that whole value back through the owner -- its place, its
+activation cell, or its observable cell. The owner and each selector evaluate exactly once; this is
+a stated MIR semantic. The materialization of that single evaluation into temporaries, and the read
+/ update / store instruction sequence, belong to MIR-to-LIR (`lowering_boundaries.md`: HIR-to-MIR
+introduces no storage placement; MIR-to-LIR introduces CFG and storage). MIR states the semantic; it
+does not create cells.
+
+**D3. The C++ in-place write is a behavior-preserving optimization, not a guarantee of an
+addressable interior.** A backend may realize a value-projection write as an in-place mutation only
+when its value library provides a write proxy semantically equivalent to the functional update --
+carrying the out-of-range and x / z index behavior, slice window normalization, the per-container
+and string special rules, the single evaluation of owner and selectors, and a single final writeback
+into an observable owner. Absent such a proxy, the realization is the functional form. This is North
+Star invariant 3: correctness is independent of optimization, and an in-place recovery is admitted
+only when behavior-preserving. MIR never asserts that a value interior is addressable.
+
+**D4. A `ref` bound to an unpacked interior is an owner-relative projection reference.** It is an
+owner reference or capability plus selector state, realized functionally: a read is read-owner then
+select; a write is read-owner, update the selected part, write-owner. It is never an in-place
+pointer into a value's interior, and never a LIR indexed place projection -- a value interior is not
+machine-addressable, which is why LIR's place vocabulary has no index or slice arm. SystemVerilog
+bounds this to unpacked interiors; a packed slice or bit-select is not a legal `ref` actual.
+
+**D5. This splits two write domains; it does not reverse the read-side or evaluate-once conclusions
+of the prior decisions.** Genuine places keep the store model. What is retired is the requirement
+that every write target be an op=-able address or location. A slice read still materializes an owned
+value; compound assignment still evaluates its left-hand side once. Only the write side of a value
+interior moves from "a location realized by a reference" to "a projection through its owner."
+
+## Rejected alternatives
+
+- **Classify the target but leave the owner and selectors for each backend to re-derive.** MIR would
+  mark a target as a place or a projection but keep it as one nested lvalue expression, and each
+  backend would walk that expression to find the owner boundary. Rejected: the boundary is then
+  re-derived, and two backends can walk it to different results -- the exact Forbidden Shape in
+  `mir.md`. The boundary must be structural.
+- **State the owner and index by materializing temporaries in MIR.** Rejected: temporaries and
+  storage placement are MIR-to-LIR's, not HIR-to-MIR's (`lowering_boundaries.md`). MIR states
+  evaluate-once as a semantic; a lowering that creates cells at the MIR boundary is doing the next
+  layer's work.
+- **Re-encode the owner and selectors as node fields that restate the target expression's
+  structure.** Rejected: `mir.md` forbids a field that duplicates what the surrounding structure
+  already fixes. Owner and selectors remain structural children; only the owner boundary -- which
+  the nested expression forces each backend to re-derive -- is stated.
+- **Keep a backend-specific functional-write primitive as a MIR concept.** Rejected:
+  `backend_contract.md` invariant 6 forbids a MIR primitive specialized for one backend. Under the
+  designator the functional update is a stated MIR fact both backends realize; the runtime call that
+  builds a new whole value is a realization of that fact below MIR, not a MIR concept one backend
+  rejects.
+- **Realize `ref`-to-interior as an in-place interior pointer or a LIR indexed place.** Rejected: an
+  in-place interior reference would alias a value's part across copies, and value semantics forbid
+  observing a sub-write through a copy. The reference is owner-relative and functional.
+
+## Consequences
+
+- Every value-aggregate interior write -- struct component, dynamic array, queue, associative array,
+  packed slice, union member, string character -- routes through one functional path on the
+  execution backend; the single-container-type gate and the per-family target switch are removed.
+- A `ref`, `output`, or `inout` bound to an unpacked interior becomes expressible on the execution
+  backend.
+- The queue and associative-array value domains may land their representation and read operations
+  independently, but their interior writes connect to the common designator path, never a new
+  per-type gate.
+- The whole-value store back through the owner is a semantic store (`value-store-discipline.md`),
+  and for an observable owner it is the observable cell's write (`value-type-concepts.md`): one
+  final writeback that fires subscribers once, whatever the selector chain's depth.
+
+## Migration shape
+
+The change reverses two accepted decisions for value interiors and is cross-cutting, so it lands in
+reviewed cuts rather than one change. The staged shape:
+
+1. A canonical target decomposition -- a target is a genuine place, or an owner place plus a
+   selector chain -- including the owner-boundary rule. This is a migration adapter over the current
+   nested-lvalue encoding, not the permanent design.
+2. All value-interior families route through one functional-update lowering on the execution
+   backend; the single-container-type gate and the backend-only branching are removed.
+3. A `ref` / `const ref` bound to an interior becomes a projection reference.
+4. The C++ backend gains value-library functional-update APIs with in-place recovery gated on proxy
+   semantic-equivalence (D3); its render becomes a fixed function of the designator.
+5. The canonical decomposition is promoted into the formal MIR write-designator node, and the old
+   nested-lvalue write encoding is deleted.
+
+The permanent design is the formal node of step 5. Step 1 exists to prove the selector vocabulary is
+complete and to unblock the container families early; it is a labeled adapter, not the endpoint. The
+danger it guards against is a container family adding another per-type branch, which would freeze
+the reference model this decision removes.
+
+## Relation to existing decisions
+
+- `slice-value-semantics.md` -- a slice read still materializes an owned value; only the write side
+  of a value interior is reframed, from an independently addressable reference to an owner-relative
+  designator.
+- `compound-assignment-write-location.md` -- the evaluate-once goal stands and is stated by D2 as
+  the single evaluation of owner and selectors; the mechanism that required every target to be an
+  op=-able location is retired for value interiors. Genuine places keep the store model.
+- `jit-value-realization.md` -- invariant 6, that a handle is immutable and every apparent mutation
+  is functional, is the driver for D2 and D3.
+- `value-store-discipline.md` -- the whole-value writeback in D2 is a semantic store that preserves
+  the owner's declared type.
+- `value-type-concepts.md` -- a projection write into an observable owner reaches the cell through
+  the cell's own write, so it fires subscribers through the same single writeback.

--- a/docs/progress/execution-backend.md
+++ b/docs/progress/execution-backend.md
@@ -9,6 +9,35 @@ coverage. The roll-up entry is the "Execution backend" item in `architecture-res
 Contracts: `../architecture/backend_contract.md`, `../architecture/lir.md`,
 `../architecture/runtime_distribution.md`, `../architecture/object_lifetime.md`.
 
+## Divergences from the C++ backend
+
+Source both backends accept, where the execution backend gives a different answer. These are a
+distinct class from the gaps below: a gap refuses to lower and announces itself the moment it is
+reached, while a divergence returns an answer that is simply wrong. In each one the semantic is
+stated in full upstream and the C++ backend honors it, so the shared MIR is not what needs to change
+-- only this backend's realization of it. The coverage item under "Other backend surfaces" is why
+they stay invisible: each was found by hand rather than by a suite.
+
+- [ ] **A four-state or wide integral literal loses its value.** A literal's unknown bits (`x` /
+      `z`) do not survive into generated code, so an `x`-bearing constant compares and prints as a
+      known value; a literal wider than one machine word keeps only its low word and reads as a
+      different number. Both backends are handed the literal's complete value, and the C++ backend
+      materializes whichever construction that value calls for.
+
+- [ ] **A task that suspends is abandoned by its enabler.** Enabling a task that contains a timing
+      control runs it up to its first suspension and never resumes it: the enabler continues
+      immediately and every statement past the suspension is skipped, with no diagnostic. Control
+      returning to the enabler only after the task completes (LRM 13.3) holds on the C++ backend.
+      The suspension protocol is stated once for every awaitable; only the awaitables that register
+      their own wakeup are realized here, not one whose completion is another body's to signal. A
+      value-carrying suspension is separately rejected outright, so the silent case is the void one.
+
+- [ ] **A net cannot be driven.** A continuous assignment to a net fails to lower: the write
+      capability a driver hands generated code is treated as storage rather than as the first-class
+      handle the net model (`../decisions/net-driver-resolution.md`) defines it to be, so installing
+      a driver is rejected. Nets resolve end to end on the C++ backend, so every net-bearing design
+      parts ways here.
+
 ## Runtime-value lifetime
 
 A runtime value crosses the execution boundary as an opaque handle into runtime-owned storage

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -927,6 +927,29 @@ enough to warrant its own focused review.
     that pays off only when several sites route through it; scope the cut so at least the queue /
     packed / managed-new forms land together with the dispatch table itself.
 
+- [ ] R61 -- A value-aggregate interior write is modeled in MIR as a write onto an lvalue expression
+      -- the reference / location model -- while the functional whole-value-update model the layer
+      contracts describe (`../architecture/mir.md`, `../architecture/lir.md`) lives one layer below,
+      synthesized during MIR-to-LIR by the execution backend and gated to a single container type.
+      One MIR node is therefore consumed two ways -- the C++ backend mutates in place, the execution
+      backend rewrites into read-whole / functional-update / write-whole -- and the
+      place-vs-value-projection fact is re-derived per backend, the shape `../architecture/mir.md`'s
+      Forbidden Shapes name. The visible consequence: an interior write to a union member, a packed
+      slice, a string character, or a queue / associative-array element, and every `ref` bound to an
+      aggregate interior, is rejected on the execution backend today; only a struct component and
+      the one gated container write take the functional path. **Target shape**: MIR states a
+      place-vs-value-projection write designator -- an interior write is an owner-relative value
+      projection, a functional whole-value update stored back through the owner with owner and
+      selectors evaluated once; a `ref` to an interior is an owner-relative projection reference;
+      the C++ in-place write becomes a behavior-preserving optimization over a semantically
+      equivalent proxy. Every value-interior family routes through one functional path; the
+      single-container gate and the per-family target branch are removed. The full model, the
+      rejected alternatives, and the staged migration are recorded in
+      `../decisions/value-projection-write.md`. **Blocker**: none unlanded, but it reverses two
+      accepted decisions for value interiors and is cross-cutting across HIR-to-MIR, both backends,
+      and the value library -- large enough to warrant its own focused review, and it lands in the
+      staged cuts the decision records rather than folded into a container-feature cut.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -927,28 +927,26 @@ enough to warrant its own focused review.
     that pays off only when several sites route through it; scope the cut so at least the queue /
     packed / managed-new forms land together with the dispatch table itself.
 
-- [ ] R61 -- A value-aggregate interior write is modeled in MIR as a write onto an lvalue expression
-      -- the reference / location model -- while the functional whole-value-update model the layer
-      contracts describe (`../architecture/mir.md`, `../architecture/lir.md`) lives one layer below,
-      synthesized during MIR-to-LIR by the execution backend and gated to a single container type.
-      One MIR node is therefore consumed two ways -- the C++ backend mutates in place, the execution
-      backend rewrites into read-whole / functional-update / write-whole -- and the
-      place-vs-value-projection fact is re-derived per backend, the shape `../architecture/mir.md`'s
-      Forbidden Shapes name. The visible consequence: an interior write to a union member, a packed
-      slice, a string character, or a queue / associative-array element, and every `ref` bound to an
-      aggregate interior, is rejected on the execution backend today; only a struct component and
-      the one gated container write take the functional path. **Target shape**: MIR states a
-      place-vs-value-projection write designator -- an interior write is an owner-relative value
-      projection, a functional whole-value update stored back through the owner with owner and
-      selectors evaluated once; a `ref` to an interior is an owner-relative projection reference;
-      the C++ in-place write becomes a behavior-preserving optimization over a semantically
-      equivalent proxy. Every value-interior family routes through one functional path; the
-      single-container gate and the per-family target branch are removed. The full model, the
-      rejected alternatives, and the staged migration are recorded in
-      `../decisions/value-projection-write.md`. **Blocker**: none unlanded, but it reverses two
-      accepted decisions for value interiors and is cross-cutting across HIR-to-MIR, both backends,
-      and the value library -- large enough to warrant its own focused review, and it lands in the
-      staged cuts the decision records rather than folded into a container-feature cut.
+- [x] R61 -- A value-aggregate interior write reached MIR as a write onto a nested lvalue
+      expression, and each backend recovered the owner and the selectors by walking that expression
+      and consulting each receiver's type. Two backends deriving one semantic fact is the shape
+      `../architecture/mir.md`'s Forbidden Shapes name, and it made every new container family
+      arrive as another per-type branch. MIR now states the write target as a designator -- the
+      place that owns the whole value, and the descent that reaches the part -- with a closed
+      selector set covering a product component, a union member, an element, and a window. Each
+      backend is a fixed function of that node: the C++ backend composes the value library's write
+      proxies in place, the execution backend folds one functional whole-value update. The nested
+      write encoding, the write-side access entries, the target decomposition, and its per-type
+      predicate are gone. Every interior write -- struct component, union member, packed slice,
+      packed or unpacked element, string character -- and every increment through one now takes the
+      same path on both backends. The full model and the questions it settles are recorded in
+      `../decisions/value-projection-write.md` and `../decisions/value-projection-designator.md`.
+  - [ ] A `ref` / `output` / `inout` actual bound to an interior, and a nonblocking assignment into
+        one, are the designator's evaluated form -- a projection reference. It is rejected on the
+        execution backend today. Landing it needs that reference to exist as a runtime value on both
+        backends, able to cross a suspension.
+  - [ ] The queue and associative-array interior writes connect to the same path once those value
+        domains are realized on the execution backend.
 
 ## Out of Scope
 

--- a/include/lyra/backend/llvm/runtime_abi.hpp
+++ b/include/lyra/backend/llvm/runtime_abi.hpp
@@ -174,6 +174,14 @@ class RuntimeAbi {
   // when the product is shared.
   auto TupleMake() -> llvm::FunctionCallee;
   auto TupleExtract() -> llvm::FunctionCallee;
+  auto ElementExtract(ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+      -> llvm::FunctionCallee;
+  auto SliceExtract(ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+      -> llvm::FunctionCallee;
+  auto ElementUpdate(ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+      -> llvm::FunctionCallee;
+  auto SliceUpdate(ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+      -> llvm::FunctionCallee;
   auto TupleUpdate() -> llvm::FunctionCallee;
 
   // The dynamic-array constructors (LRM 7.5.1 / 10.9.1): the empty array, the

--- a/include/lyra/lir/function.hpp
+++ b/include/lyra/lir/function.hpp
@@ -156,17 +156,35 @@ struct AggregateInstr {
 };
 
 // Names a subvalue within an aggregate value. A `TupleElement` selects a
-// product component by its declaration-order position -- the static, structural
-// selector an unpacked struct uses. Other aggregate families (a packed slice, a
-// union member) add their own selectors here; a dynamic, runtime-indexed access
-// (a dynamic array or queue element) is a runtime-library call, not one of
-// these, because its bounds and index are runtime values, not a static
-// projection.
+// product component by its declaration-order position, carrying no operands
+// because the position is the whole coordinate. A `UnionMember` selects a
+// union's member by the same kind of position but is a distinct selector: a
+// union holds one member at a time, so an update makes the selected member the
+// live one rather than replacing one of several that coexist.
 struct TupleElement {
   std::uint32_t index;
 };
 
-using AggregateSelector = std::variant<TupleElement>;
+struct UnionMember {
+  std::uint32_t index;
+};
+
+// One coordinate into a homogeneous or keyed value, and one fixed-width range
+// of a value. `operands` carries the source coordinates followed by whatever
+// the value's family takes from its static type rather than from the value -- a
+// declared range, a declared result shape. Which runtime entry realizes a step
+// follows from the aggregate's type, below this layer; the selector says only
+// which subvalue is named.
+struct ContainerElement {
+  std::vector<Operand> operands;
+};
+
+struct ContainerSlice {
+  std::vector<Operand> operands;
+};
+
+using AggregateSelector =
+    std::variant<TupleElement, UnionMember, ContainerElement, ContainerSlice>;
 
 // Extracts a subvalue of an aggregate value, named by `selector`. The aggregate
 // is a value, reached by value: the subvalue is copied out, not aliased. This

--- a/include/lyra/lir/type_query.hpp
+++ b/include/lyra/lir/type_query.hpp
@@ -27,6 +27,14 @@ auto Pointee(const TypeArena& types, TypeId type) -> std::optional<TypeId>;
 // address-only, never the value itself.
 auto IsAddressOnly(const TypeArena& types, TypeId type) -> bool;
 
+// The packed shape an integral type's value is structured by: a packed array is
+// its own shape, an enumeration is represented by its base's. Every consumer
+// that must know how an integral value's bits are grouped asks this, so the
+// answer is given once rather than re-derived wherever it is needed. A type
+// that is not integral has no such shape and is a caller error, never a width
+// guess.
+auto PackedShape(const TypeArena& types, TypeId type) -> const PackedArrayType&;
+
 // Whether a callable's result type states the coroutine call protocol: the body
 // may hand control back to the scheduler and completes as a coroutine, rather
 // than running to a value in one call. The protocol is the type -- nothing else

--- a/include/lyra/lowering/hir_to_mir/cast_lowering.hpp
+++ b/include/lyra/lowering/hir_to_mir/cast_lowering.hpp
@@ -4,6 +4,7 @@
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -25,6 +26,17 @@ namespace lyra::lowering::hir_to_mir {
 [[nodiscard]] auto BuildValueConversion(
     const mir::CompilationUnit& unit, mir::Block& block, mir::ExprId operand_id,
     mir::TypeId dst_type) -> mir::Expr;
+
+// The declared representation a packed value-layer call lands its result into,
+// carried as an ordinary MIR value of that type -- a default literal -- so the
+// representation reaches the runtime through the argument list, not composed by
+// the backend from type payload. Its contents are ignored; only its type's
+// declared shape matters. A select uses it to state the shape its result takes,
+// which a receiver whose own dimensions differ (an aggregate's flat base) can
+// never supply.
+[[nodiscard]] auto BuildPackedShapePrototype(
+    mir::Block& block, const mir::PackedArrayType& dst_pa, mir::TypeId dst_type)
+    -> mir::ExprId;
 
 // Returns `operand_id` already at `dst_type`: the operand unchanged when its
 // type already matches, otherwise the converted expression interned into

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -68,13 +68,6 @@ struct WalkFrame {
   // callable; replaced at a callable boundary.
   CallableBindings* bindings = nullptr;
 
-  // True while lowering an assignment's left-hand side. A queue
-  // element-select dispatches to its write-side callee (LRM 7.10.1
-  // append-aware) under this flag; the index and other rvalue
-  // sub-expressions clear it. Read only by the queue element-select
-  // lowering -- the other selector forms have explicit LHS entry points.
-  bool is_lvalue_target = false;
-
   // Pushes `cls` as the current class and links the previous `current_class`
   // into the outer chain through `chain_node`, which the caller stack-allocates
   // so its lifetime spans the descent.
@@ -145,12 +138,6 @@ struct WalkFrame {
       -> WalkFrame {
     WalkFrame next = *this;
     next.bindings = callable_bindings;
-    return next;
-  }
-
-  [[nodiscard]] auto WithLvalueTarget(bool is_target) const -> WalkFrame {
-    WalkFrame next = *this;
-    next.is_lvalue_target = is_target;
     return next;
   }
 };

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -107,7 +107,7 @@ class FunctionLowerer {
   // exactly once, and the store back through the owner is a single one -- for
   // an observable owner, one cell write whatever the path's depth.
   auto LowerProjectionUpdate(
-      const mir::Block& block, const mir::ValueProjectionExpr& projection,
+      const mir::Block& block, mir::ExprId target,
       const LeafTransform& make_leaf) -> diag::Result<lir::Operand>;
   // A write through a designated part of an owner's value (`s.f = x`,
   // `arr[i] = x`, `a[i].f = x`). The owner's whole value is read, the path is
@@ -117,8 +117,8 @@ class FunctionLowerer {
   // hold and, when the owner is an observable cell, the whole-cell update
   // fires once whatever the path's depth.
   auto LowerProjectionAssign(
-      const mir::Block& block, const mir::AssignExpr& assign,
-      const mir::ValueProjectionExpr& projection) -> diag::Result<lir::Operand>;
+      const mir::Block& block, const mir::AssignExpr& assign)
+      -> diag::Result<lir::Operand>;
   // A receiver-mutating value-container method (`arr.delete()`). The container
   // value cannot be mutated in place through a shared handle, so the method is
   // a functional operation whose result is stored back through the receiver's

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -61,11 +61,11 @@ class FunctionLowerer {
       std::variant<PlaceBinding, ValueBinding, ActivationValueBinding>;
 
   // A value-projection selector peeled from an assignment target: a product
-  // component by declaration-order position, or a value-container element by a
-  // runtime index. Each names a sub-value of the owner's whole value, so a
-  // write through it folds into a functional whole-value update.
-  // `container_type` is the value the selector projects into; `projected_type`
-  // is the sub-value it reaches.
+  // component by declaration-order position, a value-container element by a
+  // runtime index, or a part-select range by its bounds. Each names a sub-value
+  // of the owner's whole value, so a write through it folds into a functional
+  // whole-value update. `container_type` is the value the selector projects
+  // into; `projected_type` is the sub-value it reaches.
   struct ComponentSelector {
     std::uint32_t index;
     lir::TypeId container_type;
@@ -76,7 +76,15 @@ class FunctionLowerer {
     lir::TypeId container_type;
     lir::TypeId projected_type;
   };
-  using ProjectionSelector = std::variant<ComponentSelector, ElementSelector>;
+  struct SliceSelector {
+    mir::ExprId a;
+    mir::ExprId b;
+    mir::ExprId form;
+    lir::TypeId container_type;
+    lir::TypeId projected_type;
+  };
+  using ProjectionSelector =
+      std::variant<ComponentSelector, ElementSelector, SliceSelector>;
   // An assignment target split into the whole-value owner it writes back
   // through and the value-projection selectors reaching the written sub-value,
   // in owner-to-leaf order. An empty selector list means the target is the

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -80,6 +80,7 @@ class FunctionLowerer {
     mir::ExprId a;
     mir::ExprId b;
     mir::ExprId form;
+    mir::ExprId shape;
     lir::TypeId container_type;
     lir::TypeId projected_type;
   };

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <variant>
@@ -60,41 +60,6 @@ class FunctionLowerer {
   using LocalBinding =
       std::variant<PlaceBinding, ValueBinding, ActivationValueBinding>;
 
-  // A value-projection selector peeled from an assignment target: a product
-  // component by declaration-order position, a value-container element by a
-  // runtime index, or a part-select range by its bounds. Each names a sub-value
-  // of the owner's whole value, so a write through it folds into a functional
-  // whole-value update. `container_type` is the value the selector projects
-  // into; `projected_type` is the sub-value it reaches.
-  struct ComponentSelector {
-    std::uint32_t index;
-    lir::TypeId container_type;
-    lir::TypeId projected_type;
-  };
-  struct ElementSelector {
-    mir::ExprId index;
-    lir::TypeId container_type;
-    lir::TypeId projected_type;
-  };
-  struct SliceSelector {
-    mir::ExprId a;
-    mir::ExprId b;
-    mir::ExprId form;
-    mir::ExprId shape;
-    lir::TypeId container_type;
-    lir::TypeId projected_type;
-  };
-  using ProjectionSelector =
-      std::variant<ComponentSelector, ElementSelector, SliceSelector>;
-  // An assignment target split into the whole-value owner it writes back
-  // through and the value-projection selectors reaching the written sub-value,
-  // in owner-to-leaf order. An empty selector list means the target is the
-  // owner itself -- a plain place.
-  struct DecomposedTarget {
-    mir::ExprId owner;
-    std::vector<ProjectionSelector> selectors;
-  };
-
   auto LowerBlockInto(const mir::Block& block) -> diag::Result<void>;
   auto LowerStmtInto(const mir::Block& block, const mir::Stmt& stmt)
       -> diag::Result<void>;
@@ -129,25 +94,31 @@ class FunctionLowerer {
       -> diag::Result<lir::Operand>;
   auto LowerAssign(const mir::Block& block, const mir::AssignExpr& assign)
       -> diag::Result<lir::Operand>;
-  // Splits an assignment target into its whole-value owner and the value-
-  // projection selectors reaching the written sub-value. A product component
-  // (`.f`) and a value-container element (`[i]`) are selectors; the owner is
-  // the first expression that is not one -- a place, an activation handle, or
-  // an observable cell. Selectors compose freely, so a mixed static/dynamic
-  // target
-  // (`a[i].f`, `s.v[i]`) decomposes uniformly.
-  auto DecomposeTarget(const mir::Block& block, mir::ExprId target)
-      -> DecomposedTarget;
-  // A write through one or more value-projection selectors (`s.f = x`,
-  // `arr[i] = x`, `a[i].f = x`). The owner's whole value is read, the selectors
-  // are folded into a functional whole-value update -- a product component a
-  // static value instruction, a container element a runtime-library call -- and
-  // the rebuilt whole value is stored back through the owner, so value
-  // semantics hold and, when the owner is an observable cell, the whole-cell
-  // update fires.
+  // Extracts the designated part's current value; called at most once, and only
+  // by a leaf transform that needs the old value.
+  using LeafReader = std::function<lir::Operand()>;
+  // Produces the designated part's new value, given a reader for its current
+  // one and the part's type.
+  using LeafTransform =
+      std::function<diag::Result<lir::Operand>(const LeafReader&, lir::TypeId)>;
+  // The shared realization of every write through a designator: read the
+  // owner's whole value, descend the path, transform the part, rebuild the
+  // whole value outward, store it back. The owner and every coordinate evaluate
+  // exactly once, and the store back through the owner is a single one -- for
+  // an observable owner, one cell write whatever the path's depth.
+  auto LowerProjectionUpdate(
+      const mir::Block& block, const mir::ValueProjectionExpr& projection,
+      const LeafTransform& make_leaf) -> diag::Result<lir::Operand>;
+  // A write through a designated part of an owner's value (`s.f = x`,
+  // `arr[i] = x`, `a[i].f = x`). The owner's whole value is read, the path is
+  // folded into a functional whole-value update -- a product component a static
+  // value instruction, a container element a runtime-library call -- and the
+  // rebuilt whole value is stored back through the owner, so value semantics
+  // hold and, when the owner is an observable cell, the whole-cell update
+  // fires once whatever the path's depth.
   auto LowerProjectionAssign(
       const mir::Block& block, const mir::AssignExpr& assign,
-      const DecomposedTarget& target) -> diag::Result<lir::Operand>;
+      const mir::ValueProjectionExpr& projection) -> diag::Result<lir::Operand>;
   // A receiver-mutating value-container method (`arr.delete()`). The container
   // value cannot be mutated in place through a shared handle, so the method is
   // a functional operation whose result is stored back through the receiver's

--- a/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
+++ b/include/lyra/lowering/mir_to_lir/function_lowerer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <variant>
@@ -59,6 +60,32 @@ class FunctionLowerer {
   using LocalBinding =
       std::variant<PlaceBinding, ValueBinding, ActivationValueBinding>;
 
+  // A value-projection selector peeled from an assignment target: a product
+  // component by declaration-order position, or a value-container element by a
+  // runtime index. Each names a sub-value of the owner's whole value, so a
+  // write through it folds into a functional whole-value update.
+  // `container_type` is the value the selector projects into; `projected_type`
+  // is the sub-value it reaches.
+  struct ComponentSelector {
+    std::uint32_t index;
+    lir::TypeId container_type;
+    lir::TypeId projected_type;
+  };
+  struct ElementSelector {
+    mir::ExprId index;
+    lir::TypeId container_type;
+    lir::TypeId projected_type;
+  };
+  using ProjectionSelector = std::variant<ComponentSelector, ElementSelector>;
+  // An assignment target split into the whole-value owner it writes back
+  // through and the value-projection selectors reaching the written sub-value,
+  // in owner-to-leaf order. An empty selector list means the target is the
+  // owner itself -- a plain place.
+  struct DecomposedTarget {
+    mir::ExprId owner;
+    std::vector<ProjectionSelector> selectors;
+  };
+
   auto LowerBlockInto(const mir::Block& block) -> diag::Result<void>;
   auto LowerStmtInto(const mir::Block& block, const mir::Stmt& stmt)
       -> diag::Result<void>;
@@ -93,23 +120,25 @@ class FunctionLowerer {
       -> diag::Result<lir::Operand>;
   auto LowerAssign(const mir::Block& block, const mir::AssignExpr& assign)
       -> diag::Result<lir::Operand>;
-  // A write to one component of a product value (`s.f = x`). The chain of
-  // component projections is rebuilt bottom-up as pure functional-update values
-  // over the product's current whole value, then the rebuilt whole value is
-  // stored back through the product's storage owner -- so value semantics hold
-  // and, when the owner is an observable cell, the whole-cell update fires.
-  auto LowerComponentAssign(
-      const mir::Block& block, const mir::AssignExpr& assign)
-      -> diag::Result<lir::Operand>;
-  // A write to one element of a value container (`arr[i] = x`). The container
-  // is a value reached by an opaque handle, so the element write is a
-  // functional whole-value update: read the whole container, produce a new one
-  // with the element replaced, store it back through the container's owner --
-  // the runtime-library counterpart of `LowerComponentAssign`'s static value
-  // instructions, for a dynamic, runtime-indexed selector.
-  auto LowerElementAssign(
-      const mir::Block& block, const mir::AssignExpr& assign)
-      -> diag::Result<lir::Operand>;
+  // Splits an assignment target into its whole-value owner and the value-
+  // projection selectors reaching the written sub-value. A product component
+  // (`.f`) and a value-container element (`[i]`) are selectors; the owner is
+  // the first expression that is not one -- a place, an activation handle, or
+  // an observable cell. Selectors compose freely, so a mixed static/dynamic
+  // target
+  // (`a[i].f`, `s.v[i]`) decomposes uniformly.
+  auto DecomposeTarget(const mir::Block& block, mir::ExprId target)
+      -> DecomposedTarget;
+  // A write through one or more value-projection selectors (`s.f = x`,
+  // `arr[i] = x`, `a[i].f = x`). The owner's whole value is read, the selectors
+  // are folded into a functional whole-value update -- a product component a
+  // static value instruction, a container element a runtime-library call -- and
+  // the rebuilt whole value is stored back through the owner, so value
+  // semantics hold and, when the owner is an observable cell, the whole-cell
+  // update fires.
+  auto LowerProjectionAssign(
+      const mir::Block& block, const mir::AssignExpr& assign,
+      const DecomposedTarget& target) -> diag::Result<lir::Operand>;
   // A receiver-mutating value-container method (`arr.delete()`). The container
   // value cannot be mutated in place through a shared handle, so the method is
   // a functional operation whose result is stored back through the receiver's

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -91,23 +92,20 @@ struct ConditionalExpr {
 // `compound_op.has_value()` marks the assignment as `target op= value`;
 // `nullopt` is a simple write. `value` is already typed to match `target`.
 //
-// `target` is an ExprId pointing at one of: a PrimaryExpr var reference,
-// an addressable selector chain (per `mir::IsContainerAccessCall`), or a
-// queue write-side access call that returns the element reference. The
-// ConcatExpr-as-target form (LRM 11.4.12 destructuring LHS) is desugared
-// upstream into a snapshot + per-part assignment sequence, so render does
-// not encounter it.
+// `target` is either a place, whose write is a store, or a
+// `ValueProjectionExpr`, whose write is a functional whole-value update through
+// the designated part's owner. The ConcatExpr-as-target form (LRM 11.4.12
+// destructuring LHS) is desugared upstream into a snapshot + per-part
+// assignment sequence, so render does not encounter it.
 struct AssignExpr {
   ExprId target;
   std::optional<BinaryOp> compound_op = std::nullopt;
   ExprId value;
 };
 
-// LRM 11.4.2: `++a`, `a++`, `--a`, `a--`. Mirrors hir::IncDecExpr. The
-// `target` ExprId points at an addressable expression (a PrimaryExpr var
-// reference or an addressable container-access chain per
-// `mir::IsContainerAccessCallee`); ConcatExpr-as-target is illegal per
-// slang.
+// LRM 11.4.2: `++a`, `a++`, `--a`, `a--`. Mirrors hir::IncDecExpr. `target`
+// takes the same two forms an assignment target does, a place or a designated
+// part; ConcatExpr-as-target is illegal per slang.
 struct IncDecExpr {
   IncDecOp op;
   ExprId target;
@@ -493,24 +491,10 @@ struct UnionExpr {
 // union member access and the active-member analogue of `TupleGetExpr` (both
 // `std::get<I>`-style positional access). `Expr::type` is the component's type.
 // Reading an inactive member is undefined in SV (LRM 7.3) and the backend
-// returns that member's default. The write side is `UnionGetRefExpr`; the read
-// and write are separate access forms because a union member's read realization
-// (a value) differs from its write realization (a reference that activates the
-// member), exactly as a packed array element splits into element-value and
-// element-reference forms.
+// returns that member's default. A write is not this node's dual: writing a
+// member is a descent step on the target's designator, which makes the member
+// active as part of the whole-value update.
 struct UnionGetExpr {
-  ExprId union_value;
-  std::size_t index;
-};
-
-// The writable location of union member `index` (`u.f` as an assignment
-// target), the write side and by-reference counterpart of `UnionGetExpr`.
-// `Expr::type` is the component's type. As an `AssignExpr` target it carries
-// `u.f = v`, `u.f op= v`, and a nested `u.f.g = v` uniformly with every other
-// lvalue; the backend renders it as a reference to the active member (making
-// the member active first if needed), so further member or element projection
-// composes on it as on a struct member.
-struct UnionGetRefExpr {
   ExprId union_value;
   std::size_t index;
 };
@@ -540,11 +524,11 @@ struct TaggedGetExpr {
 };
 
 // The writable location of tagged-union component `tag_index` (`u.Member` as an
-// assignment target), the write side of tagged-union member access and the
-// tagged analogue of `UnionGetRefExpr`. Unlike its untagged counterpart, which
-// activates the member on write, this is a run-time error when `tag_index` is
-// not the current tag (LRM 11.9): re-tagging goes through a whole-value
-// `TaggedExpr` construction, not a member write.
+// assignment target), the write side of tagged-union member access. Writing an
+// untagged union's member makes that member active; a tagged union's does not
+// -- a write whose `tag_index` is not the current tag is a run-time error (LRM
+// 11.9), and re-tagging goes through a whole-value `TaggedExpr` construction
+// rather than a member write.
 struct TaggedGetRefExpr {
   ExprId union_value;
   std::size_t tag_index;
@@ -615,6 +599,66 @@ struct ExternalStaticPropertyRef {
   std::string property_name;
 };
 
+// One descent step into a value, naming a part of it. A step is positional (a
+// product component, a union member) or coordinate-bearing (an element, a
+// window). A coordinate-bearing step's operands are the source-level
+// coordinates followed by the operands the value's family takes from its static
+// type rather than from the value -- the declared range for the unpacked
+// family, the declared result shape for a packed window. No operand is ever a
+// rebased position: the coordinate system belongs to the value being selected.
+// Each step states the type of the part it reaches, so a consumer descending
+// the path knows every intermediate value's type without reimplementing the
+// projection rules. The value a step descends into is the previous step's part,
+// or the owner's value at the first step.
+struct ComponentSelector {
+  std::size_t index;
+  TypeId projected_type;
+};
+
+// Selecting a union member makes it the active one; the update carries that
+// activation (LRM 7.3).
+struct UnionMemberSelector {
+  std::size_t index;
+  TypeId projected_type;
+};
+
+// LRM 7.4.5 / 7.5 / 7.8 / 7.10 / 11.5.1 positional access: an array, queue, or
+// associative element, a string character, a packed bit-select.
+struct ElementSelector {
+  std::vector<ExprId> operands;
+  TypeId projected_type;
+};
+
+// LRM 7.4.6 / 11.5.1 fixed-width window: a packed part-select, an unpacked
+// slice, and a packed aggregate's member, which projects to a constant-bounds
+// window over the aggregate's base.
+struct SliceSelector {
+  std::vector<ExprId> operands;
+  TypeId projected_type;
+};
+
+using Selector = std::variant<
+    ComponentSelector, UnionMemberSelector, ElementSelector, SliceSelector>;
+
+// Designates a part of the value held by a place: the place that owns the whole
+// value, and the descent that reaches the part. Writing through it is a
+// functional whole-value update -- read the owner, rebuild it with the part
+// replaced, store it back -- because a value aggregate's interior is not
+// independently addressable. `Expr::type` is the designated part's type.
+//
+// The owner is a place and the path never crosses a dereference: where a chain
+// re-enters storage, that dereference terminates the path and whatever
+// projection reached the referent is an ordinary read inside `owner`.
+//
+// This is the write-side form. A read composes bottom-up through ordinary
+// select expressions and needs no owner, because every step of a read is a
+// function from a value to a part of it; a write has to name where the rebuilt
+// value goes.
+struct ValueProjectionExpr {
+  ExprId owner;
+  std::vector<Selector> path;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     MachineIntLiteral, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
@@ -622,8 +666,8 @@ using ExprData = std::variant<
     MoveExpr, PointerCastExpr, IntCastExpr, FieldAccessExpr,
     StructConstructExpr, ClosureExpr, ConcatExpr, ReplicationExpr,
     ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr, UnionExpr,
-    UnionGetExpr, UnionGetRefExpr, TaggedExpr, TaggedGetExpr, TaggedGetRefExpr,
-    TaggedIsExpr, FunctionRef, StaticConstantRef, StaticPropertyRef,
+    UnionGetExpr, TaggedExpr, TaggedGetExpr, TaggedGetRefExpr, TaggedIsExpr,
+    ValueProjectionExpr, FunctionRef, StaticConstantRef, StaticPropertyRef,
     ExternalUnitVariableRef, ExternalStaticPropertyRef>;
 
 struct Expr {
@@ -655,7 +699,6 @@ struct Expr {
 
 // Whether the call's `args[0]` is the container being accessed (indexed or
 // sliced). LHS-chain walkers use this to reach the root primary.
-[[nodiscard]] auto IsContainerAccessCallee(const Callee& callee) -> bool;
 
 // `lyra::runtime::current_runtime()` -- reaches the attached Runtime's
 // capability view through a thread-local pointer the Runtime publishes for

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -504,10 +504,9 @@ struct TupleType {
 // value at a time (the generic-language C `union`, distinct from the product
 // `TupleType` and from a tagged sum). The value-layer realization of an SV
 // untagged unpacked union (LRM 7.3); the member names are dropped to positions
-// at HIR-to-MIR, the index is the carrier. Built by `UnionExpr`, read by
-// `UnionGetExpr`, written through `UnionGetRefExpr`. Carries component
-// types only: a tagged union is a separate concept rejected at the HIR-to-MIR
-// gate, so no flag distinguishes one here.
+// at HIR-to-MIR, the index is the carrier. Carries component types only: a
+// tagged union is a separate concept rejected at the HIR-to-MIR gate, so no
+// flag distinguishes one here.
 struct UnionType {
   std::vector<TypeId> elements;
 

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -170,6 +170,13 @@ auto lyra_rt_packed_reduction_nand(const void* value) -> void*;
 auto lyra_rt_packed_reduction_nor(const void* value) -> void*;
 auto lyra_rt_packed_reduction_xnor(const void* value) -> void*;
 auto lyra_rt_packed_to_owned(const void* value) -> void*;
+// Positional access (LRM 11.5.1). `element` copies the bit-select / element
+// out; `with_element` returns a copy with that element replaced -- the
+// functional write the execution backend uses because it cannot mutate a packed
+// value in place.
+auto lyra_rt_packed_element(const void* value, const void* index) -> void*;
+auto lyra_rt_packed_with_element(
+    const void* value, const void* index, const void* replacement) -> void*;
 
 auto lyra_rt_string_from_packed_array(const void* bits) -> void*;
 // The C string a `string` crosses the DPI-C boundary as (LRM 35.5.6). It points
@@ -178,6 +185,12 @@ auto lyra_rt_string_from_packed_array(const void* bits) -> void*;
 auto lyra_rt_string_string_cstr(const void* value) -> const char*;
 auto lyra_rt_string_len(const void* value) -> void*;
 auto lyra_rt_string_getc(const void* value, const void* index) -> void*;
+// Positional access (LRM 6.16.2). `element` reads the character; `with_element`
+// returns a copy with one character replaced -- the functional write the
+// execution backend uses because it cannot mutate a string in place.
+auto lyra_rt_string_element(const void* value, const void* index) -> void*;
+auto lyra_rt_string_with_element(
+    const void* value, const void* index, const void* replacement) -> void*;
 auto lyra_rt_string_toupper(const void* value) -> void*;
 auto lyra_rt_string_tolower(const void* value) -> void*;
 auto lyra_rt_string_compare(const void* lhs, const void* rhs) -> void*;

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -19,9 +19,14 @@ auto lyra_rt_time_format(void* runtime) -> const void*;
 auto lyra_rt_make_string(void* cstr) -> void*;
 auto lyra_rt_make_print_literal_item(void* string_value) -> void*;
 auto lyra_rt_format(LyraSpan items, const void* time_format) -> void*;
+// A packed constant carries its full dimension stack (a flat `{left, right}`
+// pair array of `dims_count` ranges) so a multi-dim packed value keeps its
+// shape into element / slice access -- the same `PackedType` the C++ backend
+// renders inline. `value` fills the low word; a wider constant's upper words
+// are sign/zero filled.
 auto lyra_rt_packed_const(
-    std::int64_t value, std::int32_t width, bool is_signed, bool is_four_state)
-    -> void*;
+    std::int64_t value, const std::int64_t* dims, std::int64_t dims_count,
+    bool is_signed, bool is_four_state) -> void*;
 void lyra_rt_writeln(void* files, void* descriptor, void* text);
 void lyra_rt_write(void* files, void* descriptor, void* text);
 // Wraps a generated process body in a runtime-owned coroutine. `ramp` starts
@@ -177,11 +182,15 @@ auto lyra_rt_packed_to_owned(const void* value) -> void*;
 auto lyra_rt_packed_element(const void* value, const void* index) -> void*;
 auto lyra_rt_packed_with_element(
     const void* value, const void* index, const void* replacement) -> void*;
+// A part-select states the shape its result takes through `shape`, a value of
+// the result's declared type: the bounds decide which bits are selected, that
+// type decides how they are structured.
 auto lyra_rt_packed_slice(
-    const void* value, const void* a, const void* b, const void* form) -> void*;
+    const void* value, const void* a, const void* b, const void* form,
+    const void* shape) -> void*;
 auto lyra_rt_packed_with_slice(
     const void* value, const void* a, const void* b, const void* form,
-    const void* replacement) -> void*;
+    const void* shape, const void* replacement) -> void*;
 
 auto lyra_rt_string_from_packed_array(const void* bits) -> void*;
 // The C string a `string` crosses the DPI-C boundary as (LRM 35.5.6). It points

--- a/include/lyra/runtime/jit_execution.hpp
+++ b/include/lyra/runtime/jit_execution.hpp
@@ -177,6 +177,11 @@ auto lyra_rt_packed_to_owned(const void* value) -> void*;
 auto lyra_rt_packed_element(const void* value, const void* index) -> void*;
 auto lyra_rt_packed_with_element(
     const void* value, const void* index, const void* replacement) -> void*;
+auto lyra_rt_packed_slice(
+    const void* value, const void* a, const void* b, const void* form) -> void*;
+auto lyra_rt_packed_with_slice(
+    const void* value, const void* a, const void* b, const void* form,
+    const void* replacement) -> void*;
 
 auto lyra_rt_string_from_packed_array(const void* bits) -> void*;
 // The C string a `string` crosses the DPI-C boundary as (LRM 35.5.6). It points

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -12,24 +12,14 @@ namespace lyra::support {
 // observable storage cells, runtime effects, scope handle); this enum
 // carries only the method identity.
 enum class BuiltinFn : std::uint16_t {
-  // LRM 7.4 / 7.8 / 7.10 / 11.5 positional access. Bare returns value
-  // form; `Ref` returns write-through reference. `Slice` is read,
-  // `SliceRef` is write.
+  // LRM 7.4 / 7.8 / 7.10 / 11.5 positional access, both reads. A write is not
+  // an access call: it is a descent step on the target's designator.
   kElement,
-  kElementRef,
   kSlice,
-  kSliceRef,
-  // The functional element write for a value-container: yields a new container
-  // equal to the receiver with one element replaced (LRM 7.4.6). It is the
-  // value-model counterpart of the in-place `kElementRef` write, synthesized at
-  // MIR-to-LIR for a backend whose container value is reached by an opaque
-  // handle and so cannot write an element in place; it never arises from
-  // source.
+  // The functional writes those descent steps realize: a new value equal to the
+  // receiver with one element (LRM 7.4.6) or one selected range (LRM 11.5.1)
+  // replaced. Synthesized at MIR-to-LIR; neither arises from source.
   kWithElement,
-  // The functional part-select write, the slice counterpart of `kWithElement`:
-  // yields a new value equal to the receiver with the selected range replaced
-  // (LRM 11.5.1). Synthesized at MIR-to-LIR as the value-model counterpart of
-  // the in-place `kSliceRef` write; it never arises from source.
   kWithSlice,
   // LRM 7.4.3 / 7.5 / 7.9 / 7.10.2. AA's `num` is an alias of `size`;
   // String's LRM 6.16.1 `len` is its own mandated spelling.
@@ -470,7 +460,6 @@ enum class BuiltinFn : std::uint16_t {
 // True iff the call's `args[0]` is the container being indexed or sliced
 // (rather than a value receiver). Used by LHS-chain walkers to reach the
 // root primary.
-[[nodiscard]] auto IsContainerAccessFn(BuiltinFn id) -> bool;
 
 // True iff the LRM 7.12 method takes a `with`-clause closure as its second
 // argument. The other LRM 7.5 / 7.10 array entries (`size`, `delete`,

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -26,6 +26,11 @@ enum class BuiltinFn : std::uint16_t {
   // handle and so cannot write an element in place; it never arises from
   // source.
   kWithElement,
+  // The functional part-select write, the slice counterpart of `kWithElement`:
+  // yields a new value equal to the receiver with the selected range replaced
+  // (LRM 11.5.1). Synthesized at MIR-to-LIR as the value-model counterpart of
+  // the in-place `kSliceRef` write; it never arises from source.
+  kWithSlice,
   // LRM 7.4.3 / 7.5 / 7.9 / 7.10.2. AA's `num` is an alias of `size`;
   // String's LRM 6.16.1 `len` is its own mandated spelling.
   kSize,

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -13,14 +13,10 @@ namespace lyra::support {
 // carries only the method identity.
 enum class BuiltinFn : std::uint16_t {
   // LRM 7.4 / 7.8 / 7.10 / 11.5 positional access, both reads. A write is not
-  // an access call: it is a descent step on the target's designator.
+  // an access call: it is a descent step on the target's designator, and the
+  // entry that realizes it is named below this layer.
   kElement,
   kSlice,
-  // The functional writes those descent steps realize: a new value equal to the
-  // receiver with one element (LRM 7.4.6) or one selected range (LRM 11.5.1)
-  // replaced. Synthesized at MIR-to-LIR; neither arises from source.
-  kWithElement,
-  kWithSlice,
   // LRM 7.4.3 / 7.5 / 7.9 / 7.10.2. AA's `num` is an alias of `size`;
   // String's LRM 6.16.1 `len` is its own mandated spelling.
   kSize,

--- a/include/lyra/value/concepts.hpp
+++ b/include/lyra/value/concepts.hpp
@@ -154,8 +154,7 @@ concept AssocIndexable = requires(T& t, const K& key) {
 };
 
 // Sliceable: extract a fixed-width sub-window (LRM 7.4.5 / 11.5.2). Conforming
-// containers: PackedArray, DynamicArray, UnpackedArray. The shape is
-// `Slice(anchor, count, shift)`:
+// container: DynamicArray. The shape is `Slice(anchor, count, shift)`:
 //
 // - `anchor` is the SV-declared endpoint the slice hangs from; the container
 //   rebases it against its own declared range.
@@ -190,10 +189,9 @@ concept SliceableRef = requires(
 
 // The unpacked family supplies its declared coordinate range at the select as a
 // `[left:right]` operand pair sourced from the receiver's static type, rather
-// than carrying it in the value. PackedArray self-describes (its dims are
-// storage representation) and a dynamic array is zero-based, so both stay on
-// `Indexable` / `Sliceable`; the
-// unpacked value pins the range-carrying shape instead.
+// than carrying it in the value. A packed value's own dims are storage
+// representation and a dynamic array is zero-based, so neither needs the range
+// operand; the unpacked value pins the range-carrying shape instead.
 template <typename T>
 concept RangedIndexable = requires(
     T& t, const PackedArray& pos, const PackedArray& left,
@@ -215,6 +213,26 @@ concept RangedSliceableRef = requires(
     T& t, const PackedArray& a, const PackedArray& b, const PackedArray& form,
     const PackedArray& left, const PackedArray& right) {
   { t.SliceRef(a, b, form, left, right) };
+};
+
+// The packed family states the shape its slice result takes as a trailing
+// prototype operand sourced from the select's static result type. The bounds
+// decide which bits are selected; the shape decides how they are structured,
+// which the receiver cannot always supply -- a packed aggregate's base is a
+// flat bit run whose member shapes live only in the member types. The element
+// forms need no such operand: an element's shape is the receiver's own subtype.
+template <typename T>
+concept ShapedSliceable = requires(
+    const T& t, const PackedArray& a, const PackedArray& b,
+    const PackedArray& form, const PackedArray& shape) {
+  { t.Slice(a, b, form, shape) };
+};
+
+template <typename T>
+concept ShapedSliceableRef = requires(
+    T& t, const PackedArray& a, const PackedArray& b, const PackedArray& form,
+    const PackedArray& shape) {
+  { t.SliceRef(a, b, form, shape) };
 };
 
 // Ownable: materialise a borrowed view into an owning value. Models Rust's

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -457,12 +457,20 @@ class PackedArray {
   // LRM 11.5.1 out-of-range / X-Z index no-op as the in-place write.
   [[nodiscard]] auto WithElement(
       const PackedArray& idx, const PackedArray& value) const -> PackedArray;
+  // A part-select's bit window is computed from its bounds, but its result
+  // shape is declared, so `shape` states it: the selected bits are materialized
+  // with `shape`'s dimension stack rather than one derived from the receiver.
+  // The two agree for a select over an array, and differ when the receiver is a
+  // packed aggregate's flat base -- its bits carry no member structure, so the
+  // member's own declared shape can only come from the select's result type
+  // (LRM 7.2.1 / 7.3.1 member access, projected onto the same part-select the
+  // LRM 11.5.1 range form uses).
   [[nodiscard]] auto SliceRef(
-      const PackedArray& a, const PackedArray& b, const PackedArray& form)
-      -> PackedArrayRef;
+      const PackedArray& a, const PackedArray& b, const PackedArray& form,
+      const PackedArray& shape) -> PackedArrayRef;
   [[nodiscard]] auto Slice(
-      const PackedArray& a, const PackedArray& b, const PackedArray& form) const
-      -> PackedArray;
+      const PackedArray& a, const PackedArray& b, const PackedArray& form,
+      const PackedArray& shape) const -> PackedArray;
   // The functional counterpart of the in-place part-select write, for a value
   // reached by an opaque handle that cannot be mutated in place: a new value
   // equal to the receiver with the range selected by `a` / `b` / `form`
@@ -470,7 +478,7 @@ class PackedArray {
   // write.
   [[nodiscard]] auto WithSlice(
       const PackedArray& a, const PackedArray& b, const PackedArray& form,
-      const PackedArray& value) const -> PackedArray;
+      const PackedArray& shape, const PackedArray& value) const -> PackedArray;
   [[nodiscard]] auto operator<(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator<=(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator>(const PackedArray& other) const -> PackedArray;
@@ -671,8 +679,8 @@ class PackedArrayRef {
   // units; the proxy scales internally based on `dims_`.
   [[nodiscard]] auto ElementRef(const PackedArray& idx) const -> PackedArrayRef;
   [[nodiscard]] auto SliceRef(
-      const PackedArray& a, const PackedArray& b, const PackedArray& form) const
-      -> PackedArrayRef;
+      const PackedArray& a, const PackedArray& b, const PackedArray& form,
+      const PackedArray& shape) const -> PackedArrayRef;
 
  private:
   PackedArray* root_;
@@ -684,8 +692,8 @@ class PackedArrayRef {
 static_assert(LyraValue<PackedArray>);
 static_assert(BitstreamSizable<PackedArray>);
 static_assert(Indexable<PackedArray>);
-static_assert(Sliceable<PackedArray>);
-static_assert(SliceableRef<PackedArray>);
+static_assert(ShapedSliceable<PackedArray>);
+static_assert(ShapedSliceableRef<PackedArray>);
 static_assert(Ownable<PackedArray>);
 static_assert(Defaultable<PackedArray>);
 

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -463,6 +463,14 @@ class PackedArray {
   [[nodiscard]] auto Slice(
       const PackedArray& a, const PackedArray& b, const PackedArray& form) const
       -> PackedArray;
+  // The functional counterpart of the in-place part-select write, for a value
+  // reached by an opaque handle that cannot be mutated in place: a new value
+  // equal to the receiver with the range selected by `a` / `b` / `form`
+  // replaced, under the same LRM 11.5.1 out-of-range no-op as the in-place
+  // write.
+  [[nodiscard]] auto WithSlice(
+      const PackedArray& a, const PackedArray& b, const PackedArray& form,
+      const PackedArray& value) const -> PackedArray;
   [[nodiscard]] auto operator<(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator<=(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator>(const PackedArray& other) const -> PackedArray;

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -451,6 +451,12 @@ class PackedArray {
   // `concepts.hpp` for the `Indexable` / `Sliceable` protocol shape.
   [[nodiscard]] auto ElementRef(const PackedArray& idx) -> PackedArrayRef;
   [[nodiscard]] auto Element(const PackedArray& idx) const -> PackedArray;
+  // The functional counterpart of the in-place element write, for a value
+  // reached by an opaque handle that cannot be mutated in place: a new value
+  // equal to the receiver with the element at `idx` replaced, under the same
+  // LRM 11.5.1 out-of-range / X-Z index no-op as the in-place write.
+  [[nodiscard]] auto WithElement(
+      const PackedArray& idx, const PackedArray& value) const -> PackedArray;
   [[nodiscard]] auto SliceRef(
       const PackedArray& a, const PackedArray& b, const PackedArray& form)
       -> PackedArrayRef;

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -164,10 +164,11 @@ class String {
   // array element. Defined after `StringCharRef` below.
   [[nodiscard]] auto ElementRef(const PackedArray& i_arg) -> StringCharRef;
 
-  // The functional counterpart of the `ElementRef` write, for a string reached
-  // by an opaque handle that cannot be mutated in place: a new string equal to
-  // the receiver with character `i_arg` replaced under the same LRM 6.16.2
-  // `putc` rules (an out-of-range index or a NUL byte leaves it unchanged).
+  // The functional counterpart of the in-place character write, for a string
+  // reached by an opaque handle that cannot be mutated in place: a new string
+  // equal to the receiver with character `i_arg` replaced under the same LRM
+  // 6.16.2 `putc` rules (an out-of-range index or a NUL byte leaves it
+  // unchanged).
   [[nodiscard]] auto WithElement(
       const PackedArray& i_arg, const PackedArray& value) const -> String {
     String result{*this};

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -164,6 +164,17 @@ class String {
   // array element. Defined after `StringCharRef` below.
   [[nodiscard]] auto ElementRef(const PackedArray& i_arg) -> StringCharRef;
 
+  // The functional counterpart of the `ElementRef` write, for a string reached
+  // by an opaque handle that cannot be mutated in place: a new string equal to
+  // the receiver with character `i_arg` replaced under the same LRM 6.16.2
+  // `putc` rules (an out-of-range index or a NUL byte leaves it unchanged).
+  [[nodiscard]] auto WithElement(
+      const PackedArray& i_arg, const PackedArray& value) const -> String {
+    String result{*this};
+    result.Putc(i_arg, value);
+    return result;
+  }
+
   // LRM 6.16.4. Receiver unchanged.
   [[nodiscard]] auto Toupper() const -> String {
     std::string out = impl_;

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -153,15 +153,6 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Element";
     case support::BuiltinFn::kSlice:
       return "Slice";
-    case support::BuiltinFn::kWithElement:
-    case support::BuiltinFn::kWithSlice:
-      // The functional interior writes are synthesized only at MIR-to-LIR for
-      // the execution backend; the C++ backend realizes a descent step in place
-      // through the value library's write proxies, so it never renders one.
-      throw InternalError(
-          "BuiltinFnCppName: a functional interior write is an "
-          "execution-backend synthesis entry, never rendered by the C++ "
-          "backend");
     case support::BuiltinFn::kSize:
       return "Size";
     case support::BuiltinFn::kBitstreamWidth:

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -151,26 +151,17 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Realtoa";
     case support::BuiltinFn::kElement:
       return "Element";
-    case support::BuiltinFn::kElementRef:
-      return "ElementRef";
-    case support::BuiltinFn::kWithElement:
-      // The functional element write is synthesized only at MIR-to-LIR for the
-      // execution backend; the C++ backend writes an element in place through
-      // `ElementRef`, so it never renders this entry.
-      throw InternalError(
-          "BuiltinFnCppName: with_element is an execution-backend synthesis "
-          "entry, never rendered by the C++ backend");
     case support::BuiltinFn::kSlice:
       return "Slice";
-    case support::BuiltinFn::kSliceRef:
-      return "SliceRef";
+    case support::BuiltinFn::kWithElement:
     case support::BuiltinFn::kWithSlice:
-      // The functional part-select write is synthesized only at MIR-to-LIR for
-      // the execution backend; the C++ backend writes a slice in place through
-      // `SliceRef`, so it never renders this entry.
+      // The functional interior writes are synthesized only at MIR-to-LIR for
+      // the execution backend; the C++ backend realizes a descent step in place
+      // through the value library's write proxies, so it never renders one.
       throw InternalError(
-          "BuiltinFnCppName: with_slice is an execution-backend synthesis "
-          "entry, never rendered by the C++ backend");
+          "BuiltinFnCppName: a functional interior write is an "
+          "execution-backend synthesis entry, never rendered by the C++ "
+          "backend");
     case support::BuiltinFn::kSize:
       return "Size";
     case support::BuiltinFn::kBitstreamWidth:

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -164,6 +164,13 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Slice";
     case support::BuiltinFn::kSliceRef:
       return "SliceRef";
+    case support::BuiltinFn::kWithSlice:
+      // The functional part-select write is synthesized only at MIR-to-LIR for
+      // the execution backend; the C++ backend writes a slice in place through
+      // `SliceRef`, so it never renders this entry.
+      throw InternalError(
+          "BuiltinFnCppName: with_slice is an execution-backend synthesis "
+          "entry, never rendered by the C++ backend");
     case support::BuiltinFn::kSize:
       return "Size";
     case support::BuiltinFn::kBitstreamWidth:

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -409,6 +409,47 @@ auto ResolveFieldAccess(const ScopeView& view, const mir::FieldAccessExpr& m)
       m.field);
 }
 
+// A projection realized in place: the value library's write proxies carry the
+// same semantics the functional update states, so the descent composes onto the
+// owner's place as a proxy chain. Each step is a fixed function of its selector
+// kind. The result is a reference, so it serves both a write target and an
+// actual bound by reference.
+auto RenderProjectionChain(
+    const ScopeView& view, const mir::ValueProjectionExpr& projection)
+    -> std::string {
+  const auto operands =
+      [&](const std::vector<mir::ExprId>& ids) -> std::string {
+    std::string out;
+    for (const mir::ExprId id : ids) {
+      out += out.empty() ? "" : ", ";
+      out += RenderExpr(view, view.Expr(id));
+    }
+    return out;
+  };
+  std::string rendered = RenderLhsExpr(view, view.Expr(projection.owner));
+  for (const mir::Selector& selector : projection.path) {
+    rendered = std::visit(
+        Overloaded{
+            [&](const mir::ComponentSelector& c) -> std::string {
+              return std::format("({}).template Get<{}>()", rendered, c.index);
+            },
+            [&](const mir::UnionMemberSelector& m) -> std::string {
+              return std::format(
+                  "({}).template GetRef<{}>()", rendered, m.index);
+            },
+            [&](const mir::ElementSelector& e) -> std::string {
+              return std::format(
+                  "({}).ElementRef({})", rendered, operands(e.operands));
+            },
+            [&](const mir::SliceSelector& s) -> std::string {
+              return std::format(
+                  "({}).SliceRef({})", rendered, operands(s.operands));
+            }},
+        selector);
+  }
+  return rendered;
+}
+
 // LHS expression render: produces a write-target reference (a name, a
 // dereference, or a chain of container-access `CallExpr`s whose runtime
 // overloads return write-through references). The observable-cell
@@ -451,12 +492,8 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
                 "{}::{}::{}", ToCppName(r.unit_name), ToCppName(r.class_name),
                 r.property_name);
           },
-          // HIR-to-MIR lowers an LHS selector chain to write-form nodes -- a
-          // container-access `CallExpr` with a write callee (per
-          // `mir::IsContainerAccessCall`), a `UnionGetRefExpr`, a
-          // `TupleGetExpr` on a mutable base -- whose value-side render is
-          // already a writable place. So the lvalue rendering of a container
-          // access is just its value-side render, with no extra fix-up here.
+          // A call in write position is the observable cell's mutate proxy,
+          // which the value-side render already produces as a writable place.
           [&](const mir::CallExpr&) -> std::string {
             return RenderExpr(view, expr);
           },
@@ -476,10 +513,8 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
           // through the addressable union (the Mutate snapshot). The reference
           // makes the member active, so the projection is itself the assignment
           // target and composes for a nested `u.f.g`.
-          [&](const mir::UnionGetRefExpr& g) -> std::string {
-            return std::format(
-                "({}).template GetRef<{}>()",
-                RenderLhsExpr(view, view.Expr(g.union_value)), g.index);
+          [&](const mir::ValueProjectionExpr& p) -> std::string {
+            return RenderProjectionChain(view, p);
           },
           // A tagged-union member write: a reference to the payload of the
           // active tag. Unlike its untagged counterpart, this throws at
@@ -978,13 +1013,12 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
                 "({}).template Get<{}>()",
                 RenderExpr(view, view.Expr(g.union_value)), g.index);
           },
-          // The write node reaches rvalue render only as the receiver of a
-          // container-access write (`u.h[i] = v`), where it is still the active
-          // member reference; it renders the same as in lvalue position.
-          [&](const mir::UnionGetRefExpr& g) -> std::string {
-            return std::format(
-                "({}).template GetRef<{}>()",
-                RenderExpr(view, view.Expr(g.union_value)), g.index);
+          // A designator reaches value position where a construct binds one
+          // rather than writing it -- a reference actual, an output pack
+          // component, a nonblocking update. Its chain is already a reference,
+          // so the render is the same one the write target uses.
+          [&](const mir::ValueProjectionExpr& p) -> std::string {
+            return RenderProjectionChain(view, p);
           },
           [&](const mir::TaggedExpr& t) -> std::string {
             return std::format(

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -472,11 +472,30 @@ auto CodeGenFunction::LowerIntConst(const lir::IntConst& constant)
       constant.value.state_kind == lir::IntegralStateKind::kFourState;
   auto* i64_ty = llvm::Type::getInt64Ty(module_->Context());
   auto* i1_ty = llvm::Type::getInt1Ty(module_->Context());
+
+  // The declared dimension stack travels with the constant so a multi-dim
+  // packed value keeps its shape into element / slice access -- the same
+  // PackedType the C++ backend renders inline.
+  const std::vector<lir::PackedRange>& dims =
+      lir::PackedShape(module_->Unit().types, constant.type).dims;
+  std::vector<llvm::Constant*> bounds;
+  bounds.reserve(dims.size() * 2);
+  for (const lir::PackedRange& range : dims) {
+    bounds.push_back(llvm::ConstantInt::get(i64_ty, range.left));
+    bounds.push_back(llvm::ConstantInt::get(i64_ty, range.right));
+  }
+  auto* bounds_ty = llvm::ArrayType::get(i64_ty, bounds.size());
+  auto* bounds_global = new llvm::GlobalVariable(
+      module_->Module(), bounds_ty, true, llvm::GlobalValue::PrivateLinkage,
+      llvm::ConstantArray::get(bounds_ty, bounds));
+  bounds_global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+  llvm::Value* bounds_ptr =
+      builder_.CreateConstInBoundsGEP2_64(bounds_ty, bounds_global, 0, 0);
+
   return builder_.CreateCall(
       module_->Runtime().PackedConst(),
-      {llvm::ConstantInt::get(i64_ty, value),
-       llvm::ConstantInt::get(
-           llvm::Type::getInt32Ty(module_->Context()), constant.value.width),
+      {llvm::ConstantInt::get(i64_ty, value), bounds_ptr,
+       llvm::ConstantInt::get(i64_ty, static_cast<std::uint64_t>(dims.size())),
        llvm::ConstantInt::get(i1_ty, is_signed ? 1 : 0),
        llvm::ConstantInt::get(i1_ty, is_four_state ? 1 : 0)});
 }

--- a/src/lyra/backend/llvm/codegen_instruction.cpp
+++ b/src/lyra/backend/llvm/codegen_instruction.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <optional>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -399,14 +400,40 @@ auto CodeGenFunction::LowerTupleAggregate(
 auto CodeGenFunction::LowerAggregateExtract(
     const lir::AggregateExtractInstr& extract) -> llvm::Value* {
   llvm::Value* aggregate = LowerOperand(extract.aggregate);
+  const ValueDomain domain = DomainOf(OperandType(extract.aggregate));
+  const auto coordinates = [&](const std::vector<lir::Operand>& operands) {
+    std::vector<llvm::Value*> args = {aggregate};
+    std::vector<llvm::Type*> params = {module_->Types().Ptr()};
+    for (const lir::Operand& operand : operands) {
+      args.push_back(LowerOperand(operand));
+      params.push_back(module_->Types().Map(OperandType(operand)));
+    }
+    return std::pair{std::move(args), std::move(params)};
+  };
   return std::visit(
-      Overloaded{[&](const lir::TupleElement& element) -> llvm::Value* {
-        return builder_.CreateCall(
-            module_->Runtime().TupleExtract(),
-            {aggregate,
-             llvm::ConstantInt::get(
-                 llvm::Type::getInt64Ty(module_->Context()), element.index)});
-      }},
+      Overloaded{
+          [&](const lir::TupleElement& element) -> llvm::Value* {
+            return builder_.CreateCall(
+                module_->Runtime().TupleExtract(),
+                {aggregate, llvm::ConstantInt::get(
+                                llvm::Type::getInt64Ty(module_->Context()),
+                                element.index)});
+          },
+          [&](const lir::UnionMember&) -> llvm::Value* {
+            throw InternalError(
+                "llvm codegen: a union value is not yet realized on this "
+                "backend, so a member read has no entry");
+          },
+          [&](const lir::ContainerElement& e) -> llvm::Value* {
+            auto [args, params] = coordinates(e.operands);
+            return builder_.CreateCall(
+                module_->Runtime().ElementExtract(domain, params), args);
+          },
+          [&](const lir::ContainerSlice& s) -> llvm::Value* {
+            auto [args, params] = coordinates(s.operands);
+            return builder_.CreateCall(
+                module_->Runtime().SliceExtract(domain, params), args);
+          }},
       extract.selector);
 }
 
@@ -414,15 +441,43 @@ auto CodeGenFunction::LowerAggregateUpdate(
     const lir::AggregateUpdateInstr& update) -> llvm::Value* {
   llvm::Value* aggregate = LowerOperand(update.aggregate);
   llvm::Value* replacement = LowerOperand(update.replacement);
+  const ValueDomain domain = DomainOf(OperandType(update.aggregate));
+  const auto coordinates = [&](const std::vector<lir::Operand>& operands) {
+    std::vector<llvm::Value*> args = {aggregate};
+    std::vector<llvm::Type*> params = {module_->Types().Ptr()};
+    for (const lir::Operand& operand : operands) {
+      args.push_back(LowerOperand(operand));
+      params.push_back(module_->Types().Map(OperandType(operand)));
+    }
+    args.push_back(replacement);
+    params.push_back(module_->Types().Map(OperandType(update.replacement)));
+    return std::pair{std::move(args), std::move(params)};
+  };
   return std::visit(
-      Overloaded{[&](const lir::TupleElement& element) -> llvm::Value* {
-        return builder_.CreateCall(
-            module_->Runtime().TupleUpdate(),
-            {aggregate,
-             llvm::ConstantInt::get(
-                 llvm::Type::getInt64Ty(module_->Context()), element.index),
-             replacement});
-      }},
+      Overloaded{
+          [&](const lir::TupleElement& element) -> llvm::Value* {
+            return builder_.CreateCall(
+                module_->Runtime().TupleUpdate(),
+                {aggregate,
+                 llvm::ConstantInt::get(
+                     llvm::Type::getInt64Ty(module_->Context()), element.index),
+                 replacement});
+          },
+          [&](const lir::UnionMember&) -> llvm::Value* {
+            throw InternalError(
+                "llvm codegen: a union value is not yet realized on this "
+                "backend, so a member write has no entry");
+          },
+          [&](const lir::ContainerElement& e) -> llvm::Value* {
+            auto [args, params] = coordinates(e.operands);
+            return builder_.CreateCall(
+                module_->Runtime().ElementUpdate(domain, params), args);
+          },
+          [&](const lir::ContainerSlice& s) -> llvm::Value* {
+            auto [args, params] = coordinates(s.operands);
+            return builder_.CreateCall(
+                module_->Runtime().SliceUpdate(domain, params), args);
+          }},
       update.selector);
 }
 

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -304,6 +304,40 @@ auto RuntimeAbi::TupleExtract() -> llvm::FunctionCallee {
       {types_->Ptr(), llvm::Type::getInt64Ty(*ctx_)});
 }
 
+// The entries a descent step resolves to. The value domain of the aggregate
+// being descended into names each one, as it does for every value operation.
+// The write halves realize a step's update, so no source-level construct names
+// them and they are not part of the builtin namespace HIR and MIR share.
+auto RuntimeAbi::ElementExtract(
+    ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+    -> llvm::FunctionCallee {
+  return ValueBuiltin(
+      domain, lyra::support::BuiltinFn::kElement, types_->Ptr(), params);
+}
+
+auto RuntimeAbi::SliceExtract(
+    ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+    -> llvm::FunctionCallee {
+  return ValueBuiltin(
+      domain, lyra::support::BuiltinFn::kSlice, types_->Ptr(), params);
+}
+
+auto RuntimeAbi::ElementUpdate(
+    ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+    -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_{}_with_element", ValueDomainName(domain)),
+      types_->Ptr(), params);
+}
+
+auto RuntimeAbi::SliceUpdate(
+    ValueDomain domain, llvm::ArrayRef<llvm::Type*> params)
+    -> llvm::FunctionCallee {
+  return Get(
+      std::format("lyra_rt_{}_with_slice", ValueDomainName(domain)),
+      types_->Ptr(), params);
+}
+
 auto RuntimeAbi::TupleUpdate() -> llvm::FunctionCallee {
   return Get(
       "lyra_rt_tuple_update", types_->Ptr(),

--- a/src/lyra/backend/llvm/runtime_abi.cpp
+++ b/src/lyra/backend/llvm/runtime_abi.cpp
@@ -161,8 +161,9 @@ auto RuntimeAbi::MakePrintLiteralItem() -> llvm::FunctionCallee {
 auto RuntimeAbi::PackedConst() -> llvm::FunctionCallee {
   return Get(
       "lyra_rt_packed_const", types_->Ptr(),
-      {llvm::Type::getInt64Ty(*ctx_), llvm::Type::getInt32Ty(*ctx_),
-       llvm::Type::getInt1Ty(*ctx_), llvm::Type::getInt1Ty(*ctx_)});
+      {llvm::Type::getInt64Ty(*ctx_), types_->Ptr(),
+       llvm::Type::getInt64Ty(*ctx_), llvm::Type::getInt1Ty(*ctx_),
+       llvm::Type::getInt1Ty(*ctx_)});
 }
 
 auto RuntimeAbi::RealConst(ValueDomain domain) -> llvm::FunctionCallee {

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -211,6 +211,8 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_packed_to_owned", &lyra_rt_packed_to_owned);
   add("lyra_rt_packed_element", &lyra_rt_packed_element);
   add("lyra_rt_packed_with_element", &lyra_rt_packed_with_element);
+  add("lyra_rt_packed_slice", &lyra_rt_packed_slice);
+  add("lyra_rt_packed_with_slice", &lyra_rt_packed_with_slice);
   add("lyra_rt_string_from_packed_array", &lyra_rt_string_from_packed_array);
   add("lyra_rt_string_string_cstr", &lyra_rt_string_string_cstr);
   add("lyra_rt_string_len", &lyra_rt_string_len);

--- a/src/lyra/jit/executor.cpp
+++ b/src/lyra/jit/executor.cpp
@@ -209,10 +209,14 @@ void DefineRuntimeAbi(llvm::orc::LLJIT& jit) {
   add("lyra_rt_packed_reduction_nor", &lyra_rt_packed_reduction_nor);
   add("lyra_rt_packed_reduction_xnor", &lyra_rt_packed_reduction_xnor);
   add("lyra_rt_packed_to_owned", &lyra_rt_packed_to_owned);
+  add("lyra_rt_packed_element", &lyra_rt_packed_element);
+  add("lyra_rt_packed_with_element", &lyra_rt_packed_with_element);
   add("lyra_rt_string_from_packed_array", &lyra_rt_string_from_packed_array);
   add("lyra_rt_string_string_cstr", &lyra_rt_string_string_cstr);
   add("lyra_rt_string_len", &lyra_rt_string_len);
   add("lyra_rt_string_getc", &lyra_rt_string_getc);
+  add("lyra_rt_string_element", &lyra_rt_string_element);
+  add("lyra_rt_string_with_element", &lyra_rt_string_with_element);
   add("lyra_rt_string_toupper", &lyra_rt_string_toupper);
   add("lyra_rt_string_tolower", &lyra_rt_string_tolower);
   add("lyra_rt_string_compare", &lyra_rt_string_compare);

--- a/src/lyra/lir/dump.cpp
+++ b/src/lyra/lir/dump.cpp
@@ -239,9 +239,19 @@ class LirDumper {
   [[nodiscard]] static auto FormatSelector(const AggregateSelector& selector)
       -> std::string {
     return std::visit(
-        Overloaded{[](const TupleElement& e) {
-          return std::format("element {}", e.index);
-        }},
+        Overloaded{
+            [](const TupleElement& e) -> std::string {
+              return std::format("component {}", e.index);
+            },
+            [](const UnionMember& m) -> std::string {
+              return std::format("member {}", m.index);
+            },
+            [](const ContainerElement& e) -> std::string {
+              return std::format("element({})", FormatOperands(e.operands));
+            },
+            [](const ContainerSlice& s) -> std::string {
+              return std::format("slice({})", FormatOperands(s.operands));
+            }},
         selector);
   }
 

--- a/src/lyra/lir/type_query.cpp
+++ b/src/lyra/lir/type_query.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <variant>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/lir/type.hpp"
 #include "lyra/lir/type_id.hpp"
@@ -34,6 +35,18 @@ auto IsAddressOnly(const TypeArena& types, TypeId type) -> bool {
           [](const ExternalClassType&) { return true; },
           [](const auto&) { return false; }},
       types.Get(type).data);
+}
+
+auto PackedShape(const TypeArena& types, TypeId type)
+    -> const PackedArrayType& {
+  const TypeData& data = types.Get(type).data;
+  if (const auto* packed = std::get_if<PackedArrayType>(&data)) {
+    return *packed;
+  }
+  if (const auto* enumeration = std::get_if<EnumType>(&data)) {
+    return enumeration->base;
+  }
+  throw InternalError("lir: type has no packed shape; it is not integral");
 }
 
 auto IsCoroutine(const TypeArena& types, TypeId type) -> bool {

--- a/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
+++ b/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
@@ -48,20 +48,6 @@ auto BuildRoundCall(const mir::CompilationUnit& unit, mir::ExprId operand_id)
       .type = unit.builtins.machine_int64};
 }
 
-// The destination representation a packed factory call lands its result into,
-// carried as an ordinary MIR value of the destination type -- a default literal
-// -- so the representation reaches the runtime through the argument list, not
-// composed by the backend from type payload. Its contents are overwritten by
-// the factory; only its type's declared shape matters.
-auto BuildPackedShapePrototype(
-    mir::Block& block, const mir::PackedArrayType& dst_pa, mir::TypeId dst_type)
-    -> mir::ExprId {
-  return block.exprs.Add(
-      mir::Expr{
-          .data = mir::IntegerLiteral{.value = DefaultIntegralConstant(dst_pa)},
-          .type = dst_type});
-}
-
 // `PackedArray::FromInt(int_value, prototype)` -- the static factory used by
 // the real-to-integral path: lands `int_value` into the prototype's declared
 // representation.
@@ -118,6 +104,15 @@ auto BuildStringFromFactory(
 }
 
 }  // namespace
+
+auto BuildPackedShapePrototype(
+    mir::Block& block, const mir::PackedArrayType& dst_pa, mir::TypeId dst_type)
+    -> mir::ExprId {
+  return block.exprs.Add(
+      mir::Expr{
+          .data = mir::IntegerLiteral{.value = DefaultIntegralConstant(dst_pa)},
+          .type = dst_type});
+}
 
 auto BuildValueConversion(
     const mir::CompilationUnit& unit, mir::Block& block, mir::ExprId operand_id,

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -250,8 +250,7 @@ auto LowerObservableAssign(
   auto rhs_or = process.LowerExpr(hir_process.exprs.Get(a.rhs), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::ExprId rhs_id = block.exprs.Add(*std::move(rhs_or));
-  auto lhs_or = process.LowerLhsExpr(
-      hir_process.exprs.Get(a.lhs), frame.WithLvalueTarget(true));
+  auto lhs_or = process.LowerLhsExpr(hir_process.exprs.Get(a.lhs), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const mir::ExprId lhs_id = block.exprs.Add(*std::move(lhs_or));
 

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -52,22 +52,11 @@ auto IsExprRootedAtStructuralDataObject(
           [&](const mir::DerefExpr& d) {
             return IsExprRootedAtStructuralDataObject(block, d.pointer);
           },
-          [&](const mir::TupleGetExpr& g) {
-            return IsExprRootedAtStructuralDataObject(block, g.tuple);
-          },
-          [&](const mir::UnionGetRefExpr& g) {
-            return IsExprRootedAtStructuralDataObject(block, g.union_value);
+          [&](const mir::ValueProjectionExpr& p) {
+            return IsExprRootedAtStructuralDataObject(block, p.owner);
           },
           [&](const mir::TaggedGetRefExpr& g) {
             return IsExprRootedAtStructuralDataObject(block, g.union_value);
-          },
-          [&](const mir::CallExpr& c) {
-            if (!mir::IsContainerAccessCallee(c.callee) ||
-                c.arguments.empty()) {
-              return false;
-            }
-            return IsExprRootedAtStructuralDataObject(
-                block, c.arguments.front());
           },
           [&](const mir::ConcatExpr& c) {
             return std::ranges::all_of(c.operands, [&](mir::ExprId op) {
@@ -99,61 +88,40 @@ auto CloneLhsSelectorChainOntoRef(
   const auto& outer_expr = outer_block.exprs.Get(outer_id);
   return std::visit(
       Overloaded{
-          [&](const mir::CallExpr& c) -> mir::ExprId {
-            if (!mir::IsContainerAccessCallee(c.callee) ||
-                c.arguments.empty()) {
-              throw InternalError(
-                  "CloneLhsSelectorChainOntoRef: CallExpr above the NBA target "
-                  "root is not a container access");
-            }
-            // Copy the callee, argument ids, and result type up front: the
-            // recursion and `SnapshotIntoClosure` below append to
-            // `outer_block`, which can reallocate its expression storage and
-            // dangle the `outer_expr` reference `c` is bound to.
-            const auto callee = c.callee;
-            const mir::TypeId call_type = outer_expr.type;
-            const std::vector<mir::ExprId> src_args(
-                c.arguments.begin(), c.arguments.end());
-            std::vector<mir::ExprId> body_args;
-            body_args.reserve(src_args.size());
-            body_args.push_back(CloneLhsSelectorChainOntoRef(
-                unit_lowerer, outer_frame, closure, src_args.front(), root_id,
-                captured_root));
-            for (std::size_t i = 1; i < src_args.size(); ++i) {
-              body_args.push_back(SnapshotIntoClosure(
-                  unit_lowerer, outer_frame, closure, src_args[i],
-                  "_lyra_nba_arg"));
+          // The owner is rebuilt onto the body-side reference; each step's
+          // coordinates are snapshotted by value, so the body writes the part
+          // the statement designated at submit time. Copy the path up front:
+          // the recursion and snapshots below append to `outer_block`, which
+          // can reallocate and dangle the `outer_expr` reference `p` is bound
+          // to.
+          [&](const mir::ValueProjectionExpr& p) -> mir::ExprId {
+            const mir::TypeId type = outer_expr.type;
+            const mir::ExprId src_owner = p.owner;
+            std::vector<mir::Selector> path = p.path;
+            const mir::ExprId owner = CloneLhsSelectorChainOntoRef(
+                unit_lowerer, outer_frame, closure, src_owner, root_id,
+                captured_root);
+            const auto snapshot = [&](std::vector<mir::ExprId>& operands) {
+              for (mir::ExprId& operand : operands) {
+                operand = SnapshotIntoClosure(
+                    unit_lowerer, outer_frame, closure, operand,
+                    "_lyra_nba_arg");
+              }
+            };
+            for (mir::Selector& selector : path) {
+              std::visit(
+                  Overloaded{
+                      [](const mir::ComponentSelector&) {},
+                      [](const mir::UnionMemberSelector&) {},
+                      [&](mir::ElementSelector& e) { snapshot(e.operands); },
+                      [&](mir::SliceSelector& s) { snapshot(s.operands); }},
+                  selector);
             }
             return body.exprs.Add(
                 mir::Expr{
                     .data =
-                        mir::CallExpr{
-                            .callee = callee,
-                            .arguments = std::move(body_args)},
-                    .type = call_type});
-          },
-          [&](const mir::TupleGetExpr& g) -> mir::ExprId {
-            const auto index = g.index;
-            const mir::TypeId type = outer_expr.type;
-            const mir::ExprId base = CloneLhsSelectorChainOntoRef(
-                unit_lowerer, outer_frame, closure, g.tuple, root_id,
-                captured_root);
-            return body.exprs.Add(
-                mir::Expr{
-                    .data = mir::TupleGetExpr{.tuple = base, .index = index},
-                    .type = type});
-          },
-          [&](const mir::UnionGetRefExpr& g) -> mir::ExprId {
-            const auto index = g.index;
-            const mir::TypeId type = outer_expr.type;
-            const mir::ExprId base = CloneLhsSelectorChainOntoRef(
-                unit_lowerer, outer_frame, closure, g.union_value, root_id,
-                captured_root);
-            return body.exprs.Add(
-                mir::Expr{
-                    .data =
-                        mir::UnionGetRefExpr{
-                            .union_value = base, .index = index},
+                        mir::ValueProjectionExpr{
+                            .owner = owner, .path = std::move(path)},
                     .type = type});
           },
           [&](const mir::TaggedGetRefExpr& g) -> mir::ExprId {

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -591,10 +591,10 @@ auto LowerHirIncDecExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::IncDecExpr& inc,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
-  // The target is written in place, so a queue element dispatches to its
-  // write-side access just as an assignment target does.
-  auto target_or = process.LowerLhsExpr(
-      process.HirExprs().Get(inc.target), frame.WithLvalueTarget(true));
+  // An increment both reads and writes its target, so the target lowers as a
+  // write target (LRM 11.4.2), not as a read.
+  auto target_or =
+      process.LowerLhsExpr(process.HirExprs().Get(inc.target), frame);
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   mir::ExprId target_id = block.exprs.Add(*std::move(target_or));
 

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -121,9 +121,8 @@ auto WrapSliceToDeclaredType(
 // Append the receiver's declared range `[left:right]` as trailing select
 // operands when the receiver is an unpacked array: the range is a fact of the
 // receiver's static type, materialized here as a MIR operand rather than
-// carried in the value. A packed receiver self-describes (its dims are storage
-// representation) and a dynamic array is zero-based, so neither contributes an
-// operand.
+// carried in the value. A packed receiver's coordinates are its own dims, which
+// it carries, and a dynamic array is zero-based, so neither states a range.
 auto AppendReceiverRange(
     UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
     std::vector<mir::ExprId>& args) -> void {
@@ -151,6 +150,22 @@ auto AppendReceiverRange(
     args.push_back(
         block.exprs.Add(mir::MakeIntLiteral(int_type, ua->dim.right)));
   }
+}
+
+// Append the shape a packed part-select's result takes as a trailing operand,
+// sourced from the select's static result type. The bounds decide which bits
+// are selected; the result type decides how they are structured. A receiver can
+// only supply that structure when it is itself the array being selected from --
+// a packed aggregate's base is a flat bit run, and its members' shapes live in
+// the member types alone (LRM 7.2.1 / 7.3.1). Every other container's slice
+// yields its own element structure, so none contributes an operand.
+auto AppendResultShape(
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::TypeId result_type,
+    std::vector<mir::ExprId>& args) -> void {
+  const auto& result_ty = unit_lowerer.Unit().types.Get(result_type);
+  if (!result_ty.IsIntegralPacked()) return;
+  args.push_back(BuildPackedShapePrototype(
+      block, result_ty.AsIntegralPacked(), result_type));
 }
 
 // `arr[i]` element access (LRM 7.4.5 / 7.5 / 7.10). The callee carries just
@@ -220,6 +235,7 @@ auto BuildRangeSliceCallExpr(
   const auto form_id =
       block.exprs.Add(mir::MakeIntLiteral(int_type, raw_or->form));
   std::vector<mir::ExprId> args = {base_id, raw_or->a, raw_or->b, form_id};
+  AppendResultShape(unit_lowerer, block, result_type, args);
   AppendReceiverRange(unit_lowerer, block, base_id, args);
   return mir::Expr{
       .data =
@@ -249,6 +265,8 @@ auto BuildFieldSliceCallExpr(
   // A field occupies bits `[offset +: width]` -- a raw indexed-up part-select
   // (`value::SliceForm` `kIndexedUp` == 1); the value resolves the bit window.
   const auto form_id = block.exprs.Add(mir::MakeIntLiteral(int_type, 1));
+  std::vector<mir::ExprId> args = {base_id, offset_id, width_id, form_id};
+  AppendResultShape(unit_lowerer, block, result_type, args);
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -257,7 +275,7 @@ auto BuildFieldSliceCallExpr(
                       .target = side == AccessSide::kLhs
                                     ? support::BuiltinFn::kSliceRef
                                     : support::BuiltinFn::kSlice},
-              .arguments = {base_id, offset_id, width_id, form_id}},
+              .arguments = std::move(args)},
       .type = result_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -411,15 +411,14 @@ auto LowerHirElementSelectExpr(
   auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  const WalkFrame sub_frame = frame.WithLvalueTarget(false);
 
   const auto& hir_base = exprs.Get(sel.base_value);
-  auto base_or = lowerer.LowerExpr(hir_base, sub_frame);
+  auto base_or = lowerer.LowerExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   const auto& hir_idx = exprs.Get(sel.index);
-  auto idx_or = lowerer.LowerExpr(hir_idx, sub_frame);
+  auto idx_or = lowerer.LowerExpr(hir_idx, frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -40,13 +40,6 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-// Which side of an assignment a select is on. The two sides produce different
-// shapes, uniformly across every container kind (LRM 7.8.6 / 7.8.7 AA, LRM
-// 7.10.1 queue, LRM 7.4 packed / unpacked): a read composes bottom-up as a
-// value, and a write is a descent step on the target's designator, which has to
-// name the place the rebuilt value goes back to.
-enum class AccessSide : std::uint8_t { kRead, kLhs };
-
 // An element read. A write is not a call: it is a descent step on the target's
 // designator, so no write-side access entry exists.
 auto ElementAccessCallee() -> mir::Direct {
@@ -123,12 +116,11 @@ auto WrapSliceToDeclaredType(
 // carried in the value. A packed receiver's coordinates are its own dims, which
 // it carries, and a dynamic array is zero-based, so neither states a range.
 auto AppendReceiverRange(
-    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::TypeId base_type,
     std::vector<mir::ExprId>& args) -> void {
   // The declared range is a fact of the receiver's value type. On the write
   // path the base is a place -- an observable cell or a reference -- so unwrap
   // those single-level indirections to reach the underlying value type.
-  mir::TypeId base_type = block.exprs.Get(base_id).type;
   for (;;) {
     const auto& ty = unit_lowerer.Unit().types.Get(base_type);
     if (const auto* obs = std::get_if<mir::ObservableType>(&ty.data)) {
@@ -173,22 +165,18 @@ auto AppendResultShape(
 // falls out of the lowering's own recursion -- the innermost expression that is
 // not itself a descent is the owner -- and no consumer recovers it afterwards.
 auto ProjectOnto(
-    mir::Block& block, mir::ExprId base_id, mir::Selector selector,
+    mir::Block& block, mir::Expr base, mir::Selector selector,
     mir::TypeId result_type) -> mir::Expr {
-  if (const auto* projection = std::get_if<mir::ValueProjectionExpr>(
-          &block.exprs.Get(base_id).data)) {
-    std::vector<mir::Selector> path = projection->path;
-    const mir::ExprId owner = projection->owner;
-    path.push_back(std::move(selector));
-    return mir::Expr{
-        .data =
-            mir::ValueProjectionExpr{.owner = owner, .path = std::move(path)},
-        .type = result_type};
+  if (auto* projection = std::get_if<mir::ValueProjectionExpr>(&base.data)) {
+    projection->path.push_back(std::move(selector));
+    base.type = result_type;
+    return base;
   }
   return mir::Expr{
       .data =
           mir::ValueProjectionExpr{
-              .owner = base_id, .path = {std::move(selector)}},
+              .owner = block.exprs.Add(std::move(base)),
+              .path = {std::move(selector)}},
       .type = result_type};
 }
 
@@ -199,23 +187,27 @@ auto ProjectOnto(
 // selectable value resolves the coordinate against that range.
 auto BuildElementAccessCallExpr(
     UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
-    mir::ExprId idx_id, AccessSide side, mir::TypeId result_type) -> mir::Expr {
-  std::vector<mir::ExprId> operands = {idx_id};
-  AppendReceiverRange(unit_lowerer, block, base_id, operands);
-  if (side == AccessSide::kLhs) {
-    return ProjectOnto(
-        block, base_id,
-        mir::ElementSelector{
-            .operands = std::move(operands), .projected_type = result_type},
-        result_type);
-  }
-  std::vector<mir::ExprId> args = {base_id};
-  args.insert(args.end(), operands.begin(), operands.end());
+    mir::ExprId idx_id, mir::TypeId result_type) -> mir::Expr {
+  std::vector<mir::ExprId> args = {base_id, idx_id};
+  AppendReceiverRange(unit_lowerer, block, block.exprs.Get(base_id).type, args);
   return mir::Expr{
       .data =
           mir::CallExpr{
               .callee = ElementAccessCallee(), .arguments = std::move(args)},
       .type = result_type};
+}
+
+// The write-side counterpart: one element descent step on the target.
+auto ProjectElement(
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::Expr base,
+    mir::ExprId idx_id, mir::TypeId result_type) -> mir::Expr {
+  std::vector<mir::ExprId> operands = {idx_id};
+  AppendReceiverRange(unit_lowerer, block, base.type, operands);
+  return ProjectOnto(
+      block, std::move(base),
+      mir::ElementSelector{
+          .operands = std::move(operands), .projected_type = result_type},
+      result_type);
 }
 
 // `arr[hi:lo]` / `arr[base+:w]` / `arr[base-:w]` range select, lowered to a raw
@@ -226,11 +218,11 @@ auto BuildElementAccessCallExpr(
 // computed here; the selected value resolves the ordinal window against its own
 // declared range.
 template <typename LowerOne>
-auto BuildRangeSliceCallExpr(
+auto UnfoldRangeSelectOperands(
     UnitLowerer& unit_lowerer, mir::Block& block,
-    const hir::RangeBounds& bounds, mir::ExprId base_id,
-    mir::TypeId result_type, AccessSide side, LowerOne lower_one)
-    -> diag::Result<mir::Expr> {
+    const hir::RangeBounds& bounds, mir::TypeId base_type,
+    mir::TypeId result_type, LowerOne lower_one)
+    -> diag::Result<std::vector<mir::ExprId>> {
   struct RawSelector {
     mir::ExprId a;
     mir::ExprId b;
@@ -268,16 +260,22 @@ auto BuildRangeSliceCallExpr(
       block.exprs.Add(mir::MakeIntLiteral(int_type, raw_or->form));
   std::vector<mir::ExprId> operands = {raw_or->a, raw_or->b, form_id};
   AppendResultShape(unit_lowerer, block, result_type, operands);
-  AppendReceiverRange(unit_lowerer, block, base_id, operands);
-  if (side == AccessSide::kLhs) {
-    return ProjectOnto(
-        block, base_id,
-        mir::SliceSelector{
-            .operands = std::move(operands), .projected_type = result_type},
-        result_type);
-  }
+  AppendReceiverRange(unit_lowerer, block, base_type, operands);
+  return operands;
+}
+
+// A range select read: the window operands against a receiver.
+template <typename LowerOne>
+auto BuildRangeSliceCallExpr(
+    UnitLowerer& unit_lowerer, mir::Block& block,
+    const hir::RangeBounds& bounds, mir::ExprId base_id,
+    mir::TypeId result_type, LowerOne lower_one) -> diag::Result<mir::Expr> {
+  auto operands_or = UnfoldRangeSelectOperands(
+      unit_lowerer, block, bounds, block.exprs.Get(base_id).type, result_type,
+      lower_one);
+  if (!operands_or) return std::unexpected(std::move(operands_or.error()));
   std::vector<mir::ExprId> args = {base_id};
-  args.insert(args.end(), operands.begin(), operands.end());
+  args.insert(args.end(), operands_or->begin(), operands_or->end());
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -286,14 +284,30 @@ auto BuildRangeSliceCallExpr(
       .type = result_type};
 }
 
+// The write-side counterpart: one window descent step on the target.
+template <typename LowerOne>
+auto ProjectSlice(
+    UnitLowerer& unit_lowerer, mir::Block& block,
+    const hir::RangeBounds& bounds, mir::Expr base, mir::TypeId result_type,
+    LowerOne lower_one) -> diag::Result<mir::Expr> {
+  auto operands_or = UnfoldRangeSelectOperands(
+      unit_lowerer, block, bounds, base.type, result_type, lower_one);
+  if (!operands_or) return std::unexpected(std::move(operands_or.error()));
+  return ProjectOnto(
+      block, std::move(base),
+      mir::SliceSelector{
+          .operands = *std::move(operands_or), .projected_type = result_type},
+      result_type);
+}
+
 // LRM 7.2.1 packed struct / union field-as-slice. The field's
 // `(bit_offset, bit_width)` projects to the same packed-path slice shape a
 // range-select emits, so the runtime sees one slice form regardless of
 // whether the source was `s.field` or `s[hi:lo]`.
-auto BuildFieldSliceCallExpr(
-    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
-    std::uint32_t bit_offset, std::uint32_t bit_width, mir::TypeId result_type,
-    AccessSide side) -> mir::Expr {
+auto UnfoldFieldSliceOperands(
+    UnitLowerer& unit_lowerer, mir::Block& block, std::uint32_t bit_offset,
+    std::uint32_t bit_width, mir::TypeId result_type)
+    -> std::vector<mir::ExprId> {
   const mir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
   const auto offset_id = block.exprs.Add(
       mir::MakeIntLiteral(int_type, static_cast<std::int64_t>(bit_offset)));
@@ -304,13 +318,15 @@ auto BuildFieldSliceCallExpr(
   const auto form_id = block.exprs.Add(mir::MakeIntLiteral(int_type, 1));
   std::vector<mir::ExprId> operands = {offset_id, width_id, form_id};
   AppendResultShape(unit_lowerer, block, result_type, operands);
-  if (side == AccessSide::kLhs) {
-    return ProjectOnto(
-        block, base_id,
-        mir::SliceSelector{
-            .operands = std::move(operands), .projected_type = result_type},
-        result_type);
-  }
+  return operands;
+}
+
+auto BuildFieldSliceCallExpr(
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
+    std::uint32_t bit_offset, std::uint32_t bit_width, mir::TypeId result_type)
+    -> mir::Expr {
+  std::vector<mir::ExprId> operands = UnfoldFieldSliceOperands(
+      unit_lowerer, block, bit_offset, bit_width, result_type);
   std::vector<mir::ExprId> args = {base_id};
   args.insert(args.end(), operands.begin(), operands.end());
   return mir::Expr{
@@ -321,6 +337,21 @@ auto BuildFieldSliceCallExpr(
       .type = result_type};
 }
 
+// The write-side counterpart: a packed aggregate's member reached as one
+// constant-bounds window descent step on the target.
+auto ProjectFieldSlice(
+    UnitLowerer& unit_lowerer, mir::Block& block, mir::Expr base,
+    std::uint32_t bit_offset, std::uint32_t bit_width, mir::TypeId result_type)
+    -> mir::Expr {
+  return ProjectOnto(
+      block, std::move(base),
+      mir::SliceSelector{
+          .operands = UnfoldFieldSliceOperands(
+              unit_lowerer, block, bit_offset, bit_width, result_type),
+          .projected_type = result_type},
+      result_type);
+}
+
 // Per-kind inner helpers that combine the factory call with the
 // read/write-side wrapping. RHS readers wrap with `WrapPackedAsOwned`
 // (no-op for queue / AA); LHS writers leave the borrowed-view chain
@@ -328,10 +359,10 @@ auto BuildFieldSliceCallExpr(
 
 auto LowerElementSelectInner(
     UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
-    mir::ExprId idx_id, AccessSide side, mir::TypeId result_type,
-    bool wrap_packed_as_owned) -> mir::Expr {
+    mir::ExprId idx_id, mir::TypeId result_type, bool wrap_packed_as_owned)
+    -> mir::Expr {
   mir::Expr access_call = BuildElementAccessCallExpr(
-      unit_lowerer, block, base_id, idx_id, side, result_type);
+      unit_lowerer, block, base_id, idx_id, result_type);
   if (!wrap_packed_as_owned) return access_call;
   return WrapPackedAsOwned(
       unit_lowerer.Unit(), block, std::move(access_call), result_type);
@@ -341,12 +372,10 @@ template <typename LowerOne>
 auto LowerRangeSelectInner(
     UnitLowerer& unit_lowerer, mir::Block& block,
     const hir::RangeBounds& bounds, mir::ExprId base_id,
-    mir::TypeId result_type, LowerOne lower_one, AccessSide side)
-    -> diag::Result<mir::Expr> {
+    mir::TypeId result_type, LowerOne lower_one) -> diag::Result<mir::Expr> {
   auto slice_or = BuildRangeSliceCallExpr(
-      unit_lowerer, block, bounds, base_id, result_type, side, lower_one);
+      unit_lowerer, block, bounds, base_id, result_type, lower_one);
   if (!slice_or) return std::unexpected(std::move(slice_or.error()));
-  if (side == AccessSide::kLhs) return *std::move(slice_or);
   return WrapPackedAsOwned(
       unit_lowerer.Unit(), block, *std::move(slice_or), result_type);
 }
@@ -360,18 +389,13 @@ auto LowerRangeSelectInner(
 auto LowerMemberAccessInner(
     UnitLowerer& unit_lowerer, mir::Block& block,
     const hir::PackedAggregateField& field, mir::ExprId base_id,
-    mir::TypeId result_type, AccessSide side) -> mir::Expr {
-  if (side == AccessSide::kLhs) {
-    return BuildFieldSliceCallExpr(
-        unit_lowerer, block, base_id, field.bit_offset, field.bit_width,
-        result_type, side);
-  }
+    mir::TypeId result_type) -> mir::Expr {
   const mir::TypeId source_type = block.exprs.Get(base_id).type;
   const mir::TypeId slice_type =
       PartSelectNaturalType(unit_lowerer.Unit(), source_type, result_type);
   mir::Expr slice_call = BuildFieldSliceCallExpr(
       unit_lowerer, block, base_id, field.bit_offset, field.bit_width,
-      slice_type, side);
+      slice_type);
   mir::Expr owned = WrapPackedAsOwned(
       unit_lowerer.Unit(), block, std::move(slice_call), slice_type);
   return WrapSliceToDeclaredType(
@@ -387,7 +411,6 @@ auto LowerHirElementSelectExpr(
   auto& unit_lowerer = lowerer.Owner();
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  const bool is_write = frame.is_lvalue_target;
   const WalkFrame sub_frame = frame.WithLvalueTarget(false);
 
   const auto& hir_base = exprs.Get(sel.base_value);
@@ -413,18 +436,8 @@ auto LowerHirElementSelectExpr(
                 .arguments = {base_id, idx_id}},
         .type = result_type};
   }
-  // LRM 7.10.1: queue's `q[$+1] = v` appends, so a queue element write
-  // must dispatch as LHS even from this RHS entry point. The lvalue-target
-  // marker carried on the walk frame surfaces that case. The string and queue
-  // arms are reachable only in a procedural scope: slang forbids referencing
-  // an element of a dynamic-typed variable outside a procedural context, so a
-  // structural instantiation never takes them.
-  const AccessSide side =
-      (is_write && std::holds_alternative<hir::QueueType>(hir_base_ty.data))
-          ? AccessSide::kLhs
-          : AccessSide::kRead;
   return LowerElementSelectInner(
-      unit_lowerer, block, base_id, idx_id, side, result_type, true);
+      unit_lowerer, block, base_id, idx_id, result_type, true);
 }
 
 template <ExprLowerer Lowerer>
@@ -446,8 +459,7 @@ auto LowerHirRangeSelectExpr(
     return block.exprs.Add(*std::move(lowered));
   };
   return LowerRangeSelectInner(
-      unit_lowerer, block, sel.bounds, base_id, result_type, lower_one,
-      AccessSide::kRead);
+      unit_lowerer, block, sel.bounds, base_id, result_type, lower_one);
 }
 
 // LRM 7.2.1: packed struct / union field access "can be selected as if it
@@ -504,8 +516,7 @@ auto LowerHirMemberAccessExpr(
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
-      unit_lowerer, block, fields[sel.field_index.value], base_id, result_type,
-      AccessSide::kRead);
+      unit_lowerer, block, fields[sel.field_index.value], base_id, result_type);
 }
 
 // LRM 8.4: a class property read reaches the object through the handle.
@@ -539,16 +550,14 @@ auto LowerHirElementSelectExprLhs(
   const auto& hir_base = exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   const auto& hir_idx = exprs.Get(sel.index);
   auto idx_or = lowerer.LowerExpr(hir_idx, frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
-  return LowerElementSelectInner(
-      unit_lowerer, block, base_id, idx_id, AccessSide::kLhs, result_type,
-      false);
+  return ProjectElement(
+      unit_lowerer, block, *std::move(base_or), idx_id, result_type);
 }
 
 template <ExprLowerer Lowerer>
@@ -562,16 +571,15 @@ auto LowerHirRangeSelectExprLhs(
   const auto& hir_base = exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
     auto lowered = lowerer.LowerExpr(exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return block.exprs.Add(*std::move(lowered));
   };
-  return LowerRangeSelectInner(
-      unit_lowerer, block, sel.bounds, base_id, result_type, lower_one,
-      AccessSide::kLhs);
+  return ProjectSlice(
+      unit_lowerer, block, sel.bounds, *std::move(base_or), result_type,
+      lower_one);
 }
 
 template <ExprLowerer Lowerer>
@@ -589,9 +597,8 @@ auto LowerHirMemberAccessExprLhs(
       hir::TypeKind::kUnpackedStruct) {
     auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
-    const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     return ProjectOnto(
-        block, base_id,
+        block, *std::move(base_or),
         mir::ComponentSelector{
             .index = sel.field_index.value, .projected_type = result_type},
         result_type);
@@ -605,10 +612,10 @@ auto LowerHirMemberAccessExprLhs(
       hir::TypeKind::kUnpackedUnion) {
     auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
-    const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
     const auto& union_ty = std::get<hir::UnpackedUnionType>(
         unit_lowerer.Hir().types.Get(base_hir_expr.type).data);
     if (union_ty.tagged) {
+      const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
       return mir::Expr{
           .data =
               mir::TaggedGetRefExpr{
@@ -616,7 +623,7 @@ auto LowerHirMemberAccessExprLhs(
           .type = result_type};
     }
     return ProjectOnto(
-        block, base_id,
+        block, *std::move(base_or),
         mir::UnionMemberSelector{
             .index = sel.field_index.value, .projected_type = result_type},
         result_type);
@@ -629,10 +636,10 @@ auto LowerHirMemberAccessExprLhs(
   }
   auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-  return LowerMemberAccessInner(
-      unit_lowerer, block, fields[sel.field_index.value], base_id, result_type,
-      AccessSide::kLhs);
+  const hir::PackedAggregateField& field = fields[sel.field_index.value];
+  return ProjectFieldSlice(
+      unit_lowerer, block, *std::move(base_or), field.bit_offset,
+      field.bit_width, result_type);
 }
 
 // LRM 8.4: a class property write reaches the object through the handle.

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -40,16 +40,17 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-// Read vs LHS side dispatch for `arr[i]`. The split is uniform across all
-// container kinds (LRM 7.8.6 / 7.8.7 AA, LRM 7.10.1 queue, LRM 7.4 packed /
-// unpacked) and mirrors the runtime API's bare-vs-`Ref`-suffix protocol;
-// see `include/lyra/value/concepts.hpp`.
+// Which side of an assignment a select is on. The two sides produce different
+// shapes, uniformly across every container kind (LRM 7.8.6 / 7.8.7 AA, LRM
+// 7.10.1 queue, LRM 7.4 packed / unpacked): a read composes bottom-up as a
+// value, and a write is a descent step on the target's designator, which has to
+// name the place the rebuilt value goes back to.
 enum class AccessSide : std::uint8_t { kRead, kLhs };
 
-auto ElementAccessCallee(AccessSide side) -> mir::Direct {
-  return mir::Direct{
-      .target = side == AccessSide::kLhs ? support::BuiltinFn::kElementRef
-                                         : support::BuiltinFn::kElement};
+// An element read. A write is not a call: it is a descent step on the target's
+// designator, so no write-side access entry exists.
+auto ElementAccessCallee() -> mir::Direct {
+  return mir::Direct{.target = support::BuiltinFn::kElement};
 }
 
 // LRM 7.2.1 / 7.2.2: packed struct or union field table accessor. Used by
@@ -62,11 +63,9 @@ auto GetAggregateFields(const hir::Type& t)
       "GetAggregateFields: base type is not a packed struct or union");
 }
 
-// Read-side wrap that materialises a borrowed `PackedArrayRef` result into
-// an owning `PackedArray` (Rust's `&[T]::to_owned() -> Vec<T>` pattern).
-// LHS chains keep the view because they write through it; non-packed
-// receivers fall through unchanged because their access already returns an
-// owning value.
+// Read-side wrap that materialises a borrowed packed view into an owning value
+// (Rust's `&[T]::to_owned() -> Vec<T>` pattern). A non-packed receiver falls
+// through unchanged because its access already returns an owning value.
 auto WrapPackedAsOwned(
     const mir::CompilationUnit& unit, mir::Block& block, mir::Expr access_call,
     mir::TypeId result_type) -> mir::Expr {
@@ -168,21 +167,54 @@ auto AppendResultShape(
       block, result_ty.AsIntegralPacked(), result_type));
 }
 
-// `arr[i]` element access (LRM 7.4.5 / 7.5 / 7.10). The callee carries just
-// read-vs-write (`kElement` / `kElementRef`); the receiver's container kind
-// picks the runtime overload at C++ render time. The raw source index is passed
+// Extends a write target by one descent step. A target that already designates
+// a part of some owner's value gains another selector; a target that is still a
+// place becomes the owner of a new designation. The place boundary therefore
+// falls out of the lowering's own recursion -- the innermost expression that is
+// not itself a descent is the owner -- and no consumer recovers it afterwards.
+auto ProjectOnto(
+    mir::Block& block, mir::ExprId base_id, mir::Selector selector,
+    mir::TypeId result_type) -> mir::Expr {
+  if (const auto* projection = std::get_if<mir::ValueProjectionExpr>(
+          &block.exprs.Get(base_id).data)) {
+    std::vector<mir::Selector> path = projection->path;
+    const mir::ExprId owner = projection->owner;
+    path.push_back(std::move(selector));
+    return mir::Expr{
+        .data =
+            mir::ValueProjectionExpr{.owner = owner, .path = std::move(path)},
+        .type = result_type};
+  }
+  return mir::Expr{
+      .data =
+          mir::ValueProjectionExpr{
+              .owner = base_id, .path = {std::move(selector)}},
+      .type = result_type};
+}
+
+// `arr[i]` element access (LRM 7.4.5 / 7.5 / 7.10). A read is a call whose
+// receiver's container kind picks the runtime overload; a write is a descent
+// step on the target's designator. Either way the raw source index is passed
 // through, plus the receiver's declared range for the unpacked family; every
 // selectable value resolves the coordinate against that range.
 auto BuildElementAccessCallExpr(
     UnitLowerer& unit_lowerer, mir::Block& block, mir::ExprId base_id,
     mir::ExprId idx_id, AccessSide side, mir::TypeId result_type) -> mir::Expr {
-  std::vector<mir::ExprId> args = {base_id, idx_id};
-  AppendReceiverRange(unit_lowerer, block, base_id, args);
+  std::vector<mir::ExprId> operands = {idx_id};
+  AppendReceiverRange(unit_lowerer, block, base_id, operands);
+  if (side == AccessSide::kLhs) {
+    return ProjectOnto(
+        block, base_id,
+        mir::ElementSelector{
+            .operands = std::move(operands), .projected_type = result_type},
+        result_type);
+  }
+  std::vector<mir::ExprId> args = {base_id};
+  args.insert(args.end(), operands.begin(), operands.end());
   return mir::Expr{
       .data =
           mir::CallExpr{
-              .callee = ElementAccessCallee(side),
-              .arguments = std::move(args)},
+              .callee = ElementAccessCallee(), .arguments = std::move(args)},
       .type = result_type};
 }
 
@@ -234,17 +266,22 @@ auto BuildRangeSliceCallExpr(
   const mir::TypeId int_type = unit_lowerer.Unit().builtins.int_type;
   const auto form_id =
       block.exprs.Add(mir::MakeIntLiteral(int_type, raw_or->form));
-  std::vector<mir::ExprId> args = {base_id, raw_or->a, raw_or->b, form_id};
-  AppendResultShape(unit_lowerer, block, result_type, args);
-  AppendReceiverRange(unit_lowerer, block, base_id, args);
+  std::vector<mir::ExprId> operands = {raw_or->a, raw_or->b, form_id};
+  AppendResultShape(unit_lowerer, block, result_type, operands);
+  AppendReceiverRange(unit_lowerer, block, base_id, operands);
+  if (side == AccessSide::kLhs) {
+    return ProjectOnto(
+        block, base_id,
+        mir::SliceSelector{
+            .operands = std::move(operands), .projected_type = result_type},
+        result_type);
+  }
+  std::vector<mir::ExprId> args = {base_id};
+  args.insert(args.end(), operands.begin(), operands.end());
   return mir::Expr{
       .data =
           mir::CallExpr{
-              .callee =
-                  mir::Direct{
-                      .target = side == AccessSide::kLhs
-                                    ? support::BuiltinFn::kSliceRef
-                                    : support::BuiltinFn::kSlice},
+              .callee = mir::Direct{.target = support::BuiltinFn::kSlice},
               .arguments = std::move(args)},
       .type = result_type};
 }
@@ -265,16 +302,21 @@ auto BuildFieldSliceCallExpr(
   // A field occupies bits `[offset +: width]` -- a raw indexed-up part-select
   // (`value::SliceForm` `kIndexedUp` == 1); the value resolves the bit window.
   const auto form_id = block.exprs.Add(mir::MakeIntLiteral(int_type, 1));
-  std::vector<mir::ExprId> args = {base_id, offset_id, width_id, form_id};
-  AppendResultShape(unit_lowerer, block, result_type, args);
+  std::vector<mir::ExprId> operands = {offset_id, width_id, form_id};
+  AppendResultShape(unit_lowerer, block, result_type, operands);
+  if (side == AccessSide::kLhs) {
+    return ProjectOnto(
+        block, base_id,
+        mir::SliceSelector{
+            .operands = std::move(operands), .projected_type = result_type},
+        result_type);
+  }
+  std::vector<mir::ExprId> args = {base_id};
+  args.insert(args.end(), operands.begin(), operands.end());
   return mir::Expr{
       .data =
           mir::CallExpr{
-              .callee =
-                  mir::Direct{
-                      .target = side == AccessSide::kLhs
-                                    ? support::BuiltinFn::kSliceRef
-                                    : support::BuiltinFn::kSlice},
+              .callee = mir::Direct{.target = support::BuiltinFn::kSlice},
               .arguments = std::move(args)},
       .type = result_type};
 }
@@ -367,7 +409,7 @@ auto LowerHirElementSelectExpr(
     return mir::Expr{
         .data =
             mir::CallExpr{
-                .callee = ElementAccessCallee(AccessSide::kRead),
+                .callee = ElementAccessCallee(),
                 .arguments = {base_id, idx_id}},
         .type = result_type};
   }
@@ -504,19 +546,6 @@ auto LowerHirElementSelectExprLhs(
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
-  const auto& hir_base_ty = unit_lowerer.Hir().types.Get(hir_base.type);
-  // LRM 6.16: indexed character write `s[i] = ...` is the element-reference
-  // access, the write-side dual of the element-value read. It joins the generic
-  // element-access path so the place flows through the observable mutate route
-  // and the assignment shape uniformly.
-  if (hir_base_ty.Kind() == hir::TypeKind::kString) {
-    return mir::Expr{
-        .data =
-            mir::CallExpr{
-                .callee = ElementAccessCallee(AccessSide::kLhs),
-                .arguments = {base_id, idx_id}},
-        .type = result_type};
-  }
   return LowerElementSelectInner(
       unit_lowerer, block, base_id, idx_id, AccessSide::kLhs, result_type,
       false);
@@ -561,15 +590,17 @@ auto LowerHirMemberAccessExprLhs(
     auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
     const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-    return mir::Expr{
-        .data =
-            mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index.value},
-        .type = result_type};
+    return ProjectOnto(
+        block, base_id,
+        mir::ComponentSelector{
+            .index = sel.field_index.value, .projected_type = result_type},
+        result_type);
   }
-  // LRM 7.3: an unpacked union member write is the write-side access form
-  // `UnionGetRefExpr` over the union place (the by-reference counterpart of
-  // the `UnionGetExpr` read). The observable root routes through the cell's
-  // mutate path later; the place is just the projection here.
+  // LRM 7.3: an unpacked union member write descends into the union value. An
+  // untagged member write makes that member active, so it is a descent step on
+  // the designator; a tagged one instead requires the member to already be the
+  // current tag (LRM 11.9), which is its own node. The observable root routes
+  // through the cell's mutate path later.
   if (unit_lowerer.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedUnion) {
     auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
@@ -584,11 +615,11 @@ auto LowerHirMemberAccessExprLhs(
                   .union_value = base_id, .tag_index = sel.field_index.value},
           .type = result_type};
     }
-    return mir::Expr{
-        .data =
-            mir::UnionGetRefExpr{
-                .union_value = base_id, .index = sel.field_index.value},
-        .type = result_type};
+    return ProjectOnto(
+        block, base_id,
+        mir::UnionMemberSelector{
+            .index = sel.field_index.value, .projected_type = result_type},
+        result_type);
   }
   const auto& fields =
       GetAggregateFields(unit_lowerer.Hir().types.Get(base_hir_expr.type));

--- a/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
+++ b/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
@@ -10,20 +10,6 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-namespace {
-
-// Yields the container access chain's base argument when `expr` is a
-// container access (per `mir::IsContainerAccessCallee`); null otherwise.
-auto AsContainerAccessBase(const mir::Expr& expr) -> const mir::ExprId* {
-  const auto* call = std::get_if<mir::CallExpr>(&expr.data);
-  if (call == nullptr) return nullptr;
-  if (!mir::IsContainerAccessCallee(call->callee)) return nullptr;
-  if (call->arguments.empty()) return nullptr;
-  return &call->arguments.front();
-}
-
-}  // namespace
-
 auto FindLhsRootId(
     const mir::CompilationUnit& unit, const mir::Block& block,
     mir::ExprId lhs_id) -> mir::ExprId {
@@ -36,23 +22,15 @@ auto FindLhsRootId(
     if (mir::IsObservableCellType(unit.types.Get(expr.type))) {
       return lhs_id;
     }
-    // A struct member projects through a tuple component and a union member
-    // through its union access; the observable root is the base, reached the
-    // same way a container access reaches its receiver.
-    if (const auto* g = std::get_if<mir::TupleGetExpr>(&expr.data)) {
-      lhs_id = g->tuple;
-      continue;
-    }
-    if (const auto* m = std::get_if<mir::UnionGetRefExpr>(&expr.data)) {
-      lhs_id = m->union_value;
+    // A designated part of a value states its owner, so the root is reached
+    // without walking a descent chain.
+    if (const auto* projection =
+            std::get_if<mir::ValueProjectionExpr>(&expr.data)) {
+      lhs_id = projection->owner;
       continue;
     }
     if (const auto* m = std::get_if<mir::TaggedGetRefExpr>(&expr.data)) {
       lhs_id = m->union_value;
-      continue;
-    }
-    if (const auto* base = AsContainerAccessBase(expr)) {
-      lhs_id = *base;
       continue;
     }
     return lhs_id;
@@ -74,19 +52,14 @@ auto RewriteLhsRootWithMutate(
         mir::Expr{
             .data = mir::DerefExpr{.pointer = mutate_id}, .type = value_type});
   }
-  if (const auto* g = std::get_if<mir::TupleGetExpr>(&expr.data)) {
-    mir::TupleGetExpr rewritten = *g;
+  if (const auto* projection =
+          std::get_if<mir::ValueProjectionExpr>(&expr.data)) {
+    mir::ValueProjectionExpr rewritten = *projection;
     const mir::TypeId result_ty = expr.type;
-    rewritten.tuple =
-        RewriteLhsRootWithMutate(unit, block, rewritten.tuple, runtime_id);
-    return block.exprs.Add(mir::Expr{.data = rewritten, .type = result_ty});
-  }
-  if (const auto* m = std::get_if<mir::UnionGetRefExpr>(&expr.data)) {
-    mir::UnionGetRefExpr rewritten = *m;
-    const mir::TypeId result_ty = expr.type;
-    rewritten.union_value = RewriteLhsRootWithMutate(
-        unit, block, rewritten.union_value, runtime_id);
-    return block.exprs.Add(mir::Expr{.data = rewritten, .type = result_ty});
+    rewritten.owner =
+        RewriteLhsRootWithMutate(unit, block, rewritten.owner, runtime_id);
+    return block.exprs.Add(
+        mir::Expr{.data = std::move(rewritten), .type = result_ty});
   }
   if (const auto* m = std::get_if<mir::TaggedGetRefExpr>(&expr.data)) {
     mir::TaggedGetRefExpr rewritten = *m;
@@ -94,17 +67,6 @@ auto RewriteLhsRootWithMutate(
     rewritten.union_value = RewriteLhsRootWithMutate(
         unit, block, rewritten.union_value, runtime_id);
     return block.exprs.Add(mir::Expr{.data = rewritten, .type = result_ty});
-  }
-  if (AsContainerAccessBase(expr) != nullptr) {
-    auto rewritten_call = std::get<mir::CallExpr>(expr.data);
-    // Read the type out before the recursive rewrite below: that recursion
-    // appends to the same expression arena, which invalidates the `expr`
-    // reference.
-    const mir::TypeId expr_type = expr.type;
-    rewritten_call.arguments.front() = RewriteLhsRootWithMutate(
-        unit, block, rewritten_call.arguments.front(), runtime_id);
-    return block.exprs.Add(
-        mir::Expr{.data = std::move(rewritten_call), .type = expr_type});
   }
   throw InternalError(
       "RewriteLhsRootWithMutate: LHS root is neither an observable cell nor a "

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -152,12 +152,17 @@ auto LowerDestructuringAssign(
             .dims = {mir::PackedRange{
                 .left = static_cast<std::int64_t>(w) - 1, .right = 0}},
             .form = mir::PackedArrayForm::kExplicit});
+    const mir::ExprId shape_id = BuildPackedShapePrototype(
+        wrapper,
+        process.Owner().Unit().types.Get(slice_type).AsIntegralPacked(),
+        slice_type);
     const mir::ExprId raw_slice_id = wrapper.exprs.Add(
         mir::Expr{
             .data =
                 mir::CallExpr{
                     .callee = mir::Direct{.target = support::BuiltinFn::kSlice},
-                    .arguments = {temp_ref, offset_id, count_id, form_id}},
+                    .arguments =
+                        {temp_ref, offset_id, count_id, form_id, shape_id}},
             .type = slice_type});
     const mir::ExprId slice_id = wrapper.exprs.Add(
         mir::Expr{

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -162,20 +162,6 @@ auto RequiresFunctionalMutation(const mir::Type& type) -> bool {
   return type.Kind() == mir::TypeKind::kDynamicArray;
 }
 
-// Whether an element-ref or slice-ref on a value of this type is a functional
-// interior write: realized as a whole-value read / update / write-back because
-// the execution backend reaches the value through an immutable handle and
-// cannot write an interior in place. A dynamic-array element (LRM 7.4.6), a
-// string character (LRM 6.16.2), and a packed bit-select / part-select (LRM
-// 11.5.1) qualify. This is the peeling condition for an element or slice
-// selector, distinct from the mutating-method question
-// `RequiresFunctionalMutation` answers.
-auto HasFunctionalInteriorAccess(const mir::Type& type) -> bool {
-  const mir::TypeKind kind = type.Kind();
-  return kind == mir::TypeKind::kDynamicArray ||
-         kind == mir::TypeKind::kString || kind == mir::TypeKind::kPackedArray;
-}
-
 // Marks every local the canonical lowering needs an address for: one that is
 // assigned after its initialization, or has its address taken. Such a local is
 // storage, so it must be a place local. A read never makes a local storage: a
@@ -954,9 +940,9 @@ auto FunctionLowerer::LowerAssign(
   // value-container element, or any composition of them -- is not a place: the
   // aggregate is an opaque value, so the write folds into a functional
   // whole-value update stored back through the owner.
-  if (DecomposedTarget target = DecomposeTarget(block, assign.target);
-      !target.selectors.empty()) {
-    return LowerProjectionAssign(block, assign, target);
+  if (const auto* projection = std::get_if<mir::ValueProjectionExpr>(
+          &block.exprs.Get(assign.target).data)) {
+    return LowerProjectionAssign(block, assign, *projection);
   }
 
   const lir::TypeId type =
@@ -1101,88 +1087,42 @@ auto FunctionLowerer::WriteWholeValue(
   return value;
 }
 
-auto FunctionLowerer::DecomposeTarget(
-    const mir::Block& block, mir::ExprId target) -> DecomposedTarget {
-  // Peel value-projection selectors from the target inward until the expression
-  // is no longer one -- that remainder is the whole-value owner. A component
-  // (`TupleGetExpr`), a value-container element (`kElementRef`), and a
-  // part-select (`kSliceRef`) on a value reached by an opaque handle are
-  // selectors; anything else (a union member) is not one this path folds, so
-  // peeling stops there and the owner is that expression.
-  std::vector<ProjectionSelector> selectors;
-  mir::ExprId cursor = target;
-  while (true) {
-    const mir::Expr& expr = block.exprs.Get(cursor);
-    if (const auto* get = std::get_if<mir::TupleGetExpr>(&expr.data)) {
-      selectors.emplace_back(
-          ComponentSelector{
-              .index = static_cast<std::uint32_t>(get->index),
-              .container_type =
-                  unit_->TranslateType(block.exprs.Get(get->tuple).type),
-              .projected_type = unit_->TranslateType(expr.type)});
-      cursor = get->tuple;
-      continue;
-    }
-    if (const auto* call = std::get_if<mir::CallExpr>(&expr.data)) {
-      const auto fn = DirectBuiltinFn(*call);
-      const bool functional_container =
-          (fn == support::BuiltinFn::kElementRef ||
-           fn == support::BuiltinFn::kSliceRef) &&
-          HasFunctionalInteriorAccess(
-              unit_->Mir().types.Get(block.exprs.Get(call->arguments[0]).type));
-      if (functional_container && fn == support::BuiltinFn::kElementRef) {
-        selectors.emplace_back(
-            ElementSelector{
-                .index = call->arguments[1],
-                .container_type = unit_->TranslateType(
-                    block.exprs.Get(call->arguments[0]).type),
-                .projected_type = unit_->TranslateType(expr.type)});
-        cursor = call->arguments[0];
-        continue;
-      }
-      if (functional_container && fn == support::BuiltinFn::kSliceRef) {
-        selectors.emplace_back(
-            SliceSelector{
-                .a = call->arguments[1],
-                .b = call->arguments[2],
-                .form = call->arguments[3],
-                .shape = call->arguments[4],
-                .container_type = unit_->TranslateType(
-                    block.exprs.Get(call->arguments[0]).type),
-                .projected_type = unit_->TranslateType(expr.type)});
-        cursor = call->arguments[0];
-        continue;
-      }
-    }
-    break;
-  }
-  std::ranges::reverse(selectors);
-  return DecomposedTarget{.owner = cursor, .selectors = std::move(selectors)};
-}
+// Read the owner's whole value, descend the path, let `make_leaf` produce the
+// part's new value, rebuild the whole value outward, and store it back. The
+// owner and every coordinate evaluate exactly once, whatever the path's depth,
+// and the store back through the owner is a single one. `make_leaf` receives a
+// reader that extracts the part's current value on demand, so a plain store
+// never reads it and a compound or an increment reads it once.
+auto FunctionLowerer::LowerProjectionUpdate(
+    const mir::Block& block, const mir::ValueProjectionExpr& projection,
+    const LeafTransform& make_leaf) -> diag::Result<lir::Operand> {
+  const std::vector<mir::Selector>& path = projection.path;
 
-auto FunctionLowerer::LowerProjectionAssign(
-    const mir::Block& block, const mir::AssignExpr& assign,
-    const DecomposedTarget& target) -> diag::Result<lir::Operand> {
-  const std::vector<ProjectionSelector>& selectors = target.selectors;
-
-  auto owner_value = ReadWholeValue(block, target.owner);
+  auto owner_value = ReadWholeValue(block, projection.owner);
   if (!owner_value) {
     return std::unexpected(std::move(owner_value.error()));
   }
 
-  // An element's or slice's key expressions are evaluated once, shared by a
-  // compound read and the write-back; a component selector needs none.
-  std::vector<std::vector<lir::Operand>> keys(selectors.size());
-  for (std::size_t depth = 0; depth < selectors.size(); ++depth) {
-    std::vector<mir::ExprId> key_exprs;
-    if (const auto* elem = std::get_if<ElementSelector>(&selectors[depth])) {
-      key_exprs = {elem->index};
-    } else if (
-        const auto* slice = std::get_if<SliceSelector>(&selectors[depth])) {
-      key_exprs = {slice->a, slice->b, slice->form, slice->shape};
+  // A step's key expressions are evaluated once, shared by a compound read and
+  // the write-back; a positional step has none.
+  std::vector<std::vector<lir::Operand>> keys(path.size());
+  for (std::size_t depth = 0; depth < path.size(); ++depth) {
+    const std::vector<mir::ExprId>* operands = std::visit(
+        Overloaded{
+            [](const mir::ComponentSelector&) {
+              return static_cast<const std::vector<mir::ExprId>*>(nullptr);
+            },
+            [](const mir::UnionMemberSelector&) {
+              return static_cast<const std::vector<mir::ExprId>*>(nullptr);
+            },
+            [](const mir::ElementSelector& e) { return &e.operands; },
+            [](const mir::SliceSelector& s) { return &s.operands; }},
+        path[depth]);
+    if (operands == nullptr) {
+      continue;
     }
-    for (const mir::ExprId key_expr : key_exprs) {
-      auto key = LowerExpr(block, key_expr);
+    for (const mir::ExprId operand : *operands) {
+      auto key = LowerExpr(block, operand);
       if (!key) {
         return std::unexpected(std::move(key.error()));
       }
@@ -1190,117 +1130,148 @@ auto FunctionLowerer::LowerProjectionAssign(
     }
   }
 
+  // The type of the value each step descends into, and of the part it reaches.
+  const auto projected_type = [&](std::size_t depth) {
+    return unit_->TranslateType(
+        std::visit(
+            [](const auto& selector) { return selector.projected_type; },
+            path[depth]));
+  };
+  const auto container_type = [&](std::size_t depth) {
+    return depth == 0
+               ? unit_->TranslateType(block.exprs.Get(projection.owner).type)
+               : projected_type(depth - 1);
+  };
+
+  const auto call = [&](support::BuiltinFn fn, lir::TypeId result,
+                        std::vector<lir::Operand> args) {
+    return Emit(
+        result,
+        lir::CallInstr{
+            .target = lir::BuiltinTarget{.fn = fn, .qualifier = std::nullopt},
+            .args = std::move(args)});
+  };
   const auto extract = [&](const lir::Operand& container,
                            std::size_t depth) -> lir::Operand {
+    std::vector<lir::Operand> args = {container};
+    args.insert(args.end(), keys[depth].begin(), keys[depth].end());
     return std::visit(
         Overloaded{
-            [&](const ComponentSelector& c) {
+            [&](const mir::ComponentSelector& c) {
               return Emit(
-                  c.projected_type,
+                  projected_type(depth),
                   lir::AggregateExtractInstr{
                       .aggregate = container,
-                      .selector = lir::TupleElement{.index = c.index}});
+                      .selector = lir::TupleElement{
+                          .index = static_cast<std::uint32_t>(c.index)}});
             },
-            [&](const ElementSelector& e) {
+            [&](const mir::UnionMemberSelector& m) {
               return Emit(
-                  e.projected_type,
-                  lir::CallInstr{
-                      .target =
-                          lir::BuiltinTarget{
-                              .fn = support::BuiltinFn::kElement,
-                              .qualifier = std::nullopt},
-                      .args = {container, keys[depth][0]}});
+                  projected_type(depth),
+                  lir::AggregateExtractInstr{
+                      .aggregate = container,
+                      .selector = lir::TupleElement{
+                          .index = static_cast<std::uint32_t>(m.index)}});
             },
-            [&](const SliceSelector& s) {
-              return Emit(
-                  s.projected_type,
-                  lir::CallInstr{
-                      .target =
-                          lir::BuiltinTarget{
-                              .fn = support::BuiltinFn::kSlice,
-                              .qualifier = std::nullopt},
-                      .args = {
-                          container, keys[depth][0], keys[depth][1],
-                          keys[depth][2], keys[depth][3]}});
+            [&](const mir::ElementSelector&) {
+              return call(
+                  support::BuiltinFn::kElement, projected_type(depth), args);
+            },
+            [&](const mir::SliceSelector&) {
+              return call(
+                  support::BuiltinFn::kSlice, projected_type(depth), args);
             }},
-        selectors[depth]);
+        path[depth]);
   };
   const auto update = [&](const lir::Operand& container, std::size_t depth,
                           lir::Operand replacement) -> lir::Operand {
+    std::vector<lir::Operand> args = {container};
+    args.insert(args.end(), keys[depth].begin(), keys[depth].end());
+    args.push_back(replacement);
     return std::visit(
         Overloaded{
-            [&](const ComponentSelector& c) {
+            [&](const mir::ComponentSelector& c) {
               return Emit(
-                  c.container_type,
+                  container_type(depth),
                   lir::AggregateUpdateInstr{
                       .aggregate = container,
-                      .selector = lir::TupleElement{.index = c.index},
-                      .replacement = std::move(replacement)});
+                      .selector =
+                          lir::TupleElement{
+                              .index = static_cast<std::uint32_t>(c.index)},
+                      .replacement = replacement});
             },
-            [&](const ElementSelector& e) {
+            [&](const mir::UnionMemberSelector& m) {
               return Emit(
-                  e.container_type,
-                  lir::CallInstr{
-                      .target =
-                          lir::BuiltinTarget{
-                              .fn = support::BuiltinFn::kWithElement,
-                              .qualifier = std::nullopt},
-                      .args = {
-                          container, keys[depth][0], std::move(replacement)}});
+                  container_type(depth),
+                  lir::AggregateUpdateInstr{
+                      .aggregate = container,
+                      .selector =
+                          lir::TupleElement{
+                              .index = static_cast<std::uint32_t>(m.index)},
+                      .replacement = replacement});
             },
-            [&](const SliceSelector& s) {
-              return Emit(
-                  s.container_type,
-                  lir::CallInstr{
-                      .target =
-                          lir::BuiltinTarget{
-                              .fn = support::BuiltinFn::kWithSlice,
-                              .qualifier = std::nullopt},
-                      .args = {
-                          container, keys[depth][0], keys[depth][1],
-                          keys[depth][2], keys[depth][3],
-                          std::move(replacement)}});
+            [&](const mir::ElementSelector&) {
+              return call(
+                  support::BuiltinFn::kWithElement, container_type(depth),
+                  args);
+            },
+            [&](const mir::SliceSelector&) {
+              return call(
+                  support::BuiltinFn::kWithSlice, container_type(depth), args);
             }},
-        selectors[depth]);
+        path[depth]);
   };
 
   // The whole value at each chain level, descending from the owner toward the
   // sub-value being written.
   std::vector<lir::Operand> containers;
-  containers.reserve(selectors.size());
+  containers.reserve(path.size());
   containers.push_back(*std::move(owner_value));
-  for (std::size_t depth = 1; depth < selectors.size(); ++depth) {
+  for (std::size_t depth = 1; depth < path.size(); ++depth) {
     containers.push_back(extract(containers[depth - 1], depth - 1));
   }
 
-  auto rhs = LowerExpr(block, assign.value);
-  if (!rhs) {
-    return std::unexpected(std::move(rhs.error()));
-  }
-  const std::size_t leaf = selectors.size() - 1;
-  lir::Operand leaf_value = *std::move(rhs);
-  if (assign.compound_op.has_value()) {
-    const std::optional<lir::BinaryOp> op =
-        TranslateBinaryOp(*assign.compound_op);
-    if (!op) {
-      return Unsupported(
-          "mir_to_lir: compound assignment operator has no direct realization");
-    }
-    lir::Operand old = extract(containers[leaf], leaf);
-    leaf_value = Emit(
-        std::visit(
-            [](const auto& sel) { return sel.projected_type; },
-            selectors[leaf]),
-        lir::BinaryInstr{
-            .op = *op, .lhs = std::move(old), .rhs = std::move(leaf_value)});
+  const std::size_t leaf = path.size() - 1;
+  auto leaf_value = make_leaf(
+      [&] { return extract(containers[leaf], leaf); }, projected_type(leaf));
+  if (!leaf_value) {
+    return std::unexpected(std::move(leaf_value.error()));
   }
 
   // Rebuild the whole value from the written sub-value outward.
-  lir::Operand rebuilt = std::move(leaf_value);
-  for (std::size_t depth = selectors.size(); depth-- > 0;) {
+  lir::Operand rebuilt = *std::move(leaf_value);
+  for (std::size_t depth = path.size(); depth-- > 0;) {
     rebuilt = update(containers[depth], depth, std::move(rebuilt));
   }
-  return WriteWholeValue(block, target.owner, std::move(rebuilt));
+  return WriteWholeValue(block, projection.owner, std::move(rebuilt));
+}
+
+auto FunctionLowerer::LowerProjectionAssign(
+    const mir::Block& block, const mir::AssignExpr& assign,
+    const mir::ValueProjectionExpr& projection) -> diag::Result<lir::Operand> {
+  return LowerProjectionUpdate(
+      block, projection,
+      [&](const LeafReader& read_leaf,
+          lir::TypeId leaf_type) -> diag::Result<lir::Operand> {
+        auto rhs = LowerExpr(block, assign.value);
+        if (!rhs) {
+          return std::unexpected(std::move(rhs.error()));
+        }
+        if (!assign.compound_op.has_value()) {
+          return *std::move(rhs);
+        }
+        const std::optional<lir::BinaryOp> op =
+            TranslateBinaryOp(*assign.compound_op);
+        if (!op) {
+          return Unsupported(
+              "mir_to_lir: compound assignment operator has no direct "
+              "realization");
+        }
+        return Emit(
+            leaf_type,
+            lir::BinaryInstr{
+                .op = *op, .lhs = read_leaf(), .rhs = *std::move(rhs)});
+      });
 }
 
 auto FunctionLowerer::LowerMutatingCall(
@@ -1344,6 +1315,28 @@ auto FunctionLowerer::LowerIncDec(
                          inc_dec.op == mir::IncDecOp::kPreDec;
   const lir::UnaryOp op =
       is_increment ? lir::UnaryOp::kIncrement : lir::UnaryOp::kDecrement;
+
+  // A designated part increments through its owner: the part's current value is
+  // read out of the owner's whole value, stepped, and folded back in.
+  if (const auto* projection = std::get_if<mir::ValueProjectionExpr>(
+          &block.exprs.Get(inc_dec.target).data)) {
+    std::optional<lir::Operand> old;
+    std::optional<lir::Operand> stepped;
+    auto written = LowerProjectionUpdate(
+        block, *projection,
+        [&](const LeafReader& read_leaf,
+            lir::TypeId leaf_type) -> diag::Result<lir::Operand> {
+          old = read_leaf();
+          stepped = Emit(leaf_type, lir::UnaryInstr{.op = op, .operand = *old});
+          return *stepped;
+        });
+    if (!written) {
+      return std::unexpected(std::move(written.error()));
+    }
+    // What was stored is the owner's whole value; the statement's own value is
+    // the part, before or after the step.
+    return is_prefix ? *stepped : *old;
+  }
 
   // An activation-frame value local increments through its handle: read the old
   // value out, apply the step, overwrite.

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -163,14 +163,16 @@ auto RequiresFunctionalMutation(const mir::Type& type) -> bool {
 }
 
 // Whether a `kElementRef` on a value of this type is a functional element
-// write: realized as a whole-value read / update / write-back because the value
-// is reached by an opaque handle and cannot be mutated in place. A
-// dynamic-array element (LRM 7.4.6) and a string character (LRM 6.16.2)
+// write: realized as a whole-value read / update / write-back because the
+// execution backend reaches the value through an immutable handle and cannot
+// write an element in place. A dynamic-array element (LRM 7.4.6), a string
+// character (LRM 6.16.2), and a packed bit-select / element (LRM 11.5.1)
 // qualify. This is the peeling condition for an element selector, distinct from
 // the mutating-method question `RequiresFunctionalMutation` answers.
 auto HasFunctionalElementAccess(const mir::Type& type) -> bool {
   const mir::TypeKind kind = type.Kind();
-  return kind == mir::TypeKind::kDynamicArray || kind == mir::TypeKind::kString;
+  return kind == mir::TypeKind::kDynamicArray ||
+         kind == mir::TypeKind::kString || kind == mir::TypeKind::kPackedArray;
 }
 
 // Marks every local the canonical lowering needs an address for: one that is

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -1146,83 +1146,43 @@ auto FunctionLowerer::LowerProjectionUpdate(
                : projected_type(depth - 1);
   };
 
-  const auto call = [&](support::BuiltinFn fn, lir::TypeId result,
-                        std::vector<lir::Operand> args) {
-    return Emit(
-        result,
-        lir::CallInstr{
-            .target = lir::BuiltinTarget{.fn = fn, .qualifier = std::nullopt},
-            .args = std::move(args)});
+  // The step's selector, in LIR's own vocabulary. A positional step names a
+  // component slot; a coordinate-bearing one carries the operands it was
+  // evaluated with. Which runtime entry realizes a step follows from the
+  // aggregate's type, below this layer.
+  const auto selector = [&](std::size_t depth) -> lir::AggregateSelector {
+    return std::visit(
+        Overloaded{
+            [&](const mir::ComponentSelector& c) -> lir::AggregateSelector {
+              return lir::TupleElement{
+                  .index = static_cast<std::uint32_t>(c.index)};
+            },
+            [&](const mir::UnionMemberSelector& m) -> lir::AggregateSelector {
+              return lir::UnionMember{
+                  .index = static_cast<std::uint32_t>(m.index)};
+            },
+            [&](const mir::ElementSelector&) -> lir::AggregateSelector {
+              return lir::ContainerElement{.operands = keys[depth]};
+            },
+            [&](const mir::SliceSelector&) -> lir::AggregateSelector {
+              return lir::ContainerSlice{.operands = keys[depth]};
+            }},
+        path[depth]);
   };
   const auto extract = [&](const lir::Operand& container,
                            std::size_t depth) -> lir::Operand {
-    std::vector<lir::Operand> args = {container};
-    args.insert(args.end(), keys[depth].begin(), keys[depth].end());
-    return std::visit(
-        Overloaded{
-            [&](const mir::ComponentSelector& c) {
-              return Emit(
-                  projected_type(depth),
-                  lir::AggregateExtractInstr{
-                      .aggregate = container,
-                      .selector = lir::TupleElement{
-                          .index = static_cast<std::uint32_t>(c.index)}});
-            },
-            [&](const mir::UnionMemberSelector& m) {
-              return Emit(
-                  projected_type(depth),
-                  lir::AggregateExtractInstr{
-                      .aggregate = container,
-                      .selector = lir::TupleElement{
-                          .index = static_cast<std::uint32_t>(m.index)}});
-            },
-            [&](const mir::ElementSelector&) {
-              return call(
-                  support::BuiltinFn::kElement, projected_type(depth), args);
-            },
-            [&](const mir::SliceSelector&) {
-              return call(
-                  support::BuiltinFn::kSlice, projected_type(depth), args);
-            }},
-        path[depth]);
+    return Emit(
+        projected_type(depth),
+        lir::AggregateExtractInstr{
+            .aggregate = container, .selector = selector(depth)});
   };
   const auto update = [&](const lir::Operand& container, std::size_t depth,
                           lir::Operand replacement) -> lir::Operand {
-    std::vector<lir::Operand> args = {container};
-    args.insert(args.end(), keys[depth].begin(), keys[depth].end());
-    args.push_back(replacement);
-    return std::visit(
-        Overloaded{
-            [&](const mir::ComponentSelector& c) {
-              return Emit(
-                  container_type(depth),
-                  lir::AggregateUpdateInstr{
-                      .aggregate = container,
-                      .selector =
-                          lir::TupleElement{
-                              .index = static_cast<std::uint32_t>(c.index)},
-                      .replacement = replacement});
-            },
-            [&](const mir::UnionMemberSelector& m) {
-              return Emit(
-                  container_type(depth),
-                  lir::AggregateUpdateInstr{
-                      .aggregate = container,
-                      .selector =
-                          lir::TupleElement{
-                              .index = static_cast<std::uint32_t>(m.index)},
-                      .replacement = replacement});
-            },
-            [&](const mir::ElementSelector&) {
-              return call(
-                  support::BuiltinFn::kWithElement, container_type(depth),
-                  args);
-            },
-            [&](const mir::SliceSelector&) {
-              return call(
-                  support::BuiltinFn::kWithSlice, container_type(depth), args);
-            }},
-        path[depth]);
+    return Emit(
+        container_type(depth), lir::AggregateUpdateInstr{
+                                   .aggregate = container,
+                                   .selector = selector(depth),
+                                   .replacement = std::move(replacement)});
   };
 
   // The whole value at each chain level, descending from the owner toward the

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -940,9 +940,9 @@ auto FunctionLowerer::LowerAssign(
   // value-container element, or any composition of them -- is not a place: the
   // aggregate is an opaque value, so the write folds into a functional
   // whole-value update stored back through the owner.
-  if (const auto* projection = std::get_if<mir::ValueProjectionExpr>(
-          &block.exprs.Get(assign.target).data)) {
-    return LowerProjectionAssign(block, assign, *projection);
+  if (std::holds_alternative<mir::ValueProjectionExpr>(
+          block.exprs.Get(assign.target).data)) {
+    return LowerProjectionAssign(block, assign);
   }
 
   const lir::TypeId type =
@@ -1094,8 +1094,11 @@ auto FunctionLowerer::WriteWholeValue(
 // reader that extracts the part's current value on demand, so a plain store
 // never reads it and a compound or an increment reads it once.
 auto FunctionLowerer::LowerProjectionUpdate(
-    const mir::Block& block, const mir::ValueProjectionExpr& projection,
-    const LeafTransform& make_leaf) -> diag::Result<lir::Operand> {
+    const mir::Block& block, mir::ExprId target, const LeafTransform& make_leaf)
+    -> diag::Result<lir::Operand> {
+  const mir::Expr& target_expr = block.exprs.Get(target);
+  const auto& projection = std::get<mir::ValueProjectionExpr>(target_expr.data);
+  const lir::TypeId designated_type = unit_->TranslateType(target_expr.type);
   const std::vector<mir::Selector>& path = projection.path;
 
   auto owner_value = ReadWholeValue(block, projection.owner);
@@ -1231,9 +1234,17 @@ auto FunctionLowerer::LowerProjectionUpdate(
     containers.push_back(extract(containers[depth - 1], depth - 1));
   }
 
+  // The last step reaches what the designator denotes, so the two statements of
+  // that type must agree; a disagreement means the path and the node's type
+  // came from different lowerings.
   const std::size_t leaf = path.size() - 1;
+  if (projected_type(leaf) != designated_type) {
+    throw InternalError(
+        "mir_to_lir: a designator's last step reaches a different type than "
+        "the designator states");
+  }
   auto leaf_value = make_leaf(
-      [&] { return extract(containers[leaf], leaf); }, projected_type(leaf));
+      [&] { return extract(containers[leaf], leaf); }, designated_type);
   if (!leaf_value) {
     return std::unexpected(std::move(leaf_value.error()));
   }
@@ -1247,10 +1258,10 @@ auto FunctionLowerer::LowerProjectionUpdate(
 }
 
 auto FunctionLowerer::LowerProjectionAssign(
-    const mir::Block& block, const mir::AssignExpr& assign,
-    const mir::ValueProjectionExpr& projection) -> diag::Result<lir::Operand> {
+    const mir::Block& block, const mir::AssignExpr& assign)
+    -> diag::Result<lir::Operand> {
   return LowerProjectionUpdate(
-      block, projection,
+      block, assign.target,
       [&](const LeafReader& read_leaf,
           lir::TypeId leaf_type) -> diag::Result<lir::Operand> {
         auto rhs = LowerExpr(block, assign.value);
@@ -1318,12 +1329,12 @@ auto FunctionLowerer::LowerIncDec(
 
   // A designated part increments through its owner: the part's current value is
   // read out of the owner's whole value, stepped, and folded back in.
-  if (const auto* projection = std::get_if<mir::ValueProjectionExpr>(
-          &block.exprs.Get(inc_dec.target).data)) {
+  if (std::holds_alternative<mir::ValueProjectionExpr>(
+          block.exprs.Get(inc_dec.target).data)) {
     std::optional<lir::Operand> old;
     std::optional<lir::Operand> stepped;
     auto written = LowerProjectionUpdate(
-        block, *projection,
+        block, inc_dec.target,
         [&](const LeafReader& read_leaf,
             lir::TypeId leaf_type) -> diag::Result<lir::Operand> {
           old = read_leaf();

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -1146,6 +1146,7 @@ auto FunctionLowerer::DecomposeTarget(
                 .a = call->arguments[1],
                 .b = call->arguments[2],
                 .form = call->arguments[3],
+                .shape = call->arguments[4],
                 .container_type = unit_->TranslateType(
                     block.exprs.Get(call->arguments[0]).type),
                 .projected_type = unit_->TranslateType(expr.type)});
@@ -1178,7 +1179,7 @@ auto FunctionLowerer::LowerProjectionAssign(
       key_exprs = {elem->index};
     } else if (
         const auto* slice = std::get_if<SliceSelector>(&selectors[depth])) {
-      key_exprs = {slice->a, slice->b, slice->form};
+      key_exprs = {slice->a, slice->b, slice->form, slice->shape};
     }
     for (const mir::ExprId key_expr : key_exprs) {
       auto key = LowerExpr(block, key_expr);
@@ -1220,7 +1221,7 @@ auto FunctionLowerer::LowerProjectionAssign(
                               .qualifier = std::nullopt},
                       .args = {
                           container, keys[depth][0], keys[depth][1],
-                          keys[depth][2]}});
+                          keys[depth][2], keys[depth][3]}});
             }},
         selectors[depth]);
   };
@@ -1257,7 +1258,8 @@ auto FunctionLowerer::LowerProjectionAssign(
                               .qualifier = std::nullopt},
                       .args = {
                           container, keys[depth][0], keys[depth][1],
-                          keys[depth][2], std::move(replacement)}});
+                          keys[depth][2], keys[depth][3],
+                          std::move(replacement)}});
             }},
         selectors[depth]);
   };

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -162,6 +162,17 @@ auto RequiresFunctionalMutation(const mir::Type& type) -> bool {
   return type.Kind() == mir::TypeKind::kDynamicArray;
 }
 
+// Whether a `kElementRef` on a value of this type is a functional element
+// write: realized as a whole-value read / update / write-back because the value
+// is reached by an opaque handle and cannot be mutated in place. A
+// dynamic-array element (LRM 7.4.6) and a string character (LRM 6.16.2)
+// qualify. This is the peeling condition for an element selector, distinct from
+// the mutating-method question `RequiresFunctionalMutation` answers.
+auto HasFunctionalElementAccess(const mir::Type& type) -> bool {
+  const mir::TypeKind kind = type.Kind();
+  return kind == mir::TypeKind::kDynamicArray || kind == mir::TypeKind::kString;
+}
+
 // Marks every local the canonical lowering needs an address for: one that is
 // assigned after its initialization, or has its address taken. Such a local is
 // storage, so it must be a place local. A read never makes a local storage: a
@@ -936,25 +947,13 @@ auto FunctionLowerer::LowerCall(
 auto FunctionLowerer::LowerAssign(
     const mir::Block& block, const mir::AssignExpr& assign)
     -> diag::Result<lir::Operand> {
-  // A write to a product component is not a place store: the product is an
-  // opaque value, so the component write is a whole-value rebuild stored back
-  // through the product's owner.
-  if (std::holds_alternative<mir::TupleGetExpr>(
-          block.exprs.Get(assign.target).data)) {
-    return LowerComponentAssign(block, assign);
-  }
-
-  // A write to a value-container element (`arr[i] = x`) targets the container-
-  // access write reference. The container is likewise an opaque value, so the
-  // write is a functional whole-value update stored back through its owner.
-  if (const auto* call =
-          std::get_if<mir::CallExpr>(&block.exprs.Get(assign.target).data)) {
-    if (const auto fn = DirectBuiltinFn(*call);
-        fn == support::BuiltinFn::kElementRef &&
-        RequiresFunctionalMutation(
-            unit_->Mir().types.Get(block.exprs.Get(call->arguments[0]).type))) {
-      return LowerElementAssign(block, assign);
-    }
+  // A target that projects into a value aggregate -- a product component, a
+  // value-container element, or any composition of them -- is not a place: the
+  // aggregate is an opaque value, so the write folds into a functional
+  // whole-value update stored back through the owner.
+  if (DecomposedTarget target = DecomposeTarget(block, assign.target);
+      !target.selectors.empty()) {
+    return LowerProjectionAssign(block, assign, target);
   }
 
   const lir::TypeId type =
@@ -1099,58 +1098,135 @@ auto FunctionLowerer::WriteWholeValue(
   return value;
 }
 
-auto FunctionLowerer::LowerComponentAssign(
-    const mir::Block& block, const mir::AssignExpr& assign)
-    -> diag::Result<lir::Operand> {
-  // Walk the component-projection chain from the target down to its storage
-  // root, collecting each level's component index and product type.
-  struct Level {
-    std::uint32_t index;
-    lir::TypeId tuple_type;
-    lir::TypeId component_type;
-  };
-  std::vector<Level> levels;
-  mir::ExprId cursor = assign.target;
+auto FunctionLowerer::DecomposeTarget(
+    const mir::Block& block, mir::ExprId target) -> DecomposedTarget {
+  // Peel value-projection selectors from the target inward until the expression
+  // is no longer one -- that remainder is the whole-value owner. A component
+  // (`TupleGetExpr`) and a value-container element (`kElementRef` on a
+  // container reached by an opaque handle) are selectors; a bit-select, a
+  // slice, or a union member is not one this path folds, so peeling stops there
+  // and the owner is that expression.
+  std::vector<ProjectionSelector> selectors;
+  mir::ExprId cursor = target;
   while (true) {
     const mir::Expr& expr = block.exprs.Get(cursor);
-    const auto* get = std::get_if<mir::TupleGetExpr>(&expr.data);
-    if (get == nullptr) {
-      break;
+    if (const auto* get = std::get_if<mir::TupleGetExpr>(&expr.data)) {
+      selectors.emplace_back(
+          ComponentSelector{
+              .index = static_cast<std::uint32_t>(get->index),
+              .container_type =
+                  unit_->TranslateType(block.exprs.Get(get->tuple).type),
+              .projected_type = unit_->TranslateType(expr.type)});
+      cursor = get->tuple;
+      continue;
     }
-    levels.push_back(
-        Level{
-            .index = static_cast<std::uint32_t>(get->index),
-            .tuple_type =
-                unit_->TranslateType(block.exprs.Get(get->tuple).type),
-            .component_type = unit_->TranslateType(expr.type)});
-    cursor = get->tuple;
+    if (const auto* call = std::get_if<mir::CallExpr>(&expr.data)) {
+      if (const auto fn = DirectBuiltinFn(*call);
+          fn == support::BuiltinFn::kElementRef &&
+          HasFunctionalElementAccess(unit_->Mir().types.Get(
+              block.exprs.Get(call->arguments[0]).type))) {
+        selectors.emplace_back(
+            ElementSelector{
+                .index = call->arguments[1],
+                .container_type = unit_->TranslateType(
+                    block.exprs.Get(call->arguments[0]).type),
+                .projected_type = unit_->TranslateType(expr.type)});
+        cursor = call->arguments[0];
+        continue;
+      }
+    }
+    break;
   }
-  std::ranges::reverse(levels);
-  const mir::ExprId root = cursor;
+  std::ranges::reverse(selectors);
+  return DecomposedTarget{.owner = cursor, .selectors = std::move(selectors)};
+}
 
-  auto root_value = ReadWholeValue(block, root);
-  if (!root_value) {
-    return std::unexpected(std::move(root_value.error()));
+auto FunctionLowerer::LowerProjectionAssign(
+    const mir::Block& block, const mir::AssignExpr& assign,
+    const DecomposedTarget& target) -> diag::Result<lir::Operand> {
+  const std::vector<ProjectionSelector>& selectors = target.selectors;
+
+  auto owner_value = ReadWholeValue(block, target.owner);
+  if (!owner_value) {
+    return std::unexpected(std::move(owner_value.error()));
   }
 
-  // The product value at each chain level, descending from the root toward the
-  // component being written.
-  std::vector<lir::Operand> tuples;
-  tuples.reserve(levels.size());
-  tuples.push_back(*std::move(root_value));
-  for (std::size_t depth = 1; depth < levels.size(); ++depth) {
-    tuples.push_back(Emit(
-        levels[depth].tuple_type,
-        lir::AggregateExtractInstr{
-            .aggregate = tuples[depth - 1],
-            .selector = lir::TupleElement{.index = levels[depth - 1].index}}));
+  // A container element's index is evaluated once, shared by its compound read
+  // and its write-back; a component selector needs none.
+  std::vector<std::optional<lir::Operand>> indices(selectors.size());
+  for (std::size_t depth = 0; depth < selectors.size(); ++depth) {
+    if (const auto* elem = std::get_if<ElementSelector>(&selectors[depth])) {
+      auto index = LowerExpr(block, elem->index);
+      if (!index) {
+        return std::unexpected(std::move(index.error()));
+      }
+      indices[depth] = *std::move(index);
+    }
+  }
+
+  const auto extract = [&](const lir::Operand& container,
+                           std::size_t depth) -> lir::Operand {
+    return std::visit(
+        Overloaded{
+            [&](const ComponentSelector& c) {
+              return Emit(
+                  c.projected_type,
+                  lir::AggregateExtractInstr{
+                      .aggregate = container,
+                      .selector = lir::TupleElement{.index = c.index}});
+            },
+            [&](const ElementSelector& e) {
+              return Emit(
+                  e.projected_type,
+                  lir::CallInstr{
+                      .target =
+                          lir::BuiltinTarget{
+                              .fn = support::BuiltinFn::kElement,
+                              .qualifier = std::nullopt},
+                      .args = {container, *indices[depth]}});
+            }},
+        selectors[depth]);
+  };
+  const auto update = [&](const lir::Operand& container, std::size_t depth,
+                          lir::Operand replacement) -> lir::Operand {
+    return std::visit(
+        Overloaded{
+            [&](const ComponentSelector& c) {
+              return Emit(
+                  c.container_type,
+                  lir::AggregateUpdateInstr{
+                      .aggregate = container,
+                      .selector = lir::TupleElement{.index = c.index},
+                      .replacement = std::move(replacement)});
+            },
+            [&](const ElementSelector& e) {
+              return Emit(
+                  e.container_type,
+                  lir::CallInstr{
+                      .target =
+                          lir::BuiltinTarget{
+                              .fn = support::BuiltinFn::kWithElement,
+                              .qualifier = std::nullopt},
+                      .args = {
+                          container, *indices[depth], std::move(replacement)}});
+            }},
+        selectors[depth]);
+  };
+
+  // The whole value at each chain level, descending from the owner toward the
+  // sub-value being written.
+  std::vector<lir::Operand> containers;
+  containers.reserve(selectors.size());
+  containers.push_back(*std::move(owner_value));
+  for (std::size_t depth = 1; depth < selectors.size(); ++depth) {
+    containers.push_back(extract(containers[depth - 1], depth - 1));
   }
 
   auto rhs = LowerExpr(block, assign.value);
   if (!rhs) {
     return std::unexpected(std::move(rhs.error()));
   }
-  const std::size_t leaf = levels.size() - 1;
+  const std::size_t leaf = selectors.size() - 1;
   lir::Operand leaf_value = *std::move(rhs);
   if (assign.compound_op.has_value()) {
     const std::optional<lir::BinaryOp> op =
@@ -1159,88 +1235,21 @@ auto FunctionLowerer::LowerComponentAssign(
       return Unsupported(
           "mir_to_lir: compound assignment operator has no direct realization");
     }
-    lir::Operand old = Emit(
-        levels[leaf].component_type,
-        lir::AggregateExtractInstr{
-            .aggregate = tuples[leaf],
-            .selector = lir::TupleElement{.index = levels[leaf].index}});
+    lir::Operand old = extract(containers[leaf], leaf);
     leaf_value = Emit(
-        levels[leaf].component_type,
+        std::visit(
+            [](const auto& sel) { return sel.projected_type; },
+            selectors[leaf]),
         lir::BinaryInstr{
             .op = *op, .lhs = std::move(old), .rhs = std::move(leaf_value)});
   }
 
-  // Rebuild the whole value from the written component outward.
+  // Rebuild the whole value from the written sub-value outward.
   lir::Operand rebuilt = std::move(leaf_value);
-  for (std::size_t depth = levels.size(); depth-- > 0;) {
-    rebuilt = Emit(
-        levels[depth].tuple_type,
-        lir::AggregateUpdateInstr{
-            .aggregate = tuples[depth],
-            .selector = lir::TupleElement{.index = levels[depth].index},
-            .replacement = std::move(rebuilt)});
+  for (std::size_t depth = selectors.size(); depth-- > 0;) {
+    rebuilt = update(containers[depth], depth, std::move(rebuilt));
   }
-
-  return WriteWholeValue(block, root, std::move(rebuilt));
-}
-
-auto FunctionLowerer::LowerElementAssign(
-    const mir::Block& block, const mir::AssignExpr& assign)
-    -> diag::Result<lir::Operand> {
-  const auto& target =
-      std::get<mir::CallExpr>(block.exprs.Get(assign.target).data);
-  const mir::ExprId container = target.arguments[0];
-  const mir::ExprId index = target.arguments[1];
-  const lir::TypeId container_type =
-      unit_->TranslateType(block.exprs.Get(container).type);
-  const lir::TypeId element_type =
-      unit_->TranslateType(block.exprs.Get(assign.target).type);
-
-  auto array = ReadWholeValue(block, container);
-  if (!array) {
-    return std::unexpected(std::move(array.error()));
-  }
-  const lir::Operand array_value = *std::move(array);
-  auto index_value = LowerExpr(block, index);
-  if (!index_value) {
-    return std::unexpected(std::move(index_value.error()));
-  }
-  auto rhs = LowerExpr(block, assign.value);
-  if (!rhs) {
-    return std::unexpected(std::move(rhs.error()));
-  }
-
-  lir::Operand replacement = *std::move(rhs);
-  if (assign.compound_op.has_value()) {
-    const std::optional<lir::BinaryOp> op =
-        TranslateBinaryOp(*assign.compound_op);
-    if (!op) {
-      return Unsupported(
-          "mir_to_lir: compound assignment operator has no direct realization");
-    }
-    lir::Operand old = Emit(
-        element_type, lir::CallInstr{
-                          .target =
-                              lir::BuiltinTarget{
-                                  .fn = support::BuiltinFn::kElement,
-                                  .qualifier = std::nullopt},
-                          .args = {array_value, *index_value}});
-    replacement = Emit(
-        element_type,
-        lir::BinaryInstr{
-            .op = *op, .lhs = std::move(old), .rhs = std::move(replacement)});
-  }
-
-  lir::Operand updated = Emit(
-      container_type,
-      lir::CallInstr{
-          .target =
-              lir::BuiltinTarget{
-                  .fn = support::BuiltinFn::kWithElement,
-                  .qualifier = std::nullopt},
-          .args = {
-              array_value, *std::move(index_value), std::move(replacement)}});
-  return WriteWholeValue(block, container, std::move(updated));
+  return WriteWholeValue(block, target.owner, std::move(rebuilt));
 }
 
 auto FunctionLowerer::LowerMutatingCall(

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -162,14 +162,15 @@ auto RequiresFunctionalMutation(const mir::Type& type) -> bool {
   return type.Kind() == mir::TypeKind::kDynamicArray;
 }
 
-// Whether a `kElementRef` on a value of this type is a functional element
-// write: realized as a whole-value read / update / write-back because the
-// execution backend reaches the value through an immutable handle and cannot
-// write an element in place. A dynamic-array element (LRM 7.4.6), a string
-// character (LRM 6.16.2), and a packed bit-select / element (LRM 11.5.1)
-// qualify. This is the peeling condition for an element selector, distinct from
-// the mutating-method question `RequiresFunctionalMutation` answers.
-auto HasFunctionalElementAccess(const mir::Type& type) -> bool {
+// Whether an element-ref or slice-ref on a value of this type is a functional
+// interior write: realized as a whole-value read / update / write-back because
+// the execution backend reaches the value through an immutable handle and
+// cannot write an interior in place. A dynamic-array element (LRM 7.4.6), a
+// string character (LRM 6.16.2), and a packed bit-select / part-select (LRM
+// 11.5.1) qualify. This is the peeling condition for an element or slice
+// selector, distinct from the mutating-method question
+// `RequiresFunctionalMutation` answers.
+auto HasFunctionalInteriorAccess(const mir::Type& type) -> bool {
   const mir::TypeKind kind = type.Kind();
   return kind == mir::TypeKind::kDynamicArray ||
          kind == mir::TypeKind::kString || kind == mir::TypeKind::kPackedArray;
@@ -1104,10 +1105,10 @@ auto FunctionLowerer::DecomposeTarget(
     const mir::Block& block, mir::ExprId target) -> DecomposedTarget {
   // Peel value-projection selectors from the target inward until the expression
   // is no longer one -- that remainder is the whole-value owner. A component
-  // (`TupleGetExpr`) and a value-container element (`kElementRef` on a
-  // container reached by an opaque handle) are selectors; a bit-select, a
-  // slice, or a union member is not one this path folds, so peeling stops there
-  // and the owner is that expression.
+  // (`TupleGetExpr`), a value-container element (`kElementRef`), and a
+  // part-select (`kSliceRef`) on a value reached by an opaque handle are
+  // selectors; anything else (a union member) is not one this path folds, so
+  // peeling stops there and the owner is that expression.
   std::vector<ProjectionSelector> selectors;
   mir::ExprId cursor = target;
   while (true) {
@@ -1123,13 +1124,28 @@ auto FunctionLowerer::DecomposeTarget(
       continue;
     }
     if (const auto* call = std::get_if<mir::CallExpr>(&expr.data)) {
-      if (const auto fn = DirectBuiltinFn(*call);
-          fn == support::BuiltinFn::kElementRef &&
-          HasFunctionalElementAccess(unit_->Mir().types.Get(
-              block.exprs.Get(call->arguments[0]).type))) {
+      const auto fn = DirectBuiltinFn(*call);
+      const bool functional_container =
+          (fn == support::BuiltinFn::kElementRef ||
+           fn == support::BuiltinFn::kSliceRef) &&
+          HasFunctionalInteriorAccess(
+              unit_->Mir().types.Get(block.exprs.Get(call->arguments[0]).type));
+      if (functional_container && fn == support::BuiltinFn::kElementRef) {
         selectors.emplace_back(
             ElementSelector{
                 .index = call->arguments[1],
+                .container_type = unit_->TranslateType(
+                    block.exprs.Get(call->arguments[0]).type),
+                .projected_type = unit_->TranslateType(expr.type)});
+        cursor = call->arguments[0];
+        continue;
+      }
+      if (functional_container && fn == support::BuiltinFn::kSliceRef) {
+        selectors.emplace_back(
+            SliceSelector{
+                .a = call->arguments[1],
+                .b = call->arguments[2],
+                .form = call->arguments[3],
                 .container_type = unit_->TranslateType(
                     block.exprs.Get(call->arguments[0]).type),
                 .projected_type = unit_->TranslateType(expr.type)});
@@ -1153,16 +1169,23 @@ auto FunctionLowerer::LowerProjectionAssign(
     return std::unexpected(std::move(owner_value.error()));
   }
 
-  // A container element's index is evaluated once, shared by its compound read
-  // and its write-back; a component selector needs none.
-  std::vector<std::optional<lir::Operand>> indices(selectors.size());
+  // An element's or slice's key expressions are evaluated once, shared by a
+  // compound read and the write-back; a component selector needs none.
+  std::vector<std::vector<lir::Operand>> keys(selectors.size());
   for (std::size_t depth = 0; depth < selectors.size(); ++depth) {
+    std::vector<mir::ExprId> key_exprs;
     if (const auto* elem = std::get_if<ElementSelector>(&selectors[depth])) {
-      auto index = LowerExpr(block, elem->index);
-      if (!index) {
-        return std::unexpected(std::move(index.error()));
+      key_exprs = {elem->index};
+    } else if (
+        const auto* slice = std::get_if<SliceSelector>(&selectors[depth])) {
+      key_exprs = {slice->a, slice->b, slice->form};
+    }
+    for (const mir::ExprId key_expr : key_exprs) {
+      auto key = LowerExpr(block, key_expr);
+      if (!key) {
+        return std::unexpected(std::move(key.error()));
       }
-      indices[depth] = *std::move(index);
+      keys[depth].push_back(*std::move(key));
     }
   }
 
@@ -1185,7 +1208,19 @@ auto FunctionLowerer::LowerProjectionAssign(
                           lir::BuiltinTarget{
                               .fn = support::BuiltinFn::kElement,
                               .qualifier = std::nullopt},
-                      .args = {container, *indices[depth]}});
+                      .args = {container, keys[depth][0]}});
+            },
+            [&](const SliceSelector& s) {
+              return Emit(
+                  s.projected_type,
+                  lir::CallInstr{
+                      .target =
+                          lir::BuiltinTarget{
+                              .fn = support::BuiltinFn::kSlice,
+                              .qualifier = std::nullopt},
+                      .args = {
+                          container, keys[depth][0], keys[depth][1],
+                          keys[depth][2]}});
             }},
         selectors[depth]);
   };
@@ -1210,7 +1245,19 @@ auto FunctionLowerer::LowerProjectionAssign(
                               .fn = support::BuiltinFn::kWithElement,
                               .qualifier = std::nullopt},
                       .args = {
-                          container, *indices[depth], std::move(replacement)}});
+                          container, keys[depth][0], std::move(replacement)}});
+            },
+            [&](const SliceSelector& s) {
+              return Emit(
+                  s.container_type,
+                  lir::CallInstr{
+                      .target =
+                          lir::BuiltinTarget{
+                              .fn = support::BuiltinFn::kWithSlice,
+                              .qualifier = std::nullopt},
+                      .args = {
+                          container, keys[depth][0], keys[depth][1],
+                          keys[depth][2], std::move(replacement)}});
             }},
         selectors[depth]);
   };

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -853,10 +853,39 @@ class MirDumper {
                   "UnionGetExpr union=Expr[{}] index={}", g.union_value.value,
                   g.index);
             },
-            [](const UnionGetRefExpr& g) -> std::string {
+            [](const ValueProjectionExpr& p) -> std::string {
+              const auto operands =
+                  [](const std::vector<ExprId>& ids) -> std::string {
+                std::string out;
+                for (const ExprId id : ids) {
+                  out += out.empty() ? "" : ", ";
+                  out += std::format("Expr[{}]", id.value);
+                }
+                return out;
+              };
+              std::string path;
+              for (const Selector& selector : p.path) {
+                path += path.empty() ? "" : ", ";
+                path += std::visit(
+                    Overloaded{
+                        [](const ComponentSelector& c) -> std::string {
+                          return std::format("component {}", c.index);
+                        },
+                        [](const UnionMemberSelector& m) -> std::string {
+                          return std::format("member {}", m.index);
+                        },
+                        [&](const ElementSelector& e) -> std::string {
+                          return std::format(
+                              "element({})", operands(e.operands));
+                        },
+                        [&](const SliceSelector& s) -> std::string {
+                          return std::format("slice({})", operands(s.operands));
+                        }},
+                    selector);
+              }
               return std::format(
-                  "UnionGetRefExpr union=Expr[{}] index={}",
-                  g.union_value.value, g.index);
+                  "ValueProjectionExpr owner=Expr[{}] path=[{}]", p.owner.value,
+                  path);
             },
             [](const TaggedExpr& t) -> std::string {
               return std::format(

--- a/src/lyra/mir/expr.cpp
+++ b/src/lyra/mir/expr.cpp
@@ -13,11 +13,4 @@ auto IsMutatingCallee(const Callee& callee) -> bool {
   return id != nullptr && support::IsMutatingBuiltinFn(*id);
 }
 
-auto IsContainerAccessCallee(const Callee& callee) -> bool {
-  const auto* direct = std::get_if<Direct>(&callee);
-  if (direct == nullptr) return false;
-  const auto* id = std::get_if<support::BuiltinFn>(&direct->target);
-  return id != nullptr && support::IsContainerAccessFn(*id);
-}
-
 }  // namespace lyra::mir

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -621,6 +621,20 @@ auto lyra_rt_string_getc(const void* value, const void* index) -> void* {
   return Own(Read<String>(value).Getc(Read<PackedArray>(index)));
 }
 
+auto lyra_rt_string_element(const void* value, const void* index) -> void* {
+  return Own(Read<String>(value).Element(Read<PackedArray>(index)));
+}
+
+// The functional character write (LRM 6.16.2): a new string with character
+// `index` replaced. Synthesized at MIR-to-LIR for a string reached by an opaque
+// handle, the string counterpart of `lyra_rt_dynarray_with_element`.
+auto lyra_rt_string_with_element(
+    const void* value, const void* index, const void* replacement) -> void* {
+  return Own(
+      Read<String>(value).WithElement(
+          Read<PackedArray>(index), Read<PackedArray>(replacement)));
+}
+
 auto lyra_rt_string_toupper(const void* value) -> void* {
   return Own(Read<String>(value).Toupper());
 }

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -608,6 +608,23 @@ auto lyra_rt_packed_with_element(
           Read<PackedArray>(index), Read<PackedArray>(replacement)));
 }
 
+auto lyra_rt_packed_slice(
+    const void* value, const void* a, const void* b, const void* form)
+    -> void* {
+  return Own(
+      Read<PackedArray>(value).Slice(
+          Read<PackedArray>(a), Read<PackedArray>(b), Read<PackedArray>(form)));
+}
+
+auto lyra_rt_packed_with_slice(
+    const void* value, const void* a, const void* b, const void* form,
+    const void* replacement) -> void* {
+  return Own(
+      Read<PackedArray>(value).WithSlice(
+          Read<PackedArray>(a), Read<PackedArray>(b), Read<PackedArray>(form),
+          Read<PackedArray>(replacement)));
+}
+
 // Materializes a borrowed packed view (a container element or slice read) into
 // an owning value. On the execution backend a container access already copies
 // the element out, so this is an idempotent copy that keeps the ownership shape

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -157,6 +157,8 @@ using lyra::value::Chandle;
 using lyra::value::Format;
 using lyra::value::FormatSpec;
 using lyra::value::PackedArray;
+using lyra::value::PackedRange;
+using lyra::value::PackedType;
 using lyra::value::PrintItem;
 using lyra::value::PrintLiteralItem;
 using lyra::value::PrintValueItem;
@@ -205,11 +207,19 @@ auto lyra_rt_format(LyraSpan items, const void* time_format) -> void* {
 }
 
 auto lyra_rt_packed_const(
-    std::int64_t value, std::int32_t width, bool is_signed, bool is_four_state)
-    -> void* {
+    std::int64_t value, const std::int64_t* dims, std::int64_t dims_count,
+    bool is_signed, bool is_four_state) -> void* {
+  const auto count = static_cast<std::size_t>(dims_count);
+  const std::span<const std::int64_t> bounds{dims, count * 2};
+  std::vector<PackedRange> ranges;
+  ranges.reserve(count);
+  for (std::size_t i = 0; i < count; ++i) {
+    ranges.push_back(
+        PackedRange{.left = bounds[i * 2], .right = bounds[(i * 2) + 1]});
+  }
   return GeneratedCallScope::Current().Arena().New<PackedArray>(
       PackedArray::FromInt(
-          value, static_cast<std::uint64_t>(width), is_signed, is_four_state));
+          value, PackedType{std::move(ranges), is_signed, is_four_state}));
 }
 
 void lyra_rt_writeln(void* files, void* descriptor, void* text) {
@@ -609,20 +619,21 @@ auto lyra_rt_packed_with_element(
 }
 
 auto lyra_rt_packed_slice(
-    const void* value, const void* a, const void* b, const void* form)
-    -> void* {
+    const void* value, const void* a, const void* b, const void* form,
+    const void* shape) -> void* {
   return Own(
       Read<PackedArray>(value).Slice(
-          Read<PackedArray>(a), Read<PackedArray>(b), Read<PackedArray>(form)));
+          Read<PackedArray>(a), Read<PackedArray>(b), Read<PackedArray>(form),
+          Read<PackedArray>(shape)));
 }
 
 auto lyra_rt_packed_with_slice(
     const void* value, const void* a, const void* b, const void* form,
-    const void* replacement) -> void* {
+    const void* shape, const void* replacement) -> void* {
   return Own(
       Read<PackedArray>(value).WithSlice(
           Read<PackedArray>(a), Read<PackedArray>(b), Read<PackedArray>(form),
-          Read<PackedArray>(replacement)));
+          Read<PackedArray>(shape), Read<PackedArray>(replacement)));
 }
 
 // Materializes a borrowed packed view (a container element or slice read) into

--- a/src/lyra/runtime/jit_execution.cpp
+++ b/src/lyra/runtime/jit_execution.cpp
@@ -597,6 +597,17 @@ auto lyra_rt_packed_reduction_xnor(const void* value) -> void* {
   return Own(Read<PackedArray>(value).ReductionXnor());
 }
 
+auto lyra_rt_packed_element(const void* value, const void* index) -> void* {
+  return Own(Read<PackedArray>(value).Element(Read<PackedArray>(index)));
+}
+
+auto lyra_rt_packed_with_element(
+    const void* value, const void* index, const void* replacement) -> void* {
+  return Own(
+      Read<PackedArray>(value).WithElement(
+          Read<PackedArray>(index), Read<PackedArray>(replacement)));
+}
+
 // Materializes a borrowed packed view (a container element or slice read) into
 // an owning value. On the execution backend a container access already copies
 // the element out, so this is an idempotent copy that keeps the ownership shape

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -27,18 +27,6 @@ auto IsMutatingBuiltinFn(BuiltinFn id) -> bool {
   }
 }
 
-auto IsContainerAccessFn(BuiltinFn id) -> bool {
-  switch (id) {
-    case BuiltinFn::kElement:
-    case BuiltinFn::kElementRef:
-    case BuiltinFn::kSlice:
-    case BuiltinFn::kSliceRef:
-      return true;
-    default:
-      return false;
-  }
-}
-
 auto ArrayMethodTakesClosure(BuiltinFn id) -> bool {
   switch (id) {
     case BuiltinFn::kSort:
@@ -118,14 +106,10 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
   switch (id) {
     case BuiltinFn::kElement:
       return "element";
-    case BuiltinFn::kElementRef:
-      return "element_ref";
     case BuiltinFn::kWithElement:
       return "with_element";
     case BuiltinFn::kSlice:
       return "slice";
-    case BuiltinFn::kSliceRef:
-      return "slice_ref";
     case BuiltinFn::kWithSlice:
       return "with_slice";
     case BuiltinFn::kSize:

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -126,6 +126,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "slice";
     case BuiltinFn::kSliceRef:
       return "slice_ref";
+    case BuiltinFn::kWithSlice:
+      return "with_slice";
     case BuiltinFn::kSize:
       return "size";
     case BuiltinFn::kLen:

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -106,12 +106,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
   switch (id) {
     case BuiltinFn::kElement:
       return "element";
-    case BuiltinFn::kWithElement:
-      return "with_element";
     case BuiltinFn::kSlice:
       return "slice";
-    case BuiltinFn::kWithSlice:
-      return "with_slice";
     case BuiltinFn::kSize:
       return "size";
     case BuiltinFn::kLen:

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -1742,6 +1742,14 @@ auto PackedArray::Slice(
   return ExtractBits(sel.bit_offset, sel.dims);
 }
 
+auto PackedArray::WithSlice(
+    const PackedArray& a, const PackedArray& b, const PackedArray& form,
+    const PackedArray& value) const -> PackedArray {
+  PackedArray result{*this};
+  result.SliceRef(a, b, form) = value;
+  return result;
+}
+
 PackedArrayRef::PackedArrayRef(
     PackedArray& root, const PackedArray& bit_offset,
     std::vector<PackedRange> dims)

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -1717,6 +1717,13 @@ auto PackedArray::Element(const PackedArray& idx) const -> PackedArray {
   return ExtractBits(sel.bit_offset, sel.dims);
 }
 
+auto PackedArray::WithElement(
+    const PackedArray& idx, const PackedArray& value) const -> PackedArray {
+  PackedArray result{*this};
+  result.ElementRef(idx) = value;
+  return result;
+}
+
 auto PackedArray::SliceRef(
     const PackedArray& a, const PackedArray& b, const PackedArray& form)
     -> PackedArrayRef {

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -1705,6 +1705,22 @@ auto ResolveRawRangeSelector(
       .shift = PackedArray::Int(static_cast<std::int32_t>(shift))};
 }
 
+// The dimension stack a part-select materializes its result with. The declared
+// shape wins: the bounds decide which bits are selected, the result type
+// decides how those bits are structured. They span the same bits -- a
+// disagreement means the select and its stated result type were built from
+// different types.
+auto ShapeDimsOf(const PackedArray& shape, std::span<const PackedRange> derived)
+    -> std::vector<PackedRange> {
+  const std::span<const PackedRange> declared = shape.Dims();
+  if (PackedType::WidthOf(declared) != PackedType::WidthOf(derived)) {
+    throw InternalError(
+        "PackedArray::Slice: the stated result shape spans a different bit "
+        "count than the selected range");
+  }
+  return {declared.begin(), declared.end()};
+}
+
 }  // namespace
 
 auto PackedArray::ElementRef(const PackedArray& idx) -> PackedArrayRef {
@@ -1725,28 +1741,28 @@ auto PackedArray::WithElement(
 }
 
 auto PackedArray::SliceRef(
-    const PackedArray& a, const PackedArray& b, const PackedArray& form)
-    -> PackedArrayRef {
+    const PackedArray& a, const PackedArray& b, const PackedArray& form,
+    const PackedArray& shape) -> PackedArrayRef {
   const auto raw = ResolveRawRangeSelector(type_.dims.front(), a, b, form);
   auto sel = ResolveSlice(
       type_.bit_width, type_.dims, raw.anchor, raw.count, raw.shift);
-  return PackedArrayRef{*this, sel.bit_offset, std::move(sel.dims)};
+  return PackedArrayRef{*this, sel.bit_offset, ShapeDimsOf(shape, sel.dims)};
 }
 
 auto PackedArray::Slice(
-    const PackedArray& a, const PackedArray& b, const PackedArray& form) const
-    -> PackedArray {
+    const PackedArray& a, const PackedArray& b, const PackedArray& form,
+    const PackedArray& shape) const -> PackedArray {
   const auto raw = ResolveRawRangeSelector(type_.dims.front(), a, b, form);
   auto sel = ResolveSlice(
       type_.bit_width, type_.dims, raw.anchor, raw.count, raw.shift);
-  return ExtractBits(sel.bit_offset, sel.dims);
+  return ExtractBits(sel.bit_offset, ShapeDimsOf(shape, sel.dims));
 }
 
 auto PackedArray::WithSlice(
     const PackedArray& a, const PackedArray& b, const PackedArray& form,
-    const PackedArray& value) const -> PackedArray {
+    const PackedArray& shape, const PackedArray& value) const -> PackedArray {
   PackedArray result{*this};
-  result.SliceRef(a, b, form) = value;
+  result.SliceRef(a, b, form, shape) = value;
   return result;
 }
 
@@ -1776,12 +1792,12 @@ auto PackedArrayRef::ElementRef(const PackedArray& idx) const
 }
 
 auto PackedArrayRef::SliceRef(
-    const PackedArray& a, const PackedArray& b, const PackedArray& form) const
-    -> PackedArrayRef {
+    const PackedArray& a, const PackedArray& b, const PackedArray& form,
+    const PackedArray& shape) const -> PackedArrayRef {
   const auto raw = ResolveRawRangeSelector(dims_.front(), a, b, form);
   auto sel = ResolveSlice(bit_width_, dims_, raw.anchor, raw.count, raw.shift);
   return PackedArrayRef{
-      *root_, bit_offset_ + sel.bit_offset, std::move(sel.dims)};
+      *root_, bit_offset_ + sel.bit_offset, ShapeDimsOf(shape, sel.dims)};
 }
 
 auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -362,6 +362,87 @@ auto WriteDynArraySource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+// Exercises mixed static/dynamic aggregate write chains: a component of a
+// dynamic-array element (`pr[i].a`) and an element of a struct's dynamic-array
+// field (`bx.v[i]`), in both directions and under compound assignment, plus a
+// partial write to an observable dynamic-array-of-struct signal that a reader
+// reacts to. Each folds into one functional whole-value update stored back
+// through the owner.
+auto WriteMixedChainSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  typedef struct { int a; int b; } Pair;\n"
+      << "  typedef struct { int v[]; } Box;\n"
+      << "  Pair pr[];\n"
+      << "  Box bx;\n"
+      << "  int aa[][];\n"
+      << "  Box ba[];\n"
+      << "  Pair psig[];\n"
+      << "  int mirror = 0;\n"
+      << "  always_comb mirror = psig[0].a * 100 + psig[0].b;\n"
+      << "  initial begin\n"
+      << "    pr = new[2];\n"
+      << "    pr[0].a = 5;\n"
+      << "    pr[0].b = 6;\n"
+      << "    pr[1].a = 7;\n"
+      << "    pr[0].a += 10;\n"
+      << "    $display(\"da a0=%0d b0=%0d a1=%0d\", pr[0].a, pr[0].b, "
+         "pr[1].a);\n"
+      << "    bx.v = new[3];\n"
+      << "    bx.v[0] = 10;\n"
+      << "    bx.v[2] = 30;\n"
+      << "    bx.v[0] += 5;\n"
+      << "    $display(\"sd v0=%0d v2=%0d\", bx.v[0], bx.v[2]);\n"
+      << "    aa = new[2];\n"
+      << "    aa[0] = new[2];\n"
+      << "    aa[1] = new[2];\n"
+      << "    aa[0][1] = 42;\n"
+      << "    aa[1][0] = 7;\n"
+      << "    aa[0][1] += 8;\n"
+      << "    $display(\"aa 01=%0d 10=%0d\", aa[0][1], aa[1][0]);\n"
+      << "    ba = new[2];\n"
+      << "    ba[0].v = new[3];\n"
+      << "    ba[0].v[2] = 99;\n"
+      << "    ba[0].v[2] += 1;\n"
+      << "    $display(\"ba v2=%0d\", ba[0].v[2]);\n"
+      << "    psig = new[1];\n"
+      << "    psig[0].a = 1;\n"
+      << "    psig[0].b = 2;\n"
+      << "    #1;\n"
+      << "    $display(\"obs mirror=%0d\", mirror);\n"
+      << "    psig[0].a = 7;\n"
+      << "    #1;\n"
+      << "    $display(\"obs2 mirror=%0d a=%0d\", mirror, psig[0].a);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
+// Exercises indexed string-character write `s[i] = c`, including the LRM 6.16.2
+// putc corner cases: an out-of-range index and a NUL byte both leave the string
+// unchanged. On the execution backend the string is an opaque handle, so each
+// write is a functional whole-value update; the C++ backend writes in place
+// through the character proxy, and the two must agree.
+auto WriteStringCharSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  string s;\n"
+      << "  int c;\n"
+      << "  initial begin\n"
+      << "    s = \"hello\";\n"
+      << "    s[0] = \"H\";\n"
+      << "    $display(\"basic s=%s\", s);\n"
+      << "    c = s[1];\n"
+      << "    $display(\"read c=%0d\", c);\n"
+      << "    s[100] = \"X\";\n"
+      << "    $display(\"oob s=%s\", s);\n"
+      << "    s[2] = 8'h00;\n"
+      << "    $display(\"nul s=%s\", s);\n"
+      << "    s[4] = \"O\";\n"
+      << "    $display(\"last s=%s\", s);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -799,6 +880,75 @@ TEST(LyraRun, JitAndCppAgreeOnDynArray) {
       "xsusp l0=42 l1=43\n"
       "whole mirror=102\n"
       "partial mirror=702 sig0=7\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnMixedAggregateChain) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteMixedChainSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "da a0=15 b0=6 a1=7\n"
+      "sd v0=15 v2=30\n"
+      "aa 01=50 10=7\n"
+      "ba v2=100\n"
+      "obs mirror=102\n"
+      "obs2 mirror=702 a=7\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnStringCharWrite) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteStringCharSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "basic s=Hello\n"
+      "read c=101\n"
+      "oob s=Hello\n"
+      "nul s=Hello\n"
+      "last s=HellO\n")
       << "stdout: " << jit.stdout_text;
 }
 

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -362,181 +362,6 @@ auto WriteDynArraySource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
-// Exercises mixed static/dynamic aggregate write chains: a component of a
-// dynamic-array element (`pr[i].a`) and an element of a struct's dynamic-array
-// field (`bx.v[i]`), in both directions and under compound assignment, plus a
-// partial write to an observable dynamic-array-of-struct signal that a reader
-// reacts to. Each folds into one functional whole-value update stored back
-// through the owner.
-auto WriteMixedChainSource(const std::filesystem::path& path) -> void {
-  std::ofstream out(path);
-  out << "module Test;\n"
-      << "  typedef struct { int a; int b; } Pair;\n"
-      << "  typedef struct { int v[]; } Box;\n"
-      << "  Pair pr[];\n"
-      << "  Box bx;\n"
-      << "  int aa[][];\n"
-      << "  Box ba[];\n"
-      << "  Pair psig[];\n"
-      << "  int mirror = 0;\n"
-      << "  always_comb mirror = psig[0].a * 100 + psig[0].b;\n"
-      << "  initial begin\n"
-      << "    pr = new[2];\n"
-      << "    pr[0].a = 5;\n"
-      << "    pr[0].b = 6;\n"
-      << "    pr[1].a = 7;\n"
-      << "    pr[0].a += 10;\n"
-      << "    $display(\"da a0=%0d b0=%0d a1=%0d\", pr[0].a, pr[0].b, "
-         "pr[1].a);\n"
-      << "    bx.v = new[3];\n"
-      << "    bx.v[0] = 10;\n"
-      << "    bx.v[2] = 30;\n"
-      << "    bx.v[0] += 5;\n"
-      << "    $display(\"sd v0=%0d v2=%0d\", bx.v[0], bx.v[2]);\n"
-      << "    aa = new[2];\n"
-      << "    aa[0] = new[2];\n"
-      << "    aa[1] = new[2];\n"
-      << "    aa[0][1] = 42;\n"
-      << "    aa[1][0] = 7;\n"
-      << "    aa[0][1] += 8;\n"
-      << "    $display(\"aa 01=%0d 10=%0d\", aa[0][1], aa[1][0]);\n"
-      << "    ba = new[2];\n"
-      << "    ba[0].v = new[3];\n"
-      << "    ba[0].v[2] = 99;\n"
-      << "    ba[0].v[2] += 1;\n"
-      << "    $display(\"ba v2=%0d\", ba[0].v[2]);\n"
-      << "    psig = new[1];\n"
-      << "    psig[0].a = 1;\n"
-      << "    psig[0].b = 2;\n"
-      << "    #1;\n"
-      << "    $display(\"obs mirror=%0d\", mirror);\n"
-      << "    psig[0].a = 7;\n"
-      << "    #1;\n"
-      << "    $display(\"obs2 mirror=%0d a=%0d\", mirror, psig[0].a);\n"
-      << "  end\n"
-      << "endmodule\n";
-}
-
-// Exercises indexed string-character write `s[i] = c`, including the LRM 6.16.2
-// putc corner cases: an out-of-range index and a NUL byte both leave the string
-// unchanged. On the execution backend the string is an opaque handle, so each
-// write is a functional whole-value update; the C++ backend writes in place
-// through the character proxy, and the two must agree.
-auto WriteStringCharSource(const std::filesystem::path& path) -> void {
-  std::ofstream out(path);
-  out << "module Test;\n"
-      << "  string s;\n"
-      << "  int c;\n"
-      << "  initial begin\n"
-      << "    s = \"hello\";\n"
-      << "    s[0] = \"H\";\n"
-      << "    $display(\"basic s=%s\", s);\n"
-      << "    c = s[1];\n"
-      << "    $display(\"read c=%0d\", c);\n"
-      << "    s[100] = \"X\";\n"
-      << "    $display(\"oob s=%s\", s);\n"
-      << "    s[2] = 8'h00;\n"
-      << "    $display(\"nul s=%s\", s);\n"
-      << "    s[4] = \"O\";\n"
-      << "    $display(\"last s=%s\", s);\n"
-      << "  end\n"
-      << "endmodule\n";
-}
-
-auto WritePackedPartSelectSource(const std::filesystem::path& path) -> void {
-  std::ofstream out(path);
-  out << "module Test;\n"
-      << "  logic [15:0] q;\n"
-      << "  int idx;\n"
-      << "  function automatic logic [15:0] setbits(logic [15:0] x);\n"
-      << "    logic [15:0] v;\n"
-      << "    v = x;\n"
-      << "    v[0] = 1'b1;\n"
-      << "    v[7:4] = 4'hC;\n"
-      << "    return v;\n"
-      << "  endfunction\n"
-      << "  initial begin\n"
-      << "    q = 16'h0000;\n"
-      << "    idx = 3;\n"
-      << "    q[idx] = 1'b1;\n"
-      << "    q[0] = 1'b1;\n"
-      << "    $display(\"bit q=%h\", q);\n"
-      << "    q[idx] += 1'b1;\n"
-      << "    $display(\"cbit q=%h\", q);\n"
-      << "    q[20] = 1'b1;\n"
-      << "    $display(\"oob q=%h\", q);\n"
-      << "    q[7:4] = 4'hA;\n"
-      << "    $display(\"sl q=%h\", q);\n"
-      << "    q[11:8] += 4'h3;\n"
-      << "    $display(\"csl q=%h\", q);\n"
-      << "    q[12 +: 4] = 4'h5;\n"
-      << "    $display(\"up q=%h\", q);\n"
-      << "    q[3 -: 4] = 4'hF;\n"
-      << "    $display(\"dn q=%h\", q);\n"
-      << "    q = setbits(16'h0000);\n"
-      << "    $display(\"fn q=%h\", q);\n"
-      << "  end\n"
-      << "endmodule\n";
-}
-
-auto WriteMultiDimPackedSource(const std::filesystem::path& path) -> void {
-  std::ofstream out(path);
-  out << "module Test;\n"
-      << "  logic [1:0][3:0] m;\n"
-      << "  logic [3:0] e;\n"
-      << "  int idx;\n"
-      << "  initial begin\n"
-      << "    m = 8'h00;\n"
-      << "    idx = 1;\n"
-      << "    m[1] = 4'hA;\n"
-      << "    m[0] = 4'h5;\n"
-      << "    $display(\"w m=%h\", m);\n"
-      << "    e = m[1];\n"
-      << "    $display(\"r e=%h\", e);\n"
-      << "    m[idx] += 4'h1;\n"
-      << "    $display(\"c m=%h\", m);\n"
-      << "    m[0][1] = 1'b1;\n"
-      << "    $display(\"b m=%h\", m);\n"
-      << "  end\n"
-      << "endmodule\n";
-}
-
-auto WriteAggregateMemberShapeSource(const std::filesystem::path& path)
-    -> void {
-  std::ofstream out(path);
-  out << "module Test;\n"
-      << "  typedef struct packed {\n"
-      << "    logic [1:0][7:0] f;\n"
-      << "    logic [15:0] g;\n"
-      << "  } S;\n"
-      << "  typedef union packed {\n"
-      << "    logic [15:0] w;\n"
-      << "    logic [1:0][7:0] b;\n"
-      << "  } U;\n"
-      << "  S s;\n"
-      << "  U u;\n"
-      << "  logic [7:0] e;\n"
-      << "  initial begin\n"
-      << "    s = 32'h0;\n"
-      << "    s.f[0] = 8'hAB;\n"
-      << "    s.f[1] = 8'hCD;\n"
-      << "    $display(\"sf=%h g=%h\", s.f, s.g);\n"
-      << "    e = s.f[1];\n"
-      << "    $display(\"se=%h\", e);\n"
-      << "    s.f[0][3:0] = 4'h5;\n"
-      << "    $display(\"ss=%h\", s.f);\n"
-      << "    u.w = 16'h0000;\n"
-      << "    u.b[0] = 8'hAB;\n"
-      << "    u.b[1] = 8'hCD;\n"
-      << "    $display(\"uw=%h\", u.w);\n"
-      << "    e = u.b[0];\n"
-      << "    $display(\"ue=%h\", e);\n"
-      << "    u.b[0][3:0] = 4'h5;\n"
-      << "    $display(\"us=%h\", u.w);\n"
-      << "  end\n"
-      << "endmodule\n";
-}
-
 // Every descent step a write target can take, composed and nested: a product
 // component reached through another component, a packed bit-select, a packed
 // window (plain and compound), a string character, a union member, and an
@@ -557,9 +382,24 @@ auto WriteInteriorWriteSource(const std::filesystem::path& path) -> void {
       << "    logic [15:0] a;\n"
       << "    logic signed [15:0] b;\n"
       << "  } U;\n"
+      << "  typedef struct { int a; int b; } Pair;\n"
+      << "  typedef struct { int v[]; } Box;\n"
       << "  Outer o;\n"
       << "  U u;\n"
       << "  int idx;\n"
+      << "  Pair pr[];\n"
+      << "  Box bx;\n"
+      << "  int aa[][];\n"
+      << "  Pair psig[];\n"
+      << "  int mirror = 0;\n"
+      << "  always_comb mirror = psig[0].a * 100 + psig[0].b;\n"
+      << "  function automatic logic [15:0] setbits(logic [15:0] x);\n"
+      << "    logic [15:0] v;\n"
+      << "    v = x;\n"
+      << "    v[0] = 1'b1;\n"
+      << "    v[7:4] = 4'hC;\n"
+      << "    return v;\n"
+      << "  endfunction\n"
       << "  initial begin\n"
       << "    idx = 1;\n"
       << "    o.n = 7;\n"
@@ -567,16 +407,101 @@ auto WriteInteriorWriteSource(const std::filesystem::path& path) -> void {
       << "    $display(\"n=%0d\", o.n);\n"
       << "    o.i.w = 16'h0000;\n"
       << "    o.i.w[idx] = 1'b1;\n"
+      << "    o.i.w[20] = 1'b1;\n"
       << "    o.i.w[7:4] = 4'hA;\n"
       << "    o.i.w[11:8] += 4'h3;\n"
+      << "    o.i.w[12 +: 4] = 4'h5;\n"
+      << "    o.i.w[3 -: 4] = 4'hF;\n"
       << "    $display(\"w=%h\", o.i.w);\n"
+      << "    o.i.w = setbits(16'h0000);\n"
+      << "    $display(\"fn=%h\", o.i.w);\n"
       << "    o.i.s = \"hello\";\n"
       << "    o.i.s[0] = \"H\";\n"
+      << "    o.i.s[100] = \"X\";\n"
+      << "    o.i.s[2] = 8'h00;\n"
       << "    $display(\"s=%s\", o.i.s);\n"
       << "    u.a = 16'hFFFF;\n"
       << "    u.b = 16'h0000;\n"
       << "    u.a[3:0] = 4'h5;\n"
       << "    $display(\"u=%h\", u.a);\n"
+      << "    pr = new[2];\n"
+      << "    pr[0].a = 5;\n"
+      << "    pr[0].b = 6;\n"
+      << "    pr[0].a += 10;\n"
+      << "    $display(\"da a0=%0d b0=%0d\", pr[0].a, pr[0].b);\n"
+      << "    bx.v = new[3];\n"
+      << "    bx.v[0] = 10;\n"
+      << "    bx.v[0] += 5;\n"
+      << "    $display(\"sd v0=%0d\", bx.v[0]);\n"
+      << "    aa = new[2];\n"
+      << "    aa[0] = new[2];\n"
+      << "    aa[0][1] = 42;\n"
+      << "    aa[0][1] += 8;\n"
+      << "    $display(\"aa 01=%0d\", aa[0][1]);\n"
+      << "    psig = new[1];\n"
+      << "    psig[0].a = 1;\n"
+      << "    psig[0].b = 2;\n"
+      << "    #1;\n"
+      << "    $display(\"obs mirror=%0d\", mirror);\n"
+      << "    psig[0].a = 7;\n"
+      << "    #1;\n"
+      << "    $display(\"obs2 mirror=%0d a=%0d\", mirror, psig[0].a);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
+// A multi-dimensional packed value keeps its declared shape wherever it lives:
+// a variable, a packed struct's member, a packed union's member. The shape is
+// what decides how wide one element is, so an element read, an element write, a
+// compound update, and a window inside an element all depend on it reaching the
+// runtime. The execution backend carries a packed value behind an opaque
+// handle, so a shape it fails to carry is only visible as a wrong element width
+// here.
+auto WritePackedShapeSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  typedef struct packed {\n"
+      << "    logic [1:0][7:0] f;\n"
+      << "    logic [15:0] g;\n"
+      << "  } S;\n"
+      << "  typedef union packed {\n"
+      << "    logic [15:0] w;\n"
+      << "    logic [1:0][7:0] b;\n"
+      << "  } U;\n"
+      << "  logic [1:0][3:0] m;\n"
+      << "  logic [3:0] e;\n"
+      << "  S s;\n"
+      << "  U u;\n"
+      << "  logic [7:0] c;\n"
+      << "  int idx;\n"
+      << "  initial begin\n"
+      << "    m = 8'h00;\n"
+      << "    idx = 1;\n"
+      << "    m[1] = 4'hA;\n"
+      << "    m[0] = 4'h5;\n"
+      << "    $display(\"w m=%h\", m);\n"
+      << "    e = m[1];\n"
+      << "    $display(\"r e=%h\", e);\n"
+      << "    m[idx] += 4'h1;\n"
+      << "    $display(\"c m=%h\", m);\n"
+      << "    m[0][1] = 1'b1;\n"
+      << "    $display(\"b m=%h\", m);\n"
+      << "    s = 32'h0;\n"
+      << "    s.f[0] = 8'hAB;\n"
+      << "    s.f[1] = 8'hCD;\n"
+      << "    $display(\"sf=%h g=%h\", s.f, s.g);\n"
+      << "    c = s.f[1];\n"
+      << "    $display(\"se=%h\", c);\n"
+      << "    s.f[0][3:0] = 4'h5;\n"
+      << "    $display(\"ss=%h\", s.f);\n"
+      << "    u.w = 16'h0000;\n"
+      << "    u.b[0] = 8'hAB;\n"
+      << "    u.b[1] = 8'hCD;\n"
+      << "    $display(\"uw=%h\", u.w);\n"
+      << "    c = u.b[0];\n"
+      << "    $display(\"ue=%h\", c);\n"
+      << "    u.b[0][3:0] = 4'h5;\n"
+      << "    $display(\"us=%h\", u.w);\n"
       << "  end\n"
       << "endmodule\n";
 }
@@ -608,9 +533,54 @@ TEST(LyraRun, JitAndCppAgreeOnInteriorWrite) {
   EXPECT_EQ(
       jit.stdout_text,
       "n=8\n"
-      "w=03a2\n"
+      "w=53af\n"
+      "fn=00c1\n"
       "s=Hello\n"
-      "u=0005\n")
+      "u=0005\n"
+      "da a0=15 b0=6\n"
+      "sd v0=15\n"
+      "aa 01=50\n"
+      "obs mirror=102\n"
+      "obs2 mirror=702 a=7\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnPackedShape) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WritePackedShapeSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "w m=a5\n"
+      "r e=a\n"
+      "c m=b5\n"
+      "b m=b7\n"
+      "sf=cdab g=0000\n"
+      "se=cd\n"
+      "ss=cda5\n"
+      "uw=cdab\n"
+      "ue=ab\n"
+      "us=cda5\n")
       << "stdout: " << jit.stdout_text;
 }
 
@@ -1051,180 +1021,6 @@ TEST(LyraRun, JitAndCppAgreeOnDynArray) {
       "xsusp l0=42 l1=43\n"
       "whole mirror=102\n"
       "partial mirror=702 sig0=7\n")
-      << "stdout: " << jit.stdout_text;
-}
-
-TEST(LyraRun, JitAndCppAgreeOnMixedAggregateChain) {
-  const auto lyra = ResolveLyra();
-  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
-
-  auto tmp_or = MakeTempCaseDir();
-  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
-  const auto src = *tmp_or / "test.sv";
-  WriteMixedChainSource(src);
-
-  const std::vector<std::string> jit_args = {
-      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
-  const auto jit = RunChildProcess(lyra, jit_args, 120s);
-  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
-      << jit.stdout_text << jit.stderr_text;
-  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
-
-  const std::vector<std::string> cpp_args = {
-      "run", "--no-project", "--top", "Test", src.string()};
-  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
-  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
-      << cpp.stdout_text << cpp.stderr_text;
-  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
-
-  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
-  EXPECT_EQ(
-      jit.stdout_text,
-      "da a0=15 b0=6 a1=7\n"
-      "sd v0=15 v2=30\n"
-      "aa 01=50 10=7\n"
-      "ba v2=100\n"
-      "obs mirror=102\n"
-      "obs2 mirror=702 a=7\n")
-      << "stdout: " << jit.stdout_text;
-}
-
-TEST(LyraRun, JitAndCppAgreeOnStringCharWrite) {
-  const auto lyra = ResolveLyra();
-  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
-
-  auto tmp_or = MakeTempCaseDir();
-  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
-  const auto src = *tmp_or / "test.sv";
-  WriteStringCharSource(src);
-
-  const std::vector<std::string> jit_args = {
-      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
-  const auto jit = RunChildProcess(lyra, jit_args, 120s);
-  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
-      << jit.stdout_text << jit.stderr_text;
-  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
-
-  const std::vector<std::string> cpp_args = {
-      "run", "--no-project", "--top", "Test", src.string()};
-  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
-  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
-      << cpp.stdout_text << cpp.stderr_text;
-  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
-
-  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
-  EXPECT_EQ(
-      jit.stdout_text,
-      "basic s=Hello\n"
-      "read c=101\n"
-      "oob s=Hello\n"
-      "nul s=Hello\n"
-      "last s=HellO\n")
-      << "stdout: " << jit.stdout_text;
-}
-
-TEST(LyraRun, JitAndCppAgreeOnPackedPartSelectWrite) {
-  const auto lyra = ResolveLyra();
-  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
-
-  auto tmp_or = MakeTempCaseDir();
-  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
-  const auto src = *tmp_or / "test.sv";
-  WritePackedPartSelectSource(src);
-
-  const std::vector<std::string> jit_args = {
-      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
-  const auto jit = RunChildProcess(lyra, jit_args, 120s);
-  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
-      << jit.stdout_text << jit.stderr_text;
-  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
-
-  const std::vector<std::string> cpp_args = {
-      "run", "--no-project", "--top", "Test", src.string()};
-  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
-  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
-      << cpp.stdout_text << cpp.stderr_text;
-  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
-
-  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
-  EXPECT_EQ(
-      jit.stdout_text,
-      "bit q=0009\n"
-      "cbit q=0001\n"
-      "oob q=0001\n"
-      "sl q=00a1\n"
-      "csl q=03a1\n"
-      "up q=53a1\n"
-      "dn q=53af\n"
-      "fn q=00c1\n")
-      << "stdout: " << jit.stdout_text;
-}
-
-TEST(LyraRun, JitAndCppAgreeOnMultiDimPacked) {
-  const auto lyra = ResolveLyra();
-  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
-
-  auto tmp_or = MakeTempCaseDir();
-  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
-  const auto src = *tmp_or / "test.sv";
-  WriteMultiDimPackedSource(src);
-
-  const std::vector<std::string> jit_args = {
-      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
-  const auto jit = RunChildProcess(lyra, jit_args, 120s);
-  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
-      << jit.stdout_text << jit.stderr_text;
-  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
-
-  const std::vector<std::string> cpp_args = {
-      "run", "--no-project", "--top", "Test", src.string()};
-  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
-  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
-      << cpp.stdout_text << cpp.stderr_text;
-  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
-
-  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
-  EXPECT_EQ(
-      jit.stdout_text,
-      "w m=a5\n"
-      "r e=a\n"
-      "c m=b5\n"
-      "b m=b7\n")
-      << "stdout: " << jit.stdout_text;
-}
-
-TEST(LyraRun, JitAndCppAgreeOnAggregateMemberShape) {
-  const auto lyra = ResolveLyra();
-  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
-
-  auto tmp_or = MakeTempCaseDir();
-  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
-  const auto src = *tmp_or / "test.sv";
-  WriteAggregateMemberShapeSource(src);
-
-  const std::vector<std::string> jit_args = {
-      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
-  const auto jit = RunChildProcess(lyra, jit_args, 120s);
-  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
-      << jit.stdout_text << jit.stderr_text;
-  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
-
-  const std::vector<std::string> cpp_args = {
-      "run", "--no-project", "--top", "Test", src.string()};
-  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
-  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
-      << cpp.stdout_text << cpp.stderr_text;
-  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
-
-  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
-  EXPECT_EQ(
-      jit.stdout_text,
-      "sf=cdab g=0000\n"
-      "se=cd\n"
-      "ss=cda5\n"
-      "uw=cdab\n"
-      "ue=ab\n"
-      "us=cda5\n")
       << "stdout: " << jit.stdout_text;
 }
 

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -443,29 +443,38 @@ auto WriteStringCharSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
-auto WritePackedBitWriteSource(const std::filesystem::path& path) -> void {
+auto WritePackedPartSelectSource(const std::filesystem::path& path) -> void {
   std::ofstream out(path);
   out << "module Test;\n"
-      << "  logic [7:0] p;\n"
+      << "  logic [15:0] q;\n"
       << "  int idx;\n"
-      << "  function automatic logic [7:0] flip(logic [7:0] a, int i);\n"
-      << "    logic [7:0] v;\n"
-      << "    v = a;\n"
-      << "    v[i] = 1'b1;\n"
+      << "  function automatic logic [15:0] setbits(logic [15:0] x);\n"
+      << "    logic [15:0] v;\n"
+      << "    v = x;\n"
+      << "    v[0] = 1'b1;\n"
+      << "    v[7:4] = 4'hC;\n"
       << "    return v;\n"
       << "  endfunction\n"
       << "  initial begin\n"
-      << "    p = 8'h00;\n"
+      << "    q = 16'h0000;\n"
       << "    idx = 3;\n"
-      << "    p[idx] = 1'b1;\n"
-      << "    p[0] = 1'b1;\n"
-      << "    $display(\"p=%h\", p);\n"
-      << "    p[idx] += 1'b1;\n"
-      << "    $display(\"cp=%h\", p);\n"
-      << "    p[9] = 1'b1;\n"
-      << "    $display(\"oob=%h\", p);\n"
-      << "    p = flip(8'h00, 5);\n"
-      << "    $display(\"fn=%h\", p);\n"
+      << "    q[idx] = 1'b1;\n"
+      << "    q[0] = 1'b1;\n"
+      << "    $display(\"bit q=%h\", q);\n"
+      << "    q[idx] += 1'b1;\n"
+      << "    $display(\"cbit q=%h\", q);\n"
+      << "    q[20] = 1'b1;\n"
+      << "    $display(\"oob q=%h\", q);\n"
+      << "    q[7:4] = 4'hA;\n"
+      << "    $display(\"sl q=%h\", q);\n"
+      << "    q[11:8] += 4'h3;\n"
+      << "    $display(\"csl q=%h\", q);\n"
+      << "    q[12 +: 4] = 4'h5;\n"
+      << "    $display(\"up q=%h\", q);\n"
+      << "    q[3 -: 4] = 4'hF;\n"
+      << "    $display(\"dn q=%h\", q);\n"
+      << "    q = setbits(16'h0000);\n"
+      << "    $display(\"fn q=%h\", q);\n"
       << "  end\n"
       << "endmodule\n";
 }
@@ -979,14 +988,14 @@ TEST(LyraRun, JitAndCppAgreeOnStringCharWrite) {
       << "stdout: " << jit.stdout_text;
 }
 
-TEST(LyraRun, JitAndCppAgreeOnPackedBitWrite) {
+TEST(LyraRun, JitAndCppAgreeOnPackedPartSelectWrite) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
 
   auto tmp_or = MakeTempCaseDir();
   ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
   const auto src = *tmp_or / "test.sv";
-  WritePackedBitWriteSource(src);
+  WritePackedPartSelectSource(src);
 
   const std::vector<std::string> jit_args = {
       "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
@@ -1005,10 +1014,14 @@ TEST(LyraRun, JitAndCppAgreeOnPackedBitWrite) {
   EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
   EXPECT_EQ(
       jit.stdout_text,
-      "p=09\n"
-      "cp=01\n"
-      "oob=01\n"
-      "fn=20\n")
+      "bit q=0009\n"
+      "cbit q=0001\n"
+      "oob q=0001\n"
+      "sl q=00a1\n"
+      "csl q=03a1\n"
+      "up q=53a1\n"
+      "dn q=53af\n"
+      "fn q=00c1\n")
       << "stdout: " << jit.stdout_text;
 }
 

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -537,6 +537,83 @@ auto WriteAggregateMemberShapeSource(const std::filesystem::path& path)
       << "endmodule\n";
 }
 
+// Every descent step a write target can take, composed and nested: a product
+// component reached through another component, a packed bit-select, a packed
+// window (plain and compound), a string character, a union member, and an
+// increment. One source so the paths are exercised together rather than each in
+// isolation, which is where a shared write path would break first.
+auto WriteInteriorWriteSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  typedef struct {\n"
+      << "    logic [15:0] w;\n"
+      << "    string s;\n"
+      << "  } Inner;\n"
+      << "  typedef struct {\n"
+      << "    Inner i;\n"
+      << "    int n;\n"
+      << "  } Outer;\n"
+      << "  typedef union packed {\n"
+      << "    logic [15:0] a;\n"
+      << "    logic signed [15:0] b;\n"
+      << "  } U;\n"
+      << "  Outer o;\n"
+      << "  U u;\n"
+      << "  int idx;\n"
+      << "  initial begin\n"
+      << "    idx = 1;\n"
+      << "    o.n = 7;\n"
+      << "    o.n++;\n"
+      << "    $display(\"n=%0d\", o.n);\n"
+      << "    o.i.w = 16'h0000;\n"
+      << "    o.i.w[idx] = 1'b1;\n"
+      << "    o.i.w[7:4] = 4'hA;\n"
+      << "    o.i.w[11:8] += 4'h3;\n"
+      << "    $display(\"w=%h\", o.i.w);\n"
+      << "    o.i.s = \"hello\";\n"
+      << "    o.i.s[0] = \"H\";\n"
+      << "    $display(\"s=%s\", o.i.s);\n"
+      << "    u.a = 16'hFFFF;\n"
+      << "    u.b = 16'h0000;\n"
+      << "    u.a[3:0] = 4'h5;\n"
+      << "    $display(\"u=%h\", u.a);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
+TEST(LyraRun, JitAndCppAgreeOnInteriorWrite) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteInteriorWriteSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "n=8\n"
+      "w=03a2\n"
+      "s=Hello\n"
+      "u=0005\n")
+      << "stdout: " << jit.stdout_text;
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -443,6 +443,33 @@ auto WriteStringCharSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+auto WritePackedBitWriteSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  logic [7:0] p;\n"
+      << "  int idx;\n"
+      << "  function automatic logic [7:0] flip(logic [7:0] a, int i);\n"
+      << "    logic [7:0] v;\n"
+      << "    v = a;\n"
+      << "    v[i] = 1'b1;\n"
+      << "    return v;\n"
+      << "  endfunction\n"
+      << "  initial begin\n"
+      << "    p = 8'h00;\n"
+      << "    idx = 3;\n"
+      << "    p[idx] = 1'b1;\n"
+      << "    p[0] = 1'b1;\n"
+      << "    $display(\"p=%h\", p);\n"
+      << "    p[idx] += 1'b1;\n"
+      << "    $display(\"cp=%h\", p);\n"
+      << "    p[9] = 1'b1;\n"
+      << "    $display(\"oob=%h\", p);\n"
+      << "    p = flip(8'h00, 5);\n"
+      << "    $display(\"fn=%h\", p);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -949,6 +976,39 @@ TEST(LyraRun, JitAndCppAgreeOnStringCharWrite) {
       "oob s=Hello\n"
       "nul s=Hello\n"
       "last s=HellO\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnPackedBitWrite) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WritePackedBitWriteSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "p=09\n"
+      "cp=01\n"
+      "oob=01\n"
+      "fn=20\n")
       << "stdout: " << jit.stdout_text;
 }
 

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -479,6 +479,64 @@ auto WritePackedPartSelectSource(const std::filesystem::path& path) -> void {
       << "endmodule\n";
 }
 
+auto WriteMultiDimPackedSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  logic [1:0][3:0] m;\n"
+      << "  logic [3:0] e;\n"
+      << "  int idx;\n"
+      << "  initial begin\n"
+      << "    m = 8'h00;\n"
+      << "    idx = 1;\n"
+      << "    m[1] = 4'hA;\n"
+      << "    m[0] = 4'h5;\n"
+      << "    $display(\"w m=%h\", m);\n"
+      << "    e = m[1];\n"
+      << "    $display(\"r e=%h\", e);\n"
+      << "    m[idx] += 4'h1;\n"
+      << "    $display(\"c m=%h\", m);\n"
+      << "    m[0][1] = 1'b1;\n"
+      << "    $display(\"b m=%h\", m);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
+auto WriteAggregateMemberShapeSource(const std::filesystem::path& path)
+    -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  typedef struct packed {\n"
+      << "    logic [1:0][7:0] f;\n"
+      << "    logic [15:0] g;\n"
+      << "  } S;\n"
+      << "  typedef union packed {\n"
+      << "    logic [15:0] w;\n"
+      << "    logic [1:0][7:0] b;\n"
+      << "  } U;\n"
+      << "  S s;\n"
+      << "  U u;\n"
+      << "  logic [7:0] e;\n"
+      << "  initial begin\n"
+      << "    s = 32'h0;\n"
+      << "    s.f[0] = 8'hAB;\n"
+      << "    s.f[1] = 8'hCD;\n"
+      << "    $display(\"sf=%h g=%h\", s.f, s.g);\n"
+      << "    e = s.f[1];\n"
+      << "    $display(\"se=%h\", e);\n"
+      << "    s.f[0][3:0] = 4'h5;\n"
+      << "    $display(\"ss=%h\", s.f);\n"
+      << "    u.w = 16'h0000;\n"
+      << "    u.b[0] = 8'hAB;\n"
+      << "    u.b[1] = 8'hCD;\n"
+      << "    $display(\"uw=%h\", u.w);\n"
+      << "    e = u.b[0];\n"
+      << "    $display(\"ue=%h\", e);\n"
+      << "    u.b[0][3:0] = 4'h5;\n"
+      << "    $display(\"us=%h\", u.w);\n"
+      << "  end\n"
+      << "endmodule\n";
+}
+
 TEST(LyraRun, ExecutesSourceEndToEnd) {
   const auto lyra = ResolveLyra();
   ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
@@ -1022,6 +1080,74 @@ TEST(LyraRun, JitAndCppAgreeOnPackedPartSelectWrite) {
       "up q=53a1\n"
       "dn q=53af\n"
       "fn q=00c1\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnMultiDimPacked) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteMultiDimPackedSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "w m=a5\n"
+      "r e=a\n"
+      "c m=b5\n"
+      "b m=b7\n")
+      << "stdout: " << jit.stdout_text;
+}
+
+TEST(LyraRun, JitAndCppAgreeOnAggregateMemberShape) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteAggregateMemberShapeSource(src);
+
+  const std::vector<std::string> jit_args = {
+      "run", "--backend", "jit", "--no-project", "--top", "Test", src.string()};
+  const auto jit = RunChildProcess(lyra, jit_args, 120s);
+  ASSERT_EQ(jit.termination, TerminationKind::kExitedNormally)
+      << jit.stdout_text << jit.stderr_text;
+  ASSERT_EQ(jit.exit_code, 0) << jit.stderr_text;
+
+  const std::vector<std::string> cpp_args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto cpp = RunChildProcess(lyra, cpp_args, 120s);
+  ASSERT_EQ(cpp.termination, TerminationKind::kExitedNormally)
+      << cpp.stdout_text << cpp.stderr_text;
+  ASSERT_EQ(cpp.exit_code, 0) << cpp.stderr_text;
+
+  EXPECT_EQ(jit.stdout_text, cpp.stdout_text);
+  EXPECT_EQ(
+      jit.stdout_text,
+      "sf=cdab g=0000\n"
+      "se=cd\n"
+      "ss=cda5\n"
+      "uw=cdab\n"
+      "ue=ab\n"
+      "us=cda5\n")
       << "stdout: " << jit.stdout_text;
 }
 


### PR DESCRIPTION
## Summary

A write into a value aggregate -- a struct component, a union member, an array element, a packed part-select -- used to reach MIR as a nested lvalue expression chain. Each backend recovered the same two facts from it independently, by walking the chain and consulting each receiver's type kind to decide what the step meant. That is the shape `mir.md` forbids: if two backends could infer a fact differently, the fact is not yet in MIR and belongs there. This branch moves it there. MIR now states an interior write as one node naming the place that owns the whole value and the descent that reaches the part, and both backends read that boundary instead of reconstructing it.

The descent vocabulary is closed and explicit -- a component slot, a union member, an element coordinate, a fixed-width range -- with each step carrying the type it projects to. Naming a union member distinctly from a component is not decoration: writing a union member makes it the active one (LRM 7.3), and a layer that collapses the two loses that fact. LIR gained the same four-way vocabulary, so every descent kind now travels as one extract / update pair rather than splitting into an instruction for the static selectors and a runtime call for the dynamic ones. That split described a distinction that did not survive into realization -- the component path already emitted a call -- so removing it cost nothing and removed a place where the two layers disagreed about what a step is.

## Design

The two backends realize the same statement differently, and that difference is the point rather than a compromise. The C++ backend composes the value library's write proxies over the owner's place, so the host compiler turns the whole statement into read-whole, modify a private snapshot in place, write-whole. The execution backend rebuilds the value functionally, because its aggregates live behind possibly-shared handles. Both are read-whole -> produce modified whole -> write-whole; only the middle step differs, which is exactly the latitude `lir.md` grants a target whose language-level copies give it private storage.

Because the owner and the descent are now stated rather than inferred, the constructs that bind a designated part instead of writing it -- a nonblocking update, a reference actual, an output pack component -- bind the same statement, and increments share the write realization with assignments rather than duplicating it.

## Testing

The backend-agreement tests compare the execution backend and the C++ backend per source. They were consolidated from six overlapping cases into two, one covering every selector kind together with the LRM corner cases (out-of-range bit and element writes, an X-bearing part-select, chained descents through a dynamic array, an observable partial write firing subscribers, an increment through a part) and one covering a multi-dimensional packed value in a variable, a packed struct member, and a packed union member. Consolidating matters here because each case pays elaboration, lowering, emit, a full C++ compile, and a run.

## Also in this branch

The final commit records three places where the two backends already disagree, found while auditing this work and unrelated to it: a four-state or wide integral literal loses its unknown bits and its high words on the execution backend, a task that suspends is abandoned by its enabler there, and a net cannot be driven at all. In each one the semantic is stated in full upstream and the C++ backend honors it, so the shared MIR is not what needs to change. Two of the three fail silently, which is why they were invisible; they are now checkboxes in `docs/progress/execution-backend.md` rather than folklore.