### PR TITLE
Call a DPI-C import declared in any scope

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -36,3 +36,15 @@ If:
   PathMatch: playground/.*
 Diagnostics:
   Suppress: '*'
+
+---
+
+# A test case's own C sources are inputs to the project lyra emits, not to this
+# repository's build: they include the ABI header lyra generates for that
+# project, which exists only after an emit. clangd has no compilation database
+# entry for them and can only report the generated header and everything it
+# declares as missing.
+If:
+  PathMatch: tests/cases/.*
+Diagnostics:
+  Suppress: '*'

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -201,8 +201,9 @@ the detail lives in the entry itself.
 ### Foreign-language boundary
 
 - [dpi-foreign-boundary](dpi-foreign-boundary.md) -- DPI-C is the foreign arm of the one callable
-  model: an import is a bodyless callable with foreign linkage, marshaling is a cross-ABI carrier
-  conversion expressed in MIR, and an export's context is a thread-local ambient handle.
+  model: a foreign symbol is a bodyless or bodied callable the unit owns, marshaling is a cross-ABI
+  carrier conversion expressed in MIR at each call, and an export's context is a thread-local
+  ambient handle.
 - [dpi-open-array-boundary](dpi-open-array-boundary.md) -- an open array crosses as a canonical
   boundary object owning its own storage, never as a borrow of the actual; the formal's unsized
   shape rides the ABI carrier rather than the type system.

--- a/docs/decisions/dpi-foreign-boundary.md
+++ b/docs/decisions/dpi-foreign-boundary.md
@@ -39,7 +39,7 @@ conversion is one more such primitive, not backend-special lowering.
 
 ## Decisions
 
-### 1. A DPI import is a receiver-less associated callable declared without a body
+### 1. A DPI import is a bodyless receiver-less callable the unit owns
 
 An imported subroutine lowers to a callable -- not a member of any object, and not a separate DPI
 call family. Three structural facts fix its shape:
@@ -49,27 +49,29 @@ call family. Three structural facts fix its shape:
   Neither is a flag on a callable and neither is a separate declaration type -- `callable.md`
   invariant 7.
 - **It has no receiver, so it is an associated callable, not an instance method.** A DPI import is
-  called by name with no `self`: a non-context import cannot touch SV state, and a context import
-  reaches its scope through the DPI scope handle, never an instance receiver. A receiver-less
-  callable is a type-associated function in the enclosing unit's associated namespace, a category
-  distinct from the instance method set (`object_model.md` invariants 7 and 8). It is stored in a
-  class-level static-callable namespace -- `StaticCallableDecl`, the callable peer of the existing
-  `StaticConstantDecl` -- never in the instance method arena.
-- **It shares one declaration shape with SV class statics.** A DPI import and a future SV class
-  static method are the same shape -- a receiver-less associated callable, the former declared
-  without a body and the latter with one -- reached through one associated call-target identity.
-  This is the shared callable-declaration shape the callable model anticipates; the associated
-  call-target arm is permanent and serves statics too, so it is added once, never as a temporary
-  DPI-only variant refactored away later.
+  called by name with no `self`. A non-context import cannot touch SV state at all; a context import
+  observes the instantiated scope of its declaration, which the call site establishes around the
+  foreign call rather than binding as a receiver on the callable. A receiver-less callable is a
+  type-associated function (`object_model.md` invariants 7 and 8), a category distinct from the
+  instance method set.
+- **Its symbol is global, so the unit owns it.** The linkage name lives in the DPI-C name space,
+  which is separate from every compilation-unit scope name space (LRM 35.4). No class contains it,
+  so the unit that takes part in the import publishes the prototype, beside the entry point an
+  export publishes: both directions of the boundary are owned alike and separated only by whether
+  the declaration has a body.
 
-An import call is an ordinary call whose target is that associated callable.
+An import call names that symbol directly. Because the name space is its own, the call reaches it
+without naming a class or a unit, and a declaration written in a package or at `$unit` scope is
+called from any unit with no cross-unit reference at all. What the calling unit needs is the
+declaration's ABI projection -- a fact of the declaration, identical wherever it is read -- so it
+holds its own copy and depends on no other unit's artifact.
 
-Reason: putting the import in the instance method arena is a category error (it has no receiver and
-is not an instance member); a separate incompatible external-declaration type contradicts the one
-callable-declaration shape the model unifies toward; a DPI-specific target id would be a temporary
-variant. The associated-callable home follows the object model's receiver-less-function category
-directly, reuses the static-constant precedent, and is the home a future static method needs, so it
-is built once.
+Reason: putting the import in a class's callable arena is a category error twice over -- it has no
+receiver, and its symbol belongs to a name space no class contains -- and it makes an import's
+presence shift the identity of the class's other callables. A separate incompatible
+external-declaration type contradicts the one callable-declaration shape the model unifies toward.
+Owning the declaration at the unit and naming the symbol by its linkage name is what makes the
+package and `$unit` cases fall out with no mechanism of their own.
 
 ### 2. The C prototype is the callable's own signature; linkage is a separate record
 
