### PR TITLE
Support DPI-C open-array arguments

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -198,6 +198,15 @@ the detail lives in the entry itself.
   addressed, never read as a value. Physical in-frame layout is a later optimization, the
   member-storage counterpart of the opaque-handle value baseline.
 
+### Foreign-language boundary
+
+- [dpi-foreign-boundary](dpi-foreign-boundary.md) -- DPI-C is the foreign arm of the one callable
+  model: an import is a bodyless callable with foreign linkage, marshaling is a cross-ABI carrier
+  conversion expressed in MIR, and an export's context is a thread-local ambient handle.
+- [dpi-open-array-boundary](dpi-open-array-boundary.md) -- an open array crosses as a canonical
+  boundary object owning its own storage, never as a borrow of the actual; the formal's unsized
+  shape rides the ABI carrier rather than the type system.
+
 ### Compile-time model and specialization
 
 - [parameter-code-shape-over-approximation](parameter-code-shape-over-approximation.md) -- every

--- a/docs/decisions/dpi-open-array-boundary.md
+++ b/docs/decisions/dpi-open-array-boundary.md
@@ -1,0 +1,211 @@
+# An open array crosses as a canonical boundary object, not a borrow of the actual
+
+Date: 2026-07-27 Status: accepted
+
+## Context
+
+A DPI-C open array (LRM 35.5.6.1) is an imported subroutine's formal with one or more unsized
+dimensions, written `[]`. It relaxes argument matching so one foreign function serves actuals of
+different sizes. The C side receives a handle rather than a pointer and reaches the array through a
+library surface: dimension queries, a whole-array pointer, element pointers, and element accessors
+in canonical form (Annex H.12).
+
+Every other DPI argument Lyra already carries crosses either as a machine scalar or as a canonical
+buffer holding one packed value. An open array is the first argument whose extent is not fixed by
+the declaration, and the first the foreign side navigates rather than reads whole. That raises two
+questions this entry settles: what the C side is actually given, and where the formal's shape lives.
+
+## Findings that shaped the design
+
+### F1. The LRM specifies the representation, and exempts open arrays from C layout
+
+Annex H.11.4 requires every unpacked array crossing the boundary to have C-compiler layout -- with
+one exception:
+
+> Unpacked arrays, with the exception of formal arguments specified as open arrays, shall have the
+> same layout as used by a C compiler.
+
+Annex H.7.3 then states what an open array's representation is instead:
+
+> For a stand-alone array passed as an actual to an open array formal
+>
+> - If the element type is a 2- or 4-state scalar or packed type, then the representation is in
+>   canonical form.
+> - Otherwise, the representation is C compatible.
+
+So the canonical form is not a workaround for a simulator's internal layout; it is what the standard
+prescribes for an open array of integral elements. LRM 35.5.4 says the same thing from the other
+side: `"DPI-C"` passes arguments in canonical format, where the deprecated `"DPI"` passed them in
+actual simulator representation.
+
+### F2. Lyra's value representation is never C layout
+
+An integral value is one fat self-describing object carrying width, signedness, and state domain as
+runtime fields ([integral-representation](integral-representation.md)), so an SV `byte` is not a C
+`char`. An unpacked array is a vector of such elements, one container layer per declared dimension
+([unpacked-array-representation](unpacked-array-representation.md)). On the execution backend every
+aggregate is a runtime-owned opaque value
+([jit-aggregate-realization](jit-aggregate-realization.md)).
+
+No backend has C layout for an SV array. Combined with F1 this decides the whole family: the sized
+unpacked array formal, which H.11.4 requires to have C layout, cannot be supported; the open array,
+which H.11.4 exempts, can. Open arrays are the only unpacked-array DPI formal Lyra can serve, which
+inverts the intuition that the unsized form is the harder one.
+
+### F3. The pointer accessors are conditional, and the condition is a classification Lyra already has
+
+Annex H.12.4 makes the whole-array and element pointers conditional:
+
+> the above functions shall return NULL if the representation of the array elements differs from the
+> representation of individual values of the same type.
+
+An individual `byte` crosses as a C `char` (Table H.1) while a canonical element of a `byte` array
+is a 32-bit group (H.7.7), so those differ and the pointer is NULL. An individual `bit [7:0]`
+crosses by reference as `svBitVecVal*` -- canonical -- so those agree and the pointer is valid. The
+dividing line is exactly whether the element's own DPI carrier is a canonical vector rather than a
+by-value scalar, which is the type-shape classification (LRM 35.6.1.1 WYSIWYG) the boundary already
+computes for every formal.
+
+### F4. The formal's unsized shape is never the type of a value that crosses
+
+LRM 35.6.1.1: "The unsized ranges of open arrays are determined at a call site; the rest of the type
+information is specified at the import declaration." Every consumer of a formal's SV type -- the
+boundary temporary, the prototype that shapes a marshaled value, the write-back destination -- needs
+the actual's type, not the formal's. A type describing the formal's unsized shape would therefore be
+a type no consumer of the SV type system may use.
+
+`mir.md` states where such a fact belongs: the ABI classification of a foreign call's formal is a
+property of the signature and belongs on the callable's declaration.
+
+### F5. Per-dimension ranges follow the declaration, not normalization
+
+Annex H.7.5 excludes open arrays' unpacked dimensions from normalization, and H.7.6 fixes each
+dimension's reported range:
+
+> The range of a sized dimension in an open array formal argument is specified by the import or
+> export declaration. Each unsized, unpacked dimension has the same range as the corresponding
+> dimension of the actual argument. An open array formal argument's unsized, packed dimension has
+> the linearized, normalized range of all the actual's packed dimensions.
+
+So an open array's sized unpacked dimension reports its declared range (`[3:1]`), not a normalized
+one. Normalization applies to a formal that is a sized array throughout -- which is not an open
+array at all. Both sources are static at lowering: one from the declaration, one from the actual's
+type.
+
+## Decision
+
+### 1. An open array crosses as a canonical boundary object owning its own storage
+
+The call site materializes the actual into a contiguous canonical image of the array -- every
+element in its Annex H.7.7 form, dimensions flattened in the LRM 7.6 left-to-right element order --
+and hands the foreign side a handle to it. A write-back direction reconstructs one SV value from
+that image after the call and stores it through the actual's ordinary write path.
+
+Nothing aliases live SV storage. The boundary object is the same ABI temporary every other carrier
+is: produced by marshal-in, consumed by the foreign call and marshal-out, gone at the end of the
+lowered-call window ([dpi-foreign-boundary](dpi-foreign-boundary.md) decision 3).
+
+The object is monomorphic -- a canonical image is element-type-independent -- so it needs no type
+parameter, no accessor table, and no per-element-type generated code. Its two-state and four-state
+forms are one type distinguished by a runtime field, because the C side spells both
+`svOpenArrayHandle` and the ABI draws no distinction; this is the same shape choice
+[integral-representation](integral-representation.md) made for packed values.
+
+### 2. Whether the pointer accessors work is a property of the element, answered from its carrier
+
+The whole-array and element pointers are served when the element's canonical form is also how an
+individual value of that type crosses, and are NULL otherwise (F3). The boundary object carries that
+one fact; lowering supplies it from the element's own carrier classification. A NULL return is the
+LRM-sanctioned answer, not a gap: the canonical and scalar element accessors are the paths the
+standard makes unconditional, and they serve every supported element type.
+
+The object may therefore expose contiguous canonical storage, but exposing it is not part of its
+contract. A future realization that is not contiguous changes only what the pointer accessors
+return.
+
+### 3. The formal's open-array shape lives on the ABI carrier, not in the type system
+
+The carrier records only what the formal's SV type does not: whether the sole packed dimension is
+unsized, and for each unpacked dimension the range the declaration fixes or its absence where the
+actual supplies it (F5). The element type, its width, and its state domain stay on the formal's SV
+type and are read from there.
+
+There is one record of the shape, so there is nothing for a second record to drift from. The
+alternative -- an open-array type in HIR and MIR -- is rejected in full below.
+
+### 4. A DPI argument has two lowering shapes, not one per carrier
+
+An argument either crosses by value (a scalar: the SV value converts to a machine value and is
+passed directly) or through a boundary object (a canonical buffer for one packed value, a canonical
+image for an open array: construct a local from the actual, pass its pointer or handle, and for a
+write-back direction reconstruct and store afterwards). The open array joins the second shape rather
+than adding a third.
+
+## Rejected alternatives
+
+- **A handle aliasing the live SV value.** The first shape considered: the descriptor holds a
+  pointer to the actual's storage plus its declared ranges, and each foreign element access
+  transcodes on demand. It is O(1) at the call where the canonical image is O(N). Rejected because
+  it is a borrow of an aggregate's interior, which the value model does not admit
+  ([slice-value-semantics](slice-value-semantics.md)); because a fat element has no C representation
+  so every pointer accessor would return NULL, losing the whole-array and element-pointer paths the
+  LRM's own examples use; and because reaching an element of an arbitrary element type from a
+  type-erased handle needs either a generated accessor table or per-element-type runtime code, where
+  the canonical image needs neither. The O(N) marshal is also the order of the usage: open arrays
+  exist so foreign code can walk arrays of any size.
+
+- **Native C element layout for elements whose individual form is a C scalar** -- a `byte` array
+  laid out as `char[]` rather than one 32-bit group per element. This is what a `char*`-assuming
+  foreign source would want, and other simulators do it. Rejected because H.7.3 states the
+  representation directly for exactly this case: an open array whose element type is a 2- or 4-state
+  scalar or packed type is in canonical form. Adopting native layout would also add a layout mode to
+  the boundary object -- a second axis -- to serve an access path H.12.4 already permits to be NULL.
+  The consequence to accept: a foreign source that bypasses the canonical accessors and treats
+  `svGetArrayPtr` on a narrow-element array as a C array is not portable, and against Lyra receives
+  the NULL that tells it so.
+
+- **An open-array type in the HIR and MIR type systems**, so the formal's shape rides its SV type
+  and the carrier becomes a marker. Rejected on F4: the formal's unsized shape is not the type of
+  any value that crosses, so this hands every consumer of a formal's SV type a type none of them may
+  use, and grows a never-taken arm in every dispatch over the type variant. `mir.md` puts a formal's
+  ABI classification on the callable's declaration for this reason.
+
+- **A named argument-lowering protocol object** with construct / argument / commit operations, one
+  implementation per carrier. The two shapes of decision 4 are real, but an interface with two
+  implementations, justified by species that do not exist, is surface built ahead of its consumers.
+  The shapes are two functions until a third species makes them three.
+
+- **Sized unpacked array formals alongside open ones.** They look like the easier half of the same
+  feature and are the opposite: H.11.4 requires them to have C-compiler layout, which a fat value
+  cannot provide (F2).
+
+## Consequences
+
+- The supported element types are exactly the 2- and 4-state scalar and packed types -- the ones
+  H.7.3 puts in canonical form. An element type H.7.3 puts in C-compatible form (`real`,
+  `shortreal`, `string`, `chandle`, an unpacked struct) is legal SystemVerilog that Lyra does not
+  yet accept, because serving it requires C layout for that element; the diagnostic says so rather
+  than implying the LRM forbids it.
+- Both backends consume the same MIR: a boundary-object local constructed from the actual, a handle
+  argument, and a reconstruct-and-store for a write-back direction. Only the realization of the
+  boundary object differs.
+- An exported subroutine cannot take an open array (LRM 35.5.6.1, H.8.2), and the frontend already
+  rejects the declaration that would produce one, so the boundary carries no export-side arm.
+
+## Cross-references
+
+- LRM 35.5.6.1 (open arrays), 35.6.1.1 (WYSIWYG; ranges determined at the call site), 35.5.4
+  (`"DPI-C"` passes canonical format), 35.5.5 (a result is a small value).
+- Annex H.7.3 (data representation), H.7.5 / H.7.6 (normalized and declared ranges), H.7.7
+  (canonical representation of packed arrays), H.8.6 (argument passing by handle), H.11.4 (C layout
+  for unpacked arrays), H.12 (the open-array surface).
+- [dpi-foreign-boundary](dpi-foreign-boundary.md) -- the callable model, the ABI-temporary carrier,
+  and the marshaling-as-MIR-call rule this extends.
+- [integral-representation](integral-representation.md),
+  [unpacked-array-representation](unpacked-array-representation.md),
+  [jit-aggregate-realization](jit-aggregate-realization.md) -- the value representations that make C
+  layout unavailable.
+- [slice-value-semantics](slice-value-semantics.md) -- the value-not-borrow access model the
+  aliasing alternative would have contradicted.
+- [unpacked-range-belongs-to-type](unpacked-range-belongs-to-type.md) -- the declared range as a
+  type-derived operand materialized at lowering, which the dimension operands follow.

--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -51,11 +51,16 @@ free function directly with no instance (D4a, D4c); reaching any export now requ
 context, so its caller must be a context import or set the scope with `svSetScope`. The user-facing
 surface (D9) is in too: the design's foreign declarations generate a C header the user's own sources
 compile against, and an emitted project carries that header alongside a copy of every foreign source
-and a recipe that builds them, so it links and runs standalone. What remains is the disable protocol
-across the boundary (D6c). On the execution backend scalar import (D10) is in: a foreign call lowers
-to an external-linkage symbol and the by-value carriers marshal. The rest of the import surface
-(D11) is blocked, and not by anything DPI owns: by-pointer marshaling is expressed as a closure,
-which that backend does not yet lower at all (`architecture-reset.md`).
+and a recipe that builds them, so it links and runs standalone. Open-array arguments (D8) close the
+type surface: one imported subroutine now serves actuals of any size and range, in every direction,
+the foreign side reading them through the Annex H.12 introspection, addressing, and element
+accessors. What remains is the disable protocol across the boundary (D6c) and the element types
+Annex H.7.3 puts in C-compatible representation. A DPI-C import is still reachable only from the
+compilation unit that declares it; one declared in a package or at `$unit` scope is rejected. On the
+execution backend scalar import (D10) is in: a foreign call lowers to an external-linkage symbol and
+the by-value carriers marshal. The rest of the import surface (D11) is blocked, and not by anything
+DPI owns: by-pointer marshaling is expressed as a closure, which that backend does not yet lower at
+all (`architecture-reset.md`).
 
 ## Sub-Steps
 