@@ -81,7 +83,8 @@ CallableSignature = the SV semantic signature (type checking, diagnostics; slang
 callable code     = the C prototype: one binding per formal, typed as the value crosses the
                     boundary, plus the result type. A bodyless callable carries it with an empty
                     body, exactly as a pure virtual prototype does.
-ForeignLinkage    = linkage name + language + calling convention + purity / context
+ForeignLinkage    = the linkage name the symbol is reached by. Source language and calling
+                    convention are implicitly C, the only foreign linkage; a second one adds them.
 ```
 
 `ForeignLinkage` is an independent axis on a callable declaration, not part of the bodyless
@@ -94,9 +97,11 @@ them can disagree.
 
 The boundary type of a formal is a fixed function of its SV type and direction, computed once at
 lowering and interned there. The ABI **classification** that computes it -- the carrier and the
-direction, LRM 35.5.6 and 35.5.1.2 -- rides on the bodyless arm, where an import's call site reads
-it to build its marshaling; an export's marshaling is already lowered into its body, so nothing
-downstream reads a classification for it. SV semantic checking stays on `CallableSignature`.
+direction, LRM 35.5.6 and 35.5.1.2 -- stays on the source-near declaration, which is where a call
+site reads it to build its marshaling and where the diagnostic for a signature outside the mapping
+is reported. Nothing below reads it: an import's marshaling is expanded at the call, an export's is
+lowered into its entry point's body, so by the time a backend sees a foreign callable all that
+remains is its signature and its linkage name. SV semantic checking stays on `CallableSignature`.
 
 Reason: conflating the SV signature with the C prototype loses the separation that keeps type
 checking, diagnostics, and header emission each reading the surface they need. Keeping the prototype
@@ -110,6 +115,11 @@ The boundary conversion between an SV value and its foreign ABI carrier is an or
 against a runtime conversion primitive, emitted at HIR-to-MIR. An import call desugars to: marshal
 each input to its carrier, call the external symbol over the carriers, marshal each output carrier
 back to the actual's write path.
+
+That desugaring happens at each call rather than once per declaration, because an open-array formal
+leaves a dimension unsized (LRM 35.5.6.1): what crosses is then a function of the _actual's_ static
+type, which only the call site holds. One mechanism serves every import, so the call site is where
+all of them marshal.
 
 The carrier is a **backend-ABI carrier type**, not an SV value-semantic type. It lives in the same
 category as the runtime plumbing types the MIR type system already carries (the services, scope,
@@ -187,10 +197,9 @@ usage inflate the scope.
 - **A process-global (non-thread-local) export context.** Works under a single-threaded engine but
   assumes one global engine and aliases across concurrent or multi-engine runs; the thread-local
   form is the precise scope.
-- **The imported callable stored as an instance method (in the per-class method arena).** A DPI
-  import has no receiver and is not an instance member; a receiver-less callable is a
-  type-associated function (`object_model.md` invariants 7, 8), so its home is the
-  associated-callable namespace, not the instance method set.
+- **The imported callable owned by a class.** Beyond the category error decision 1 states, a class
+  arena orders its entries, so an import's presence shifts the identity of every callable declared
+  after it -- and a package, which has no class at all, could then declare no import.
 - **A temporary DPI-only callable-target variant, unified later.** Leaves a DPI-specific identity in
   the IR to be refactored away; the unification is done once, consistent with the reset.
 - **The export's C entry point as its own species beside the callable arena.** It is exactly what a

--- a/docs/progress/dpi.md
+++ b/docs/progress/dpi.md
@@ -31,42 +31,26 @@ context surface, a generated ABI header, and link-input orchestration.
 
 ## Actionable
 
-Two frontiers are open. On the C++ backend the function import surface (D1-D3) is in, the export
-marshaling surface (D4, D4b) runs -- an export executes end to end through the import -> export
-chain across every argument direction and both value families (by-value scalars, by-pointer scalar
-`output` / `inout`, and canonical 2-state / 4-state packed vectors), its wrapper recovering the
-exported subroutine's receiver from the running design -- and the DPI task surface runs in both
-directions: the import task (D5) has SV call a foreign C task, and the export task (D6) has foreign
-C call back an SV task, both under the uniform task protocol. A foreign task also consumes
-simulation time (D6b): its call runs on a fiber, so an exported task it reaches suspends on a delay
-across the boundary and resumes when time advances. The `svdpi` context surface (D7) runs: a
-`context` import observes the fully qualified scope of its declaration, foreign code sets and gets
-the current scope and resolves a scope to and from its name, stores per-scope user data, and reads
-the scope's effective time unit and precision and the current time scaled to it -- the current scope
-riding the calling process so concurrent time-consuming imports never cross. Instance-bound export
-dispatch (D4a) now runs too: a module-scoped export dispatches to the instance the foreign call
-targets -- the current DPI scope the caller established, or one `svSetScope` redirected to -- rather
-than a single hardcoded instance, and a receiver-less package- or `$unit`-scoped export calls its
-free function directly with no instance (D4a, D4c); reaching any export now requires a valid scope
-context, so its caller must be a context import or set the scope with `svSetScope`. The user-facing
-surface (D9) is in too: the design's foreign declarations generate a C header the user's own sources
-compile against, and an emitted project carries that header alongside a copy of every foreign source
-and a recipe that builds them, so it links and runs standalone. Open-array arguments (D8) close the
-type surface: one imported subroutine now serves actuals of any size and range, in every direction,
-the foreign side reading them through the Annex H.12 introspection, addressing, and element
-accessors. What remains is the disable protocol across the boundary (D6c) and the element types
-Annex H.7.3 puts in C-compatible representation. A DPI-C import is still reachable only from the
-compilation unit that declares it; one declared in a package or at `$unit` scope is rejected. On the
-execution backend scalar import (D10) is in: a foreign call lowers to an external-linkage symbol and
-the by-value carriers marshal. The rest of the import surface (D11) is blocked, and not by anything
-DPI owns: by-pointer marshaling is expressed as a closure, which that backend does not yet lower at
-all (`architecture-reset.md`).
+Two frontiers are open, the two backends.
+
+On the C++ backend the boundary runs in both directions and the surfaces below are closed: import
+(D1-D3, D13) including open arrays (D8), export (D4, D4a-D4c) including instance-bound and
+receiver-less dispatch, DPI tasks in both directions including one that consumes simulation time
+(D5, D6, D6b, D6d), the `svdpi` context surface (D7), and the generated ABI header with link-input
+orchestration (D9). What remains is the disable protocol across the boundary (D6c) and the element
+types Annex H.7.3 puts in C-compatible representation.
+
+On the execution backend scalar import (D10) is in: a foreign call lowers to an external-linkage
+symbol and the by-value carriers marshal. The rest of the import surface (D11) is blocked, and not
+by anything DPI owns: by-pointer marshaling is expressed as a closure, which that backend does not
+yet lower at all (`architecture-reset.md`). Export and tasks there (D12) follow once the C++-backend
+items fix their shape.
 
 ## Sub-Steps
 
 The `D*` IDs are stable references. They do not impose a total order; real dependencies are stated
-inline. D1-D9 are deliverables on the C++ backend; D10 onward bring the same backend-agnostic MIR up
-on the execution backend, mirroring the C++-backend items one surface at a time.
+inline. D1-D9 and D13 are deliverables on the C++ backend; D10-D12 bring the same backend-agnostic
+MIR up on the execution backend, mirroring the C++-backend items one surface at a time.
 
 ### Import: SV calls foreign C
 
@@ -90,6 +74,15 @@ on the execution backend, mirroring the C++-backend items one surface at a time.
         declaration rather than mis-marshalled at the call. The wired carriers are the packed
         vector, the by-value scalar, `real`, `string`, and `chandle`; `shortreal` and a packed
         struct / union are the notable types outside them.
+- [x] D13 -- Where an import is declared does not restrict who calls it. A declaration in a package
+      (LRM 26.3) or at `$unit` scope (LRM 3.12.1) is called from any unit, exactly as one in the
+      calling scope is: an imported subroutine resolves to a program-global symbol in a name space
+      of its own (LRM 35.4), so the declaration's position is a name-resolution fact only and the
+      call crosses no unit boundary -- the calling unit holds its own record of the ABI projection
+      and depends on no other unit's artifact. A `context` import declared in such a namespace
+      observes no scope (LRM 35.5.3), a package and `$unit` never being instantiated; a
+      receiver-less export stays directly reachable from it, and any other needs `svSetScope`, which
+      is what the LRM already requires of a caller with no scope of its own.
 
 ### Export: foreign C calls SV
 

--- a/docs/progress/packages.md
+++ b/docs/progress/packages.md
@@ -27,8 +27,8 @@ declared with an initializer, initialized once at time zero before the top modul
 written from another unit by name, including from a package function or task, by explicit
 `pkg::item` or by a bare name (brought into scope by import, or lying at `$unit` scope), and
 including waking a process on its change. A package or `$unit` task enabled from another unit
-suspends its caller until it completes. The remaining PK2 and PK3 increments (checkboxes below) are
-the independent follow-ups.
+suspends its caller until it completes. The remaining PK3 increments (checkboxes below) are the
+independent follow-ups.
 
 ## Sub-Steps
 
@@ -56,8 +56,6 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
         intra-unit call does (LRM 13.5): output and inout are copied back after the call, and ref /
         const ref alias the caller's cell. Covers a function whose return value and an output
         argument are written back together, and a task whose output crosses a suspension.
-  - [ ] A DPI-C import declared inside a package (LRM 35.4), which is rejected with a diagnostic
-        rather than mis-emitted.
 - [x] PK3 -- Package variables. A package variable is static storage owned by the namespace -- one
       program-global cell, shared, not a member of any instance -- read and written from other units
       by name. It is the same type-associated storage a class static property uses, not a
@@ -106,15 +104,15 @@ callable-bearing part of PK4 reuse; PK1 is independent of it.
 
 ## Blocked
 
-Nothing blocked. The remaining PK2 and PK3 increment checkboxes are the actionable follow-ups.
+Nothing blocked. The remaining PK3 increment checkboxes are the actionable follow-ups.
 
 ## Out of Scope
 
 - Classes declared inside a package (LRM 26.2). The class is an ordinary type-level member of the
   namespace; its own semantics ride the class workstream, not this one.
-- Package / `$unit`-scoped DPI export wrappers. The export makes a package-scoped subroutine
-  callable from foreign C; it rides on PK1-PK2 for the package unit and the callable, and is tracked
-  as the next C++-backend deliverable in `dpi.md`.
+- Package / `$unit`-scoped DPI imports and exports. An export makes a package-scoped subroutine
+  callable from foreign C; an import declared at package or `$unit` scope is called from any unit.
+  Both ride on PK1-PK2 for the package unit and the callable, and are tracked in `dpi.md`.
 
 ## Cross-references
 
@@ -127,5 +125,5 @@ Nothing blocked. The remaining PK2 and PK3 increment checkboxes are the actionab
   object type), `../architecture/reference_resolution.md` and `../architecture/emission_model.md`
   (by-name cross-unit resolution and per-unit emission), `../architecture/north_star.md` (the
   cross-unit dependency is explicitly declared, per the incremental / parallel constraints).
-- Unblocks: `ibex.md` (the Ibex design leans on `ibex_pkg`), `dpi.md` D4 (package / `$unit`-scoped
-  export hangs off the package unit and callable established here).
+- Unblocks: `ibex.md` (the Ibex design leans on `ibex_pkg`), `dpi.md` (the package / `$unit`-scoped
+  side of both DPI directions hangs off the package unit and callable established here).

--- a/include/lyra/hir/compilation_unit.hpp
+++ b/include/lyra/hir/compilation_unit.hpp
@@ -8,6 +8,8 @@
 #include "lyra/base/registry.hpp"
 #include "lyra/hir/class_decl.hpp"
 #include "lyra/hir/class_id.hpp"
+#include "lyra/hir/foreign_import.hpp"
+#include "lyra/hir/foreign_import_id.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -46,6 +48,14 @@ struct CompilationUnit {
   // A class can be referenced -- as a handle type or a `new` target -- before
   // its body is built, so its identity must exist before its definition.
   base::Registry<ClassDecl, ClassId> classes;
+  // Every DPI-C import this unit takes part in (LRM 35.4), whether declared
+  // inside it or declared elsewhere and called from it. The unit owns them
+  // rather than any scope because an import's foreign symbol is program-global,
+  // in a name space of its own that no compilation-unit scope contains -- so a
+  // call reaches it without depending on whichever unit spelled the
+  // declaration, and one declaration read by several units yields one identical
+  // entry in each. One entry per declaration; a repeat is the same entry.
+  base::Arena<ForeignImportDecl, ForeignImportId> foreign_imports;
 
   explicit CompilationUnit(std::string name)
       : name(std::move(name)), builtins(MakeBuiltins(types)) {

--- a/include/lyra/hir/foreign_import.hpp
+++ b/include/lyra/hir/foreign_import.hpp
@@ -27,7 +27,12 @@ struct DpiParamAbi {
 // projection of the signature are resolved once here (where slang types are
 // available) and are the sole downstream source for the import; no layer below
 // reads slang.
-// Lowered to a MIR static external callable at HIR-to-MIR.
+//
+// The record is self-contained: it names the foreign symbol and states how each
+// value crosses, and nothing in it refers to the scope or the unit the
+// declaration was written in. That is what lets a unit hold its own entry for
+// an import declared in a package or at `$unit` scope, identical to the one the
+// declaring unit holds.
 struct ForeignImportDecl {
   std::string name;
   std::string foreign_name;

--- a/include/lyra/hir/foreign_import_id.hpp
+++ b/include/lyra/hir/foreign_import_id.hpp
@@ -5,7 +5,7 @@
 
 namespace lyra::hir {
 
-// Identity of a DPI-C import (LRM 35.4) within its structural scope's
+// Identity of a DPI-C import (LRM 35.4) within its compilation unit's
 // `foreign_imports` arena. A bodyless external callable, distinct from a
 // body-bearing structural subroutine.
 struct ForeignImportId {

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -12,8 +12,6 @@
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/foreign_export.hpp"
-#include "lyra/hir/foreign_import.hpp"
-#include "lyra/hir/foreign_import_id.hpp"
 #include "lyra/hir/pattern.hpp"
 #include "lyra/hir/procedural_scope.hpp"
 #include "lyra/hir/process.hpp"
@@ -244,10 +242,9 @@ struct StructuralScope {
   std::vector<PortConnection> port_connections;
   base::Arena<RoutedRefDecl, RoutedRefId> routed_refs;
   // Body-bearing SV subroutines only. A bodyless DPI-C import never enters this
-  // arena; it lives in `foreign_imports` (invariant relied on by the
-  // per-subroutine body lowering, which assumes every entry here has a body).
+  // arena; the unit owns it, because its foreign symbol is program-global and
+  // belongs to no scope (LRM 35.4).
   base::Arena<SubroutineDecl, StructuralSubroutineId> structural_subroutines;
-  base::Arena<ForeignImportDecl, ForeignImportId> foreign_imports;
   std::vector<ForeignExportDecl> foreign_exports;
   base::Arena<ProceduralScopeDecl, ProceduralScopeId> procedural_scopes;
   std::vector<TypeAliasDecl> type_aliases;

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -26,12 +26,22 @@ struct StructuralSubroutineRef {
   StructuralSubroutineId subroutine;
 };
 
-// Calls a DPI-C import (LRM 35.4) declared in the unit (or an enclosing scope,
-// reached through `hops`). A bodyless external callable, resolved separately
-// from a body-bearing structural subroutine.
+// Calls a DPI-C import (LRM 35.4). `id` names the unit's own record of the
+// import; the import's foreign symbol is program-global, so the call reaches it
+// without naming whichever unit spelled the declaration, and a declaration in a
+// package or at `$unit` scope is called exactly as one in this unit's own scope
+// is.
+//
+// The instantiated scope the declaration sits in, so many enclosing levels up
+// from the call site, is the one thing about an import that is not global: a
+// `context` import observes it for the duration of its foreign call (LRM
+// 35.5.3). It is absent when the declaration sits in a namespace that is never
+// instantiated -- a package or `$unit` scope -- and the import then observes no
+// scope, so only a receiver-less export is directly reachable from it and any
+// other needs `svSetScope`.
 struct ForeignImportRef {
-  StructuralHops hops;
-  ForeignImportId id;
+  ForeignImportId id{};
+  std::optional<StructuralHops> declaring_scope;
 };
 
 // The receiver form of an instance-method call (LRM 8.6, 8.15). The three

--- a/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp
@@ -80,8 +80,7 @@ class StructuralScopeLowerer {
   auto PopulateSubroutineMember(
       const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
       -> diag::Result<void>;
-  auto PopulateForeignImportMember(
-      const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
+  auto PopulateForeignImportMember(const slang::ast::SubroutineSymbol& sym)
       -> diag::Result<void>;
   auto PopulateProceduralBlockMember(
       const slang::ast::ProceduralBlockSymbol& proc, WalkFrame frame)

--- a/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
+++ b/include/lyra/lowering/ast_to_hir/subroutine_decl.hpp
@@ -75,8 +75,10 @@ auto LowerMethodPrototypeDecl(
 // Lowers a slang `import "DPI-C"` subroutine (LRM 35.4) into a bodyless
 // hir::ForeignImportDecl: the resolved foreign name, the pure property, and the
 // ABI projection of its signature. Distinct from LowerSubroutineDecl because a
-// DPI import has no SV body; the caller records the result in the scope's
-// `foreign_imports` arena, never in its subroutine arena.
+// DPI import has no SV body; the unit records the result among its foreign
+// imports, never in a scope's subroutine arena. The result reads only the
+// declaration, so every unit that lowers the same declaration gets the same
+// record.
 auto LowerForeignImport(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
     -> diag::Result<hir::ForeignImportDecl>;

--- a/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
@@ -56,17 +56,21 @@ struct SubroutineBinding {
 using SubroutineBindings =
     std::unordered_map<const slang::ast::SubroutineSymbol*, SubroutineBinding>;
 
-// A DPI-C import call resolves to the scope that declares the import, reached
-// through `owner_frame`, and to the import's `foreign_imports` id. A separate
-// binding space from SubroutineBinding: an import is a bodyless external
-// callable, not a body-bearing structural subroutine.
-struct ForeignImportBinding {
-  ScopeFrameId owner_frame{};
-  hir::ForeignImportId import_id{};
-};
-
+// A DPI-C import call resolves to the unit's own record of the import. An
+// import is a bodyless external callable, not a body-bearing structural
+// subroutine, so it binds in a space of its own. The map is also what makes one
+// entry per declaration: a unit that both declares an import and calls it, or
+// calls one declaration from several places, interns it once.
 using ForeignImportBindings = std::unordered_map<
-    const slang::ast::SubroutineSymbol*, ForeignImportBinding>;
+    const slang::ast::SubroutineSymbol*, hir::ForeignImportId>;
+
+// The instantiated scope a DPI-C import declaration sits in, for the imports
+// written inside this unit's own scopes. A `context` import observes that scope
+// for the duration of its foreign call (LRM 35.5.3). An import declared in a
+// package or at `$unit` scope has no entry, because such a namespace is never
+// instantiated and the import therefore observes no scope.
+using ForeignImportScopes =
+    std::unordered_map<const slang::ast::SubroutineSymbol*, ScopeFrameId>;
 
 // A downward reference's leading component names an owned child this scope
 // declares: an instance / instance-array member (`c.x`, `c[1].x`), or a
@@ -306,12 +310,19 @@ class UnitLowerer {
       const slang::ast::SubroutineSymbol& sym) const
       -> std::optional<SubroutineBinding>;
 
-  void MapForeignImportBinding(
-      const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
-      hir::ForeignImportId import_id);
-  [[nodiscard]] auto LookupForeignImportBinding(
+  // Interns this unit's record of a DPI-C import (LRM 35.4), classifying its
+  // ABI projection on first sight and answering with the same id every later
+  // time. Both the declaration walk and a call site reach an import through
+  // here, so a unit that calls an import declared elsewhere holds an entry
+  // identical to the declaring unit's, classified from the same declaration.
+  auto EnsureForeignImport(const slang::ast::SubroutineSymbol& sym)
+      -> diag::Result<hir::ForeignImportId>;
+
+  void MapForeignImportScope(
+      const slang::ast::SubroutineSymbol& sym, ScopeFrameId declaring_frame);
+  [[nodiscard]] auto LookupForeignImportScope(
       const slang::ast::SubroutineSymbol& sym) const
-      -> std::optional<ForeignImportBinding>;
+      -> std::optional<ScopeFrameId>;
 
   // Pattern-bound identifiers (LRM 12.6). The declaration is the
   // `VariablePattern` node itself, so a reference resolves to that node's
@@ -431,6 +442,7 @@ class UnitLowerer {
   StructuralDataObjectBindings structural_data_object_bindings_;
   SubroutineBindings subroutine_bindings_;
   ForeignImportBindings foreign_import_bindings_;
+  ForeignImportScopes foreign_import_scopes_;
   OwnedChildBindings owned_child_bindings_;
   std::unordered_map<const slang::ast::PatternVarSymbol*, hir::PatternId>
       pattern_var_bindings_;

--- a/include/lyra/lowering/hir_to_mir/expression/dpi_call.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/dpi_call.hpp
@@ -5,7 +5,7 @@
 // carrier, calls the foreign symbol, and marshals results back; an `export
 // "DPI-C"` synthesizes the C entry point foreign code calls to reach an SV
 // subroutine. Both sides share the carrier-marshaling vocabulary, kept here so
-// the ordinary-call dispatch in `calls.hpp` stays free of the DPI ABI surface.
+// the ordinary-call dispatch stays free of the DPI ABI surface.
 
 #include <span>
 
@@ -18,7 +18,6 @@
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/callable.hpp"
 #include "lyra/mir/expr.hpp"
-#include "lyra/mir/foreign_linkage.hpp"
 #include "lyra/mir/type_id.hpp"
 #include "lyra/support/dpi_abi.hpp"
 
@@ -28,22 +27,28 @@ class UnitLowerer;
 
 // The signature a DPI-C declaration publishes to the C side (LRM 35.5.6): one
 // binding per formal, typed as the value crosses the boundary, plus the type
-// the entry point returns. The result carries no body, since this is what an
-// import -- a declaration the user's C defines -- is made of; carrying the
-// prototype as an ordinary signature is what lets an import's declaration and
-// an export's definition render through one path.
+// the entry point returns. It is the signature alone; a direction that defines
+// the callable adds its body on top. Carrying the prototype as an ordinary
+// signature is what lets an import's declaration and an export's definition
+// render through one path, so the two can never disagree.
 auto MakeForeignSignature(
     mir::CompilationUnit& unit, std::span<const hir::DpiParamAbi> params,
     support::DpiScalarAbi ret_abi, bool is_task) -> mir::CallableCode;
 
-// LRM 35.4 import call: an ordinary call to the external static callable,
-// wrapped in boundary marshaling. The carriers and directions are read from the
-// callable's own declaration, resolved once at its declaration lowering. A task
-// call is a coroutine the caller awaits, so it always sequences through a
-// closure; a function call whose every actual is a by-value scalar input is a
-// plain expression, and one with any actual that needs a boundary temp (an
-// output / inout, or a canonical vector of any direction) sequences through a
-// closure.
+// The bodyless callable that publishes an import's foreign prototype (LRM
+// 35.4). The unit owns it, because the DPI-C name space is program-global and
+// contains no class; a backend emits it as the declaration the foreign call
+// resolves against, and the user's C supplies the definition.
+auto MakeForeignImportDecl(
+    mir::CompilationUnit& unit, const hir::ForeignImportDecl& import)
+    -> mir::CallableDecl;
+
+// LRM 35.4 import call: a call to the foreign symbol, wrapped in boundary
+// marshaling. The marshaling is built here, at the call, because an open-array
+// formal leaves a dimension unsized (LRM 35.5.6.1) and the actual's own static
+// type is what fixes it -- a fact only the call site holds. A boundary that
+// needs body locals of its own lowers to a statement sequence; one that needs
+// none is a plain expression.
 template <ExprLowerer Lowerer>
 auto LowerForeignImportCall(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -163,25 +163,6 @@ class StructuralScopeLowerer {
         hir::StructuralHops{.value = hops.value - 1}, id);
   }
 
-  // Resolve a DPI-C import reference to its HIR declaration by walking `hops`
-  // scopes outward. The import's task-or-function kind decides whether its call
-  // site is a suspension point (LRM 35.8), which the statement lowering reads
-  // from here.
-  [[nodiscard]] auto LookupForeignImport(
-      hir::StructuralHops hops, hir::ForeignImportId id) const
-      -> const hir::ForeignImportDecl& {
-    if (hops.value == 0) {
-      return hir_scope_->foreign_imports.Get(id);
-    }
-    if (parent_ == nullptr) {
-      throw InternalError(
-          "StructuralScopeLowerer::LookupForeignImport: hops walk ran "
-          "past the root scope");
-    }
-    return parent_->LookupForeignImport(
-        hir::StructuralHops{.value = hops.value - 1}, id);
-  }
-
   void AddRoutedRefTarget(mir::FieldId target, mir::TypeId slot_type) {
     routed_ref_targets_.push_back(
         RoutedRefMeta{.target = target, .slot_type = slot_type});

--- a/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/unit_lowerer.hpp
@@ -277,11 +277,13 @@ class UnitLowerer {
   auto LowerModuleUnit(PackageInitializationPlan package_init_plan)
       -> diag::Result<mir::CompilationUnit>;
 
-  // Mints every class identity, interns every HIR type, and lowers every HIR
-  // class body into the unit. Shared prologue of `Run` and `RunPackage`: both a
-  // module and a package own the same declaration kinds; they differ only in
-  // whether the root scope becomes a top class or a set of namespace callables.
-  auto PopulateTypesAndClasses() -> diag::Result<void>;
+  // Publishes everything the unit declares before any root-scope body lowers:
+  // every class identity and body, every interned type, and the prototype of
+  // every foreign symbol the unit takes part in. Shared prologue of every unit
+  // kind -- a module and a package own the same declaration kinds; they differ
+  // only in whether the root scope becomes a top class or a set of namespace
+  // callables.
+  auto PublishUnitDeclarations() -> diag::Result<void>;
 
   [[nodiscard]] auto TranslateTypeData(const hir::TypeData& data)
       -> mir::TypeData;

--- a/include/lyra/mir/callable.hpp
+++ b/include/lyra/mir/callable.hpp
@@ -30,7 +30,8 @@ enum class CallableVisibility : std::uint8_t { kPublic, kInternal };
 //   - `foreign`, when present, is the C linkage the callable is reached under.
 //     It is orthogonal to the body: bodyless plus foreign is an import the
 //     user's C defines, bodied plus foreign is the entry point of an export the
-//     user's C calls.
+//     user's C calls. A foreign name is program-global and belongs to no class
+//     (LRM 35.4, 35.7), so only a unit's own callables ever carry one.
 //   - `virtual_dispatch`, when present, states this callable's role in the
 //     class's dispatch table (LRM 8.20) -- introducing a new slot or overriding
 //     an ancestor's -- so a backend renders the marker off stated structure,

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -101,13 +101,17 @@ struct CompilationUnit {
   base::Registry<Class, ClassId> classes;
   std::optional<ClassId> root;
   // Callables the unit's namespace owns directly rather than through one of its
-  // classes -- a package's functions and tasks (LRM 26.3), and the C entry
-  // point of every DPI-C export the unit contributes (LRM 35.5). All are
-  // receiver-less and bodied: an export's entry point is a program-global
-  // symbol in its own name space and never a class member (LRM 35.4, 35.7), so
-  // a module-scoped export and a package-scoped one are owned here alike, each
-  // body recovering whatever context it needs. A class's own callables live on
-  // that class; these are the unit-level namespace's, one scope up.
+  // classes -- a package's functions and tasks (LRM 26.3), and both directions
+  // of the DPI-C boundary (LRM 35.5): the prototype of every import the unit
+  // takes part in, and the C entry point of every export it contributes. All
+  // are receiver-less. A DPI-C name is program-global, in a name space no
+  // compilation-unit scope contains (LRM 35.4, 35.7), so no class ever owns
+  // one, and a module-scoped export and a package-scoped one are owned here
+  // alike, each body recovering whatever context it needs. Which direction a
+  // foreign callable is reads off its body: an import is the declaration the
+  // user's C defines, an export entry point the definition the user's C calls.
+  // A class's own callables live on that class; these are the unit-level
+  // namespace's, one scope up.
   base::Arena<CallableDecl, CallableId> callables;
   // Static variables the unit's namespace owns directly rather than through one
   // of its classes -- a package's variables (LRM 26.2), one program-global cell

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -157,6 +157,19 @@ struct ImportedRuntimeCallTarget {
   auto operator==(const ImportedRuntimeCallTarget&) const -> bool = default;
 };
 
+// Identity of a symbol in the DPI-C name space (LRM 35.4): the program-global
+// linkage names imported and exported subroutines resolve to, a name space of
+// its own that no compilation-unit scope contains. It is therefore neither a
+// callable of this unit nor one of another unit's namespace, and a call names
+// it by linkage name alone. A backend renders the unqualified symbol; the
+// prototype it resolves against is published once by the unit that declares the
+// import.
+struct ForeignSymbolTarget {
+  std::string linkage_name;
+
+  auto operator==(const ForeignSymbolTarget&) const -> bool = default;
+};
+
 // Identity of a receiver-less callable owned by another compilation unit's
 // namespace -- a package function or task (LRM 26.3) reached from this unit.
 // The target lives outside this unit, so it carries no unit-local id: it names
@@ -188,18 +201,19 @@ struct ExternalUnitClassMethodTarget {
 };
 
 // The target of a `Direct` call -- the symbol identity. The identity spaces: an
-// owner-qualified callable of this unit (`CallableTarget` -- an instance
-// method, a receiver-less static callable, or a DPI-C import, all one arena), a
-// built-in runtime entry (closed-namespace `BuiltinFn`), a method the runtime
-// library provides for an imported class (`ImportedRuntimeCallTarget`,
-// LRM 9.7), a receiver-less callable of another compilation unit
-// (`ExternalUnitCallableTarget`, named across the unit boundary), and a class
-// method of another compilation unit
-// (`ExternalUnitClassMethodTarget`, class-qualified across the unit boundary).
-// None is recovered from the receiver's runtime type.
+// owner-qualified callable of this unit (`CallableTarget` -- an instance method
+// or a receiver-less static callable, one arena), a built-in runtime entry
+// (closed-namespace `BuiltinFn`), a method the runtime library provides for an
+// imported class (`ImportedRuntimeCallTarget`, LRM 9.7), a receiver-less
+// callable of another compilation unit (`ExternalUnitCallableTarget`, named
+// across the unit boundary), a class method of another compilation unit
+// (`ExternalUnitClassMethodTarget`, class-qualified across the unit boundary),
+// and a name in the DPI-C name space (`ForeignSymbolTarget`, LRM 35.4). None is
+// recovered from the receiver's runtime type.
 using DirectTarget = std::variant<
     CallableTarget, support::BuiltinFn, ImportedRuntimeCallTarget,
-    ExternalUnitCallableTarget, ExternalUnitClassMethodTarget>;
+    ExternalUnitCallableTarget, ExternalUnitClassMethodTarget,
+    ForeignSymbolTarget>;
 
 // A direct call to a named symbol. The single shape for every direct
 // invocation -- user method, built-in instance method, type-qualified

--- a/include/lyra/mir/foreign_linkage.hpp
+++ b/include/lyra/mir/foreign_linkage.hpp
@@ -1,41 +1,8 @@
 #pragma once
 
-#include <optional>
 #include <string>
-#include <vector>
-
-#include "lyra/mir/type_id.hpp"
-#include "lyra/support/dpi_abi.hpp"
 
 namespace lyra::mir {
-
-// One formal of a foreign signature's SV-side projection (LRM 35.5.6): the SV
-// type the boundary marshals from, the C ABI carrier it crosses as, and its
-// direction (LRM 35.5.1.2). Fixed once at HIR-to-MIR and read where a call
-// lowers its boundary, never re-derived from the type. The carrier decides how
-// the value crosses -- a scalar in a register, a canonical vector by pointer to
-// a buffer -- and the direction decides whether the boundary copies it in,
-// back, or both.
-struct ForeignParam {
-  TypeId sv_type;
-  support::DpiCarrier carrier;
-  support::DpiDirection direction;
-};
-
-// How a foreign signature projects onto SV values, which is what a call site
-// needs to build its boundary. A function result is restricted to a small value
-// (LRM 35.5.5), so the return is always a by-value scalar, which makes a vector
-// return unrepresentable. `is_task` marks a task rather than a function (LRM
-// 35.5): its call is a suspension point the caller awaits, and its foreign
-// symbol returns the disable-acknowledgment int (LRM 35.8) that the call
-// discards. A `void`-returning function also has no return value, so the task
-// distinction cannot be recovered from the return alone.
-struct ForeignMarshal {
-  std::vector<ForeignParam> params;
-  TypeId ret_sv_type;
-  support::DpiScalarAbi ret_abi;
-  bool is_task;
-};
 
 // The C linkage contract of a callable that crosses the DPI-C boundary, in
 // either direction. The two directions carry one shape because they are one
@@ -47,21 +14,11 @@ struct ForeignMarshal {
 // A foreign name is program-global and lives in its own name space, distinct
 // from any compilation-unit scope (LRM 35.4, 35.7), and all declarations
 // sharing one name must agree on one prototype (LRM 35.5.4) -- that prototype
-// is the callable's own signature, so nothing is restated here. `is_pure` marks
-// an import the simulator may treat as side-effect-free (LRM 35.5.4).
-// `is_context` marks a callable that observes the instantiated scope of its
-// declaration and may reach SV state (LRM 35.5.3); every export is one (LRM
-// 35.7). The source language and calling convention are implicitly C, the only
-// foreign linkage today; a second linkage adds them here.
+// is the callable's own signature, so nothing is restated here. The source
+// language and calling convention are implicitly C, the only foreign linkage
+// today; a second linkage adds them here.
 struct ForeignLinkage {
   std::string foreign_name;
-  bool is_pure;
-  bool is_context;
-  // Present for the direction whose calls this program lowers: an import, where
-  // every call site builds the boundary from this projection. An export is
-  // called only from foreign code, and its entry point's body already carries
-  // the marshaling as ordinary statements, so it needs none.
-  std::optional<ForeignMarshal> marshal;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -384,6 +384,13 @@ enum class RuntimeLibraryKind : std::uint8_t {
   // popping it when the body's scope exits. An inert scoped value MIR never
   // inspects; its lifetime -- not its contents -- is the effect.
   kDpiScopeGuard,
+  // What a DPI-C import task's foreign call is awaited through (LRM 35.5.2):
+  // `lyra::runtime::ForeignTaskAwaitable`, which runs the call on a fiber whose
+  // native stack can be parked while simulation time advances, so an exported
+  // task the call reaches can suspend across the boundary. It is the result of
+  // the runtime's fiber entry and the operand of the await that consumes it,
+  // and nothing else names it.
+  kForeignTaskAwaitable,
 };
 
 struct RuntimeLibraryType {

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -368,6 +368,14 @@ enum class BuiltinFn : std::uint16_t {
   // which the call site builds from the actual before the foreign call.
   kDpiOpenArrayHandle,
   kDpiOpenArrayValue,
+  // Runs a DPI-C import task's foreign call (LRM 35.5.2) on a fiber whose
+  // native stack can be parked while simulation time advances, and yields the
+  // awaitable that suspends the caller until the call returns. The call itself
+  // is `args[0]`, a closure of the whole boundary; a foreign task may consume
+  // time by calling back an exported task that suspends, and the fiber is what
+  // lets that suspension cross a native stack the runtime does not own. A free
+  // function over that closure.
+  kRunForeignTaskOnFiber,
   // Runs an exported SV task's coroutine body to completion synchronously and
   // yields its completion payload. A foreign C caller of an exported task (LRM
   // 35.8) is not a coroutine and cannot await the task body, so the C entry

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -464,16 +464,13 @@ auto RenderScopeAsClass(
   // object's public callable surface, a scope's processes and lifecycle hooks
   // are internal -- and the access specifier follows that stated visibility,
   // coalescing a run of callables that share one. The constructor is not in
-  // this arena; it was emitted above with C++ mem-init-list syntax. An
-  // foreign callable (a DPI-C import) is a program-global symbol, not a class
-  // member; it is emitted as a prototype outside the class. A pure virtual
-  // prototype (LRM 8.21) is a class member and renders inline with its `= 0`
-  // marker.
+  // this arena; it was emitted above with C++ mem-init-list syntax. A pure
+  // virtual prototype (LRM 8.21) is a class member and renders inline with its
+  // `= 0` marker.
   std::optional<mir::CallableVisibility> open_section;
   for (std::size_t i = 0; i < s.callables.size(); ++i) {
     const mir::CallableId cid{static_cast<std::uint32_t>(i)};
     const auto& callable = s.callables.Get(cid);
-    if (callable.foreign.has_value()) continue;
     if (open_section != callable.visibility) {
       open_section = callable.visibility;
       out += std::format(
@@ -546,25 +543,6 @@ auto RenderFreeCallableSignature(
       callable.LinkedName(), params, RenderTypeAsCpp(unit, code.result_type));
 }
 
-// The declaration of every DPI-C import the unit calls (LRM 35.4): a
-// class-owned callable under foreign linkage is one, since a class never owns
-// an export's entry point. Emitted before the classes that call them so a
-// foreign call resolves against a declared signature; the definitions come from
-// the user's linked C. Empty when the unit declares no import.
-auto RenderForeignImportDeclarations(const mir::CompilationUnit& unit)
-    -> std::string {
-  std::string out;
-  for (std::size_t i = 0; i < unit.classes.size(); ++i) {
-    const mir::ClassId id{static_cast<std::uint32_t>(i)};
-    if (!unit.classes.IsDefined(id)) continue;
-    for (const auto& callable : unit.GetClass(id).callables) {
-      if (!callable.foreign.has_value()) continue;
-      out += RenderFreeCallableSignature(unit, callable) + ";\n";
-    }
-  }
-  return out;
-}
-
 auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
     -> std::vector<std::string> {
   std::vector<std::string> names;
@@ -611,23 +589,30 @@ auto RenderFreeCallable(
   return out;
 }
 
+// The three places a callable the unit owns directly can land in the emitted
+// file, in the order the file needs them.
 struct UnitCallableText {
+  std::string declarations;
   std::string in_namespace;
   std::string at_file_scope;
 };
 
-// The unit's own callables, split by the name space each symbol belongs to: a
-// plain one is a member of the unit's namespace (LRM 26.3 for a package), while
-// a DPI-C export entry point is program-global and never inside it (LRM 35.4,
-// 35.7). One walk produces both halves, so the two placements stay one
-// decision; each unit kind then wraps its namespace block around the first and
-// emits the second after it, once the class or namespace they call into is
-// complete.
+// Where each callable the unit owns directly lands, decided once here for all
+// three destinations. Two facts the declaration already states place it: C
+// linkage puts the symbol in the program-global DPI-C name space rather than in
+// the unit's namespace (LRM 35.4, 35.7), and the presence of a body separates a
+// definition this program emits from a declaration the user's linked C defines.
+// So a plain callable is a namespace member (LRM 26.3 for a package), a bodied
+// foreign one is an export's entry point at file scope, and a bodyless foreign
+// one is an import's prototype -- which leads, because the classes and bodies
+// below it call through it.
 auto RenderUnitCallables(const mir::CompilationUnit& unit) -> UnitCallableText {
   UnitCallableText text;
-  for (std::size_t i = 0; i < unit.callables.size(); ++i) {
-    const auto& callable =
-        unit.callables.Get(mir::CallableId{static_cast<std::uint32_t>(i)});
+  for (const auto& callable : unit.callables) {
+    if (!callable.code.body.has_value()) {
+      text.declarations += RenderFreeCallableSignature(unit, callable) + ";\n";
+      continue;
+    }
     std::string& target =
         callable.foreign.has_value() ? text.at_file_scope : text.in_namespace;
     target += "\n";
@@ -636,18 +621,15 @@ auto RenderUnitCallables(const mir::CompilationUnit& unit) -> UnitCallableText {
   return text;
 }
 
-// Whether the unit defines a symbol in the program-global DPI-C name space. A
-// unit whose only consumer is foreign C has no SV referrer to pull its header
-// into the include graph, so the program entry must include it directly for
-// that definition to land and link (LRM 35.7).
+// Whether the unit defines a symbol in the program-global DPI-C name space --
+// an export's entry point (LRM 35.7). A unit whose only consumer is foreign C
+// has no SV referrer to pull its header into the include graph, so the program
+// entry must include it directly for that definition to land and link. An
+// import's prototype is a declaration, not a definition, and pulls nothing.
 auto DefinesForeignSymbol(const mir::CompilationUnit& unit) -> bool {
-  for (std::size_t i = 0; i < unit.callables.size(); ++i) {
-    if (unit.callables.Get(mir::CallableId{static_cast<std::uint32_t>(i)})
-            .foreign.has_value()) {
-      return true;
-    }
-  }
-  return false;
+  return std::ranges::any_of(unit.callables, [](const auto& callable) {
+    return callable.foreign.has_value() && callable.code.body.has_value();
+  });
 }
 
 // The include preamble every emitted unit header shares: the standard library,
@@ -747,15 +729,12 @@ auto RenderUnitTypeDeclarations(const mir::CompilationUnit& unit)
 
 auto RenderScopeHeaderFile(
     const mir::CompilationUnit& unit, const mir::Class& s) -> std::string {
+  const UnitCallableText callables = RenderUnitCallables(unit);
   std::string out;
   out += "#pragma once\n";
   out += RenderUnitIncludes(unit);
   out += "\n";
-  if (const std::string foreign_decls = RenderForeignImportDeclarations(unit);
-      !foreign_decls.empty()) {
-    out += foreign_decls;
-    out += "\n";
-  }
+  out += callables.declarations;
   out += RenderUnitTypeDeclarations(unit);
 
   // A SystemVerilog class is a free-standing registry object with no
@@ -772,9 +751,9 @@ auto RenderScopeHeaderFile(
   }
 
   out += RenderScopeAsClass(unit, s, 0, nullptr);
-  // A rooted unit has no namespace block of its own, so only the file-scope
-  // half can arise here -- a DPI-C export entry point its module contributes.
-  out += RenderUnitCallables(unit).at_file_scope;
+  // A rooted unit has no namespace block of its own, so nothing lands in that
+  // part -- only a DPI-C export entry point its module contributes.
+  out += callables.at_file_scope;
   return out;
 }
 
@@ -785,10 +764,15 @@ auto RenderScopeHeaderFile(
 // tree construction.
 auto RenderNamespaceUnitHeaderFile(const mir::CompilationUnit& unit)
     -> std::string {
+  const UnitCallableText callables = RenderUnitCallables(unit);
   std::string out;
   out += "#pragma once\n";
   out += RenderUnitIncludes(unit);
   out += "\n";
+  // Outside the namespace block: a DPI-C name is program-global and belongs to
+  // no scope (LRM 35.4), so the prototype a namespace callable's foreign call
+  // resolves against is declared at file scope, exactly as a rooted unit's is.
+  out += callables.declarations;
   out += std::format("namespace {} {{\n\n", ToCppName(unit.name));
   out += RenderUnitTypeDeclarations(unit);
   // A package variable is one program-global observable cell (LRM 26.2). C++17
@@ -816,7 +800,6 @@ auto RenderNamespaceUnitHeaderFile(const mir::CompilationUnit& unit)
         unit, mir::ClassId{static_cast<std::uint32_t>(i)}, emitted, out);
   }
 
-  const UnitCallableText callables = RenderUnitCallables(unit);
   out += callables.in_namespace;
   out += std::format("\n}}  // namespace {}\n", ToCppName(unit.name));
   out += callables.at_file_scope;

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -289,6 +289,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Handle";
     case support::BuiltinFn::kDpiOpenArrayValue:
       return "ToValue";
+    case support::BuiltinFn::kRunForeignTaskOnFiber:
+      return "RunForeignTaskOnFiber";
     case support::BuiltinFn::kRunExportedTaskToCompletion:
       return "RunExportedTaskToCompletion";
     case support::BuiltinFn::kCurrentExportScope:
@@ -414,6 +416,7 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
     case support::BuiltinFn::kValuePlusargs:
     case support::BuiltinFn::kReadMem:
     case support::BuiltinFn::kWriteMem:
+    case support::BuiltinFn::kRunForeignTaskOnFiber:
     case support::BuiltinFn::kRunExportedTaskToCompletion:
     case support::BuiltinFn::kCurrentExportScope:
       return "lyra::runtime";
@@ -436,10 +439,8 @@ struct CalleeRender {
 };
 
 // Renders a `Direct` callee naming an owner-qualified callable this class
-// owns -- an instance method (LRM 8.6), a static method (LRM 8.10), or a
-// DPI-C import, all one arena. A DPI-C import (external) is a global
-// `extern "C"` symbol reached by its foreign linkage name, no receiver
-// absorbed. An instance callable renders as `(receiver)->Owner::name`, an
+// owns -- an instance method (LRM 8.6) or a static method (LRM 8.10), one
+// arena. An instance callable renders as `(receiver)->Owner::name`, an
 // owner-qualified C++ member call: the owner prefix is a fixed function of
 // the target's owner, redundant for a non-virtual method and, for a virtual
 // method reached through Direct (LRM 8.15 super), forcing C++ to bypass the
@@ -458,11 +459,6 @@ auto RenderDirectCallableCall(
   }
   const auto& cls = view.Unit().GetClass(target.owner);
   const auto& callable = cls.callables.Get(target.slot);
-  // A foreign-linkage callable is reached by its linkage name, not by any
-  // SV-scoped spelling (LRM 35.4).
-  if (callable.foreign.has_value()) {
-    return {.expr = callable.foreign->foreign_name, .leading_arg_count = 0};
-  }
   // Instance vs static (LRM 8.10) reads off the target's signature: an
   // instance call binds the receiver as `(recv)->Owner::name(rest)`, a
   // static call is the free type-qualified form `Owner::name(args)` with no
@@ -584,6 +580,14 @@ auto RenderDirectImportedRuntimeCall(
       .leading_arg_count = 0};
 }
 
+// Renders a call to a name in the DPI-C name space (LRM 35.4). The symbol is
+// program-global, so it is spelled unqualified and carries no receiver; the
+// prototype it resolves against is declared once in this artifact.
+auto RenderDirectForeignSymbolCall(const mir::ForeignSymbolTarget& target)
+    -> CalleeRender {
+  return {.expr = target.linkage_name, .leading_arg_count = 0};
+}
+
 auto RenderCalleePart(
     const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
     -> CalleeRender {
@@ -609,6 +613,9 @@ auto RenderCalleePart(
                     },
                     [&](const mir::ImportedRuntimeCallTarget& i) {
                       return RenderDirectImportedRuntimeCall(i);
+                    },
+                    [](const mir::ForeignSymbolTarget& f) {
+                      return RenderDirectForeignSymbolCall(f);
                     },
                 },
                 d.target);
@@ -716,27 +723,6 @@ auto RenderMakeQueueConcatCall(
   return out;
 }
 
-// Whether the call is to an imported foreign task (LRM 35.5.2). A foreign task
-// may consume simulation time, so its call runs on a fiber that can suspend
-// across the boundary rather than as a plain synchronous call; a foreign
-// function never does.
-auto IsForeignTaskCall(const ScopeView& view, const mir::CallExpr& call)
-    -> bool {
-  const auto* direct = std::get_if<mir::Direct>(&call.callee);
-  if (direct == nullptr) {
-    return false;
-  }
-  const auto* target = std::get_if<mir::CallableTarget>(&direct->target);
-  if (target == nullptr) {
-    return false;
-  }
-  const auto& callable =
-      view.Unit().GetClass(target->owner).callables.Get(target->slot);
-  return callable.foreign.has_value() &&
-         callable.foreign->marshal.has_value() &&
-         callable.foreign->marshal->is_task;
-}
-
 auto RenderCallExpr(
     const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
     -> std::string {
@@ -753,16 +739,7 @@ auto RenderCallExpr(
     if (i != callee.leading_arg_count) args += ", ";
     args += RenderExpr(view, view.Expr(call.arguments[i]));
   }
-  const std::string call_text = std::format("{}({})", callee.expr, args);
-
-  // A foreign task's call is awaited on a fiber so an exported task it reaches
-  // can suspend across the boundary; the call itself is the fiber's entry.
-  if (IsForeignTaskCall(view, call)) {
-    return std::format(
-        "co_await ::lyra::runtime::RunForeignTaskOnFiber([&] {{ {}; }})",
-        call_text);
-  }
-  return call_text;
+  return std::format("{}({})", callee.expr, args);
 }
 
 }  // namespace lyra::backend::cpp

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -192,6 +192,8 @@ auto RenderTypeAsCpp(const mir::CompilationUnit& unit, mir::TypeId type_id)
                 return std::string{"const svOpenArrayHandle"};
               case mir::RuntimeLibraryKind::kDpiScopeGuard:
                 return std::string{"lyra::runtime::DpiScopeGuard"};
+              case mir::RuntimeLibraryKind::kForeignTaskAwaitable:
+                return std::string{"lyra::runtime::ForeignTaskAwaitable"};
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },

--- a/src/lyra/dpi/abi_header.cpp
+++ b/src/lyra/dpi/abi_header.cpp
@@ -1,7 +1,6 @@
 #include "lyra/dpi/abi_header.hpp"
 
 #include <cstddef>
-#include <cstdint>
 #include <format>
 #include <span>
 #include <string>
@@ -13,7 +12,6 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/mir/callable.hpp"
-#include "lyra/mir/class_id.hpp"
 #include "lyra/mir/type.hpp"
 #include "lyra/mir/type_id.hpp"
 
@@ -161,19 +159,11 @@ void RecordCallable(
       .push_back(std::move(entry));
 }
 
+// A DPI-C name is program-global and belongs to no class (LRM 35.4, 35.7), so
+// the unit's own callables are the whole of its foreign surface.
 void CollectUnit(const mir::CompilationUnit& unit, ForeignSurface& surface) {
-  for (std::size_t i = 0; i < unit.classes.size(); ++i) {
-    const mir::ClassId id{static_cast<std::uint32_t>(i)};
-    if (!unit.classes.IsDefined(id)) continue;
-    for (const mir::CallableDecl& callable : unit.GetClass(id).callables) {
-      RecordCallable(unit, callable, surface);
-    }
-  }
-  for (std::size_t i = 0; i < unit.callables.size(); ++i) {
-    RecordCallable(
-        unit,
-        unit.callables.Get(mir::CallableId{static_cast<std::uint32_t>(i)}),
-        surface);
+  for (const mir::CallableDecl& callable : unit.callables) {
+    RecordCallable(unit, callable, surface);
   }
 }
 

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -653,10 +653,13 @@ class HirDumper {
                   "BuiltinFn \"{}\"", support::BuiltinFnName(b.method));
             },
             [this](const ForeignImportRef& f) -> std::string {
-              const auto& owner = ResolveScope(f.hops);
-              const auto& decl = owner.foreign_imports.Get(f.id);
+              const auto& decl = unit_->foreign_imports.Get(f.id);
               return std::format(
-                  "ForeignImport[{}](hops={}) \"{}\"", f.id.value, f.hops.value,
+                  "ForeignImport[{}]({}) \"{}\"", f.id.value,
+                  f.declaring_scope.has_value()
+                      ? std::format(
+                            "declaring_scope=hops:{}", f.declaring_scope->value)
+                      : "declaring_scope=none",
                   decl.name);
             },
             [](const ImportedMethodRef& i) -> std::string {
@@ -938,6 +941,12 @@ class HirDumper {
     }
     Dedent();
 
+    for (std::size_t i = 0; i < u.foreign_imports.size(); ++i) {
+      DumpForeignImport(
+          i, u.foreign_imports.Get(
+                 ForeignImportId{static_cast<std::uint32_t>(i)}));
+    }
+
     if (u.classes.size() > 0) {
       Line("Classes:");
       Indent();
@@ -1026,11 +1035,6 @@ class HirDumper {
           "StructuralSubroutine", i,
           s.structural_subroutines.Get(
               StructuralSubroutineId{static_cast<std::uint32_t>(i)}));
-    }
-    for (std::size_t i = 0; i < s.foreign_imports.size(); ++i) {
-      DumpForeignImport(
-          i, s.foreign_imports.Get(
-                 ForeignImportId{static_cast<std::uint32_t>(i)}));
     }
     if (!s.exprs.empty()) {
       Line("Exprs:");

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -660,17 +660,25 @@ auto LowerCallExpr(
     };
   }
 
-  // A DPI-C import is a bodyless external callable, bound in a separate space
-  // from body-bearing subroutines. Resolve it to a ForeignImportRef; its ABI
-  // and foreign name were classified once at declaration and are not re-derived
-  // here.
-  if (const auto import_binding =
-          unit_lowerer.LookupForeignImportBinding(*sym)) {
-    const auto import_hops = frame.HopsTo(import_binding->owner_frame);
-    if (!import_hops.has_value()) {
-      throw InternalError(
-          "AST->HIR call: DPI import owner frame is not on the current scope "
-          "stack");
+  // A DPI-C import is a bodyless external callable whose symbol is
+  // program-global (LRM 35.4), so this unit reaches it through its own record
+  // and never across a unit boundary -- which is why a declaration in a
+  // package or at `$unit` scope resolves here exactly as one written in this
+  // unit's own scope does, before the cross-unit branch below.
+  if (sym->flags.has(slang::ast::MethodFlags::DPIImport)) {
+    auto import_id = unit_lowerer.EnsureForeignImport(*sym);
+    if (!import_id) return std::unexpected(std::move(import_id.error()));
+    // The declaration's own instantiated scope, reached from here. It is absent
+    // when the declaring scope is a namespace that is never instantiated.
+    std::optional<hir::StructuralHops> declaring_scope;
+    if (const auto declaring_frame =
+            unit_lowerer.LookupForeignImportScope(*sym)) {
+      declaring_scope = frame.HopsTo(*declaring_frame);
+      if (!declaring_scope.has_value()) {
+        throw InternalError(
+            "AST->HIR call: the scope declaring this DPI import is not on the "
+            "current scope stack");
+      }
     }
     auto import_result_type = unit_lowerer.InternType(*call.type, span);
     if (!import_result_type) {
@@ -682,7 +690,7 @@ auto LowerCallExpr(
             hir::CallExpr{
                 .callee =
                     hir::ForeignImportRef{
-                        .hops = *import_hops, .id = import_binding->import_id},
+                        .id = *import_id, .declaring_scope = declaring_scope},
                 .arguments = std::move(arg_ids),
             },
         .span = span,
@@ -698,17 +706,6 @@ auto LowerCallExpr(
   // boundary exactly as an intra-unit one. The call's result type is the
   // enclosing expression's own type and is not recorded again here.
   if (const auto* unit = DeclaringUnitOfSubroutine(*sym)) {
-    // A DPI-C import declared outside this unit is not reached this way: it has
-    // no SV body to call across the boundary, and its formals carry an ABI
-    // classification rather than the ordinary marshalling interface recomputed
-    // below -- some of which, such as an open array (LRM 35.5.6.1), are not
-    // data types at all. Reject it here so the gap reads as the one it is.
-    if (sym->flags.has(slang::ast::MethodFlags::DPIImport)) {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedDpi,
-          "a DPI-C import declared outside the calling unit is not yet "
-          "supported");
-    }
     std::vector<hir::ExternalUnitParam> params;
     params.reserve(sym->getArguments().size());
     for (const auto* formal : sym->getArguments()) {

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -91,19 +91,23 @@ auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
   // Forward-declare every subroutine's binding before lowering any body so a
   // call resolves regardless of source order: direct self-recursion, mutual
   // recursion, and forward references (LRM 13.4.2). Ids are sequential in
-  // source order and match the index `PopulateSubroutineMember` will write to.
+  // source order and match the arena index the member walk below fills.
+  // A DPI-C import declares no body and is not one of these: the unit interns
+  // its record on first sight from either side, so it reserves no id. What it
+  // does record here is the scope it is declared in, which a `context` import
+  // observes during its foreign call (LRM 35.5.3) -- established ahead of the
+  // bodies for the same reason the ids are, so a call preceding the declaration
+  // resolves it too.
   std::uint32_t reserved_subroutine_id = 0;
-  std::uint32_t reserved_foreign_import_id = 0;
   for (const auto& member : slang_scope_->members()) {
     if (member.kind != slang::ast::SymbolKind::Subroutine) continue;
     const auto& sub = member.as<slang::ast::SubroutineSymbol>();
     if (sub.flags.has(slang::ast::MethodFlags::DPIImport)) {
-      owner_->MapForeignImportBinding(
-          sub, frame_, hir::ForeignImportId{reserved_foreign_import_id++});
-    } else {
-      owner_->MapSubroutineBinding(
-          sub, frame_, hir::StructuralSubroutineId{reserved_subroutine_id++});
+      owner_->MapForeignImportScope(sub, frame_);
+      continue;
     }
+    owner_->MapSubroutineBinding(
+        sub, frame_, hir::StructuralSubroutineId{reserved_subroutine_id++});
   }
 
   // Instance member decls are built ahead of the port-connection synthesis
@@ -174,7 +178,7 @@ auto StructuralScopeLowerer::PopulateMember(
     case slang::ast::SymbolKind::Subroutine: {
       const auto& sub = member.as<slang::ast::SubroutineSymbol>();
       if (sub.flags.has(slang::ast::MethodFlags::DPIImport)) {
-        return PopulateForeignImportMember(sub, frame);
+        return PopulateForeignImportMember(sub);
       }
       return PopulateSubroutineMember(sub, frame);
     }
@@ -338,22 +342,13 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
 }
 
 auto StructuralScopeLowerer::PopulateForeignImportMember(
-    const slang::ast::SubroutineSymbol& sym, WalkFrame frame)
-    -> diag::Result<void> {
-  auto decl_or = LowerForeignImport(*owner_, sym);
-  if (!decl_or) return std::unexpected(std::move(decl_or.error()));
-
-  const auto binding = owner_->LookupForeignImportBinding(sym);
-  if (!binding.has_value() ||
-      binding->import_id.value !=
-          static_cast<std::uint32_t>(
-              frame.current_structural_scope->foreign_imports.size())) {
-    throw InternalError(
-        "StructuralScopeLowerer::PopulateForeignImportMember: DPI import added "
-        "out of reserved order; the reserve pass must run first in the same "
-        "order");
-  }
-  frame.current_structural_scope->foreign_imports.Add(*std::move(decl_or));
+    const slang::ast::SubroutineSymbol& sym) -> diag::Result<void> {
+  // The declaration is classified here even when nothing in this unit calls it,
+  // so a signature outside the DPI-C type mapping (LRM 35.5.6) is reported
+  // against the declaration that wrote it rather than against a call site far
+  // away, or nowhere at all.
+  auto id_or = owner_->EnsureForeignImport(sym);
+  if (!id_or) return std::unexpected(std::move(id_or.error()));
   return {};
 }
 

--- a/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
+++ b/src/lyra/lowering/ast_to_hir/subroutine_decl.cpp
@@ -501,13 +501,16 @@ auto ClassifyDpiParams(
 }
 
 // Lowers a DPI-C import declaration (LRM 35.4) to a bodyless external callable.
-// It has no SV body, so it is not a `SubroutineDecl`; the caller records it
-// among the scope's foreign imports, not its subroutines. The ABI
+// It has no SV body, so it is not a `SubroutineDecl`; the unit records it among
+// its foreign imports, not in a scope's subroutine arena. The ABI
 // classification and the foreign name are resolved once here and never
 // re-derived downstream. A function or a task is accepted; a task carries no
 // return, so its `void` return classifies as `kVoid` through the same path. A
 // `context` import (LRM 35.5.3) carries its context property forward; the call
-// site establishes the declaration scope around the foreign call.
+// site establishes the declaration scope around the foreign call. Every
+// diagnostic here is reported against the declaration, so a unit that reaches
+// an unsupported signature through a call still names the declaration that
+// wrote it.
 auto LowerForeignImport(
     UnitLowerer& unit_lowerer, const slang::ast::SubroutineSymbol& sym)
     -> diag::Result<hir::ForeignImportDecl> {

--- a/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
@@ -36,6 +36,7 @@
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/subroutine_decl.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -220,27 +221,38 @@ auto UnitLowerer::LookupSubroutineBinding(
   return it->second;
 }
 
-void UnitLowerer::MapForeignImportBinding(
-    const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
-    hir::ForeignImportId import_id) {
-  const auto [_, inserted] = foreign_import_bindings_.emplace(
-      &sym,
-      ForeignImportBinding{.owner_frame = owner_frame, .import_id = import_id});
+void UnitLowerer::MapForeignImportScope(
+    const slang::ast::SubroutineSymbol& sym, ScopeFrameId declaring_frame) {
+  const auto [_, inserted] =
+      foreign_import_scopes_.emplace(&sym, declaring_frame);
   if (!inserted) {
     throw InternalError(
-        "UnitLowerer::MapForeignImportBinding: DPI import symbol already "
-        "mapped");
+        "UnitLowerer::MapForeignImportScope: DPI import symbol already mapped");
   }
 }
 
-auto UnitLowerer::LookupForeignImportBinding(
+auto UnitLowerer::LookupForeignImportScope(
     const slang::ast::SubroutineSymbol& sym) const
-    -> std::optional<ForeignImportBinding> {
-  const auto it = foreign_import_bindings_.find(&sym);
-  if (it == foreign_import_bindings_.end()) {
+    -> std::optional<ScopeFrameId> {
+  const auto it = foreign_import_scopes_.find(&sym);
+  if (it == foreign_import_scopes_.end()) {
     return std::nullopt;
   }
   return it->second;
+}
+
+auto UnitLowerer::EnsureForeignImport(const slang::ast::SubroutineSymbol& sym)
+    -> diag::Result<hir::ForeignImportId> {
+  if (const auto it = foreign_import_bindings_.find(&sym);
+      it != foreign_import_bindings_.end()) {
+    return it->second;
+  }
+  auto decl_or = LowerForeignImport(*this, sym);
+  if (!decl_or) return std::unexpected(std::move(decl_or.error()));
+  const hir::ForeignImportId id =
+      unit_.foreign_imports.Add(*std::move(decl_or));
+  foreign_import_bindings_.emplace(&sym, id);
+  return id;
 }
 
 void UnitLowerer::MapPatternVar(

--- a/src/lyra/lowering/hir_to_mir/expression/dpi_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dpi_call.cpp
@@ -238,20 +238,6 @@ auto MarshalCarrierToSv(
   throw InternalError("MarshalCarrierToSv: unknown DpiScalarAbi");
 }
 
-// The SV-side projection an import call marshals through (LRM 35.5.6). An
-// import is the only foreign callable SV can name at a call site, and every
-// import publishes this projection, so a call site reaching a callable without
-// one resolved to something that is not an import.
-auto ImportMarshal(const mir::CallableDecl& callable)
-    -> const mir::ForeignMarshal& {
-  if (!callable.foreign.has_value() || !callable.foreign->marshal.has_value()) {
-    throw InternalError(
-        "ImportMarshal: a DPI-C import call resolved to a callable that "
-        "publishes no marshaling projection");
-  }
-  return *callable.foreign->marshal;
-}
-
 // An argument crosses the boundary in one of two shapes (LRM 35.5.6). It
 // crosses **by value** when it is a scalar the callee only reads: the SV value
 // converts to a machine value the call passes directly, with no local and no
@@ -260,7 +246,7 @@ auto ImportMarshal(const mir::CallableDecl& callable)
 // receives and which a writeback direction reads back afterwards. A canonical
 // vector and an open array are the second shape in either direction, because
 // the C ABI reaches them by pointer and by handle respectively even to read.
-[[nodiscard]] auto CrossesByValue(const mir::ForeignParam& p) -> bool {
+[[nodiscard]] auto CrossesByValue(const hir::DpiParamAbi& p) -> bool {
   return std::holds_alternative<support::ScalarCarrier>(p.carrier) &&
          !support::DpiDirectionWritesBack(p.direction);
 }
@@ -460,6 +446,34 @@ auto BuildBoundaryReadback(
       carrier);
 }
 
+// Whether the foreign symbol hands a value back that the call marshals into the
+// SV result. A function result is restricted to a small value (LRM 35.5.5), so
+// it is always a by-value scalar; a `void` function and a task both yield none,
+// and a task's disable-acknowledgment `int` (LRM 35.8) is not an SV result.
+[[nodiscard]] auto ReturnsValue(const hir::ForeignImportDecl& import) -> bool {
+  return import.ret_abi != support::DpiScalarAbi::kVoid;
+}
+
+// The call to the foreign symbol itself, over already-marshaled arguments. The
+// callee is the linkage name in the DPI-C name space (LRM 35.4), reached by
+// name and never through a class or another unit's namespace.
+auto BuildForeignSymbolCall(
+    mir::CompilationUnit& unit, const hir::ForeignImportDecl& import,
+    std::vector<mir::ExprId> carrier_args) -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::Direct{
+                      .target =
+                          mir::ForeignSymbolTarget{
+                              .linkage_name = import.foreign_name}},
+              .arguments = std::move(carrier_args)},
+      .type = ReturnsValue(import)
+                  ? CarrierTypeId(unit, support::ScalarCarrier{import.ret_abi})
+                  : unit.builtins.void_type};
+}
+
 // The all-input function import call: every actual crosses by value, so the
 // call is a plain expression -- no statement sequencing, no boundary temps.
 // Each actual is marshaled to its ABI carrier, the foreign symbol is called
@@ -469,13 +483,12 @@ auto BuildBoundaryReadback(
 template <ExprLowerer Lowerer>
 auto LowerForeignImportInputsOnly(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const mir::CallableDecl& callable, mir::CallableTarget target,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+    const hir::ForeignImportDecl& import, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
   auto& unit_lowerer = lowerer.Owner();
   auto& unit = unit_lowerer.Unit();
   auto& block = *frame.current_block;
   const auto& hir_exprs = lowerer.HirExprs();
-  const mir::ForeignMarshal& decl = ImportMarshal(callable);
 
   std::vector<mir::ExprId> carrier_args;
   carrier_args.reserve(c.arguments.size());
@@ -487,25 +500,17 @@ auto LowerForeignImportInputsOnly(
     if (!sv_or) return std::unexpected(std::move(sv_or.error()));
     const mir::ExprId sv_id = block.exprs.Add(*std::move(sv_or));
     carrier_args.push_back(
-        MarshalSvToCarrier(unit, block, sv_id, decl.params[i].carrier));
+        MarshalSvToCarrier(unit, block, sv_id, import.params[i].carrier));
   }
 
-  const bool is_void = decl.ret_abi == support::DpiScalarAbi::kVoid;
-  const mir::TypeId call_type =
-      is_void ? unit.builtins.void_type
-              : CarrierTypeId(unit, support::ScalarCarrier{decl.ret_abi});
-  mir::Expr foreign_call{
-      .data =
-          mir::CallExpr{
-              .callee = mir::Direct{.target = target},
-              .arguments = std::move(carrier_args)},
-      .type = call_type};
-  if (is_void) {
+  mir::Expr foreign_call =
+      BuildForeignSymbolCall(unit, import, std::move(carrier_args));
+  if (!ReturnsValue(import)) {
     return foreign_call;
   }
   const mir::ExprId call_id = block.exprs.Add(std::move(foreign_call));
   return MarshalCarrierToSv(
-      unit_lowerer, frame, call_id, support::ScalarCarrier{decl.ret_abi},
+      unit_lowerer, frame, call_id, support::ScalarCarrier{import.ret_abi},
       result_type);
 }
 
@@ -516,49 +521,20 @@ auto LowerForeignImportInputsOnly(
 // its carrier result in a temp, returned so the caller marshals it after the
 // read-backs; a void call (including a task, whose foreign symbol's disable-ack
 // `int` is discarded) is a bare statement and returns no temp. Shared by the
-// function and task import lowerings, which differ only in how they finish the
-// closure.
+// function and task import lowerings, which differ only in what they wrap the
+// finished boundary in.
 template <ExprLowerer Lowerer>
 auto PopulateForeignImportBoundary(
     Lowerer& lowerer, ClosureBuilder& closure, const hir::CallExpr& c,
-    const mir::CallableDecl& callable, mir::CallableTarget target,
-    mir::EnclosingHops hops) -> diag::Result<std::optional<mir::LocalId>> {
+    const hir::ForeignImportDecl& import)
+    -> diag::Result<std::optional<mir::LocalId>> {
   auto& unit_lowerer = lowerer.Owner();
   auto& unit = unit_lowerer.Unit();
   const auto& hir_exprs = lowerer.HirExprs();
   const mir::TypeId void_t = unit.builtins.void_type;
-  const mir::ForeignMarshal& decl = ImportMarshal(callable);
 
   mir::Block& body = closure.Body();
   const WalkFrame& cframe = closure.Frame();
-
-  // A context import (LRM 35.5.3) observes the scope of its declaration and may
-  // call an exported subroutine back, so the boundary opens with an RAII guard
-  // that pushes the declaration scope (the enclosing instance `hops` levels up)
-  // on the calling process's DPI scope chain for the foreign call's duration.
-  // Declared first so its scope-exit pop is the last effect, on a normal return
-  // or an unwind.
-  if (callable.foreign->is_context) {
-    const mir::TypeId guard_type = unit.types.Intern(
-        mir::RuntimeLibraryType{
-            .kind = mir::RuntimeLibraryKind::kDpiScopeGuard});
-    const mir::LocalId guard = closure.Bindings().DeclareAnonymous(
-        mir::LocalDecl{.name = "_lyra_dpi_scope", .type = guard_type});
-    const mir::ExprId services_id =
-        body.exprs.Add(BuildCurrentRuntimeCallExpr(unit_lowerer));
-    const mir::ExprId decl_scope_id =
-        BuildEnclosingScopeReceiver(cframe, unit, hops);
-    body.AppendStmt(
-        mir::LocalDeclStmt{
-            .target = guard,
-            .init = body.exprs.Add(
-                mir::Expr{
-                    .data =
-                        mir::CallExpr{
-                            .callee = mir::Construct{},
-                            .arguments = {services_id, decl_scope_id}},
-                    .type = guard_type})});
-  }
 
   // One output / inout argument, and what its boundary object needs to be read
   // back into the actual once the call returns.
@@ -578,7 +554,7 @@ auto PopulateForeignImportBoundary(
       throw InternalError("DPI-C import call argument unexpectedly elided");
     }
     const hir::ExprId actual = *c.arguments[i];
-    const mir::ForeignParam& param = decl.params[i];
+    const hir::DpiParamAbi& param = import.params[i];
     const support::DpiCarrier& carrier = param.carrier;
 
     auto sv_or = lowerer.LowerExpr(hir_exprs.Get(actual), cframe);
@@ -622,25 +598,18 @@ auto PopulateForeignImportBoundary(
               .sv_type =
                   std::holds_alternative<support::OpenArrayCarrier>(carrier)
                       ? actual_type
-                      : param.sv_type});
+                      : unit_lowerer.TranslateType(param.sv_type)});
     }
   }
 
-  const bool is_void = decl.ret_abi == support::DpiScalarAbi::kVoid;
-  const mir::TypeId call_type =
-      is_void ? void_t
-              : CarrierTypeId(unit, support::ScalarCarrier{decl.ret_abi});
-  mir::Expr foreign_call{
-      .data =
-          mir::CallExpr{
-              .callee = mir::Direct{.target = target},
-              .arguments = std::move(call_args)},
-      .type = call_type};
+  mir::Expr foreign_call =
+      BuildForeignSymbolCall(unit, import, std::move(call_args));
+  const mir::TypeId call_type = foreign_call.type;
 
   // A valued call captures its carrier result in a temp so the copy-backs run
-  // before it is marshaled and returned; a void call is a bare statement.
+  // before it is marshaled and returned.
   std::optional<mir::LocalId> ret_temp;
-  if (!is_void) {
+  if (ReturnsValue(import)) {
     ret_temp = closure.Bindings().DeclareAnonymous(
         mir::LocalDecl{.name = "_lyra_dpi_ret", .type = call_type});
     body.AppendStmt(
@@ -673,6 +642,45 @@ auto PopulateForeignImportBoundary(
   return ret_temp;
 }
 
+// The DPI scope a `context` import observes (LRM 35.5.3): an RAII guard pushing
+// the declaration's own instantiated scope on the calling process's DPI scope
+// chain, so an export the foreign side calls back resolves against that scope.
+// It opens the boundary, so its scope-exit pop is the last effect, on a normal
+// return or an unwind. A declaration in a namespace that is never instantiated
+// -- a package or `$unit` scope -- observes no scope and pushes a null one; the
+// push still happens, so the call never inherits an enclosing chain entry that
+// is not its declaration's.
+auto BuildDpiScopeGuard(
+    UnitLowerer& unit_lowerer, ClosureBuilder& closure,
+    std::optional<hir::StructuralHops> declaring_scope) -> mir::LocalDeclStmt {
+  mir::CompilationUnit& unit = unit_lowerer.Unit();
+  mir::Block& body = closure.Body();
+  const mir::TypeId guard_type = unit.types.Intern(
+      mir::RuntimeLibraryType{.kind = mir::RuntimeLibraryKind::kDpiScopeGuard});
+  const mir::LocalId guard = closure.Bindings().DeclareAnonymous(
+      mir::LocalDecl{.name = "_lyra_dpi_scope", .type = guard_type});
+  const mir::ExprId services_id =
+      body.exprs.Add(BuildCurrentRuntimeCallExpr(unit_lowerer));
+  const mir::ExprId decl_scope_id =
+      declaring_scope.has_value()
+          ? BuildEnclosingScopeReceiver(
+                closure.Frame(), unit,
+                mir::EnclosingHops{.value = declaring_scope->value})
+          : body.exprs.Add(
+                mir::Expr{
+                    .data = mir::NullLiteral{},
+                    .type = unit.builtins.scope_ptr});
+  return mir::LocalDeclStmt{
+      .target = guard,
+      .init = body.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee = mir::Construct{},
+                      .arguments = {services_id, decl_scope_id}},
+              .type = guard_type})};
+}
+
 // The general function import call: at least one actual crosses through a
 // boundary object rather than by value, so the boundary is a statement sequence
 // yielding a value. It lowers to an immediately-invoked closure, uniform for
@@ -681,16 +689,18 @@ auto PopulateForeignImportBoundary(
 template <ExprLowerer Lowerer>
 auto LowerForeignImportSequenced(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const mir::CallableDecl& callable, mir::CallableTarget target,
-    mir::EnclosingHops hops, mir::TypeId result_type)
+    const hir::ForeignImportDecl& import,
+    std::optional<hir::StructuralHops> declaring_scope, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
   auto& unit_lowerer = lowerer.Owner();
   auto& unit = unit_lowerer.Unit();
-  const mir::ForeignMarshal& decl = ImportMarshal(callable);
 
   ClosureBuilder closure(unit, frame);
-  auto ret_temp = PopulateForeignImportBoundary(
-      lowerer, closure, c, callable, target, hops);
+  if (import.is_context) {
+    closure.Body().AppendStmt(
+        BuildDpiScopeGuard(unit_lowerer, closure, declaring_scope));
+  }
+  auto ret_temp = PopulateForeignImportBoundary(lowerer, closure, c, import);
   if (!ret_temp) return std::unexpected(std::move(ret_temp.error()));
 
   if (!ret_temp->has_value()) {
@@ -700,49 +710,70 @@ auto LowerForeignImportSequenced(
   mir::Block& body = closure.Body();
   const WalkFrame& cframe = closure.Frame();
   const mir::TypeId call_type =
-      CarrierTypeId(unit, support::ScalarCarrier{decl.ret_abi});
+      CarrierTypeId(unit, support::ScalarCarrier{import.ret_abi});
   const mir::ExprId ret_ref =
       body.exprs.Add(mir::MakeLocalRefExpr(**ret_temp, call_type));
   const mir::ExprId result_id = body.exprs.Add(MarshalCarrierToSv(
-      unit_lowerer, cframe, ret_ref, support::ScalarCarrier{decl.ret_abi},
+      unit_lowerer, cframe, ret_ref, support::ScalarCarrier{import.ret_abi},
       result_type));
   return BuildClosureCallExpr(
       unit, *frame.current_block, closure.Build(result_id));
 }
 
-// The task import call (LRM 35.5.2): the same boundary as a function, but a
-// task has no SV return, so the closure finishes as a coroutine -- the
-// awaitable the caller drives, the same call protocol as a native task enable
-// (LRM 35.8), uniform whether or not the foreign side consumes time. The
-// boundary always sequences through the closure, even all-input, because the
-// await needs a coroutine to drive. The coroutine closure is returned directly,
-// not called: it renders self-invoking to a `Coroutine`, and the statement
-// lowering awaits it.
+// The task import call (LRM 35.5.2): a task has no SV return, so the call
+// finishes as a coroutine -- the awaitable the caller drives, the same call
+// protocol as a native task enable (LRM 35.8), uniform whether or not the
+// foreign side consumes time. The coroutine closure is returned directly, not
+// called: it renders self-invoking to a `Coroutine`, and the statement lowering
+// awaits it.
+//
+// A foreign task may consume simulation time, which it does by calling back an
+// exported task that suspends. The foreign call therefore runs on a fiber whose
+// native stack can be parked and resumed, and awaiting that fiber is what
+// suspends the caller. Both facts are stated here as ordinary MIR -- a call to
+// the runtime's fiber entry over a closure of the whole boundary, awaited --
+// rather than left for a backend to infer from the callee being a foreign task.
+// The scope guard stays outside the fiber, on the awaiting coroutine, so the
+// scope is pushed on the process before the native stack is entered.
 template <ExprLowerer Lowerer>
 auto LowerForeignImportTask(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    const mir::CallableDecl& callable, mir::CallableTarget target,
-    mir::EnclosingHops hops) -> diag::Result<mir::Expr> {
-  auto& unit = lowerer.Owner().Unit();
-  ClosureBuilder closure(unit, frame);
-  auto ret_temp = PopulateForeignImportBoundary(
-      lowerer, closure, c, callable, target, hops);
-  if (!ret_temp) return std::unexpected(std::move(ret_temp.error()));
-  return closure.BuildCoroutine();
-}
+    const hir::ForeignImportDecl& import,
+    std::optional<hir::StructuralHops> declaring_scope)
+    -> diag::Result<mir::Expr> {
+  auto& unit_lowerer = lowerer.Owner();
+  auto& unit = unit_lowerer.Unit();
+  ClosureBuilder outer(unit, frame);
+  if (import.is_context) {
+    outer.Body().AppendStmt(
+        BuildDpiScopeGuard(unit_lowerer, outer, declaring_scope));
+  }
 
-// The compilation-unit identity of the class `hops` enclosing levels up. A
-// receiver-less callable names its owner in the call target, so that owner must
-// be a unit-stable class identity rather than a position in the lowering walk;
-// a class carries its own identity in its self-pointer type, so recover it from
-// there.
-auto EnclosingClassIdAtHops(
-    const WalkFrame& frame, const mir::CompilationUnit& unit,
-    mir::EnclosingHops hops) -> mir::ClassId {
-  const mir::TypeId self_ptr =
-      frame.EnclosingClassAtHops(hops).self_pointer_type;
-  const auto& ptr = std::get<mir::PointerType>(unit.types.Get(self_ptr).data);
-  return std::get<mir::ObjectType>(unit.types.Get(ptr.pointee).data).class_id;
+  ClosureBuilder fiber_body(unit, outer.Frame());
+  auto ret_temp = PopulateForeignImportBoundary(lowerer, fiber_body, c, import);
+  if (!ret_temp) return std::unexpected(std::move(ret_temp.error()));
+
+  mir::Block& body = outer.Body();
+  const mir::TypeId awaitable = unit.types.Intern(
+      mir::RuntimeLibraryType{
+          .kind = mir::RuntimeLibraryKind::kForeignTaskAwaitable});
+  const mir::ExprId fiber_id = body.exprs.Add(fiber_body.BuildVoid());
+  const mir::ExprId run_id = body.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::Direct{
+                          .target = support::BuiltinFn::kRunForeignTaskOnFiber},
+                  .arguments = {fiber_id}},
+          .type = awaitable});
+  body.AppendStmt(
+      mir::ExprStmt{
+          .expr = body.exprs.Add(
+              mir::Expr{
+                  .data = mir::AwaitExpr{.awaitable = run_id},
+                  .type = unit.builtins.void_type})});
+  return outer.BuildCoroutine();
 }
 
 // The MIR type one foreign formal is declared with, the ABI carrier realized as
@@ -814,38 +845,40 @@ auto MakeForeignSignature(
   return code;
 }
 
+auto MakeForeignImportDecl(
+    mir::CompilationUnit& unit, const hir::ForeignImportDecl& import)
+    -> mir::CallableDecl {
+  return mir::CallableDecl{
+      .name = import.name,
+      .code = MakeForeignSignature(
+          unit, import.params, import.ret_abi, import.is_task),
+      .foreign = mir::ForeignLinkage{.foreign_name = import.foreign_name},
+      .virtual_dispatch = std::nullopt,
+      .visibility = mir::CallableVisibility::kInternal};
+}
+
 template <ExprLowerer Lowerer>
 auto LowerForeignImportCall(
     Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     const hir::ForeignImportRef& ref, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
-  // An import is a receiver-less associated callable of the scope that declares
-  // it. `hops` is how far out that scope sits from the caller -- a declaration
-  // lookup distance, resolved here and then gone; the callable has no body and
-  // no receiver, so nothing is reached at run time and the call names its owner
-  // directly.
-  const mir::CompilationUnit& unit = lowerer.Owner().Unit();
-  const mir::EnclosingHops hops{.value = ref.hops.value};
-  const mir::CallableTarget target{
-      .owner = EnclosingClassIdAtHops(frame, unit, hops),
-      .slot = mir::CallableId{ref.id.value}};
-  const mir::CallableDecl& callable =
-      frame.EnclosingClassAtHops(hops).callables.Get(target.slot);
-  const mir::ForeignMarshal& decl = ImportMarshal(callable);
+  const hir::ForeignImportDecl& import =
+      lowerer.Owner().Hir().foreign_imports.Get(ref.id);
 
-  if (decl.is_task) {
-    return LowerForeignImportTask(lowerer, frame, c, callable, target, hops);
+  if (import.is_task) {
+    return LowerForeignImportTask(
+        lowerer, frame, c, import, ref.declaring_scope);
   }
-  // A context import sequences through a closure even when every actual is a
-  // by-value input, because its scope guard is a scoped body local the plain
-  // single-expression form has no room for.
-  const bool needs_temp = !std::ranges::all_of(decl.params, CrossesByValue);
-  if (needs_temp || callable.foreign->is_context) {
+  // The boundary needs a statement sequence when anything in it is a scoped
+  // body local: an actual crossing through a boundary object, or a context
+  // import's scope guard, which a plain single-expression call has no room for.
+  const bool sequences =
+      import.is_context || !std::ranges::all_of(import.params, CrossesByValue);
+  if (sequences) {
     return LowerForeignImportSequenced(
-        lowerer, frame, c, callable, target, hops, result_type);
+        lowerer, frame, c, import, ref.declaring_scope, result_type);
   }
-  return LowerForeignImportInputsOnly(
-      lowerer, frame, c, callable, target, result_type);
+  return LowerForeignImportInputsOnly(lowerer, frame, c, import, result_type);
 }
 
 template auto LowerForeignImportCall(
@@ -1122,18 +1155,11 @@ auto SynthesizeForeignExportEntry(
   // The entry point's identity is its linkage name: it is a program-global
   // symbol in the DPI name space, not an SV declaration the source can call
   // (LRM 35.4, 35.7), so it shares no name with the subroutine it dispatches
-  // into. Every export is a context callable (LRM 35.7). It publishes no
-  // marshaling projection: no SV call site reaches it, and the marshaling it
-  // does is already lowered into the body above.
+  // into.
   return mir::CallableDecl{
       .name = export_decl.foreign_name,
       .code = std::move(code),
-      .foreign =
-          mir::ForeignLinkage{
-              .foreign_name = export_decl.foreign_name,
-              .is_pure = false,
-              .is_context = true,
-              .marshal = std::nullopt},
+      .foreign = mir::ForeignLinkage{.foreign_name = export_decl.foreign_name},
       .virtual_dispatch = std::nullopt,
       .visibility = mir::CallableVisibility::kInternal};
 }

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -233,9 +233,7 @@ auto CallSuspends(ProcessLowerer& process, const hir::CallExpr& call) -> bool {
             return support::ImportedRuntimeMethodSuspends(m.method);
           },
           [&](const hir::ForeignImportRef& f) {
-            return process.EnclosingScopeLowerer()
-                .LookupForeignImport(f.hops, f.id)
-                .is_task;
+            return process.Owner().Hir().foreign_imports.Get(f.id).is_task;
           },
           [](const hir::ExternalUnitSubroutineRef& e) {
             // A cross-unit task enable (LRM 26.3) awaits, the same as an

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -9,6 +9,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <variant>
@@ -1065,14 +1066,12 @@ auto StructuralScopeLowerer::DeclareShape() -> diag::Result<mir::ClassId> {
 
   // Reserve each subroutine's MIR id before any body lowers, so a call in one
   // body resolves a forward or mutual reference to a peer (LRM 13.7). The id is
-  // the index the decl will occupy in the class's callable arena; the DPI-C
-  // imports are the arena's first entries, so a subroutine sits past them.
-  const auto callable_prefix =
-      static_cast<std::uint32_t>(hir_scope.foreign_imports.size());
+  // the index the decl will occupy in the class's callable arena, which the
+  // subroutines fill in declaration order.
   for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
     lowerer.MapStructuralSubroutine(
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)},
-        mir::CallableId{callable_prefix + static_cast<std::uint32_t>(i)});
+        mir::CallableId{static_cast<std::uint32_t>(i)});
   }
 
   // Recursively declare every owned generate child's class shape; each child
@@ -1524,46 +1523,6 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
   mir_class.fields = shape.fields;
   mir_class.contained = shape.contained;
 
-  // A DPI-C import declares no body, so it never enters the subroutine body
-  // machinery below. Its ABI projection and foreign name were resolved once at
-  // AST-to-HIR; here they translate straight into a receiver-less bodyless
-  // callable of the class carrying that linkage, the callable the import call
-  // lowers against. The imports are the class's first callables, so a
-  // body-bearing subroutine sits past them (its reserved id accounts for the
-  // import count).
-  for (std::size_t i = 0; i < hir_scope.foreign_imports.size(); ++i) {
-    const hir::ForeignImportDecl& imp = hir_scope.foreign_imports.Get(
-        hir::ForeignImportId{static_cast<std::uint32_t>(i)});
-    std::vector<mir::ForeignParam> params;
-    params.reserve(imp.params.size());
-    for (const hir::DpiParamAbi& p : imp.params) {
-      params.push_back(
-          mir::ForeignParam{
-              .sv_type = unit_lowerer.TranslateType(p.sv_type),
-              .carrier = p.carrier,
-              .direction = p.direction});
-    }
-    mir_class.callables.Add(
-        mir::CallableDecl{
-            .name = imp.name,
-            .code = MakeForeignSignature(
-                unit_lowerer.Unit(), imp.params, imp.ret_abi, imp.is_task),
-            .foreign =
-                mir::ForeignLinkage{
-                    .foreign_name = imp.foreign_name,
-                    .is_pure = imp.is_pure,
-                    .is_context = imp.is_context,
-                    .marshal =
-                        mir::ForeignMarshal{
-                            .params = std::move(params),
-                            .ret_sv_type =
-                                unit_lowerer.TranslateType(imp.ret_sv_type),
-                            .ret_abi = imp.ret_abi,
-                            .is_task = imp.is_task}},
-            .virtual_dispatch = std::nullopt,
-            .visibility = mir::CallableVisibility::kInternal});
-  }
-
   const mir::TypeId void_type = unit_lowerer.Unit().builtins.void_type;
   const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
   ScopeChainNode outer_scope_link{};
@@ -1948,6 +1907,9 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     exported_names.insert(e.sv_name);
   }
 
+  // The callable each subroutine lowered to, recorded where it is created so an
+  // export below names its own by identity.
+  std::unordered_map<std::string_view, mir::CallableId> subroutine_callables;
   for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
     const auto& src = hir_scope.structural_subroutines.Get(
         hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
@@ -1965,11 +1927,14 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
             .visibility = exported_names.contains(src.name)
                               ? mir::CallableVisibility::kPublic
                               : mir::CallableVisibility::kInternal});
-    if (added.value != hir_scope.foreign_imports.size() + i) {
+    // A body lowered earlier may already name this one through the id reserved
+    // for it, so the arena position it actually lands in has to be that id.
+    if (added.value != i) {
       throw InternalError(
           "StructuralScopeLowerer::PopulateBodies: subroutine added out of "
           "mapped id order");
     }
+    subroutine_callables.emplace(src.name, added);
     for (const auto& pending :
          subroutine_lowerer.TakePendingStaticInitializers()) {
       auto integ = IntegratePendingStaticInitializer(
@@ -1978,34 +1943,23 @@ auto StructuralScopeLowerer::PopulateBodies(WalkFrame parent_frame)
     }
   }
 
-  // Each exported subroutine (LRM 35.5) already lowered as a callable above, in
-  // structural-subroutine id order past the leading DPI imports, so its
-  // callable id is the import count plus its subroutine index. Its C entry
-  // point calls that method on the receiver recovered from the current DPI
-  // scope (LRM 35.5.3) -- the instance the foreign call chain targets, which
-  // svSetScope may have redirected -- and the unit owns it, since a DPI-C name
-  // is program-global and never a class member (LRM 35.4, 35.7).
+  // An exported subroutine's C entry point calls that method on the receiver
+  // recovered from the current DPI scope (LRM 35.5.3) -- the instance the
+  // foreign call chain targets, which svSetScope may have redirected -- and the
+  // unit owns the entry point, since a DPI-C name is program-global and never a
+  // class member (LRM 35.4, 35.7).
   for (const hir::ForeignExportDecl& export_decl : hir_scope.foreign_exports) {
-    std::optional<mir::CallableId> method_id;
-    for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
-      if (hir_scope.structural_subroutines
-              .Get(hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)})
-              .name == export_decl.sv_name) {
-        method_id = mir::CallableId{
-            static_cast<std::uint32_t>(hir_scope.foreign_imports.size() + i)};
-        break;
-      }
-    }
-    if (!method_id.has_value()) {
+    const auto entry = subroutine_callables.find(export_decl.sv_name);
+    if (entry == subroutine_callables.end()) {
       throw InternalError(
           "StructuralScopeLowerer::PopulateBodies: exported subroutine has no "
           "lowered method");
     }
     const mir::TypeId method_result_type =
-        mir_class.callables.Get(*method_id).code.result_type;
+        mir_class.callables.Get(entry->second).code.result_type;
     unit_lowerer.Unit().callables.Add(SynthesizeForeignExportEntry(
         unit_lowerer, ctor_frame,
-        mir::CallableTarget{.owner = class_id_, .slot = *method_id},
+        mir::CallableTarget{.owner = class_id_, .slot = entry->second},
         method_result_type, export_decl));
   }
 

--- a/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/unit_lowerer.cpp
@@ -7,6 +7,7 @@
 #include <format>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <variant>
@@ -178,7 +179,7 @@ auto PopulatePackageStaticVariables(
 
 }  // namespace
 
-auto UnitLowerer::PopulateTypesAndClasses() -> diag::Result<void> {
+auto UnitLowerer::PublishUnitDeclarations() -> diag::Result<void> {
   unit_.name = hir_->name;
 
   // Every class identity is minted before any type is translated, so a class
@@ -200,6 +201,14 @@ auto UnitLowerer::PopulateTypesAndClasses() -> diag::Result<void> {
     const mir::TypeId mir_id =
         unit_.types.Intern(TranslateTypeData(hir_type.data));
     MapType(hir_id, mir_id);
+  }
+
+  // The prototype of every DPI-C import this unit takes part in (LRM 35.4),
+  // published as a bodyless callable of the unit: the DPI-C name space contains
+  // no class, so no class owns one. Every call to the import resolves against
+  // this one declaration, whichever unit wrote the source declaration.
+  for (const hir::ForeignImportDecl& import : hir_->foreign_imports) {
+    unit_.callables.Add(MakeForeignImportDecl(unit_, import));
   }
 
   // Two-stage class lowering. Stage 1 publishes every class's shape so a
@@ -238,7 +247,7 @@ auto UnitLowerer::RunDesignRoot(PackageInitializationPlan package_init_plan)
 auto UnitLowerer::LowerModuleUnit(PackageInitializationPlan package_init_plan)
     -> diag::Result<mir::CompilationUnit> {
   WalkFrame root_frame;
-  if (auto prologue = PopulateTypesAndClasses(); !prologue) {
+  if (auto prologue = PublishUnitDeclarations(); !prologue) {
     return std::unexpected(std::move(prologue.error()));
   }
 
@@ -259,7 +268,7 @@ auto UnitLowerer::LowerModuleUnit(PackageInitializationPlan package_init_plan)
 }
 
 auto UnitLowerer::RunPackage() -> diag::Result<mir::CompilationUnit> {
-  if (auto prologue = PopulateTypesAndClasses(); !prologue) {
+  if (auto prologue = PublishUnitDeclarations(); !prologue) {
     return std::unexpected(std::move(prologue.error()));
   }
 
@@ -284,53 +293,37 @@ auto UnitLowerer::RunPackage() -> diag::Result<mir::CompilationUnit> {
       unit_.nominal_type_names.try_emplace(target, alias.name);
     }
   }
-  // A DPI-C import declared in a package (LRM 35.4) has no lowering here yet;
-  // it would otherwise drop silently, since only the subroutines below are
-  // walked.
-  if (!scope.foreign_imports.empty()) {
-    return diag::Fail(
-        diag::DiagCode::kUnsupportedExpressionForm,
-        "a DPI-C import declared in a package is not yet supported");
-  }
-  for (std::size_t i = 0; i < scope.structural_subroutines.size(); ++i) {
-    const hir::SubroutineDecl& src = scope.structural_subroutines.Get(
-        hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
+  // The callable each package subroutine lowered to, recorded where it is
+  // created so an export below names its own by identity.
+  std::unordered_map<std::string_view, mir::CallableId> subroutine_callables;
+  for (const hir::SubroutineDecl& src : scope.structural_subroutines) {
     ProcessLowerer subroutine_lowerer(
         *this, nullptr, scope.time_resolution, src.body, src.name, WalkFrame{},
         empty_storage_plan);
     auto code_or = subroutine_lowerer.Run(src);
     if (!code_or) return std::unexpected(std::move(code_or.error()));
-    unit_.callables.Add(
-        mir::CallableDecl{
-            .name = src.name,
-            .code = *std::move(code_or),
-            .foreign = std::nullopt,
-            .virtual_dispatch = std::nullopt,
-            .visibility = mir::CallableVisibility::kInternal});
+    subroutine_callables.emplace(
+        src.name, unit_.callables.Add(
+                      mir::CallableDecl{
+                          .name = src.name,
+                          .code = *std::move(code_or),
+                          .foreign = std::nullopt,
+                          .virtual_dispatch = std::nullopt,
+                          .visibility = mir::CallableVisibility::kInternal}));
   }
 
   // Each exported package subroutine (LRM 26.3, 35.7) is receiver-less: its
   // C entry point recovers the run's services instead of a calling
-  // instance and calls the package's own free function by name. The callables
-  // above were added in structural-subroutine order and a package has no
-  // leading DPI imports, so an export's callable id is its subroutine index.
+  // instance and calls the package's own free function by name.
   for (const hir::ForeignExportDecl& export_decl : scope.foreign_exports) {
-    std::optional<mir::CallableId> callable_id;
-    for (std::size_t i = 0; i < scope.structural_subroutines.size(); ++i) {
-      if (scope.structural_subroutines
-              .Get(hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)})
-              .name == export_decl.sv_name) {
-        callable_id = mir::CallableId{static_cast<std::uint32_t>(i)};
-        break;
-      }
-    }
-    if (!callable_id.has_value()) {
+    const auto entry = subroutine_callables.find(export_decl.sv_name);
+    if (entry == subroutine_callables.end()) {
       throw InternalError(
           "UnitLowerer::RunPackage: exported subroutine has no lowered "
           "callable");
     }
     const mir::TypeId result_type =
-        unit_.callables.Get(*callable_id).code.result_type;
+        unit_.callables.Get(entry->second).code.result_type;
     unit_.callables.Add(SynthesizeForeignExportEntry(
         *this, WalkFrame{},
         mir::ExternalUnitCallableTarget{

--- a/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
+++ b/src/lyra/lowering/mir_to_lir/function_lowerer.cpp
@@ -213,16 +213,6 @@ auto LowerCallTarget(
                 Overloaded{
                     [&](const mir::CallableTarget& t)
                         -> diag::Result<lir::CallTarget> {
-                      // An ordinary callable lowers to a direct method call; a
-                      // foreign-linkage one to its linkage symbol. The target
-                      // names its own owner, so either is reached without a
-                      // receiver to recover it from.
-                      const mir::CallableDecl& decl =
-                          unit.Mir().GetClass(t.owner).callables.Get(t.slot);
-                      if (decl.foreign.has_value()) {
-                        return lir::CallTarget{lir::ForeignTarget{
-                            .symbol = decl.foreign->foreign_name}};
-                      }
                       if (qualifier.has_value()) {
                         return Unsupported(
                             "mir_to_lir: a qualified method call is not yet "
@@ -230,6 +220,15 @@ auto LowerCallTarget(
                       }
                       return lir::CallTarget{lir::MethodTarget{
                           .method = unit.MethodSlot(t.owner, t.slot)}};
+                    },
+                    [&](const mir::ForeignSymbolTarget& f)
+                        -> diag::Result<lir::CallTarget> {
+                      // A name in the DPI-C name space is reached as an
+                      // external-linkage symbol the execution session resolves
+                      // (LRM 35.4); nothing about the call names a unit or a
+                      // class.
+                      return lir::CallTarget{
+                          lir::ForeignTarget{.symbol = f.linkage_name}};
                     },
                     [&](const support::BuiltinFn& fn)
                         -> diag::Result<lir::CallTarget> {

--- a/src/lyra/lowering/mir_to_lir/translate_type.cpp
+++ b/src/lyra/lowering/mir_to_lir/translate_type.cpp
@@ -114,10 +114,12 @@ auto TranslateRuntimeLibraryKind(mir::RuntimeLibraryKind k)
           "compile-time constant consumed by the backend directly and does not "
           "flow through MIR-to-LIR");
     case mir::RuntimeLibraryKind::kDpiScopeGuard:
+    case mir::RuntimeLibraryKind::kForeignTaskAwaitable:
       throw InternalError(
-          "TranslateRuntimeLibraryKind: the DPI context scope guard is a "
-          "C++-backend marshaling artifact; the execution backend does not "
-          "consume the DPI context surface");
+          "TranslateRuntimeLibraryKind: the DPI context scope guard and the "
+          "foreign-task fiber awaitable are C++-backend marshaling artifacts; "
+          "the execution backend does not consume the DPI context or task "
+          "surface");
   }
   throw InternalError(
       "TranslateRuntimeLibraryKind: unknown RuntimeLibraryKind");

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -25,7 +25,6 @@
 #include "lyra/mir/type.hpp"
 #include "lyra/mir/unary_op.hpp"
 #include "lyra/support/builtin_fn.hpp"
-#include "lyra/support/dpi_abi.hpp"
 #include "lyra/value/format.hpp"
 
 namespace lyra::mir {
@@ -331,6 +330,8 @@ class MirDumper {
                   return "RuntimeLibrary(DpiLogicChunk)";
                 case RuntimeLibraryKind::kDpiScopeGuard:
                   return "RuntimeLibrary(DpiScopeGuard)";
+                case RuntimeLibraryKind::kForeignTaskAwaitable:
+                  return "RuntimeLibrary(ForeignTaskAwaitable)";
               }
               throw InternalError("dump: unknown RuntimeLibraryKind");
             },
@@ -579,6 +580,9 @@ class MirDumper {
               return std::format(
                   "external_class_method={}::{}::{}", e.unit_name, e.class_name,
                   e.method_name);
+            },
+            [](const ForeignSymbolTarget& f) -> std::string {
+              return std::format("foreign_symbol=\"{}\"", f.linkage_name);
             }},
         target);
   }
@@ -1013,36 +1017,8 @@ class MirDumper {
     }
   }
 
-  void DumpForeignMarshal(const ForeignMarshal& marshal) {
-    Line(
-        std::format(
-            "Marshal:{} ret={} : {}", marshal.is_task ? " task" : "",
-            support::DpiScalarAbiName(marshal.ret_abi),
-            FormatVarType(marshal.ret_sv_type)));
-    Indent();
-    for (std::size_t i = 0; i < marshal.params.size(); ++i) {
-      Line(
-          std::format(
-              "Param[{}] {} {} : {}", i,
-              support::DpiDirectionName(marshal.params[i].direction),
-              support::DpiCarrierName(marshal.params[i].carrier),
-              FormatVarType(marshal.params[i].sv_type)));
-    }
-    Dedent();
-  }
-
   void DumpForeignLinkage(const ForeignLinkage& linkage) {
-    Line(
-        std::format(
-            R"(ForeignLinkage: c_name="{}"{}{})", linkage.foreign_name,
-            linkage.is_pure ? " pure" : "",
-            linkage.is_context ? " context" : ""));
-    if (!linkage.marshal.has_value()) {
-      return;
-    }
-    Indent();
-    DumpForeignMarshal(*linkage.marshal);
-    Dedent();
+    Line(std::format(R"(ForeignLinkage: c_name="{}")", linkage.foreign_name));
   }
 
   void DumpCallable(const CallableDecl& d, std::size_t index) {

--- a/src/lyra/runtime/ambient_run_context.cpp
+++ b/src/lyra/runtime/ambient_run_context.cpp
@@ -37,9 +37,14 @@ auto CurrentExportScope() -> Scope* {
       AmbientRunContext::Current().Effects().TryCurrentProcess();
   Scope* scope = process == nullptr ? nullptr : process->CurrentDpiScope();
   if (scope == nullptr) {
+    // The foreign side reached an instance-bound export with no scope
+    // established. An import declared in a package or at `$unit` scope observes
+    // no scope of its own (LRM 35.5.3), so reaching such an export from one
+    // requires svSetScope first.
     throw InternalError(
         "DPI export reached without a scope context: the calling import must "
-        "be a context import or set the scope with svSetScope (LRM 35.5.3)");
+        "be a context import declared in an instantiated scope, or set the "
+        "scope with svSetScope (LRM 35.5.3)");
   }
   return scope;
 }

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -392,6 +392,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "dpi_open_array_handle";
     case BuiltinFn::kDpiOpenArrayValue:
       return "dpi_open_array_value";
+    case BuiltinFn::kRunForeignTaskOnFiber:
+      return "run_foreign_task_on_fiber";
     case BuiltinFn::kRunExportedTaskToCompletion:
       return "run_exported_task_to_completion";
     case BuiltinFn::kCurrentExportScope:

--- a/tests/cases/cpp/dpi_import_namespace_scope/case.yaml
+++ b/tests/cases/cpp/dpi_import_namespace_scope/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.dpi_import_namespace_scope
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  link_sources: [dpi.c]
+expect:
+  exit: 0
+  variables:
+    from_module: 42
+    from_pkg_fn: 10
+    from_unit: -7
+    with_context: 108
+    lo: 5
+    hi: 6

--- a/tests/cases/cpp/dpi_import_namespace_scope/dpi.c
+++ b/tests/cases/cpp/dpi_import_namespace_scope/dpi.c
@@ -1,0 +1,20 @@
+/* The generated ABI header declares every name this design takes part in,
+   including the package-scoped export `probe` calls back, so this source
+   states no prototype of its own. */
+#include "dpi.h"
+
+int32_t scale(int32_t a) { return a * 2; }
+
+/* Declared in a package, which is never instantiated, so this context import
+   observes no scope (LRM 35.5.3) -- and a receiver-less export is still
+   directly reachable from it, because it needs no instance to dispatch to. */
+int32_t probe(int32_t a) {
+  return (svGetScope() == 0 ? 100 : 200) + pkg_double(a);
+}
+
+void split(int32_t a, int32_t* lo, int32_t* hi) {
+  *lo = a % 100;
+  *hi = a / 100;
+}
+
+int32_t negate(int32_t a) { return -a; }

--- a/tests/cases/cpp/dpi_import_namespace_scope/main.sv
+++ b/tests/cases/cpp/dpi_import_namespace_scope/main.sv
@@ -1,0 +1,50 @@
+`timescale 1ns / 1ps
+// LRM 35.4: an imported subroutine resolves to a program-global symbol in a
+// name space of its own, separate from every compilation-unit scope name space.
+// So where the declaration was written is a name-resolution fact only: an import
+// declared in a package (LRM 26.3) or at `$unit` scope (LRM 3.12.1) is called
+// exactly as one declared in the calling module, from the calling module and
+// from the declaring package's own function alike.
+//
+// LRM 35.5.3 pins the one thing about an import that is not global: a `context`
+// import observes the instantiated scope of its declaration. A package and
+// `$unit` are never instantiated, so such an import observes no scope -- it can
+// still reach a receiver-less export directly, since that export needs no
+// instance, which is what `probe` proves by seeing a null scope and calling
+// `pkg_double` anyway.
+package dpi_pkg;
+  import "DPI-C" function int scale(input int a);
+  import "DPI-C" context function int probe(input int a);
+  import "DPI-C" function void split(input int a, output int lo,
+                                     output int hi);
+
+  export "DPI-C" function pkg_double;
+  function automatic int pkg_double(input int a);
+    return a * 2;
+  endfunction
+
+  // The declaring unit calls its own import, so it holds the same record the
+  // calling module does.
+  function automatic int via_pkg(input int a);
+    return scale(a);
+  endfunction
+endpackage
+
+import "DPI-C" function int negate(input int a);
+
+module Top;
+  import dpi_pkg::*;
+  int from_module;
+  int from_pkg_fn;
+  int from_unit;
+  int with_context;
+  int lo;
+  int hi;
+  initial begin
+    from_module = scale(21);
+    from_pkg_fn = via_pkg(5);
+    from_unit = negate(7);
+    with_context = probe(4);
+    split(605, lo, hi);
+  end
+endmodule


### PR DESCRIPTION
## Summary

A DPI-C import declared in a package (LRM 26.3) or at `$unit` scope (LRM 3.12.1) is now callable from any unit, exactly as one declared in the calling scope is. It was previously rejected with a diagnostic. Nothing was added to make this work: three misplaced ownership decisions were removed, and the capability is what remained.

## Design

LRM 35.4 says an imported subroutine resolves to a program-global symbol in a linkage name space of its own, separate from every compilation-unit scope name space. So where the declaration was written is a name-resolution fact only, consumed at AST-to-HIR; the entity it names belongs to no scope and to no unit. Three consequences follow, each of which was a defect:

The import table moves from `StructuralScope` to the compilation unit. A package is not on any caller's scope stack, so a scope-owned record was unreachable from elsewhere by construction. Each unit interns its own record of every import it declares or calls, keyed by the slang symbol; the record reads only the declaration, so every unit's copy is identical and the calling unit depends on no other unit's artifact.

The two jobs the old `hops` field did are split. Finding the record needed no hops once the record is unit-level. The declaring instantiated scope is a separate, genuinely optional fact, present only for a `context` import (LRM 35.5.3) whose declaration sits in a scope that is instantiated. A package and `$unit` never are, so such an import observes a null scope -- which is the LRM-correct outcome: a receiver-less export stays directly reachable from it (its entry point recovers the runtime, not a scope), and any instance-bound export needs `svSetScope` first, which the LRM already requires of a caller with no scope of its own.

No class owns a foreign callable any more. An import's prototype joins the export's entry point in the unit's own callable arena, and the direction reads off body presence everywhere. This also fixes an identity defect: the class arena previously held `[imports][subroutines][exports]` spliced by position, so declaring an import shifted every subroutine's `CallableId`.

Two smaller shapes fell out. `DirectTarget` gains `ForeignSymbolTarget`, the DPI-C name space as its own call-target identity, so render emits the symbol with no lookup and no branch. And the foreign-task fiber protocol is now stated in MIR as an awaited call over a closure, removing a `backend_contract.md` invariant-2 violation where render inferred it by walking to the callee's declaration.

Marshaling stays at the call site. An open-array formal leaves a dimension unsized (LRM 35.5.6.1), so what crosses is a function of the actual's static type -- a fact only the call site holds -- and one mechanism serves every import.

`mir::ForeignLinkage` shrinks to the linkage name: `ForeignMarshal`, `ForeignParam`, `is_pure`, and `is_context` had no consumer left below HIR.

## Testing

One end-to-end case covers a package-declared import called from a module and from the declaring package's own function, a `$unit`-declared import, an `output` argument across the boundary, and a package-declared `context` import. That last one asserts `108`: `svGetScope()` returns null (100) while the import still reaches the package-scoped export directly (`pkg_double(4)` = 8), which is the LRM 35.5.3 behaviour the design predicts.

The whole change is net negative -- 712 insertions against 680 deletions across 43 files.