@@ -81,12 +86,10 @@ on the execution backend, mirroring the C++-backend items one surface at a time.
       `bit [31:0]` (canonical vector) get distinct C ABIs; the canonical layout matches Lyra's
       two-plane representation, so marshaling is a plane reshape. A 4-state scalar `logic` result
       crosses by value; a wider result stays restricted to a small value (LRM 35.5.5).
-  - [ ] `shortreal` as a DPI-C argument or result type (LRM 35.5.6) is rejected; `real` is
-        supported.
-  - [ ] A packed struct / union as a DPI-C argument (LRM 35.5.6, Annex H) is rejected; only the
-        packed-vector, scalar, `real`, `string`, and `chandle` carriers are wired.
-  - [ ] A DPI-C signature carrying any other unmapped type (LRM 35.5.6, Table H.1) is rejected
-        rather than mis-marshalled.
+  - [x] A signature carrying a type outside that mapping (LRM 35.5.6, Table H.1) is rejected at the
+        declaration rather than mis-marshalled at the call. The wired carriers are the packed
+        vector, the by-value scalar, `real`, `string`, and `chandle`; `shortreal` and a packed
+        struct / union are the notable types outside them.
 
 ### Export: foreign C calls SV
 
@@ -172,8 +175,25 @@ protocol on top of it.
 
 ### Open arrays
 
-- [ ] D8 -- Open-array arguments (LRM 35.5.6.1): the introspection and pointer surface (array
-      bounds, size, dimension queries, element pointers) and packed / scalar element access.
+- [x] D8 -- Open-array arguments (LRM 35.5.6.1): a formal that leaves a dimension unsized accepts
+      actuals of any size and range, in every direction. The actual crosses as a canonical image of
+      the whole array (LRM Annex H.7.3, the representation `"DPI-C"` specifies for an open array),
+      and a writeback direction reconstructs one SV value from that image and stores it, so nothing
+      aliases the actual's storage. The foreign side gets the introspection surface (bounds, size,
+      increment, dimension count, reported per dimension from the declared range the call site
+      supplied), the addressing surface (whole-array and element addresses, answered where an
+      element's canonical form is also how an individual value of its type crosses and with a null
+      where it is not, per Annex H.12.4), and the canonical and scalar element accessors. Element
+      types are the 2- and 4-state scalar and packed ones; the design record is
+      `../decisions/dpi-open-array-boundary.md`.
+  - [ ] An element type Annex H.7.3 puts in C-compatible rather than canonical representation
+        (`real`, `shortreal`, `string`, `chandle`, an unpacked struct) is legal SystemVerilog that
+        is rejected: serving it needs C-compiler layout for the element, which a SystemVerilog value
+        does not have. The same limitation rejects a sized (non-open) unpacked array argument, which
+        Annex H.11.4 requires to have that layout.
+  - [ ] An open array of more than three unpacked dimensions is rejected. The foreign side reaches
+        an element through the one-, two-, and three-index entries of Annex H.12.3; the
+        variable-argument forms a deeper array needs are not published.
 
 ### Driver and link
 
@@ -224,7 +244,8 @@ and the out-of-scope boundary. Work proceeds against that record.
 ## Cross-references
 
 - Design record: `../decisions/dpi-foreign-boundary.md` (the settled callable / marshaling / export
-  model and the rejected alternatives).
+  model and the rejected alternatives) and `../decisions/dpi-open-array-boundary.md` (the open-array
+  boundary object and where the formal's unsized shape lives).
 - LRM 35: 35.4 (imported subroutines), 35.5 (functions and tasks; type mapping 35.5.6; scope
   35.5.3), 35.9 (disable protocol).
 - Architecture: `callable.md` (the external-symbol callable), `backend_contract.md` (mechanical

--- a/include/lyra/hir/foreign_import.hpp
+++ b/include/lyra/hir/foreign_import.hpp
@@ -8,10 +8,11 @@
 
 namespace lyra::hir {
 
-// One argument of a DPI-C import's ABI projection (LRM 35.5.6): the SV type it
-// was declared with, the C ABI carrier it crosses the boundary as, and its
+// One argument of a DPI-C import's ABI projection (LRM 35.5.6): the SV type
+// whose values the boundary marshals, the C ABI carrier it crosses as, and its
 // direction (LRM 35.5.1.2), which decides whether the boundary copies the value
-// in, back, or both.
+// in, back, or both. For an open array `sv_type` is the element type, since the
+// declaration fixes nothing else about the actual's shape (LRM 35.6.1.1).
 struct DpiParamAbi {
   TypeId sv_type{};
   support::DpiCarrier carrier =

--- a/include/lyra/lir/type.hpp
+++ b/include/lyra/lir/type.hpp
@@ -49,6 +49,8 @@ enum class RuntimeLibraryKind : std::uint8_t {
   kDpiLogicBuffer,
   kDpiBitChunk,
   kDpiLogicChunk,
+  kDpiOpenArray,
+  kDpiOpenArrayHandle,
   kTrigger,
 };
 

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -369,6 +369,14 @@ enum class RuntimeLibraryKind : std::uint8_t {
   // layout-equivalent word / record.
   kDpiBitChunk,
   kDpiLogicChunk,
+  // A DPI-C open array as the foreign side sees it (LRM 35.5.6.1, Annex H.12):
+  // `lyra::value::DpiOpenArray`, the canonical image of a whole actual plus the
+  // declared coordinate system of each dimension, built at the call site and
+  // read back after it. `kDpiOpenArrayHandle` is the opaque handle the foreign
+  // side receives in its place -- `svOpenArrayHandle`, the ABI spelling of a
+  // reference to that image, and the only one of the two a prototype names.
+  kDpiOpenArray,
+  kDpiOpenArrayHandle,
   // The RAII bracket a `context` DPI import's marshaling body opens over its
   // declaration scope (LRM 35.5.3): `lyra::runtime::DpiScopeGuard`, constructed
   // from the run services and the declaration scope, pushing that scope on the

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -359,6 +359,15 @@ enum class BuiltinFn : std::uint16_t {
   kWriteCanonicalBitVec,
   kWriteCanonicalLogicVec,
   kDpiBufferData,
+  // The open-array boundary image (LRM 35.5.6.1, Annex H.12).
+  // `kDpiOpenArrayHandle`
+  // reads the opaque handle the foreign side receives in place of the actual;
+  // `kDpiOpenArrayValue` reads the image back as an SV value shaped like the
+  // prototype it takes (`args[1]`), which is what an `output` / `inout` open
+  // array stores into its actual. Instance methods on the image (`args[0]`),
+  // which the call site builds from the actual before the foreign call.
+  kDpiOpenArrayHandle,
+  kDpiOpenArrayValue,
   // Runs an exported SV task's coroutine body to completion synchronously and
   // yields its completion payload. A foreign C caller of an exported task (LRM
   // 35.8) is not a coroutine and cannot await the task body, so the C entry

--- a/include/lyra/support/dpi_abi.hpp
+++ b/include/lyra/support/dpi_abi.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <cstdint>
+#include <format>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 namespace lyra::support {
 
@@ -52,15 +55,52 @@ struct VectorCarrier {
   auto operator==(const VectorCarrier&) const -> bool = default;
 };
 
-// The C ABI carrier an SV value crosses the DPI-C boundary as. Exactly one of a
-// by-value scalar or a by-pointer canonical vector -- the two are different
-// families (register value vs boundary buffer), so the variant carries each
-// family's own payload. It is the ABI-family projection of a formal, not the
-// whole formal: the SV type shape (width, signedness) stays on the formal's SV
-// type, carried alongside this, and this never duplicates it. Shared by HIR and
-// MIR so no layer re-derives the classification. Kept in `support` as pure data
-// (no HIR / MIR / slang types) so it stays IR-agnostic.
-using DpiCarrier = std::variant<ScalarCarrier, VectorCarrier>;
+// One declared unpacked dimension of an open-array formal, `[left:right]`.
+// Spelled here rather than reused from an IR layer so the carrier stays
+// IR-agnostic.
+struct DpiRange {
+  std::int64_t left = 0;
+  std::int64_t right = 0;
+
+  auto operator==(const DpiRange&) const -> bool = default;
+};
+
+// A by-handle open-array carrier (LRM 35.5.6.1, Annex H.8.6): the formal leaves
+// at least one dimension unsized, so the actual's extent is fixed per call and
+// the value crosses as a handle to a canonical image of the whole array.
+//
+// Only what the formal's SV type does not already fix lives here. `unpacked`
+// runs outermost-first, one entry per unpacked dimension, holding the range the
+// declaration fixes or nothing where the dimension is unsized and the actual
+// supplies it at the call (LRM Annex H.7.6). `packed_unsized` says the same for
+// the sole packed dimension, whose width then comes from the actual; a sized
+// one takes its width from the element type. The element type itself, its
+// width, and its state domain stay on the formal's SV type and are read from
+// there.
+//
+// `element_crosses_as_canonical_vector` is the element's own ABI family: it
+// says an individual value of the element type crosses in the same canonical
+// form the array image holds it in, which is what decides whether the foreign
+// side may take the address of the whole array or of one element (LRM Annex
+// H.12.4).
+struct OpenArrayCarrier {
+  bool packed_unsized = false;
+  bool element_crosses_as_canonical_vector = false;
+  std::vector<std::optional<DpiRange>> unpacked;
+
+  auto operator==(const OpenArrayCarrier&) const -> bool = default;
+};
+
+// The C ABI carrier an SV value crosses the DPI-C boundary as: a by-value
+// scalar, a by-pointer canonical vector, or a by-handle open array. The three
+// are different families (register value, boundary buffer, boundary image), so
+// the variant carries each family's own payload. It is the ABI-family
+// projection of a formal, not the whole formal: the SV type shape (width,
+// signedness) stays on the formal's SV type, carried alongside this, and this
+// never duplicates it. Shared by HIR and MIR so no layer re-derives the
+// classification. Kept in `support` as pure data (no HIR / MIR / slang types)
+// so it stays IR-agnostic.
+using DpiCarrier = std::variant<ScalarCarrier, VectorCarrier, OpenArrayCarrier>;
 
 // The direction of a DPI-C formal argument (LRM 35.5.1.2). `ref` is illegal in
 // import declarations, so the set is exactly input / output / inout. The
@@ -72,6 +112,28 @@ enum class DpiDirection : std::uint8_t {
   kOutput,
   kInout,
 };
+
+// Whether the category is one of the 2- and 4-state scalar and packed types --
+// the ones an open array holds in canonical form (LRM Annex H.7.3). The
+// remainder (`real`, `string`, `chandle`, and `void`, which is not an argument
+// at all) are the C-compatible-representation half of that rule.
+[[nodiscard]] constexpr auto DpiScalarAbiIsIntegral(DpiScalarAbi abi) -> bool {
+  switch (abi) {
+    case DpiScalarAbi::kBitScalar:
+    case DpiScalarAbi::kLogicScalar:
+    case DpiScalarAbi::kByte:
+    case DpiScalarAbi::kShortInt:
+    case DpiScalarAbi::kInt:
+    case DpiScalarAbi::kLongInt:
+      return true;
+    case DpiScalarAbi::kVoid:
+    case DpiScalarAbi::kReal:
+    case DpiScalarAbi::kString:
+    case DpiScalarAbi::kChandle:
+      return false;
+  }
+  return false;
+}
 
 // Whether the direction writes the actual back after the call: output and inout
 // copy the foreign-written carrier back into the SV actual, input does not.
@@ -124,14 +186,24 @@ enum class DpiDirection : std::uint8_t {
 }
 
 // A human-readable spelling of a carrier, for HIR and MIR dumps: a scalar names
-// its ABI category, a vector names its chunk kind and declared width.
+// its ABI category, a vector its chunk kind, an open array its per-dimension
+// shape with `[]` for each dimension the actual sizes.
 [[nodiscard]] inline auto DpiCarrierName(const DpiCarrier& carrier)
     -> std::string {
   if (const auto* scalar = std::get_if<ScalarCarrier>(&carrier)) {
     return std::string{DpiScalarAbiName(scalar->abi)};
   }
-  const auto& vec = std::get<VectorCarrier>(carrier);
-  return vec.four_state ? "logicvec" : "bitvec";
+  if (const auto* vec = std::get_if<VectorCarrier>(&carrier)) {
+    return vec->four_state ? "logicvec" : "bitvec";
+  }
+  const auto& open = std::get<OpenArrayCarrier>(carrier);
+  std::string out = "openarray";
+  out += open.packed_unsized ? "[]" : "";
+  for (const std::optional<DpiRange>& dim : open.unpacked) {
+    out += dim.has_value() ? std::format("[{}:{}]", dim->left, dim->right)
+                           : std::string{"[]"};
+  }
+  return out;
 }
 
 }  // namespace lyra::support

--- a/include/lyra/value/dpi_canonical.hpp
+++ b/include/lyra/value/dpi_canonical.hpp
@@ -5,13 +5,14 @@
 
 #include "lyra/value/packed_array.hpp"
 
-// The canonical DPI-C representation of packed values (LRM Annex H.10.1.2): the
-// C ABI a packed SV value crosses the foreign boundary as. The layout is fixed
-// by the standard and matches svdpi.h, so an emitted `extern "C"` declaration
-// and a user's svdpi.h agree at the ABI level. A `svBitVecVal` chunk is 32 bits
-// of a 2-state value; a `svLogicVecVal` chunk is 32 bits of a 4-state value,
-// with `aval` the value plane and `bval` the unknown (X/Z) plane -- exactly
-// Lyra's internal two-plane representation, split into 32-bit chunks.
+// The DPI-C ABI names an emitted artifact needs, spelled here so it compiles
+// without the standard header while still agreeing with a user's svdpi.h at the
+// ABI level. The canonical representation of packed values (LRM Annex H.7.7 /
+// H.10.1.2) is a sequence of 32-bit groups: a `svBitVecVal` group is 32 bits of
+// a 2-state value; a `svLogicVecVal` group is 32 bits of a 4-state value, with
+// `aval` the value plane and `bval` the unknown (X/Z) plane -- exactly Lyra's
+// internal two-plane representation, split into 32-bit groups. An open array
+// crosses as an opaque handle instead (LRM Annex H.8.6).
 #ifndef LYRA_SV_CANONICAL_DEFINED
 #define LYRA_SV_CANONICAL_DEFINED
 using svBitVecVal = std::uint32_t;
@@ -19,6 +20,7 @@ struct svLogicVecVal {
   std::uint32_t aval;
   std::uint32_t bval;
 };
+using svOpenArrayHandle = void*;
 #endif
 
 namespace lyra::value {

--- a/include/lyra/value/dpi_open_array.hpp
+++ b/include/lyra/value/dpi_open_array.hpp
@@ -1,0 +1,216 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "lyra/value/dpi_canonical.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/unpacked_array.hpp"
+
+namespace lyra::value {
+
+namespace detail {
+
+// The leftmost leaf of a nest of unpacked layers, whose declared width and
+// state domain every leaf of the nest shares.
+[[nodiscard]] inline auto FirstLeaf(const PackedArray& value)
+    -> const PackedArray& {
+  return value;
+}
+template <typename T>
+[[nodiscard]] auto FirstLeaf(const UnpackedArray<T>& value)
+    -> const PackedArray& {
+  return FirstLeaf(value.RawAt(0));
+}
+
+}  // namespace detail
+
+// A DPI-C open array as the foreign side sees it (LRM 35.5.6.1, Annex H.12): a
+// canonical image of the whole actual, plus the coordinate system of each
+// dimension. It is an ABI temporary of one foreign call -- built from the SV
+// value before the call, read back into an SV value after -- and owns its
+// storage, so nothing here aliases the actual and no foreign write reaches SV
+// storage directly.
+//
+// The image is a sequence of elements, each in the canonical form of its
+// declared width (Annex H.7.7), so its storage element type is the 32-bit group
+// of the array's own state domain. Elements run in ascending declared-index
+// order per dimension, the C layout order Annex H.7.3 fixes, which reverses
+// relative to SV element order for a descending declared range.
+//
+// Dimension 0 is the sole packed dimension, always normalized to `[width-1:0]`;
+// dimensions 1 and up are the unpacked ones, each reporting the declared range
+// the call site supplied (Annex H.7.5, H.7.6).
+class DpiOpenArray {
+ public:
+  // `bounds` is the declared `(left, right)` pair of each unpacked dimension,
+  // outermost first -- empty where the actual is a single packed value.
+  // `addressable_elements` says an individual value of the element type crosses
+  // in the same canonical form the image holds it in, which is what lets the
+  // foreign side take the address of the array or of one element (Annex
+  // H.12.4).
+  template <typename T>
+  DpiOpenArray(
+      const T& sv, std::span<const PackedArray> bounds,
+      bool addressable_elements) {
+    Shape(bounds, detail::FirstLeaf(sv), addressable_elements);
+    std::size_t position = 0;
+    Fill(sv, 0, position);
+  }
+
+  // The SV value the image now holds, shaped like `prototype` -- the write-back
+  // of an `output` or `inout` open array. Reading through a prototype is what
+  // gives each element its declared width, signedness, and state domain, since
+  // the canonical form carries none of them.
+  template <typename T>
+  [[nodiscard]] auto ToValue(const T& prototype) const -> T {
+    std::size_t position = 0;
+    return Rebuild(prototype, 0, position);
+  }
+
+  [[nodiscard]] auto Handle() -> svOpenArrayHandle {
+    return this;
+  }
+
+  // The number of unpacked dimensions; the packed dimension is dimension 0 and
+  // is not counted (Annex H.12.2).
+  [[nodiscard]] auto Dimensions() const -> int {
+    return static_cast<int>(dims_.size());
+  }
+
+  // The declared bounds of one dimension, or the empty range for a dimension
+  // the array does not have -- from which every query derives a zero size and a
+  // zero bound, so no query carries an out-of-range arm of its own.
+  [[nodiscard]] auto Bounds(int dimension) const -> UnpackedRange;
+
+  // The address and byte size of the image as one array. Both answer with
+  // nothing where an element's canonical form is not how an individual value of
+  // its type crosses, which is the null address Annex H.12.4 prescribes; they
+  // travel together so neither caller re-checks the condition.
+  [[nodiscard]] auto Image() -> void*;
+  [[nodiscard]] auto ImageSizeInBytes() const -> std::size_t;
+
+  // The address of one element, or null under the condition above or for
+  // indices this array has no element at.
+  [[nodiscard]] auto ElementAddress(std::span<const int> indices) -> void*;
+
+  // The canonical groups of the element at the given declared indices, one
+  // index per unpacked dimension and outermost first, in the state domain the
+  // caller asked for. Empty for an index outside its dimension, an index count
+  // the array does not have, or a state domain that is not the image's -- each
+  // a call the foreign side made against a shape this array does not have.
+  template <typename Word>
+  [[nodiscard]] auto Element(std::span<const int> indices) -> std::span<Word> {
+    const std::optional<std::size_t> position = PositionOf(indices);
+    return position.has_value() ? GroupsAt<Word>(*position) : std::span<Word>{};
+  }
+
+ private:
+  // Fixes the coordinate system, the element shape, and the storage the image
+  // needs, all of which follow from the bounds and one leaf.
+  void Shape(
+      std::span<const PackedArray> bounds, const PackedArray& leaf,
+      bool addressable_elements);
+
+  // The 32-bit groups one element occupies in canonical form (Annex H.7.7).
+  [[nodiscard]] auto GroupsPerElement() const -> std::size_t {
+    return (static_cast<std::size_t>(element_width_) + 31U) / 32U;
+  }
+
+  [[nodiscard]] auto ElementCount() const -> std::size_t;
+
+  // The image position of the element at the given declared indices, or nothing
+  // where the index count or any index does not fit this array.
+  [[nodiscard]] auto PositionOf(std::span<const int> indices) const
+      -> std::optional<std::size_t>;
+
+  // The address of the element at an image position, or null where the foreign
+  // side may not address elements at all.
+  [[nodiscard]] auto AddressAt(std::size_t position) -> void*;
+
+  // The storage ordinal of the element at C position `position` in a dimension:
+  // the two agree while the declared range ascends and mirror each other while
+  // it descends, since SV element order runs from the left bound (LRM 7.6) and
+  // the C layout runs from the lowest index (Annex H.7.3).
+  [[nodiscard]] auto OrdinalAt(
+      std::size_t dimension, std::size_t position) const -> std::size_t;
+
+  // The one place an image position becomes storage. Empty where the image
+  // holds the other state domain, so a caller that asked for the wrong word
+  // type gets the same non-answer as a caller that asked for a missing element.
+  template <typename Word>
+  [[nodiscard]] auto GroupsAt(std::size_t position) -> std::span<Word> {
+    auto* words = std::get_if<std::vector<Word>>(&storage_);
+    if (words == nullptr) {
+      return {};
+    }
+    const std::size_t groups = GroupsPerElement();
+    return std::span{*words}.subspan(position * groups, groups);
+  }
+  template <typename Word>
+  [[nodiscard]] auto GroupsAt(std::size_t position) const
+      -> std::span<const Word> {
+    const auto* words = std::get_if<std::vector<Word>>(&storage_);
+    if (words == nullptr) {
+      return {};
+    }
+    const std::size_t groups = GroupsPerElement();
+    return std::span{*words}.subspan(position * groups, groups);
+  }
+
+  // One element's canonical groups at an image position, in whichever state
+  // domain the image holds.
+  void WriteLeaf(const PackedArray& value, std::size_t position);
+  [[nodiscard]] auto ReadLeaf(
+      const PackedArray& prototype, std::size_t position) const -> PackedArray;
+
+  // Walks a value against the dimensions, descending one layer per dimension
+  // and visiting the leaves in C layout order so `position` advances with the
+  // image. A leaf ends the walk, so the innermost layer consumes no dimension.
+  template <typename T>
+  void Fill(const T& value, std::size_t dimension, std::size_t& position) {
+    if constexpr (std::is_same_v<T, PackedArray>) {
+      WriteLeaf(value, position);
+      ++position;
+    } else {
+      for (std::size_t p = 0; p < value.RawSize(); ++p) {
+        Fill(value.RawAt(OrdinalAt(dimension, p)), dimension + 1, position);
+      }
+    }
+  }
+
+  template <typename T>
+  [[nodiscard]] auto Rebuild(
+      const T& prototype, std::size_t dimension, std::size_t& position) const
+      -> T {
+    if constexpr (std::is_same_v<T, PackedArray>) {
+      const PackedArray value = ReadLeaf(prototype, position);
+      ++position;
+      return value;
+    } else {
+      const std::size_t count = prototype.RawSize();
+      std::vector<typename T::ElementType> elements(count);
+      for (std::size_t p = 0; p < count; ++p) {
+        const std::size_t ordinal = OrdinalAt(dimension, p);
+        elements[ordinal] =
+            Rebuild(prototype.RawAt(ordinal), dimension + 1, position);
+      }
+      typename T::ElementType element_default = prototype.RawAt(0);
+      element_default.ResetToDefault();
+      return T(std::move(element_default), elements);
+    }
+  }
+
+  std::variant<std::vector<svBitVecVal>, std::vector<svLogicVecVal>> storage_;
+  std::vector<UnpackedRange> dims_;
+  std::uint32_t element_width_ = 0;
+  bool addressable_elements_ = false;
+};
+
+}  // namespace lyra::value

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -45,6 +45,22 @@ struct UnpackedRange {
   [[nodiscard]] auto FromOrdinal(std::int64_t ordinal) const -> std::int64_t {
     return IsAscending() ? ordinal + left : left - ordinal;
   }
+  // A declared range spans `|left - right| + 1` elements and is never empty.
+  // `[0:-1]` is the one exception -- the synthetic empty range standing in for
+  // a dimension that does not exist, which no real declared range spells.
+  [[nodiscard]] auto Count() const -> std::size_t {
+    if (left == 0 && right == -1) {
+      return 0;
+    }
+    return static_cast<std::size_t>(
+               IsAscending() ? right - left : left - right) +
+           1U;
+  }
+  // The lowest declared index, which is C index 0 in the DPI layout of an
+  // unpacked dimension (LRM Annex H.7.3).
+  [[nodiscard]] auto Low() const -> std::int64_t {
+    return IsAscending() ? left : right;
+  }
 };
 
 // SystemVerilog fixed-size unpacked array (LRM 7.4.2). One C++ container layer
@@ -130,12 +146,12 @@ class UnpackedArray {
     return data_.size();
   }
 
-  // Flat-storage element read. `i` is in [0, RawSize()); no SV-index
-  // translation, no invalid-index handling. Sole consumer is the
-  // aggregate-format path
-  // (`Formatter<UnpackedArray<T>>::Format`), which traverses storage to defer
-  // each element to its own `Formatter` specialization. SV-semantics access
-  // goes through `Element(PackedArray)`.
+  // Flat-storage element read: `i` is a storage ordinal in [0, RawSize()), with
+  // no SV-index translation and no invalid-index handling. It serves a
+  // traversal that already walks storage in ordinal order and needs no
+  // coordinate resolution; access by a source-level index is a separate
+  // operation that resolves the coordinate against the receiver's declared
+  // range (LRM 7.4.5).
   [[nodiscard]] auto RawAt(std::size_t i) const -> const T& {
     return data_[i];
   }

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -681,6 +681,7 @@ auto RenderUnitIncludes(const mir::CompilationUnit& unit) -> std::string {
   out += "#include \"lyra/runtime/scope.hpp\"\n";
   out += "#include \"lyra/runtime/sim_time.hpp\"\n";
   out += "#include \"lyra/runtime/var.hpp\"\n";
+  out += "#include \"lyra/value/dpi_open_array.hpp\"\n";
   out += "#include \"lyra/value/enum.hpp\"\n";
   out += "#include \"lyra/value/format.hpp\"\n";
   out += "#include \"lyra/value/packed_type.hpp\"\n";

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -285,6 +285,10 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "WriteCanonicalLogicVec";
     case support::BuiltinFn::kDpiBufferData:
       return "Data";
+    case support::BuiltinFn::kDpiOpenArrayHandle:
+      return "Handle";
+    case support::BuiltinFn::kDpiOpenArrayValue:
+      return "ToValue";
     case support::BuiltinFn::kRunExportedTaskToCompletion:
       return "RunExportedTaskToCompletion";
     case support::BuiltinFn::kCurrentExportScope:

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -186,6 +186,10 @@ auto RenderTypeAsCpp(const mir::CompilationUnit& unit, mir::TypeId type_id)
                 return std::string{"svBitVecVal"};
               case mir::RuntimeLibraryKind::kDpiLogicChunk:
                 return std::string{"svLogicVecVal"};
+              case mir::RuntimeLibraryKind::kDpiOpenArray:
+                return std::string{"lyra::value::DpiOpenArray"};
+              case mir::RuntimeLibraryKind::kDpiOpenArrayHandle:
+                return std::string{"const svOpenArrayHandle"};
               case mir::RuntimeLibraryKind::kDpiScopeGuard:
                 return std::string{"lyra::runtime::DpiScopeGuard"};
             }

--- a/src/lyra/dpi/abi_header.cpp
+++ b/src/lyra/dpi/abi_header.cpp
@@ -24,8 +24,8 @@ namespace {
 // The C spelling of a type that crosses the DPI-C boundary (LRM 35.5.6, Annex
 // H) -- the C target's type mapping, the peer of the emitted backend's. The
 // set is closed: a foreign signature names only machine scalars, a borrowed
-// pointer to one, or a canonical vector chunk, so anything else reaching here
-// is a boundary the lowering should have rejected.
+// pointer to one, a canonical vector chunk, or an open-array handle, so
+// anything else reaching here is a boundary the lowering should have rejected.
 auto RenderTypeAsC(const mir::CompilationUnit& unit, mir::TypeId id)
     -> std::string {
   return std::visit(
@@ -63,6 +63,12 @@ auto RenderTypeAsC(const mir::CompilationUnit& unit, mir::TypeId id)
             }
             if (r.kind == mir::RuntimeLibraryKind::kDpiLogicChunk) {
               return "svLogicVecVal";
+            }
+            // LRM Annex H.8.6: an open array is passed by handle in either
+            // direction, and the handle carries a `const` qualifier because the
+            // foreign side may not modify it.
+            if (r.kind == mir::RuntimeLibraryKind::kDpiOpenArrayHandle) {
+              return "const svOpenArrayHandle";
             }
             throw InternalError(
                 "RenderTypeAsC: this runtime library type does not cross the "

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -698,6 +698,17 @@ auto LowerCallExpr(
   // boundary exactly as an intra-unit one. The call's result type is the
   // enclosing expression's own type and is not recorded again here.
   if (const auto* unit = DeclaringUnitOfSubroutine(*sym)) {
+    // A DPI-C import declared outside this unit is not reached this way: it has
+    // no SV body to call across the boundary, and its formals carry an ABI
+    // classification rather than the ordinary marshalling interface recomputed
+    // below -- some of which, such as an open array (LRM 35.5.6.1), are not
+    // data types at all. Reject it here so the gap reads as the one it is.
+    if (sym->flags.has(slang::ast::MethodFlags::DPIImport)) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedDpi,
+          "a DPI-C import declared outside the calling unit is not yet "
+          "supported");
+    }
     std::vector<hir::ExternalUnitParam> params;
     params.reserve(sym->getArguments().size());
     for (const auto* formal : sym->getArguments()) {

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -1,9 +1,12 @@
 #include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
 
+#include <algorithm>
+#include <cstdint>
 #include <expected>
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <slang/ast/Expression.h>
@@ -47,9 +50,21 @@ auto ParamDirectionOf(const slang::ast::FormalArgumentSymbol& formal)
 
 namespace {
 
-// Classifies an SV type into its DPI-C carrier (LRM 35.5.6, Annex H.10 /
-// Table H.1). This is the one place slang types are inspected for DPI. The
-// dispatch is on the declared type shape, not the bit width -- WYSIWYG
+// The ABI projection of one DPI-C type: the carrier it crosses as, and the SV
+// type whose values the boundary marshals. The two differ for an open array,
+// whose extent is the actual's (LRM 35.6.1.1) -- the declaration fixes only the
+// element type, so that is what the boundary marshals values of.
+struct DpiTypeAbi {
+  support::DpiCarrier carrier;
+  const slang::ast::Type* marshaled_type = nullptr;
+};
+
+auto ClassifyDpiType(const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<DpiTypeAbi>;
+
+// Classifies one SV value type into its DPI-C carrier (LRM 35.5.6, Annex H.10 /
+// Table H.1). The dispatch is on the declared type shape, not the bit width --
+// WYSIWYG
 // (LRM 35.6.1.1) makes `int` (by-value C `int`) and `bit [31:0]` (canonical
 // `svBitVecVal*`) different DPI ABIs even though both are 32-bit 2-state.
 //
@@ -59,9 +74,9 @@ namespace {
 //   packed `bit [N:0]`                    -> canonical bit vector
 //   packed `logic [N:0]`                  -> canonical logic vector
 //
-// `real`, `string`, `chandle`, `void` are by-value scalars. `shortreal`, packed
-// struct / union, and open arrays are a located Unsupported so the gap stays a
-// clean diagnostic.
+// `real`, `string`, `chandle`, `void` are by-value scalars. `shortreal` and
+// packed struct / union are a located Unsupported so the gap stays a clean
+// diagnostic.
 auto ClassifyDpiCarrier(const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<support::DpiCarrier> {
   const auto& t = type.getCanonicalType();
@@ -121,16 +136,108 @@ auto ClassifyDpiCarrier(const slang::ast::Type& type, diag::SourceSpan span)
       span, diag::DiagCode::kUnsupportedDpi, "DPI-C type is not yet supported");
 }
 
+// LRM 35.5.6.1: a formal leaving at least one dimension unsized crosses as an
+// open array. Walks the declared dimensions outermost-first -- a sized one is a
+// fixed unpacked layer, an unsized one an open layer -- to the element type,
+// recording per dimension the range the declaration fixes or nothing where the
+// actual supplies it (Annex H.7.6).
+//
+// An array with no unsized dimension is not an open array and is rejected:
+// Annex H.11.4 requires it to have C-compiler layout, which an SV value does
+// not have. An element type Annex H.7.3 puts in C-compatible rather than
+// canonical form is rejected for the same reason -- the LRM permits it, Lyra
+// cannot yet represent it.
+auto ClassifyOpenArray(const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<DpiTypeAbi> {
+  support::OpenArrayCarrier open;
+  const slang::ast::Type* cursor = &type;
+  while (true) {
+    const auto& layer = cursor->getCanonicalType();
+    if (layer.kind == slang::ast::SymbolKind::FixedSizeUnpackedArrayType) {
+      const auto& fixed = layer.as<slang::ast::FixedSizeUnpackedArrayType>();
+      open.unpacked.emplace_back(
+          support::DpiRange{
+              .left = static_cast<std::int64_t>(fixed.range.left),
+              .right = static_cast<std::int64_t>(fixed.range.right)});
+      cursor = &fixed.elementType;
+      continue;
+    }
+    if (layer.kind != slang::ast::SymbolKind::DPIOpenArrayType) {
+      break;
+    }
+    const auto& unsized = layer.as<slang::ast::DPIOpenArrayType>();
+    cursor = &unsized.elementType;
+    if (unsized.isPacked) {
+      open.packed_unsized = true;
+      break;
+    }
+    open.unpacked.emplace_back();
+  }
+
+  const auto dimension_is_unsized =
+      [](const std::optional<support::DpiRange>& declared) {
+        return !declared.has_value();
+      };
+  if (!open.packed_unsized &&
+      !std::ranges::any_of(open.unpacked, dimension_is_unsized)) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedDpi,
+        "a sized unpacked array is not yet supported as a DPI-C argument; "
+        "leave a dimension unsized to pass it as an open array");
+  }
+  // The foreign side reaches an element through the indexing entries Annex
+  // H.12.3 specializes for one, two, and three indices. Its variable-argument
+  // forms, which an array of more dimensions would need, are not published.
+  if (open.unpacked.size() > 3) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedDpi,
+        "an open array of more than three unpacked dimensions is not yet "
+        "supported");
+  }
+
+  auto element = ClassifyDpiType(*cursor, span);
+  if (!element) return std::unexpected(std::move(element.error()));
+  if (const auto* scalar =
+          std::get_if<support::ScalarCarrier>(&element->carrier);
+      scalar != nullptr && !DpiScalarAbiIsIntegral(scalar->abi)) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedDpi,
+        "an open array of this element type is not yet supported; only 2- and "
+        "4-state scalar and packed element types are");
+  }
+  // An unsized packed dimension makes every element a packed vector of the
+  // actual's own width, which the foreign side reaches through the canonical
+  // representation whatever the declared element atom is (LRM Annex H.12.1).
+  // With the packed dimension sized, the element's own ABI family decides.
+  open.element_crosses_as_canonical_vector =
+      open.packed_unsized ||
+      std::holds_alternative<support::VectorCarrier>(element->carrier);
+  return DpiTypeAbi{
+      .carrier = std::move(open), .marshaled_type = element->marshaled_type};
+}
+
+auto ClassifyDpiType(const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<DpiTypeAbi> {
+  const slang::ast::SymbolKind kind = type.getCanonicalType().kind;
+  if (kind == slang::ast::SymbolKind::DPIOpenArrayType ||
+      kind == slang::ast::SymbolKind::FixedSizeUnpackedArrayType) {
+    return ClassifyOpenArray(type, span);
+  }
+  auto carrier = ClassifyDpiCarrier(type, span);
+  if (!carrier) return std::unexpected(std::move(carrier.error()));
+  return DpiTypeAbi{.carrier = *std::move(carrier), .marshaled_type = &type};
+}
+
 // Classifies a DPI-C function result. LRM 35.5.5 restricts a result to a small
 // value -- a by-value scalar; a canonical vector (a packed value, `integer`, or
-// `time`) cannot be returned. So a vector carrier here is an error, not a
-// by-pointer result.
+// `time`) and an open array cannot be returned. So anything but a scalar
+// carrier here is an error, not a by-pointer or by-handle result.
 auto ClassifyDpiScalarResult(
     const slang::ast::Type& type, diag::SourceSpan span)
     -> diag::Result<support::DpiScalarAbi> {
-  auto carrier = ClassifyDpiCarrier(type, span);
-  if (!carrier) return std::unexpected(std::move(carrier.error()));
-  if (const auto* scalar = std::get_if<support::ScalarCarrier>(&*carrier)) {
+  auto abi = ClassifyDpiType(type, span);
+  if (!abi) return std::unexpected(std::move(abi.error()));
+  if (const auto* scalar = std::get_if<support::ScalarCarrier>(&abi->carrier)) {
     return scalar->abi;
   }
   return diag::Fail(
@@ -365,8 +472,11 @@ auto LowerMethodPrototypeDecl(
 }
 
 // Classifies each formal argument's ABI projection (LRM 35.5.6): its direction,
-// C ABI carrier, and SV type. Import and export declarations project their
-// arguments identically, so both build their parameter list here.
+// C ABI carrier, and the SV type the boundary marshals values of. Import and
+// export declarations build their parameter list here alike -- the forms they
+// admit differ (an export cannot take an open array, LRM 35.5.6.1), but the
+// frontend rejects such a declaration before it reaches this classification, so
+// no arm here is direction-specific.
 auto ClassifyDpiParams(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
     -> diag::Result<std::vector<hir::DpiParamAbi>> {
@@ -377,14 +487,14 @@ auto ClassifyDpiParams(
     const auto floc = mapper.PointSpanOf(formal->location);
     auto direction = ClassifyDpiDirection(*formal, floc);
     if (!direction) return std::unexpected(std::move(direction.error()));
-    auto carrier = ClassifyDpiCarrier(formal->getType(), floc);
-    if (!carrier) return std::unexpected(std::move(carrier.error()));
-    auto param_type = unit_lowerer.InternType(formal->getType(), floc);
+    auto abi = ClassifyDpiType(formal->getType(), floc);
+    if (!abi) return std::unexpected(std::move(abi.error()));
+    auto param_type = unit_lowerer.InternType(*abi->marshaled_type, floc);
     if (!param_type) return std::unexpected(std::move(param_type.error()));
     abi_params.push_back(
         hir::DpiParamAbi{
             .sv_type = *param_type,
-            .carrier = *carrier,
+            .carrier = std::move(abi->carrier),
             .direction = *direction});
   }
   return abi_params;

--- a/src/lyra/lowering/hir_to_mir/expression/dpi_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dpi_call.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/foreign_export.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
@@ -36,15 +37,21 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-// The type a value has once it is marshaled to a DPI-C carrier (LRM 35.5.6,
-// Table H.1). The carrier classifies the *formal*'s ABI; the value that crosses
-// is an ordinary machine value, so it is typed as one -- an integer of the
+// The type of the object one argument crosses the DPI-C boundary in (LRM
+// 35.5.6, Table H.1). The carrier classifies the *formal*'s ABI; a by-value
+// scalar is an ordinary machine value and is typed as one -- an integer of the
 // declared C width, a machine float, a borrowed C string, a raw pointer. A
-// packed vector crosses in a canonical chunk buffer, which is a runtime library
-// value. No type exists solely to mark a value as being at the boundary.
+// packed vector crosses in a canonical chunk buffer and an open array in a
+// canonical image of the whole actual, both runtime library values. No type
+// exists solely to mark a value as being at the boundary.
 auto CarrierTypeId(
     mir::CompilationUnit& unit, const support::DpiCarrier& carrier)
     -> mir::TypeId {
+  if (std::holds_alternative<support::OpenArrayCarrier>(carrier)) {
+    return unit.types.Intern(
+        mir::TypeData{mir::RuntimeLibraryType{
+            .kind = mir::RuntimeLibraryKind::kDpiOpenArray}});
+  }
   if (const auto* vec = std::get_if<support::VectorCarrier>(&carrier)) {
     return unit.types.Intern(
         mir::TypeData{mir::RuntimeLibraryType{
@@ -82,21 +89,21 @@ auto CarrierTypeId(
   throw InternalError("CarrierTypeId: unknown DPI-C scalar ABI");
 }
 
-// SV value -> foreign ABI carrier (LRM 35.5.6). An integral value yields its
-// widest machine integer, narrowed to the carrier's C width by a machine cast;
-// a real yields its native floating value; a string borrows a NUL-terminated C
-// string that stays valid for the call. Reuses the ordinary value accessors;
-// the boundary conversion is a plain expression, not a DPI-specific primitive.
-// Feeds both an input argument (crossed by value) and the copy-in of an inout /
-// output argument (seeding its boundary temp).
+// SV value -> by-value machine carrier (LRM 35.5.6). An integral value yields
+// its widest machine integer, narrowed to the carrier's C width by a machine
+// cast; a real yields its native floating value; a string borrows a
+// NUL-terminated C string that stays valid for the call. Reuses the ordinary
+// value accessors; the boundary conversion is a plain expression, not a
+// DPI-specific primitive. Feeds an argument that crosses by value and the seed
+// of a scalar boundary object the callee writes back through.
 auto MarshalSvToCarrier(
     mir::CompilationUnit& unit, mir::Block& block, mir::ExprId sv_id,
     const support::DpiCarrier& carrier_desc) -> mir::ExprId {
   const auto* scalar = std::get_if<support::ScalarCarrier>(&carrier_desc);
   if (scalar == nullptr) {
     throw InternalError(
-        "MarshalSvToCarrier: a canonical-vector carrier is not yet "
-        "implemented");
+        "MarshalSvToCarrier: only a by-value scalar converts to a machine "
+        "value; every other carrier crosses through a boundary object");
   }
   const mir::TypeId carrier = CarrierTypeId(unit, carrier_desc);
   switch (scalar->abi) {
@@ -176,8 +183,9 @@ auto MarshalCarrierToSv(
   const auto* scalar = std::get_if<support::ScalarCarrier>(&carrier_desc);
   if (scalar == nullptr) {
     throw InternalError(
-        "MarshalCarrierToSv: a canonical-vector carrier is not yet "
-        "implemented");
+        "MarshalCarrierToSv: only a by-value scalar converts back from a "
+        "machine value; every other carrier reads back from its boundary "
+        "object");
   }
   mir::Block& block = *frame.current_block;
   switch (scalar->abi) {
@@ -244,13 +252,17 @@ auto ImportMarshal(const mir::CallableDecl& callable)
   return *callable.foreign->marshal;
 }
 
-// A canonical-vector actual crosses by pointer to a boundary buffer, regardless
-// of direction -- even an input, since the C ABI is `const svLogicVecVal*`. The
-// buffer is a `DpiBitBuffer` / `DpiLogicBuffer` value, so it needs a boundary
-// temp and the sequenced closure path.
-[[nodiscard]] auto NeedsBoundaryTemp(const mir::ForeignParam& p) -> bool {
-  return support::DpiDirectionWritesBack(p.direction) ||
-         std::holds_alternative<support::VectorCarrier>(p.carrier);
+// An argument crosses the boundary in one of two shapes (LRM 35.5.6). It
+// crosses **by value** when it is a scalar the callee only reads: the SV value
+// converts to a machine value the call passes directly, with no local and no
+// sequencing. Every other argument crosses **through a boundary object** -- a
+// local the call site builds from the actual, whose address or handle the call
+// receives and which a writeback direction reads back afterwards. A canonical
+// vector and an open array are the second shape in either direction, because
+// the C ABI reaches them by pointer and by handle respectively even to read.
+[[nodiscard]] auto CrossesByValue(const mir::ForeignParam& p) -> bool {
+  return std::holds_alternative<support::ScalarCarrier>(p.carrier) &&
+         !support::DpiDirectionWritesBack(p.direction);
 }
 
 // The read-back builtin for a canonical-vector carrier: 4-state reads both
@@ -286,6 +298,166 @@ auto BuildBufferDataCall(
     -> support::BuiltinFn {
   return v.four_state ? support::BuiltinFn::kWriteCanonicalLogicVec
                       : support::BuiltinFn::kWriteCanonicalBitVec;
+}
+
+// The declared coordinate system each unpacked dimension of an open array
+// reports to the foreign side (LRM Annex H.7.6): the range the declaration
+// fixes, or the actual's own where the declaration left the dimension unsized.
+// The actual's ranges come from its static type, the only place an unsized
+// extent is fixed (LRM 35.6.1.1). The pairs flatten outermost-first into one
+// array literal, the shape a runtime entry takes a bounds list in.
+auto BuildOpenArrayBounds(
+    mir::CompilationUnit& unit, mir::Block& block,
+    const support::OpenArrayCarrier& open, mir::TypeId actual_type)
+    -> mir::ExprId {
+  const mir::TypeId int_type = unit.builtins.int_type;
+  std::vector<mir::ExprId> bounds;
+  bounds.reserve(open.unpacked.size() * 2);
+  mir::TypeId cursor = actual_type;
+  for (const std::optional<support::DpiRange>& declared : open.unpacked) {
+    const auto* layer =
+        std::get_if<mir::UnpackedArrayType>(&unit.types.Get(cursor).data);
+    if (layer == nullptr) {
+      throw InternalError(
+          "BuildOpenArrayBounds: the actual of an open-array formal has fewer "
+          "unpacked dimensions than the declaration");
+    }
+    const support::DpiRange range = declared.value_or(
+        support::DpiRange{.left = layer->dim.left, .right = layer->dim.right});
+    bounds.push_back(
+        block.exprs.Add(mir::MakeIntLiteral(int_type, range.left)));
+    bounds.push_back(
+        block.exprs.Add(mir::MakeIntLiteral(int_type, range.right)));
+    cursor = layer->element_type;
+  }
+  const mir::TypeId bounds_type = unit.types.Intern(
+      mir::UnpackedArrayType{
+          .element_type = int_type,
+          .dim = mir::UnpackedRange::ZeroBased(bounds.size())});
+  return block.exprs.Add(
+      mir::Expr{
+          .data = mir::ArrayLiteralExpr{.elements = std::move(bounds)},
+          .type = bounds_type});
+}
+
+// The initializer of one argument's boundary object, seeded from the actual's
+// current value. A scalar's object is the by-value carrier itself; a canonical
+// vector's is a buffer its constructor fills; an open array's is the canonical
+// image of the whole actual, which additionally takes the coordinate system of
+// each dimension and whether an element's canonical form is how an individual
+// value of its type crosses (LRM Annex H.12.4).
+auto BuildBoundaryInit(
+    mir::CompilationUnit& unit, mir::Block& block,
+    const support::DpiCarrier& carrier, mir::ExprId seed_sv,
+    mir::TypeId actual_type, mir::TypeId carrier_type) -> mir::ExprId {
+  const auto construct = [&](std::vector<mir::ExprId> arguments) {
+    return block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::CallExpr{
+                    .callee = mir::Construct{},
+                    .arguments = std::move(arguments)},
+            .type = carrier_type});
+  };
+  return std::visit(
+      Overloaded{
+          [&](const support::ScalarCarrier&) {
+            return MarshalSvToCarrier(unit, block, seed_sv, carrier);
+          },
+          [&](const support::VectorCarrier&) { return construct({seed_sv}); },
+          [&](const support::OpenArrayCarrier& open) {
+            const mir::ExprId addressable = block.exprs.Add(
+                mir::Expr{
+                    .data =
+                        mir::MachineIntLiteral{
+                            .value = static_cast<std::int64_t>(
+                                open.element_crosses_as_canonical_vector)},
+                    .type = unit.builtins.machine_int64});
+            return construct(
+                {seed_sv, BuildOpenArrayBounds(unit, block, open, actual_type),
+                 addressable});
+          }},
+      carrier);
+}
+
+// The argument the foreign call receives for one boundary object: a scalar's
+// address, a buffer's canonical chunk pointer, or an open array's handle.
+auto BuildBoundaryArgument(
+    mir::CompilationUnit& unit, mir::Block& block,
+    const support::DpiCarrier& carrier, mir::LocalId temp,
+    mir::TypeId carrier_type) -> mir::ExprId {
+  const mir::ExprId object =
+      block.exprs.Add(mir::MakeLocalRefExpr(temp, carrier_type));
+  return std::visit(
+      Overloaded{
+          [&](const support::ScalarCarrier&) {
+            return block.exprs.Add(
+                mir::MakeAddressOfExpr(
+                    object,
+                    unit.types.PointerTo(
+                        carrier_type, mir::PointerOwnership::kBorrowed)));
+          },
+          [&](const support::VectorCarrier&) {
+            return BuildBufferDataCall(unit, block, object, carrier_type);
+          },
+          [&](const support::OpenArrayCarrier&) {
+            return block.exprs.Add(
+                mir::Expr{
+                    .data =
+                        mir::CallExpr{
+                            .callee =
+                                mir::Direct{
+                                    .target = support::BuiltinFn::
+                                        kDpiOpenArrayHandle},
+                            .arguments = {object}},
+                    .type = unit.types.Intern(
+                        mir::TypeData{mir::RuntimeLibraryType{
+                            .kind = mir::RuntimeLibraryKind::
+                                kDpiOpenArrayHandle}})});
+          }},
+      carrier);
+}
+
+// The SV value one boundary object holds once the call returns, the read-back
+// that pairs with its build: a scalar marshals its by-value carrier, a vector
+// reads its buffer's canonical chunks, an open array reads its whole image.
+// Each yields one value, so the store into the actual is the ordinary one
+// whatever the carrier. Reading through a prototype of the destination's type
+// is what gives the value its declared width, signedness, and state domain,
+// which no carrier carries.
+auto BuildBoundaryReadback(
+    UnitLowerer& unit_lowerer, WalkFrame frame,
+    const support::DpiCarrier& carrier, mir::ExprId object,
+    mir::TypeId carrier_type, mir::TypeId sv_type) -> mir::ExprId {
+  mir::CompilationUnit& unit = unit_lowerer.Unit();
+  mir::Block& block = *frame.current_block;
+  const auto prototype = [&] {
+    return block.exprs.Add(BuildDefaultValueExpr(unit_lowerer, frame, sv_type));
+  };
+  const auto read = [&](support::BuiltinFn target, mir::ExprId source) {
+    return block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::CallExpr{
+                    .callee = mir::Direct{.target = target},
+                    .arguments = {source, prototype()}},
+            .type = sv_type});
+  };
+  return std::visit(
+      Overloaded{
+          [&](const support::ScalarCarrier&) {
+            return block.exprs.Add(MarshalCarrierToSv(
+                unit_lowerer, frame, object, carrier, sv_type));
+          },
+          [&](const support::VectorCarrier& vector) {
+            return read(
+                VectorReadBuiltin(vector),
+                BuildBufferDataCall(unit, block, object, carrier_type));
+          },
+          [&](const support::OpenArrayCarrier&) {
+            return read(support::BuiltinFn::kDpiOpenArrayValue, object);
+          }},
+      carrier);
 }
 
 // The all-input function import call: every actual crosses by value, so the
@@ -337,15 +509,15 @@ auto LowerForeignImportInputsOnly(
       result_type);
 }
 
-// Populates `closure`'s body with the DPI import boundary: each actual
-// marshaled to its carrier -- a by-value scalar input crossing by value, a
-// writeback direction or a canonical vector of any direction seeded into a
-// boundary temp passed by pointer -- then the foreign call, then the copy-back
-// of each writeback into its actual's cell. A valued call captures its carrier
-// result in a temp, returned so the caller marshals it after the copy-backs; a
-// void call (including a task, whose foreign symbol's disable-ack `int` is
-// discarded) is a bare statement and returns no temp. Shared by the function
-// and task import lowerings, which differ only in how they finish the closure.
+// Populates `closure`'s body with the DPI import boundary: each actual crossed
+// in its own shape -- by value, or through a boundary object the foreign call
+// reaches by pointer or by handle -- then the foreign call, then the read-back
+// of each writeback direction into its actual's cell. A valued call captures
+// its carrier result in a temp, returned so the caller marshals it after the
+// read-backs; a void call (including a task, whose foreign symbol's disable-ack
+// `int` is discarded) is a bare statement and returns no temp. Shared by the
+// function and task import lowerings, which differ only in how they finish the
+// closure.
 template <ExprLowerer Lowerer>
 auto PopulateForeignImportBoundary(
     Lowerer& lowerer, ClosureBuilder& closure, const hir::CallExpr& c,
@@ -388,7 +560,8 @@ auto PopulateForeignImportBoundary(
                     .type = guard_type})});
   }
 
-  // One output / inout argument to copy back after the call.
+  // One output / inout argument, and what its boundary object needs to be read
+  // back into the actual once the call returns.
   struct Writeback {
     mir::LocalId temp{};
     mir::TypeId carrier_type{};
@@ -405,76 +578,51 @@ auto PopulateForeignImportBoundary(
       throw InternalError("DPI-C import call argument unexpectedly elided");
     }
     const hir::ExprId actual = *c.arguments[i];
-    const support::DpiCarrier& carrier = decl.params[i].carrier;
-    const support::DpiDirection direction = decl.params[i].direction;
-    const bool writes_back = support::DpiDirectionWritesBack(direction);
-    const auto* vector = std::get_if<support::VectorCarrier>(&carrier);
+    const mir::ForeignParam& param = decl.params[i];
+    const support::DpiCarrier& carrier = param.carrier;
 
-    // A by-value scalar input crosses by value: no boundary temp, no
-    // sequencing.
-    if (vector == nullptr && !writes_back) {
-      auto sv_or = lowerer.LowerExpr(hir_exprs.Get(actual), cframe);
-      if (!sv_or) return std::unexpected(std::move(sv_or.error()));
-      const mir::ExprId sv_id = body.exprs.Add(*std::move(sv_or));
-      call_args.push_back(MarshalSvToCarrier(unit, body, sv_id, carrier));
+    auto sv_or = lowerer.LowerExpr(hir_exprs.Get(actual), cframe);
+    if (!sv_or) return std::unexpected(std::move(sv_or.error()));
+    const mir::TypeId actual_type = sv_or->type;
+    const mir::ExprId seed_sv = body.exprs.Add(*std::move(sv_or));
+
+    if (CrossesByValue(param)) {
+      call_args.push_back(MarshalSvToCarrier(unit, body, seed_sv, carrier));
       continue;
     }
 
-    // Every other actual seeds a boundary temp from the actual's current value.
-    // inout requires that initial value (LRM 35.5.1.2); for output the initial
-    // carrier value is implementation-defined, so seeding from the actual is a
-    // legal, uniform choice; a vector input seeds the same way. The foreign
-    // side writes through the pointer (for writeback directions); the copy-back
-    // below lands the result back in the actual's cell.
+    // Every other actual seeds a boundary object from the actual's current
+    // value. inout requires that initial value (LRM 35.5.1.2); for output the
+    // initial carrier value is implementation-defined, so seeding from the
+    // actual is a legal, uniform choice; an input that crosses this way seeds
+    // the same way. The foreign side reads and writes the object, and the
+    // read-back below lands the result in the actual's cell.
     const mir::TypeId carrier_type = CarrierTypeId(unit, carrier);
     const mir::LocalId temp = closure.Bindings().DeclareAnonymous(
         mir::LocalDecl{
             .name = "_lyra_dpi_arg" + std::to_string(i), .type = carrier_type});
-    auto seed_or = lowerer.LowerExpr(hir_exprs.Get(actual), cframe);
-    if (!seed_or) return std::unexpected(std::move(seed_or.error()));
-    const mir::ExprId seed_sv = body.exprs.Add(*std::move(seed_or));
+    body.AppendStmt(
+        mir::LocalDeclStmt{
+            .target = temp,
+            .init = BuildBoundaryInit(
+                unit, body, carrier, seed_sv, actual_type, carrier_type)});
+    call_args.push_back(
+        BuildBoundaryArgument(unit, body, carrier, temp, carrier_type));
 
-    if (vector != nullptr) {
-      // A canonical vector's boundary temp is a buffer value constructed from
-      // the seed (its constructor fills it). The foreign call and the copy-back
-      // read reach the chunks through its writable data pointer.
-      body.AppendStmt(
-          mir::LocalDeclStmt{
-              .target = temp,
-              .init = body.exprs.Add(
-                  mir::Expr{
-                      .data =
-                          mir::CallExpr{
-                              .callee = mir::Construct{},
-                              .arguments = {seed_sv}},
-                      .type = carrier_type})});
-      const mir::ExprId buffer_ref =
-          body.exprs.Add(mir::MakeLocalRefExpr(temp, carrier_type));
-      call_args.push_back(
-          BuildBufferDataCall(unit, body, buffer_ref, carrier_type));
-    } else {
-      // A scalar output / inout's boundary temp is the by-value carrier, seeded
-      // by the marshal-in rvalue and passed by pointer.
-      body.AppendStmt(
-          mir::LocalDeclStmt{
-              .target = temp,
-              .init = MarshalSvToCarrier(unit, body, seed_sv, carrier)});
-      const mir::TypeId ptr_type =
-          unit.types.PointerTo(carrier_type, mir::PointerOwnership::kBorrowed);
-      const mir::ExprId temp_ref =
-          body.exprs.Add(mir::MakeLocalRefExpr(temp, carrier_type));
-      call_args.push_back(
-          body.exprs.Add(mir::MakeAddressOfExpr(temp_ref, ptr_type)));
-    }
-
-    if (writes_back) {
+    if (support::DpiDirectionWritesBack(param.direction)) {
       writebacks.push_back(
           Writeback{
               .temp = temp,
               .carrier_type = carrier_type,
               .actual = actual,
               .carrier = carrier,
-              .sv_type = decl.params[i].sv_type});
+              // An open array's shape is the actual's, fixed only at the call
+              // (LRM 35.6.1.1), where every other carrier reads back into the
+              // shape the declaration fixed.
+              .sv_type =
+                  std::holds_alternative<support::OpenArrayCarrier>(carrier)
+                      ? actual_type
+                      : param.sv_type});
     }
   }
 
@@ -511,26 +659,9 @@ auto PopulateForeignImportBoundary(
     const mir::ExprId temp_ref =
         body.exprs.Add(mir::MakeLocalRefExpr(wb.temp, wb.carrier_type));
 
-    // A scalar carrier marshals its by-value temp back; a vector carrier reads
-    // its buffer's chunks back through the buffer's data pointer.
-    mir::ExprId rhs_id{};
-    if (const auto* vector = std::get_if<support::VectorCarrier>(&wb.carrier)) {
-      const mir::ExprId data =
-          BuildBufferDataCall(unit, body, temp_ref, wb.carrier_type);
-      const mir::ExprId prototype = body.exprs.Add(
-          BuildDefaultValueExpr(unit_lowerer, cframe, wb.sv_type));
-      rhs_id = body.exprs.Add(
-          mir::Expr{
-              .data =
-                  mir::CallExpr{
-                      .callee =
-                          mir::Direct{.target = VectorReadBuiltin(*vector)},
-                      .arguments = {data, prototype}},
-              .type = wb.sv_type});
-    } else {
-      rhs_id = body.exprs.Add(MarshalCarrierToSv(
-          unit_lowerer, cframe, temp_ref, wb.carrier, wb.sv_type));
-    }
+    const mir::ExprId rhs_id = BuildBoundaryReadback(
+        unit_lowerer, cframe, wb.carrier, temp_ref, wb.carrier_type,
+        wb.sv_type);
     const mir::ExprId runtime_id =
         body.exprs.Add(BuildCurrentRuntimeCallExpr(unit_lowerer));
     const mir::Expr assign = BuildObservableAssignExpr(
@@ -542,12 +673,11 @@ auto PopulateForeignImportBoundary(
   return ret_temp;
 }
 
-// The general function import call: at least one actual needs a boundary temp
-// -- an output / inout of any carrier, or a canonical vector of any direction
-// (a vector crosses by pointer even as an input). The boundary is a statement
-// sequence yielding a value, so it lowers to an immediately-invoked closure,
-// uniform for void / valued and statement / expression position. A by-value
-// scalar input still crosses by value with no temp.
+// The general function import call: at least one actual crosses through a
+// boundary object rather than by value, so the boundary is a statement sequence
+// yielding a value. It lowers to an immediately-invoked closure, uniform for
+// void / valued and statement / expression position. A by-value scalar input in
+// the same call still crosses by value, with no object of its own.
 template <ExprLowerer Lowerer>
 auto LowerForeignImportSequenced(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
@@ -615,16 +745,23 @@ auto EnclosingClassIdAtHops(
   return std::get<mir::ObjectType>(unit.types.Get(ptr.pointee).data).class_id;
 }
 
-// The MIR type one foreign formal crosses the boundary as, the ABI carrier
-// realized as a concrete type so every consumer spells it through ordinary type
-// mapping. A scalar `input` is its by-value carrier; a scalar `output` /
-// `inout` is a borrowed pointer to it. A packed vector is a borrowed pointer to
-// its canonical chunk, read-only for an `input` the boundary only reads
-// (rendering `const svBitVecVal*` through the pointer's mutability) and mutable
-// for a writeback direction.
+// The MIR type one foreign formal is declared with, the ABI carrier realized as
+// a concrete type so every consumer spells it through ordinary type mapping. A
+// scalar `input` is its by-value carrier; a scalar `output` / `inout` is a
+// borrowed pointer to it. A packed vector is a borrowed pointer to its
+// canonical chunk, read-only for an `input` the boundary only reads (rendering
+// `const svBitVecVal*` through the pointer's mutability) and mutable for a
+// writeback direction. An open array is an opaque handle either way.
 auto ForeignBoundaryType(
     mir::CompilationUnit& unit, const support::DpiCarrier& carrier,
     support::DpiDirection direction) -> mir::TypeId {
+  // An open array crosses by handle in either direction (LRM Annex H.8.6), so
+  // its boundary type does not read the direction at all.
+  if (std::holds_alternative<support::OpenArrayCarrier>(carrier)) {
+    return unit.types.Intern(
+        mir::TypeData{mir::RuntimeLibraryType{
+            .kind = mir::RuntimeLibraryKind::kDpiOpenArrayHandle}});
+  }
   if (const auto* vec = std::get_if<support::VectorCarrier>(&carrier)) {
     const mir::TypeId chunk = unit.types.Intern(
         mir::TypeData{mir::RuntimeLibraryType{
@@ -702,7 +839,7 @@ auto LowerForeignImportCall(
   // A context import sequences through a closure even when every actual is a
   // by-value input, because its scope guard is a scoped body local the plain
   // single-expression form has no room for.
-  const bool needs_temp = std::ranges::any_of(decl.params, NeedsBoundaryTemp);
+  const bool needs_temp = !std::ranges::all_of(decl.params, CrossesByValue);
   if (needs_temp || callable.foreign->is_context) {
     return LowerForeignImportSequenced(
         lowerer, frame, c, callable, target, hops, result_type);
@@ -726,6 +863,18 @@ auto SynthesizeForeignExportEntry(
     const hir::ForeignExportDecl& export_decl) -> mir::CallableDecl {
   mir::CompilationUnit& unit = module.Unit();
   const mir::TypeId void_type = unit.builtins.void_type;
+
+  // An exported subroutine cannot take an open array (LRM 35.5.6.1, Annex
+  // H.8.2), and its declaration is rejected before any of this runs, so the
+  // marshaling below reads only the two fixed-shape carriers.
+  const auto crosses_by_handle = [](const hir::DpiParamAbi& p) {
+    return std::holds_alternative<support::OpenArrayCarrier>(p.carrier);
+  };
+  if (std::ranges::any_of(export_decl.params, crosses_by_handle)) {
+    throw InternalError(
+        "SynthesizeForeignExportEntry: an export declared an open-array "
+        "formal");
+  }
 
   // An exported task lowers to a coroutine -- the result type is the call
   // protocol -- while a function's result is its payload directly.

--- a/src/lyra/lowering/mir_to_lir/translate_type.cpp
+++ b/src/lyra/lowering/mir_to_lir/translate_type.cpp
@@ -98,6 +98,10 @@ auto TranslateRuntimeLibraryKind(mir::RuntimeLibraryKind k)
       return lir::RuntimeLibraryKind::kDpiBitChunk;
     case mir::RuntimeLibraryKind::kDpiLogicChunk:
       return lir::RuntimeLibraryKind::kDpiLogicChunk;
+    case mir::RuntimeLibraryKind::kDpiOpenArray:
+      return lir::RuntimeLibraryKind::kDpiOpenArray;
+    case mir::RuntimeLibraryKind::kDpiOpenArrayHandle:
+      return lir::RuntimeLibraryKind::kDpiOpenArrayHandle;
     case mir::RuntimeLibraryKind::kTrigger:
       return lir::RuntimeLibraryKind::kTrigger;
     case mir::RuntimeLibraryKind::kScopeProgram:

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -321,6 +321,10 @@ class MirDumper {
                   return "RuntimeLibrary(DpiBitBuffer)";
                 case RuntimeLibraryKind::kDpiLogicBuffer:
                   return "RuntimeLibrary(DpiLogicBuffer)";
+                case RuntimeLibraryKind::kDpiOpenArray:
+                  return "RuntimeLibrary(DpiOpenArray)";
+                case RuntimeLibraryKind::kDpiOpenArrayHandle:
+                  return "RuntimeLibrary(DpiOpenArrayHandle)";
                 case RuntimeLibraryKind::kDpiBitChunk:
                   return "RuntimeLibrary(DpiBitChunk)";
                 case RuntimeLibraryKind::kDpiLogicChunk:

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -388,6 +388,10 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "write_canonical_logic_vec";
     case BuiltinFn::kDpiBufferData:
       return "dpi_buffer_data";
+    case BuiltinFn::kDpiOpenArrayHandle:
+      return "dpi_open_array_handle";
+    case BuiltinFn::kDpiOpenArrayValue:
+      return "dpi_open_array_value";
     case BuiltinFn::kRunExportedTaskToCompletion:
       return "run_exported_task_to_completion";
     case BuiltinFn::kCurrentExportScope:

--- a/src/lyra/value/dpi_open_array.cpp
+++ b/src/lyra/value/dpi_open_array.cpp
@@ -1,0 +1,405 @@
+#include "lyra/value/dpi_open_array.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include "lyra/value/dpi_canonical.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+void DpiOpenArray::Shape(
+    std::span<const PackedArray> bounds, const PackedArray& leaf,
+    bool addressable_elements) {
+  addressable_elements_ = addressable_elements;
+  element_width_ = static_cast<std::uint32_t>(leaf.BitWidth());
+  const std::size_t dimensions = bounds.size() / 2;
+  dims_.reserve(dimensions);
+  for (std::size_t d = 0; d < dimensions; ++d) {
+    dims_.push_back(
+        UnpackedRange{
+            .left = bounds[2 * d].ToInt64(),
+            .right = bounds[(2 * d) + 1].ToInt64()});
+  }
+  const std::size_t words = ElementCount() * GroupsPerElement();
+  if (leaf.IsFourState()) {
+    storage_ = std::vector<svLogicVecVal>(words);
+  } else {
+    storage_ = std::vector<svBitVecVal>(words);
+  }
+}
+
+auto DpiOpenArray::ElementCount() const -> std::size_t {
+  std::size_t count = 1;
+  for (const UnpackedRange& dim : dims_) {
+    count *= dim.Count();
+  }
+  return count;
+}
+
+auto DpiOpenArray::Bounds(int dimension) const -> UnpackedRange {
+  if (dimension == 0) {
+    return UnpackedRange{
+        .left = static_cast<std::int64_t>(element_width_) - 1, .right = 0};
+  }
+  if (dimension < 0 || static_cast<std::size_t>(dimension) > dims_.size()) {
+    return UnpackedRange{.left = 0, .right = -1};
+  }
+  return dims_[static_cast<std::size_t>(dimension) - 1];
+}
+
+auto DpiOpenArray::OrdinalAt(std::size_t dimension, std::size_t position) const
+    -> std::size_t {
+  const UnpackedRange& range = dims_[dimension];
+  return range.IsAscending() ? position : range.Count() - 1U - position;
+}
+
+auto DpiOpenArray::PositionOf(std::span<const int> indices) const
+    -> std::optional<std::size_t> {
+  if (indices.size() != dims_.size()) {
+    return std::nullopt;
+  }
+  std::size_t position = 0;
+  for (std::size_t d = 0; d < dims_.size(); ++d) {
+    const UnpackedRange& range = dims_[d];
+    const std::int64_t offset = std::int64_t{indices[d]} - range.Low();
+    if (offset < 0 || static_cast<std::size_t>(offset) >= range.Count()) {
+      return std::nullopt;
+    }
+    position = (position * range.Count()) + static_cast<std::size_t>(offset);
+  }
+  return position;
+}
+
+auto DpiOpenArray::AddressAt(std::size_t position) -> void* {
+  if (!addressable_elements_) {
+    return nullptr;
+  }
+  const std::size_t groups = GroupsPerElement();
+  return std::visit(
+      [&](auto& words) -> void* {
+        return std::span{words}.subspan(position * groups, groups).data();
+      },
+      storage_);
+}
+
+auto DpiOpenArray::Image() -> void* {
+  return AddressAt(0);
+}
+
+auto DpiOpenArray::ImageSizeInBytes() const -> std::size_t {
+  if (!addressable_elements_) {
+    return 0;
+  }
+  return std::visit(
+      [](const auto& words) -> std::size_t {
+        using Word = typename std::remove_cvref_t<decltype(words)>::value_type;
+        return words.size() * sizeof(Word);
+      },
+      storage_);
+}
+
+auto DpiOpenArray::ElementAddress(std::span<const int> indices) -> void* {
+  const std::optional<std::size_t> position = PositionOf(indices);
+  return position.has_value() ? AddressAt(*position) : nullptr;
+}
+
+void DpiOpenArray::WriteLeaf(const PackedArray& value, std::size_t position) {
+  const std::span<svBitVecVal> bits = GroupsAt<svBitVecVal>(position);
+  if (!bits.empty()) {
+    WriteCanonicalBitVec(bits.data(), value);
+    return;
+  }
+  WriteCanonicalLogicVec(GroupsAt<svLogicVecVal>(position).data(), value);
+}
+
+auto DpiOpenArray::ReadLeaf(
+    const PackedArray& prototype, std::size_t position) const -> PackedArray {
+  const std::span<const svBitVecVal> bits = GroupsAt<svBitVecVal>(position);
+  if (!bits.empty()) {
+    return ReadCanonicalBitVec(bits.data(), prototype);
+  }
+  return ReadCanonicalLogicVec(
+      GroupsAt<svLogicVecVal>(position).data(), prototype);
+}
+
+}  // namespace lyra::value
+
+namespace {
+
+using lyra::value::DpiOpenArray;
+
+[[nodiscard]] auto Array(void* handle) -> DpiOpenArray* {
+  return static_cast<DpiOpenArray*>(handle);
+}
+
+// The declared bounds a query reports, or the empty range for a null handle --
+// the svdpi surface answers rather than faults.
+[[nodiscard]] auto Bounds(void* handle, int dimension)
+    -> lyra::value::UnpackedRange {
+  if (handle == nullptr) {
+    return lyra::value::UnpackedRange{.left = 0, .right = -1};
+  }
+  return Array(handle)->Bounds(dimension);
+}
+
+// The element the foreign side named, in the word type the calling entry works
+// in. The entries differ only in how many indices they name and which word type
+// they carry, so each resolves its element through here and then does its own
+// one operation on the result. An empty result is every way the named element
+// can fail to exist -- a null handle, an index outside its dimension, the wrong
+// index count, the other state domain -- so no entry tests those separately.
+template <typename Word, typename... Indices>
+[[nodiscard]] auto ElementOf(void* handle, Indices... indices)
+    -> std::span<Word> {
+  const std::array<int, sizeof...(Indices)> at{indices...};
+  return handle == nullptr ? std::span<Word>{}
+                           : Array(handle)->Element<Word>(at);
+}
+
+template <typename... Indices>
+[[nodiscard]] auto AddressOf(void* handle, Indices... indices) -> void* {
+  const std::array<int, sizeof...(Indices)> at{indices...};
+  return handle == nullptr ? nullptr : Array(handle)->ElementAddress(at);
+}
+
+// Copies one element's canonical groups between the image and a caller buffer.
+// An element that does not exist leaves the destination untouched, the same
+// non-answer the addressing entries give as a null.
+template <typename Word>
+void CopyOut(std::span<Word> source, Word* destination) {
+  if (source.empty() || destination == nullptr) {
+    return;
+  }
+  const std::span<Word> out{destination, source.size()};
+  for (std::size_t i = 0; i < source.size(); ++i) {
+    out[i] = source[i];
+  }
+}
+
+template <typename Word>
+void CopyIn(std::span<Word> destination, const Word* source) {
+  if (destination.empty() || source == nullptr) {
+    return;
+  }
+  const std::span<const Word> in{source, destination.size()};
+  for (std::size_t i = 0; i < destination.size(); ++i) {
+    destination[i] = in[i];
+  }
+}
+
+// A one-bit element's `svBit` / `svLogic` scalar encoding (Annex H.10.1.1):
+// `value | unknown << 1`, read from and written to the element's first group.
+[[nodiscard]] auto ScalarBitOf(std::span<svBitVecVal> element)
+    -> unsigned char {
+  return element.empty() ? 0U
+                         : static_cast<unsigned char>(element.front() & 1U);
+}
+
+[[nodiscard]] auto ScalarLogicOf(std::span<svLogicVecVal> element)
+    -> unsigned char {
+  if (element.empty()) {
+    return 0U;
+  }
+  const svLogicVecVal& group = element.front();
+  return static_cast<unsigned char>(
+      (group.aval & 1U) | ((group.bval & 1U) << 1U));
+}
+
+void PutScalarBit(std::span<svBitVecVal> element, unsigned char value) {
+  if (!element.empty()) {
+    element.front() = value & 1U;
+  }
+}
+
+void PutScalarLogic(std::span<svLogicVecVal> element, unsigned char value) {
+  if (!element.empty()) {
+    element.front().aval = value & 1U;
+    element.front().bval = (value >> 1U) & 1U;
+  }
+}
+
+}  // namespace
+
+// The Annex H.12 open-array surface, linked into the simulation binary and
+// resolved against the user's C by name. A handle is the canonical image the
+// call site built from the actual; every entry takes the declared indices the
+// SV source uses and resolves them against the image's own dimensions. Errors
+// follow the svdpi contract -- a null handle, a dimension the array does not
+// have, or an index outside its range yields a zero, a null, or an untouched
+// destination rather than a fault -- and never throw across the C boundary.
+//
+// The indexing entries are the one-, two-, and three-index forms. Annex H.12.3
+// also defines a variable-argument form of each for an array of arbitrarily
+// many dimensions; a design that would need one is rejected at its declaration
+// instead, so no such entry is published here.
+extern "C" {
+
+auto svDimensions(void* handle) -> int {
+  return handle == nullptr ? 0 : Array(handle)->Dimensions();
+}
+
+auto svLeft(void* handle, int d) -> int {
+  return static_cast<int>(Bounds(handle, d).left);
+}
+
+auto svRight(void* handle, int d) -> int {
+  return static_cast<int>(Bounds(handle, d).right);
+}
+
+auto svLow(void* handle, int d) -> int {
+  return static_cast<int>(Bounds(handle, d).Low());
+}
+
+auto svHigh(void* handle, int d) -> int {
+  const lyra::value::UnpackedRange range = Bounds(handle, d);
+  return static_cast<int>(range.IsAscending() ? range.right : range.left);
+}
+
+auto svIncrement(void* handle, int d) -> int {
+  return Bounds(handle, d).IsAscending() ? -1 : 1;
+}
+
+auto svSize(void* handle, int d) -> int {
+  return static_cast<int>(Bounds(handle, d).Count());
+}
+
+auto svGetArrayPtr(void* handle) -> void* {
+  return handle == nullptr ? nullptr : Array(handle)->Image();
+}
+
+auto svSizeOfArray(void* handle) -> int {
+  return handle == nullptr
+             ? 0
+             : static_cast<int>(Array(handle)->ImageSizeInBytes());
+}
+
+auto svGetArrElemPtr1(void* handle, int i1) -> void* {
+  return AddressOf(handle, i1);
+}
+
+auto svGetArrElemPtr2(void* handle, int i1, int i2) -> void* {
+  return AddressOf(handle, i1, i2);
+}
+
+auto svGetArrElemPtr3(void* handle, int i1, int i2, int i3) -> void* {
+  return AddressOf(handle, i1, i2, i3);
+}
+
+auto svGetBitArrElem1VecVal(svBitVecVal* d, void* handle, int i1) -> void {
+  CopyOut(ElementOf<svBitVecVal>(handle, i1), d);
+}
+
+auto svGetBitArrElem2VecVal(svBitVecVal* d, void* handle, int i1, int i2)
+    -> void {
+  CopyOut(ElementOf<svBitVecVal>(handle, i1, i2), d);
+}
+
+auto svGetBitArrElem3VecVal(
+    svBitVecVal* d, void* handle, int i1, int i2, int i3) -> void {
+  CopyOut(ElementOf<svBitVecVal>(handle, i1, i2, i3), d);
+}
+
+auto svGetLogicArrElem1VecVal(svLogicVecVal* d, void* handle, int i1) -> void {
+  CopyOut(ElementOf<svLogicVecVal>(handle, i1), d);
+}
+
+auto svGetLogicArrElem2VecVal(svLogicVecVal* d, void* handle, int i1, int i2)
+    -> void {
+  CopyOut(ElementOf<svLogicVecVal>(handle, i1, i2), d);
+}
+
+auto svGetLogicArrElem3VecVal(
+    svLogicVecVal* d, void* handle, int i1, int i2, int i3) -> void {
+  CopyOut(ElementOf<svLogicVecVal>(handle, i1, i2, i3), d);
+}
+
+auto svPutBitArrElem1VecVal(void* handle, const svBitVecVal* s, int i1)
+    -> void {
+  CopyIn(ElementOf<svBitVecVal>(handle, i1), s);
+}
+
+auto svPutBitArrElem2VecVal(void* handle, const svBitVecVal* s, int i1, int i2)
+    -> void {
+  CopyIn(ElementOf<svBitVecVal>(handle, i1, i2), s);
+}
+
+auto svPutBitArrElem3VecVal(
+    void* handle, const svBitVecVal* s, int i1, int i2, int i3) -> void {
+  CopyIn(ElementOf<svBitVecVal>(handle, i1, i2, i3), s);
+}
+
+auto svPutLogicArrElem1VecVal(void* handle, const svLogicVecVal* s, int i1)
+    -> void {
+  CopyIn(ElementOf<svLogicVecVal>(handle, i1), s);
+}
+
+auto svPutLogicArrElem2VecVal(
+    void* handle, const svLogicVecVal* s, int i1, int i2) -> void {
+  CopyIn(ElementOf<svLogicVecVal>(handle, i1, i2), s);
+}
+
+auto svPutLogicArrElem3VecVal(
+    void* handle, const svLogicVecVal* s, int i1, int i2, int i3) -> void {
+  CopyIn(ElementOf<svLogicVecVal>(handle, i1, i2, i3), s);
+}
+
+auto svGetBitArrElem1(void* handle, int i1) -> unsigned char {
+  return ScalarBitOf(ElementOf<svBitVecVal>(handle, i1));
+}
+
+auto svGetBitArrElem2(void* handle, int i1, int i2) -> unsigned char {
+  return ScalarBitOf(ElementOf<svBitVecVal>(handle, i1, i2));
+}
+
+auto svGetBitArrElem3(void* handle, int i1, int i2, int i3) -> unsigned char {
+  return ScalarBitOf(ElementOf<svBitVecVal>(handle, i1, i2, i3));
+}
+
+auto svGetLogicArrElem1(void* handle, int i1) -> unsigned char {
+  return ScalarLogicOf(ElementOf<svLogicVecVal>(handle, i1));
+}
+
+auto svGetLogicArrElem2(void* handle, int i1, int i2) -> unsigned char {
+  return ScalarLogicOf(ElementOf<svLogicVecVal>(handle, i1, i2));
+}
+
+auto svGetLogicArrElem3(void* handle, int i1, int i2, int i3) -> unsigned char {
+  return ScalarLogicOf(ElementOf<svLogicVecVal>(handle, i1, i2, i3));
+}
+
+auto svPutBitArrElem1(void* handle, unsigned char value, int i1) -> void {
+  PutScalarBit(ElementOf<svBitVecVal>(handle, i1), value);
+}
+
+auto svPutBitArrElem2(void* handle, unsigned char value, int i1, int i2)
+    -> void {
+  PutScalarBit(ElementOf<svBitVecVal>(handle, i1, i2), value);
+}
+
+auto svPutBitArrElem3(void* handle, unsigned char value, int i1, int i2, int i3)
+    -> void {
+  PutScalarBit(ElementOf<svBitVecVal>(handle, i1, i2, i3), value);
+}
+
+auto svPutLogicArrElem1(void* handle, unsigned char value, int i1) -> void {
+  PutScalarLogic(ElementOf<svLogicVecVal>(handle, i1), value);
+}
+
+auto svPutLogicArrElem2(void* handle, unsigned char value, int i1, int i2)
+    -> void {
+  PutScalarLogic(ElementOf<svLogicVecVal>(handle, i1, i2), value);
+}
+
+auto svPutLogicArrElem3(
+    void* handle, unsigned char value, int i1, int i2, int i3) -> void {
+  PutScalarLogic(ElementOf<svLogicVecVal>(handle, i1, i2, i3), value);
+}
+
+}  // extern "C"

--- a/tests/cases/cpp/dpi_open_array/case.yaml
+++ b/tests/cases/cpp/dpi_open_array/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.dpi_open_array
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      few=20
+      many=100
+      shape=31133
+      filled=7 8 9
+      words=000b 000x 000d
+      grid=175
+      width=1112
+      addressable=1

--- a/tests/cases/cpp/dpi_open_array/dpi.c
+++ b/tests/cases/cpp/dpi_open_array/dpi.c
@@ -1,0 +1,87 @@
+/* The generated ABI header declares every open-array prototype, so each
+   handle argument is spelled the way LRM Annex H.8.6 fixes it. Every entry
+   here reads the declared indices the SystemVerilog source uses; none assumes
+   a normalized range. */
+#include "dpi.h"
+
+/* An index-weighted sum, so an element reached under the wrong index changes
+   the result rather than cancelling out. */
+int32_t weigh(const svOpenArrayHandle h) {
+  int total = 0;
+  for (int i = svLow(h, 1); i <= svHigh(h, 1); i++) {
+    svBitVecVal w;
+    svGetBitArrElem1VecVal(&w, h, i);
+    total += i * (int)(signed char)(w & 0xff);
+  }
+  return (int32_t)total;
+}
+
+/* The dimension queries over a descending declared range. A `byte` element's
+   canonical form is not how an individual `byte` crosses (Annex H.7.7 versus
+   Table H.1), so the addressing entries answer with a null. */
+int32_t describe(const svOpenArrayHandle h) {
+  if (svDimensions(h) != 1) return -1;
+  if (svIncrement(h, 1) != 1) return -2;
+  if (svGetArrayPtr(h) != 0) return -3;
+  if (svSizeOfArray(h) != 0) return -4;
+  return (int32_t)(svLeft(h, 1) * 10000 + svRight(h, 1) * 1000 +
+                   svLow(h, 1) * 100 + svHigh(h, 1) * 10 + svSize(h, 1));
+}
+
+/* An `output` open array: the space is the actual's, and what the C code
+   leaves in it is what the actual holds after the call. */
+void fill(const svOpenArrayHandle h) {
+  svBitVecVal w = 7;
+  for (int i = svLow(h, 1); i <= svHigh(h, 1); i++) {
+    svPutBitArrElem1VecVal(h, &w, i);
+    w++;
+  }
+}
+
+/* A four-state packed element crosses in both planes, so an element that is
+   partly unknown stays unknown across the boundary. */
+void bump(const svOpenArrayHandle h) {
+  for (int i = svLow(h, 1); i <= svHigh(h, 1); i++) {
+    svLogicVecVal v;
+    svGetLogicArrElem1VecVal(&v, h, i);
+    if (v.bval == 0) {
+      v.aval += 10;
+      svPutLogicArrElem1VecVal(h, &v, i);
+    }
+  }
+}
+
+/* Two unsized unpacked dimensions, weighted per coordinate so a row-major
+   mix-up changes the result. */
+int32_t trace(const svOpenArrayHandle h) {
+  int total = 0;
+  if (svDimensions(h) != 2) return -1;
+  for (int i = svLow(h, 1); i <= svHigh(h, 1); i++) {
+    for (int j = svLow(h, 2); j <= svHigh(h, 2); j++) {
+      svBitVecVal w;
+      svGetBitArrElem2VecVal(&w, h, i, j);
+      total += ((i * 10) + j) * (int)w;
+    }
+  }
+  return (int32_t)total;
+}
+
+/* An unsized packed dimension: the array has no unpacked dimension, and
+   dimension 0 reports the linearized, normalized range of the actual's packed
+   dimensions (LRM Annex H.7.6). */
+int32_t width_of(const svOpenArrayHandle h) {
+  if (svDimensions(h) != 0) return -1;
+  if (svIncrement(h, 0) != 1) return -2;
+  return (int32_t)(svLeft(h, 0) * 100 + svRight(h, 0) * 10 + svSize(h, 0));
+}
+
+/* A packed-vector element does cross as its canonical form individually, so
+   the array and its elements have addresses (Annex H.12.4). */
+int32_t addressable(const svOpenArrayHandle h) {
+  const svBitVecVal* p;
+  if (svGetArrayPtr(h) == 0) return -1;
+  if (svSizeOfArray(h) != 8) return -2;
+  p = (const svBitVecVal*)svGetArrElemPtr1(h, 1);
+  if (p == 0) return -3;
+  return (int32_t)(*p == 0x22222222u);
+}

--- a/tests/cases/cpp/dpi_open_array/main.sv
+++ b/tests/cases/cpp/dpi_open_array/main.sv
@@ -1,0 +1,61 @@
+module Top;
+  // LRM 35.5.6.1: one imported function serves actuals of any size and range,
+  // because the unsized dimension takes its extent from the actual at the call.
+  import "DPI-C" function int weigh(input byte data[]);
+  import "DPI-C" function int describe(input byte data[]);
+  import "DPI-C" function void fill(output byte data[]);
+  import "DPI-C" function void bump(inout logic [15:0] w[]);
+  import "DPI-C" function int trace(input int m[][]);
+  import "DPI-C" function int width_of(input logic [] v);
+  import "DPI-C" function int addressable(input bit [31:0] wide[]);
+
+  byte few[4];
+  byte many[3:1];
+  byte out_buf[0:2];
+  logic [15:0] words[0:2];
+  int grid[2][3];
+  logic [11:0] narrow;
+  bit [31:0] wide[0:1];
+
+  initial begin
+    few[0] = 1;
+    few[1] = 2;
+    few[2] = 3;
+    few[3] = 4;
+    // An index-weighted sum, so a wrong index-to-element mapping shows up.
+    $display("few=%0d", weigh(few));
+
+    many[3] = 10;
+    many[2] = 20;
+    many[1] = 30;
+    $display("many=%0d", weigh(many));
+
+    // The same import over a descending range reports the declared bounds
+    // rather than a normalized one (LRM Annex H.7.5, H.7.6).
+    $display("shape=%0d", describe(many));
+
+    fill(out_buf);
+    $display("filled=%0d %0d %0d", out_buf[0], out_buf[1], out_buf[2]);
+
+    words[0] = 16'h0001;
+    words[1] = 16'h000x;
+    words[2] = 16'h0003;
+    bump(words);
+    $display("words=%h %h %h", words[0], words[1], words[2]);
+
+    grid[0][0] = 1;
+    grid[0][1] = 2;
+    grid[0][2] = 3;
+    grid[1][0] = 4;
+    grid[1][1] = 5;
+    grid[1][2] = 6;
+    $display("grid=%0d", trace(grid));
+
+    narrow = 12'hABC;
+    $display("width=%0d", width_of(narrow));
+
+    wide[0] = 32'h11111111;
+    wide[1] = 32'h22222222;
+    $display("addressable=%0d", addressable(wide));
+  end
+endmodule

--- a/tests/cases/errors/dpi_open_array_element_type/case.yaml
+++ b/tests/cases/errors/dpi_open_array_element_type/case.yaml
@@ -1,0 +1,16 @@
+id: errors.dpi_open_array_element_type
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "open array of this element type"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/dpi_open_array_element_type/main.sv
+++ b/tests/cases/errors/dpi_open_array_element_type/main.sv
@@ -1,0 +1,8 @@
+// LRM Annex H.7.3 puts an open array of a `real` element in C-compatible
+// representation, which a SystemVerilog value does not have.
+module Top;
+  import "DPI-C" function void take(input real r[]);
+  initial take_nothing();
+  function void take_nothing();
+  endfunction
+endmodule

--- a/tests/cases/errors/dpi_open_array_rank/case.yaml
+++ b/tests/cases/errors/dpi_open_array_rank/case.yaml
@@ -1,0 +1,16 @@
+id: errors.dpi_open_array_rank
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "more than three unpacked dimensions"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/dpi_open_array_rank/main.sv
+++ b/tests/cases/errors/dpi_open_array_rank/main.sv
@@ -1,0 +1,9 @@
+// The foreign side reaches an element through the one-, two-, and three-index
+// entries of LRM Annex H.12.3; a deeper array would need the variable-argument
+// forms.
+module Top;
+  import "DPI-C" function void take(input int m[][][][]);
+  initial take_nothing();
+  function void take_nothing();
+  endfunction
+endmodule

--- a/tests/cases/errors/dpi_sized_unpacked_arg/case.yaml
+++ b/tests/cases/errors/dpi_sized_unpacked_arg/case.yaml
@@ -1,0 +1,17 @@
+id: errors.dpi_sized_unpacked_arg
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "sized unpacked array"
+      - "open array"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/dpi_sized_unpacked_arg/main.sv
+++ b/tests/cases/errors/dpi_sized_unpacked_arg/main.sv
@@ -1,0 +1,8 @@
+// LRM Annex H.11.4 requires an unpacked array that is not an open array to
+// have C-compiler layout, which a SystemVerilog value does not have.
+module Top;
+  import "DPI-C" function void take(input byte s[1:4]);
+  initial take_nothing();
+  function void take_nothing();
+  endfunction
+endmodule

--- a/tests/cases/errors/dpi_unsupported_arg_type/case.yaml
+++ b/tests/cases/errors/dpi_unsupported_arg_type/case.yaml
@@ -1,0 +1,16 @@
+id: errors.dpi_unsupported_arg_type
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "shortreal"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/dpi_unsupported_arg_type/main.sv
+++ b/tests/cases/errors/dpi_unsupported_arg_type/main.sv
@@ -1,0 +1,10 @@
+// An SV type outside the DPI-C mapping Lyra wires (LRM 35.5.6, Table H.1) is
+// rejected at the declaration rather than mis-marshalled at the call.
+// `shortreal` stands for that family; a packed struct and any other unmapped
+// type reject through the same classification.
+module Top;
+  import "DPI-C" function void take(input shortreal f);
+  initial take_nothing();
+  function void take_nothing();
+  endfunction
+endmodule


### PR DESCRIPTION
## Summary

An imported DPI-C subroutine can now take an open array (LRM 35.5.6.1) -- a formal that leaves one or more dimensions unsized -- so one foreign function serves actuals of any size and range, in every direction. The foreign side receives a handle and reaches the array through the Annex H.12 surface: the dimension queries, the whole-array and element addresses, and the canonical and scalar element accessors. This closes the DPI-C type surface on the C++ backend; what remains on that backend is the disable protocol (LRM 35.9).

## Design

The actual crosses as a canonical image of the whole array that the call site builds and owns, not as a borrow of the actual's storage. That is what `"DPI-C"` specifies rather than a way around Lyra's value representation: Annex H.7.3 puts an open array of 2- or 4-state scalar or packed elements in canonical form, and Annex H.11.4 exempts open arrays -- and only open arrays -- from the C-compiler layout every other unpacked array must have. A write-back direction reconstructs one SV value from the image after the call and stores it through the ordinary write path, so nothing aliases live storage and no foreign write reaches an SV value directly. The reasoning, and the alternatives rejected along the way, are recorded in `docs/decisions/dpi-open-array-boundary.md`.

The formal's unsized shape rides the ABI carrier rather than the type system, because it is never the type of a value that crosses -- LRM 35.6.1.1 fixes an unsized extent at the call site, so every consumer of a formal's SV type needs the actual's. Elements are laid out in ascending declared-index order (Annex H.7.3), which reverses against SV element order for a descending declared range, and each dimension reports the declared range the call site supplied rather than a normalized one (Annex H.7.5, H.7.6).

Whether the foreign side may take an address is a property of the element, answered from the classification the boundary already computes: an address is served where an element's canonical form is also how an individual value of that type crosses, and is null otherwise, which is what Annex H.12.4 prescribes. So `svGetArrayPtr` works for a packed-vector element and returns null for a `byte` element, whose individual form is a C `char`.

Alongside, the DPI argument lowering now states its two shapes explicitly -- an argument crosses by value or through a boundary object that is built, passed, and read back -- instead of testing carrier alternatives at each step. The open array joins the second shape rather than adding a third.

## Scope

An element type Annex H.7.3 puts in C-compatible rather than canonical representation (`real`, `shortreal`, `string`, `chandle`, an unpacked struct) is legal SystemVerilog that is rejected, because serving it needs C-compiler layout for the element. The same limitation rejects a sized unpacked array argument. An open array of more than three unpacked dimensions is rejected: the indexing entries published here are the one-, two-, and three-index forms Annex H.12.3 specializes, not its variable-argument forms.

## Testing

One end-to-end case exercises the whole surface -- differently sized actuals through one import, a descending declared range, `output` and `inout`, a four-state packed element that keeps its unknown bits across the boundary, two dimensions, an unsized packed dimension, and the addressable and non-addressable element cases -- with index-weighted results so an element reached under the wrong index changes the answer. Four cases cover the rejections.