### PR TITLE
Resolve a value's cell once for every consumer

### DIFF
--- a/docs/decisions/front-end-semantic-boundary.md
+++ b/docs/decisions/front-end-semantic-boundary.md
@@ -115,8 +115,7 @@ one translation; they must not each re-derive it.
 1. `TranslateSensitivityReads` stops dropping on a failed `HopsTo`: a dependency whose target is not
    an enclosing structural object is routed through the reference the body resolved, never
    discarded. This removes the order-dependent loss for every consumer that infers a read set
-   (`always_comb`, `always @*`, continuous assign, `wait`, port connection). Interim correctness
-   repair; it does not yet remove the parallel classifier.
+   (`always_comb`, `always @*`, continuous assign, `wait`, port connection).
 2. `always_comb` / `always_latch` read `AnalyzedProcedure::getSensitivityList()` rather than raw
    `getRValues()`, so function-body reads contribute per LRM 9.2.2.2.1. The other consumers already
    read the surface their semantics require -- `always @*` and `wait` the reads of their controlled

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -26,7 +26,10 @@ The whole Ibex RTL already parses, type-checks, and elaborates through the front
 
 ## Two walls
 
-1. **Feature-lowering gaps** -- the unsupported SystemVerilog forms below.
+1. **Feature-lowering gaps** -- the unsupported SystemVerilog forms below. No construct in the
+   design is rejected: the whole `ibex_simple_system_tb` lowers and emits C++ with no diagnostics.
+   The frontier is one stage later, at the emitted program's own correctness -- each form left open
+   below emits C++ that a host compiler refuses, so the design does not link.
 2. **Execution backend** -- the C++ path is wired and runs end to end: `lyra run` emits, builds, and
    executes a supported design. The blanket "no way to run anything" wall is down, so a
    fully-lowered Ibex can in principle run. What remains here is not the ability to run at all but
@@ -63,7 +66,7 @@ full support.
       rather than reconstructed in the deferred body. Pervasive in banked, width-parameterized RTL:
       with this, the counter, prefetch-buffer, fetch-FIFO, decoder, and compressed-decoder families
       lower and emit C++ end-to-end.
-- [ ] **Variable-width part-select inside a conditional generate** -- a part-select whose _width_
+- [x] **Variable-width part-select inside a conditional generate** -- a part-select whose _width_
       depends on a `genvar` (e.g. `x[i-1:0]`, which widens with `i`) appearing in a
       `generate     if`/`else` branch. Distinct from the genvar-dependent select _bounds_ of
       constant width above (the ibex_alu butterfly form), which already lower; here the selected
@@ -117,9 +120,8 @@ full support.
       reference, written inside a conditional or loop generate block, that descends into a module
       instance owned by an enclosing scope (the RVFI trap logic in `ibex_core`, and `ibex_ex_block`
       reaching its generate-instantiated multiplier and divider the same way). No longer a lowering
-      blocker: with `$readmemh` cleared, the whole `ibex_simple_system_tb` now lowers to MIR with no
-      diagnostics, so this form lowers as part of the full design. C++ emit / build / run of the
-      full top is the next thing to verify and is not yet re-checked.
+      blocker: with `$readmemh` cleared, the whole `ibex_simple_system_tb` lowers to MIR with no
+      diagnostics and emits C++, so this form carries through the full design.
 - [x] **`$value$plusargs` / `$test$plusargs`** -- runtime plusarg query (LRM 21.6). The full surface
       is live: `$test$plusargs` probes for a prefix, `$value$plusargs` parses the matched plusarg's
       remainder under `%d` / `%o` / `%h` / `%x` / `%b` / `%s`, and the host command line populates
@@ -142,14 +144,20 @@ full support.
       enum value as its base packed integral (the enum value model is now base-integral; see
       `datatypes.md` Enum). The same change removed the anonymous-enum cross-module name collision
       that otherwise blocked the full-system C++ compile.
-- [ ] **Cross-unit reference to a package's enum-member or `localparam` constant** -- a module reads
-      a package-scoped compile-time constant by its qualified name (an `exc_cause_e` member, a CSR
-      bit-index / register parameter); the constant is not materialized in the referenced package,
-      so the emitted C++ names an undefined symbol. It should fold to its value or resolve as a
-      link-time symbol. Hits `ibex_controller`, `ibex_if_stage`, `ibex_cs_registers`.
+- [x] **A constant read where sensitivity is inferred** -- a `parameter`, `localparam`, or enum
+      member read inside `always_comb`, `always @*`, a `wait`, or a continuous assign (an
+      `exc_cause_e` member, a CSR bit-index parameter, the instruction-encoding `casez` in
+      `ibex_tracer`). LRM 9.2.2.2.1 infers the implicit sensitivity list from net and variable
+      identifiers, and a constant is neither, so such a read contributes nothing to it -- neither
+      folding it into the subscription nor materializing a cell for it is right, since a value that
+      cannot change is not something a process can wait on. Hits `ibex_controller`, `ibex_if_stage`,
+      `ibex_cs_registers`, `ibex_tracer`.
 - [ ] **DPI-C export from inside a generate scope** -- an `export "DPI-C"` declared within a
       generate block (the icache scramble-key helpers in `ibex_if_stage`); the emitted C entry names
       the generate scope's type without the qualification that reaches it.
+- [ ] **A net whose value is an unpacked array** -- an unpacked-array port declared with no data
+      type is an implicit net array (LRM 6.9), which net resolution does not admit. The system bus
+      (`shared/rtl/bus.sv`) declares its per-host request, address, and write-enable ports this way.
 - [ ] Further structural-expression forms surfaced as later passes get deeper (recorded here as
       discovery continues).
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -195,16 +195,16 @@ struct DelayControl {
   ExprId duration;
 };
 
-// One leaf entry of a wait's projection set. Identity-only: which structural
-// variable, the flat-bit footprint of its packed encoding the leaf observes,
-// and what edge polarity the leaf was subscribed under. An absent footprint
+// One leaf entry of a wait's projection set. Identity-only: which cell, the
+// flat-bit footprint of its packed encoding the leaf observes, and what edge
+// polarity the leaf was subscribed under. An absent footprint
 // means the whole signal is observed; an edge then reduces to its LSB. Implicit
 // sensitivity sources (always_comb / always_latch / `@*` / wait cond /
 // continuous assignment) supply leaves with `edge_kind == kAnyChange`. Explicit
 // event control `@(posedge ...)` / `@(negedge ...)` / `@(edge ...)` set the
 // per-leaf edge.
 struct SensitivityEntry {
-  SensitivityTarget ref;
+  ValueTarget ref;
   std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint;
   support::EventEdge edge_kind = support::EventEdge::kAnyChange;
 };

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -105,21 +105,19 @@ struct PatternVarRef {
   auto operator==(const PatternVarRef&) const -> bool = default;
 };
 
-// A reference to a variable that belongs to another compilation unit's
-// namespace -- a package variable (LRM 26.2), reached by name. Like
-// `ExternalUnitSubroutineRef` for a call, it carries no unit-local id: a
-// package has no instance and no receiver, so its variable is named and
-// resolved against the target unit's interface at link time, never through a
-// `self`-based route within any unit. The same by-name form serves a referrer
-// in another unit and the package's own callable reading its own variable,
-// since neither has a receiver to reach it through. One form serves read,
-// write, and observation.
+// A reference to a variable declared in a namespace unit -- a package (LRM
+// 26.2) or the anonymous `$unit` scope (LRM 3.12.1) -- reached by name. Such a
+// unit has no instance and no receiver, so its variable is one program-global
+// cell, resolved against that unit's interface at link time rather than reached
+// by a route out of anyone's storage. The same by-name form serves a referrer
+// in another unit and the declaring unit's own body, neither of which has a
+// receiver to reach it through.
 struct ExternalUnitValueRef {
   std::string unit_name;
   std::string variable_name;
-  // The variable's value type. Carried on the node so it is self-describing: a
-  // sensitivity leaf reaches the observed cell's type from the reference alone,
-  // with no enclosing expression to type it.
+  // The cell's type. The declaring unit compiles separately, so no member of
+  // this unit states it; it crosses as part of what this unit knows of that
+  // unit's interface.
   TypeId value_type;
 
   auto operator==(const ExternalUnitValueRef&) const -> bool = default;
@@ -127,16 +125,17 @@ struct ExternalUnitValueRef {
 
 // A reader-relative reference to a value: either a direct member of the
 // reader's own scope, or a routed reference sealed to a per-instance endpoint
-// in the resolve phase. One route serves every consumer of the reference --
-// value read, value write, and change observation -- so the name is neutral to
-// the consumer, not owned by sensitivity.
+// in the resolve phase.
 using ReferenceRoute = std::variant<DirectMemberRef, RoutedRef>;
 
-// What a sensitivity leaf watches: a reader-relative route to an intra-unit
-// observable cell, or a by-name reference to a package variable's one
-// program-global cell (LRM 26.2). A package variable's change wakes the process
-// the same way an intra-unit signal's does, but it is reached by name, not
-// through a route, since a package has no per-instance storage to route to.
-using SensitivityTarget = std::variant<ReferenceRoute, ExternalUnitValueRef>;
+// Where a value's cell is, as the reader reaches it: through a reader-relative
+// route to a cell in the reader's own unit, or by name across the boundary to a
+// namespace unit's one program-global cell (LRM 26.2, 3.12.1), which has no
+// per-instance storage to route to. One target serves every consumer of the
+// reference -- value read, value write, and change observation -- so the name
+// is neutral to the consumer and owned by none of them. A value with no cell at
+// all has no target: a compile-time constant folds where it is used, leaving
+// nothing to read through and nothing to observe.
+using ValueTarget = std::variant<ReferenceRoute, ExternalUnitValueRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/expression/references.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/references.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 // Lowering of name resolution expressions: NamedValue (LRM 6.6 names) and
-// HierarchicalValue (LRM 23.6 hierarchical references). Routed reference
-// construction lives on UnitLowerer; this file handles the expression-level
-// resolution into DirectMemberRef / ProceduralVarRef / RoutedRef per context.
+// HierarchicalValue (LRM 23.6 hierarchical references). Where a named value's
+// cell is gets settled once, for every consumer of a name; this file turns
+// that answer -- together with the forms that have no cell at all, a folded
+// constant, a class property, a pattern binding -- into an Expr.
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
@@ -19,16 +20,6 @@ class ValueSymbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
-
-// The compilation unit a value is declared directly in when that unit is
-// reached by name across the boundary -- a package (LRM 26.2) or the anonymous
-// `$unit` scope (LRM 3.12.1) -- or nullptr when the value belongs to this unit
-// and routes locally. Such a value is one program-global cell reached by name;
-// both the value-reference path and the sensitivity path detect it here so a
-// read and a wait on its change agree on the by-name form. The returned symbol
-// is the declaring unit, from which the caller computes its published name.
-auto DeclaringUnitOfValue(const slang::ast::ValueSymbol& value)
-    -> const slang::ast::Symbol*;
 
 auto LowerNamedValueProc(
     ProcessLowerer& proc, WalkFrame frame,

--- a/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/unit_lowerer.hpp
@@ -25,8 +25,10 @@
 #include "lyra/hir/pattern_id.hpp"
 #include "lyra/hir/structural_data_object.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
+#include "lyra/support/event_edge.hpp"
 
 namespace slang::ast {
 class Expression;
@@ -120,16 +122,14 @@ class LoweringFacts {
   bool disable_assertions_;
 };
 
-// Per-unit lowerer, over a module instance body or a package.
+// Per-unit lowerer, over a module instance body or a package. It holds the
+// in-progress compilation unit together with the registries that record which
+// HIR identity this unit gave each slang symbol, so a reference resolves
+// against what the unit already decided rather than by re-reading the frontend.
 //
-// Facts: the shared lowering facts (source mapper + sensitivity analyzer) and
-// a reference to the slang scope being walked.
-// Registries: type cache (slang canonical type -> hir TypeId), structural-var
-// / subroutine / loop-var / owned-child binding tables, per-frame cross-unit
-// ref slot tables, and a scope-frame counter.
-// Root output: the in-progress `hir::CompilationUnit`. Constructed in the ctor
-// with the unit's name and an initial builtins table; populated by `Run`; moved
-// out by `Run`'s return. After `Run` returns the class holds no IR pointer.
+// The unit is constructed with its name and an initial builtins table,
+// populated by `Run`, and moved out by `Run`'s return; afterwards the lowerer
+// holds no IR.
 class UnitLowerer {
  public:
   UnitLowerer(
@@ -282,7 +282,6 @@ class UnitLowerer {
         "recorded id; the owning class was not interned before this lookup");
   }
 
-  // Facts.
   [[nodiscard]] auto SourceMapper() const
       -> const frontend::SlangSourceMapper& {
     return facts_.SourceMapper();
@@ -294,8 +293,6 @@ class UnitLowerer {
     return facts_.DisableAssertions();
   }
 
-  // Binding registries. Each Map* asserts no double-mapping for the same
-  // slang symbol.
   void MapStructuralDataObjectBinding(
       const slang::ast::ValueSymbol& var, ScopeFrameId home_frame,
       hir::StructuralDataObjectId local, hir::TypeId type);
@@ -385,45 +382,53 @@ class UnitLowerer {
   auto InternOwnClassDeclarations() -> diag::Result<void>;
 
   // Builds a HIR Expr referring to a leaf reached by navigating `path` down
-  // from `head`. `target` is the leaf value symbol (routed-ref dedup key);
-  // `slot_owner_frame` is the frame whose `routed_refs` arena holds the slot
-  // (see `MapOrGetRoutedRef`).
+  // from `head`. `target` is the leaf value symbol, which is also the key two
+  // references to one target dedup on; `slot_owner_frame` is the frame whose
+  // routed-reference arena holds the slot.
   auto MakeRoutedMemberRef(
       const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
       hir::RoutedRefHead head, std::vector<hir::PathSegment> path,
       hir::TypeId type, diag::SourceSpan span) -> hir::Expr;
 
-  // Translates slang-side reads to HIR SensitivityEntries. Each read resolves
-  // to the same reader-relative route the reader would use to reach the target,
-  // derived from the target's elaborated position -- not reclassified from a
-  // global table lookup.
-  [[nodiscard]] auto TranslateSensitivityReads(
-      const std::vector<SensitivityRead>& reads, const WalkFrame& frame)
-      -> std::vector<hir::SensitivityEntry>;
+  // Where a named value lives, as this unit reaches it. One answer serves
+  // every consumer of a reference -- reading it, writing it, and waiting on it
+  // changing. A variable or net resolves to a route from the reader to its
+  // cell, sealed once at elaboration; a variable of a namespace unit, which has
+  // no instance to route through, resolves to its name across the boundary. A
+  // constant resolves to nothing at all -- it names a value, not a cell, so
+  // there is nothing to read through and nothing to wait on -- as does a target
+  // whose route form is not yet supported. Asking here, once, is what stops one
+  // symbol being a value to one consumer and a signal to another.
+  [[nodiscard]] auto ResolveValueTarget(
+      const WalkFrame& frame, const slang::ast::ValueSymbol& value)
+      -> diag::Result<std::optional<hir::ValueTarget>>;
 
-  // The one route translator for every reference consumer -- value read, value
-  // write, and change observation. From the reader's elaborated position
-  // (`frame.reader_scope` and its unit-local chain) and the target symbol it
-  // computes the reader-relative route and classifies each segment by layout
-  // visibility: a direct member when the target sits on the reader's own scope,
-  // a routed reference otherwise -- a typed enclosing climb to a this-unit
-  // ancestor member, a typed downward head when the head's class this unit
-  // emits, or a by-name head where the route crosses the compilation-unit
-  // boundary. Returns nullopt when the target is not an addressable signal or
-  // its form is not yet supported.
+  // The reads of a dependency set that name a cell, as the entries that wake on
+  // it under `edge`. A read of anything else contributes none, so a constant
+  // read alongside a signal leaves only the signal subscribed (LRM 9.2.2.2.1).
+  // An inferred sensitivity wakes on any change; only an explicit event control
+  // qualifies its terms with a polarity (LRM 9.4.2), and every leaf of one term
+  // carries that term's own.
+  [[nodiscard]] auto TranslateSensitivityReads(
+      const std::vector<SensitivityRead>& reads, const WalkFrame& frame,
+      support::EventEdge edge)
+      -> diag::Result<std::vector<hir::SensitivityEntry>>;
+
+ private:
+  // The reader-relative route to a cell in an instantiated scope: a direct
+  // member when the target sits on the reader's own scope, a routed reference
+  // otherwise -- a typed enclosing climb to a this-unit ancestor member, a
+  // typed downward head when this unit emits the head's class, or a by-name
+  // head where the route crosses into another instance's unit.
   [[nodiscard]] auto TranslateReferenceRoute(
       const WalkFrame& frame, const slang::ast::ValueSymbol& value)
       -> std::optional<hir::ReferenceRoute>;
 
- private:
-  // Facts.
   LoweringFacts facts_;
   const slang::ast::Scope* scope_;
 
-  // Root output.
   hir::CompilationUnit unit_;
 
-  // Registries.
   std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;
   // The classification of every class this unit's lowering has resolved: the
   // Local / External arm chosen by walking slang's parent chain to find the

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -507,8 +507,7 @@ class HirDumper {
         ref);
   }
 
-  static auto FormatSensitivityTarget(const SensitivityTarget& target)
-      -> std::string {
+  static auto FormatValueTarget(const ValueTarget& target) -> std::string {
     return std::visit(
         Overloaded{
             [](const ReferenceRoute& route) -> std::string {
@@ -565,7 +564,7 @@ class HirDumper {
                   if (j != 0) out += ", ";
                   const auto& r = e.triggers[i].sensitivity_list[j];
                   out += std::format(
-                      "{{{} bits={} edge={}}}", FormatSensitivityTarget(r.ref),
+                      "{{{} bits={} edge={}}}", FormatValueTarget(r.ref),
                       FormatFootprint(r.footprint),
                       FormatEventEdge(r.edge_kind));
                 }
@@ -580,7 +579,7 @@ class HirDumper {
                 if (i != 0) out += ", ";
                 const auto& r = ie.sensitivity_list[i];
                 out += std::format(
-                    "{{{} bits={} edge={}}}", FormatSensitivityTarget(r.ref),
+                    "{{{} bits={} edge={}}}", FormatValueTarget(r.ref),
                     FormatFootprint(r.footprint), FormatEventEdge(r.edge_kind));
               }
               out += "]";
@@ -1230,7 +1229,7 @@ class HirDumper {
       for (const auto& r : p.implicit_sensitivity_list) {
         Line(
             std::format(
-                "{} bits={}", FormatSensitivityTarget(r.ref),
+                "{} bits={}", FormatValueTarget(r.ref),
                 FormatFootprint(r.footprint)));
       }
       Dedent();
@@ -1299,7 +1298,7 @@ class HirDumper {
       for (const auto& r : ca.sensitivity_list) {
         Line(
             std::format(
-                "{} bits={}", FormatSensitivityTarget(r.ref),
+                "{} bits={}", FormatValueTarget(r.ref),
                 FormatFootprint(r.footprint)));
       }
       Dedent();
@@ -1643,7 +1642,7 @@ class HirDumper {
                 if (i != 0) sens += ", ";
                 const auto& r = w.sensitivity_list[i];
                 sens += std::format(
-                    "{{{} bits={}}}", FormatSensitivityTarget(r.ref),
+                    "{{{} bits={}}}", FormatValueTarget(r.ref),
                     FormatFootprint(r.footprint));
               }
               sens += "]";

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -19,20 +19,21 @@ namespace lyra::lowering::ast_to_hir {
 namespace {
 
 // Assembles a continuous assignment (LRM 10.3.2) from its two already-built
-// operand expressions and the read set its sensitivity derives from. The
-// sensitivity list is always `TranslateSensitivityReads(reads)`, the single
-// place a read set is mapped to its runtime projection.
+// operand expressions and the read set its sensitivity derives from.
 auto BuildContinuousAssign(
     UnitLowerer& unit_lowerer, WalkFrame frame, diag::SourceSpan span,
     hir::Expr lhs, hir::Expr rhs, const std::vector<SensitivityRead>& reads)
-    -> hir::ContinuousAssign {
+    -> diag::Result<hir::ContinuousAssign> {
+  auto sensitivity = unit_lowerer.TranslateSensitivityReads(
+      reads, frame, support::EventEdge::kAnyChange);
+  if (!sensitivity) return std::unexpected(std::move(sensitivity.error()));
   const hir::ExprId lhs_id = frame.Exprs().Add(std::move(lhs));
   const hir::ExprId rhs_id = frame.Exprs().Add(std::move(rhs));
   return hir::ContinuousAssign{
       .span = span,
       .lhs = lhs_id,
       .rhs = rhs_id,
-      .sensitivity_list = unit_lowerer.TranslateSensitivityReads(reads, frame),
+      .sensitivity_list = *std::move(sensitivity),
   };
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -12,20 +12,19 @@
 #include <slang/ast/Symbol.h>
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/symbols/ClassSymbols.h>
-#include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
 #include <slang/numeric/ConstantValue.h>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/expr_builders.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/expression/selects.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
-#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -268,72 +267,49 @@ auto MakeClassPropertyRefExpr(
       *type_id, span);
 }
 
-// Wraps a resolved reader-relative route as a reference Expr. A route is one of
-// two primaries -- a direct member of the reader's own scope or a routed
-// reference sealed to a per-instance endpoint -- and each wraps identically.
-auto RouteRefExpr(
-    const hir::ReferenceRoute& route, hir::TypeId type, diag::SourceSpan span)
+// Wraps a resolved value target as a reference Expr. Every way of reaching a
+// cell -- a direct member of the reader's own scope, a routed reference sealed
+// to a per-instance endpoint, a namespace unit's cell named across the boundary
+// -- is a reference primary, so one wrap serves them all.
+auto ValueTargetRefExpr(
+    const hir::ValueTarget& target, hir::TypeId type, diag::SourceSpan span)
     -> hir::Expr {
+  const auto wrap = [&](const auto& primary) -> hir::Expr {
+    return hir::MakeRefExpr(primary, type, span);
+  };
   return std::visit(
-      [&](const auto& primary) -> hir::Expr {
-        return hir::MakeRefExpr(primary, type, span);
+      Overloaded{
+          [&](const hir::ReferenceRoute& route) -> hir::Expr {
+            return std::visit(wrap, route);
+          },
+          [&](const hir::ExternalUnitValueRef& external) -> hir::Expr {
+            return wrap(external);
+          },
       },
-      route);
+      target);
 }
 
-// Lowers a reference to a variable owned by another unit's namespace as an
-// `ExternalUnitValueRef` naming that unit and the variable. The same by-name
-// form serves a referrer in another unit and the owning unit's own callable
-// reading its own variable; neither has a receiver to route through. The unit
-// is a package or the anonymous `$unit` scope, already resolved to its
-// published name by the caller.
-auto LowerExternalUnitValueRef(
-    UnitLowerer& unit_lowerer, std::string unit_name,
-    const slang::ast::ValueSymbol& value, const slang::ast::Type& type,
-    diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = unit_lowerer.InternType(type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::MakeRefExpr(
-      hir::ExternalUnitValueRef{
-          .unit_name = std::move(unit_name),
-          .variable_name = std::string{value.name},
-          .value_type = *type_id},
-      *type_id, span);
-}
-
-// Lowers a reference to a structural signal (a variable or net of an enclosing
-// scope) through the one reference-route translator. Shared by the procedural
-// and structural named-value paths once each has ruled out the non-signal forms
-// its context admits. A simple name is always lexically enclosing, so the route
-// is always available and its absence is a compiler-bug invariant.
-auto LowerStructuralSignalRef(
+// Lowers a reference to a value that has a cell -- a variable or a net --
+// wherever that cell lives, through the one resolver. Shared by every
+// named-value entry once each has ruled out the forms its context admits that
+// have no cell. A storage referent always resolves here: a simple name is
+// lexically enclosing and a hierarchical path is fully elaborated by the
+// frontend, so absence is a compiler-bug invariant.
+auto LowerValueRef(
     UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::ValueSymbol& value, const slang::ast::Type& type,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto type_id = unit_lowerer.InternType(type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
-  auto route = unit_lowerer.TranslateReferenceRoute(frame, value);
-  if (!route) {
-    throw InternalError(
-        "LowerStructuralSignalRef: structural signal has no reader-relative "
-        "route");
+  auto target = unit_lowerer.ResolveValueTarget(frame, value);
+  if (!target) return std::unexpected(std::move(target.error()));
+  if (!target->has_value()) {
+    throw InternalError("LowerValueRef: storage symbol has no reachable cell");
   }
-  return RouteRefExpr(*route, *type_id, span);
+  return ValueTargetRefExpr(**target, *type_id, span);
 }
 
 }  // namespace
-
-auto DeclaringUnitOfValue(const slang::ast::ValueSymbol& value)
-    -> const slang::ast::Symbol* {
-  const slang::ast::Scope* scope = value.getParentScope();
-  if (scope == nullptr) return nullptr;
-  const slang::ast::Symbol& owner = scope->asSymbol();
-  if (owner.kind != slang::ast::SymbolKind::Package &&
-      owner.kind != slang::ast::SymbolKind::CompilationUnit) {
-    return nullptr;
-  }
-  return &owner;
-}
 
 auto LowerNamedValueProc(
     ProcessLowerer& proc, WalkFrame frame,
@@ -358,14 +334,15 @@ auto LowerNamedValueProc(
     // receiver, so it lowers to a receiver-relative property reference.
     case Referent::kClassProperty:
       return MakeClassPropertyRefExpr(unit_lowerer, sym, *named.type, span);
-    // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
-    // variable-family symbols; each binds to procedural-var storage when the
-    // enclosing process declares it, otherwise to the structural signal of the
-    // same name reached through the reference-route translator.
     case Referent::kPatternBinding:
       return MakePatternVarRefExpr(
           unit_lowerer, sym.as<slang::ast::PatternVarSymbol>(), *named.type,
           span);
+    // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
+    // variable-family symbols too, so this arm covers a name bound to the
+    // enclosing body's own storage as well as one naming a cell elsewhere. The
+    // lexical binding wins: only a name the body does not declare is a value
+    // reached through the object graph.
     case Referent::kVariableStorage: {
       const auto& var = sym.as<slang::ast::VariableSymbol>();
       if (auto local = proc.LookupProceduralVar(var)) {
@@ -374,17 +351,11 @@ auto LowerNamedValueProc(
         return hir::MakeRefExpr(
             hir::ProceduralVarRef{.var = *local}, type, span);
       }
-      const auto& value = sym.as<slang::ast::ValueSymbol>();
-      if (const auto* unit = DeclaringUnitOfValue(value)) {
-        return LowerExternalUnitValueRef(
-            unit_lowerer, CompilationUnitName(*unit), value, *named.type, span);
-      }
-      return LowerStructuralSignalRef(
-          unit_lowerer, frame, value, *named.type, span);
+      return LowerValueRef(unit_lowerer, frame, var, *named.type, span);
     }
     // A net (LRM 6.5) is always a structural signal, never a procedural local.
     case Referent::kNetStorage:
-      return LowerStructuralSignalRef(
+      return LowerValueRef(
           unit_lowerer, frame, sym.as<slang::ast::ValueSymbol>(), *named.type,
           span);
     case Referent::kUnsupported:
@@ -396,9 +367,10 @@ auto LowerNamedValueProc(
 }
 
 // LRM 23.6 hierarchical reference. A reached constant folds to its value; a
-// reached signal's route is produced by the one canonical route translator from
-// the reader's elaborated position and the target symbol. slang's resolved
-// `ref.path` is provenance, not a routing authority, so it is not consulted.
+// reached cell is located from the reader's elaborated position and the target
+// symbol, the same way a simple name's is -- the path a reference was written
+// with is provenance, not a routing authority, so slang's resolved `ref.path`
+// is not consulted.
 auto LowerHierarchicalValue(
     UnitLowerer& unit_lowerer, WalkFrame frame,
     const slang::ast::HierarchicalValueExpression& hve)
@@ -436,19 +408,18 @@ auto LowerHierarchicalValue(
     case Referent::kVariableStorage:
     case Referent::kNetStorage: {
       const auto& value = target.as<slang::ast::ValueSymbol>();
-      if (const auto* unit = DeclaringUnitOfValue(value)) {
-        return LowerExternalUnitValueRef(
-            unit_lowerer, CompilationUnitName(*unit), value, *hve.type, span);
-      }
       auto type_id = unit_lowerer.InternType(*hve.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
-      auto route = unit_lowerer.TranslateReferenceRoute(frame, value);
-      if (!route) {
+      auto reached = unit_lowerer.ResolveValueTarget(frame, value);
+      if (!reached) return std::unexpected(std::move(reached.error()));
+      // A path this unit cannot yet express reaches a real cell the user
+      // named, so it is a lowering gap rather than a compiler-bug invariant.
+      if (!reached->has_value()) {
         return diag::Fail(
             span, diag::DiagCode::kUnsupportedExpressionForm,
             "hierarchical reference to this target form is not yet supported");
       }
-      return RouteRefExpr(*route, *type_id, span);
+      return ValueTargetRefExpr(**reached, *type_id, span);
     }
   }
   throw InternalError("LowerHierarchicalValue: unknown Referent");
@@ -474,15 +445,10 @@ auto LowerNamedValueStructural(
           unit_lowerer, sym.as<slang::ast::PatternVarSymbol>(), *named.type,
           span);
     case Referent::kVariableStorage:
-    case Referent::kNetStorage: {
-      const auto& value = sym.as<slang::ast::ValueSymbol>();
-      if (const auto* unit = DeclaringUnitOfValue(value)) {
-        return LowerExternalUnitValueRef(
-            unit_lowerer, CompilationUnitName(*unit), value, *named.type, span);
-      }
-      return LowerStructuralSignalRef(
-          unit_lowerer, frame, value, *named.type, span);
-    }
+    case Referent::kNetStorage:
+      return LowerValueRef(
+          unit_lowerer, frame, sym.as<slang::ast::ValueSymbol>(), *named.type,
+          span);
     // A static property (LRM 8.9) is one cell owned by the class, reached
     // without a receiver, so it reads here exactly as it does in a process. An
     // instance property is reachable only through a receiver, which a

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -153,8 +153,11 @@ auto ConnectElementPorts(
           auto peer_or = scope.LowerExpr(*expr, frame);
           if (!peer_or) return std::unexpected(std::move(peer_or.error()));
           peer = frame.Exprs().Add(*std::move(peer_or));
-          sensitivity = unit_lowerer.TranslateSensitivityReads(
-              unit_lowerer.Sensitivity().AnalyzeReads(*expr, inst), frame);
+          auto entries = unit_lowerer.TranslateSensitivityReads(
+              unit_lowerer.Sensitivity().AnalyzeReads(*expr, inst), frame,
+              support::EventEdge::kAnyChange);
+          if (!entries) return std::unexpected(std::move(entries.error()));
+          sensitivity = *std::move(entries);
         }
         break;
       }
@@ -175,9 +178,11 @@ auto ConnectElementPorts(
             expr->as<slang::ast::AssignmentExpression>().left(), frame);
         if (!peer_or) return std::unexpected(std::move(peer_or.error()));
         peer = frame.Exprs().Add(*std::move(peer_or));
-        sensitivity = unit_lowerer.TranslateSensitivityReads(
+        auto entries = unit_lowerer.TranslateSensitivityReads(
             {SensitivityRead{.symbol = internal, .footprint = std::nullopt}},
-            frame);
+            frame, support::EventEdge::kAnyChange);
+        if (!entries) return std::unexpected(std::move(entries.error()));
+        sensitivity = *std::move(entries);
         break;
       }
       case slang::ast::ArgumentDirection::Ref: {

--- a/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
@@ -105,8 +105,11 @@ auto ProcessLowerer::Run(
     // of its whole procedure, including reads inside any function it calls --
     // the procedure-level sensitivity, not the raw read set of the body node,
     // which reflects only call arguments across a function boundary.
-    out.implicit_sensitivity_list = owner_->TranslateSensitivityReads(
-        owner_->Sensitivity().AnalyzeProcedureSensitivity(proc), frame);
+    auto sensitivity = owner_->TranslateSensitivityReads(
+        owner_->Sensitivity().AnalyzeProcedureSensitivity(proc), frame,
+        support::EventEdge::kAnyChange);
+    if (!sensitivity) return std::unexpected(std::move(sensitivity.error()));
+    out.implicit_sensitivity_list = *std::move(sensitivity);
   }
   return out;
 }

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -67,18 +67,19 @@ auto LowerSignalEventTrigger(
 
   const auto& reads = proc.Owner().Sensitivity().AnalyzeReads(
       sig.expr, proc.ContainingSymbol());
-  auto sensitivity_list = proc.Owner().TranslateSensitivityReads(reads, frame);
   // Faithful record of SV: every leaf carries the trigger's edge identifier.
   // Whether the runtime can act on it directly (single leaf, LSB-reduce) or
   // needs a snapshot + re-eval wrapper (compound) is a HIR -> MIR decision.
-  for (auto& leaf : sensitivity_list) {
-    leaf.edge_kind = edge_kind;
+  auto sensitivity_list =
+      proc.Owner().TranslateSensitivityReads(reads, frame, edge_kind);
+  if (!sensitivity_list) {
+    return std::unexpected(std::move(sensitivity_list.error()));
   }
 
   return hir::EventTrigger{
       .signal = frame.Exprs().Add(*std::move(expr_or)),
       .edge = edge_kind,
-      .sensitivity_list = std::move(sensitivity_list),
+      .sensitivity_list = *std::move(sensitivity_list),
   };
 }
 
@@ -116,9 +117,14 @@ auto LowerNamedEventControl(
   };
 }
 
+// `controlled` is the statement the control gates. Only `@*` reads it: LRM
+// 9.4.2.2 defines its sensitivity as the reads of that statement, so the
+// control cannot be built until the statement has lowered and each read's
+// reference is resolved.
 auto LowerTimingControl(
     ProcessLowerer& proc, WalkFrame frame, const slang::ast::TimingControl& tc,
-    diag::SourceSpan span) -> diag::Result<hir::TimingControl> {
+    const slang::ast::Statement& controlled, diag::SourceSpan span)
+    -> diag::Result<hir::TimingControl> {
   switch (tc.kind) {
     case slang::ast::TimingControlKind::Delay: {
       const auto& delay = tc.as<slang::ast::DelayControl>();
@@ -161,8 +167,15 @@ auto LowerTimingControl(
       return hir::TimingControl{
           hir::EventControl{.triggers = std::move(triggers)}};
     }
-    case slang::ast::TimingControlKind::ImplicitEvent:
-      return hir::TimingControl{hir::ImplicitEventControl{}};
+    case slang::ast::TimingControlKind::ImplicitEvent: {
+      const auto& reads = proc.Owner().Sensitivity().AnalyzeReads(
+          controlled, proc.ContainingSymbol());
+      auto sensitivity = proc.Owner().TranslateSensitivityReads(
+          reads, frame, support::EventEdge::kAnyChange);
+      if (!sensitivity) return std::unexpected(std::move(sensitivity.error()));
+      return hir::TimingControl{hir::ImplicitEventControl{
+          .sensitivity_list = *std::move(sensitivity)}};
+    }
     case slang::ast::TimingControlKind::RepeatedEvent:
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedTimingControlKind,
@@ -179,20 +192,14 @@ auto LowerTimingControl(
 auto LowerTimedStmt(
     ProcessLowerer& proc, WalkFrame frame, const slang::ast::TimedStatement& ts,
     diag::SourceSpan span) -> diag::Result<hir::Stmt> {
-  auto timing = LowerTimingControl(proc, frame, ts.timing, span);
-  if (!timing) return std::unexpected(std::move(timing.error()));
+  // The controlled statement lowers first: a control whose sensitivity is
+  // inferred from it needs each read's reference already resolved.
   auto inner_stmt = proc.LowerStmt(ts.stmt, frame);
   if (!inner_stmt) return std::unexpected(std::move(inner_stmt.error()));
   const hir::StmtId inner_id =
       frame.current_procedural_body->stmts.Add(*std::move(inner_stmt));
-  // LRM 9.4.2.2: `@*` watches every read in the controlled body. Inferred after
-  // the body lowers so a read's cross-unit reference is already resolved when
-  // its subscription is built.
-  if (auto* ie = std::get_if<hir::ImplicitEventControl>(&*timing)) {
-    const auto& reads = proc.Owner().Sensitivity().AnalyzeReads(
-        ts.stmt, proc.ContainingSymbol());
-    ie->sensitivity_list = proc.Owner().TranslateSensitivityReads(reads, frame);
-  }
+  auto timing = LowerTimingControl(proc, frame, ts.timing, ts.stmt, span);
+  if (!timing) return std::unexpected(std::move(timing.error()));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::TimedStmt{.timing = *std::move(timing), .stmt = inner_id},
@@ -235,9 +242,10 @@ auto LowerEventTriggerStmt(
       .span = span};
 }
 
-// LRM 9.4.3 `wait (cond) body`. Sensitivity is precomputed by driving slang's
-// flow analysis on `w.cond` via a per-wait `DefaultDFA` run upstream; the
-// result is looked up here keyed by the cond expression.
+// LRM 9.4.3 `wait (cond) body`. The wait re-evaluates when any cell the
+// condition reads changes, so its sensitivity is that condition's own read set
+// -- narrower than the enclosing body's, which is why it is analyzed here
+// rather than inherited.
 auto LowerWaitStmt(
     ProcessLowerer& proc, WalkFrame frame, const slang::ast::WaitStatement& w,
     diag::SourceSpan span) -> diag::Result<hir::Stmt> {
@@ -250,14 +258,16 @@ auto LowerWaitStmt(
       frame.current_procedural_body->stmts.Add(*std::move(body_or));
   const auto& reads =
       proc.Owner().Sensitivity().AnalyzeReads(w.cond, proc.ContainingSymbol());
-  auto sensitivity = proc.Owner().TranslateSensitivityReads(reads, frame);
+  auto sensitivity = proc.Owner().TranslateSensitivityReads(
+      reads, frame, support::EventEdge::kAnyChange);
+  if (!sensitivity) return std::unexpected(std::move(sensitivity.error()));
   return hir::Stmt{
       .label = std::nullopt,
       .data =
           hir::WaitStmt{
               .cond = cond_id,
               .body = body_id,
-              .sensitivity_list = std::move(sensitivity)},
+              .sensitivity_list = *std::move(sensitivity)},
       .span = span};
 }
 

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -278,13 +278,15 @@ auto StructuralScopeLowerer::PopulateNetMember(
             hir::DirectMemberRef{.var = local}, *type_id_or, span));
     const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
     const auto& reads = owner_->Sensitivity().AnalyzeReads(*init, net);
+    auto sensitivity = owner_->TranslateSensitivityReads(
+        reads, frame, support::EventEdge::kAnyChange);
+    if (!sensitivity) return std::unexpected(std::move(sensitivity.error()));
     frame.current_structural_scope->continuous_assigns.Add(
         hir::ContinuousAssign{
             .span = span,
             .lhs = lhs_id,
             .rhs = rhs_id,
-            .sensitivity_list =
-                owner_->TranslateSensitivityReads(reads, frame)});
+            .sensitivity_list = *std::move(sensitivity)});
   }
   return {};
 }

--- a/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/unit_lowerer.cpp
@@ -257,7 +257,13 @@ auto UnitLowerer::EnsureForeignImport(const slang::ast::SubroutineSymbol& sym)
 
 void UnitLowerer::MapPatternVar(
     const slang::ast::PatternVarSymbol& sym, hir::PatternId pattern) {
-  pattern_var_bindings_.insert_or_assign(&sym, pattern);
+  const auto [_, inserted] = pattern_var_bindings_.emplace(&sym, pattern);
+  if (!inserted) {
+    throw InternalError(
+        "UnitLowerer::MapPatternVar: pattern-bound identifier already mapped; "
+        "its id indexes one body's arena, so a second mapping would silently "
+        "redirect the first body's references");
+  }
 }
 
 auto UnitLowerer::LookupPatternVar(const slang::ast::PatternVarSymbol& sym)
@@ -313,6 +319,23 @@ auto TargetNetType(const slang::ast::ValueSymbol& target)
   }
 }
 
+// The compilation unit a value is declared directly in when that unit is a
+// namespace -- a package (LRM 26.2) or the anonymous `$unit` scope (LRM
+// 3.12.1) -- or nullptr when the value belongs to an instantiated scope and is
+// reached by a route. A namespace unit has no instance, so its declarations are
+// one program-global cell each, named rather than routed to.
+auto DeclaringUnitOfValue(const slang::ast::ValueSymbol& value)
+    -> const slang::ast::Symbol* {
+  const slang::ast::Scope* scope = value.getParentScope();
+  if (scope == nullptr) return nullptr;
+  const slang::ast::Symbol& owner = scope->asSymbol();
+  if (owner.kind != slang::ast::SymbolKind::Package &&
+      owner.kind != slang::ast::SymbolKind::CompilationUnit) {
+    return nullptr;
+  }
+  return &owner;
+}
+
 }  // namespace
 
 auto UnitLowerer::MapOrGetRoutedRef(
@@ -361,13 +384,6 @@ auto UnitLowerer::MakeRoutedMemberRef(
 auto UnitLowerer::TranslateReferenceRoute(
     const WalkFrame& frame, const slang::ast::ValueSymbol& value)
     -> std::optional<hir::ReferenceRoute> {
-  // Only a variable or a net is an addressable, observable signal. A genvar or
-  // parameter folds to an elaboration constant with no cell to reach.
-  if (value.kind != slang::ast::SymbolKind::Variable &&
-      value.kind != slang::ast::SymbolKind::Net) {
-    return std::nullopt;
-  }
-
   // The target sits on the reader's own scope or an ancestor scope of the same
   // unit. `hops == 0` is a direct member of `self` -- an empty route with no
   // sealed endpoint. `hops > 0` reaches an enclosing ancestor member: a routed
@@ -507,50 +523,63 @@ auto UnitLowerer::TranslateReferenceRoute(
   return std::nullopt;
 }
 
+auto UnitLowerer::ResolveValueTarget(
+    const WalkFrame& frame, const slang::ast::ValueSymbol& value)
+    -> diag::Result<std::optional<hir::ValueTarget>> {
+  // Only a variable or a net has a cell. A parameter, genvar, or enum value is
+  // a compile-time constant that folds where it is used, so there is nothing to
+  // reach: no route to seal and nothing to observe. Deciding this once, ahead
+  // of both ways of reaching a cell, is what stops a constant declared in a
+  // namespace unit from being mistaken for that unit's program-global cell.
+  if (value.kind != slang::ast::SymbolKind::Variable &&
+      value.kind != slang::ast::SymbolKind::Net) {
+    return std::nullopt;
+  }
+
+  // A namespace unit has no instance, so its cell is reached by name rather
+  // than by a route out of the reader's own storage (LRM 26.2, 3.12.1). The
+  // same by-name form serves a referrer in another unit and the owning unit's
+  // own body, neither of which has a receiver to route through.
+  if (const auto* unit = DeclaringUnitOfValue(value)) {
+    auto value_type =
+        InternType(value.getType(), SourceMapper().PointSpanOf(value.location));
+    if (!value_type) return std::unexpected(std::move(value_type.error()));
+    return hir::ValueTarget{hir::ExternalUnitValueRef{
+        .unit_name = CompilationUnitName(*unit),
+        .variable_name = std::string{value.name},
+        .value_type = *value_type}};
+  }
+
+  if (auto route = TranslateReferenceRoute(frame, value)) {
+    return hir::ValueTarget{*std::move(route)};
+  }
+  return std::nullopt;
+}
+
 auto UnitLowerer::TranslateSensitivityReads(
-    const std::vector<SensitivityRead>& reads, const WalkFrame& frame)
-    -> std::vector<hir::SensitivityEntry> {
+    const std::vector<SensitivityRead>& reads, const WalkFrame& frame,
+    support::EventEdge edge)
+    -> diag::Result<std::vector<hir::SensitivityEntry>> {
   std::vector<hir::SensitivityEntry> out;
   out.reserve(reads.size());
   for (const auto& read : reads) {
-    // Both a variable and a net are observable value symbols a process can wait
-    // on; sensitivity subscribes to either (a net's resolved value changing is
-    // an update event just like a variable write, LRM 9.4.2).
-    const auto* value = read.symbol->as_if<slang::ast::ValueSymbol>();
-    if (value == nullptr) continue;
+    auto target = ResolveValueTarget(frame, *read.symbol);
+    if (!target) return std::unexpected(std::move(target.error()));
+    if (!target->has_value()) continue;
     // A footprint is meaningful only for a signal the runtime bit-addresses: a
     // packed bit vector, which renders to one observable cell whose change set
     // is read per bit. For an enum, unpacked aggregate, string, or real the
     // runtime observes the whole signal on any change, so the read carries no
     // footprint regardless of the flat-bit view the DFA computed over its own
     // encoding.
-    const auto& read_type = value->getType();
-    const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
-        read_type.isIntegral() && !read_type.isEnum() ? read.footprint
-                                                      : std::nullopt;
-    // A variable owned by another unit's namespace is watched the same way, but
-    // by name: it has no reader-relative route, so it wakes the process through
-    // a reference to its one program-global cell (LRM 26.2 / 3.12.1), the
-    // observation dual of reading it.
-    if (const auto* unit = DeclaringUnitOfValue(*value)) {
-      auto value_type =
-          InternType(read_type, SourceMapper().PointSpanOf(value->location));
-      if (!value_type) continue;
-      out.push_back(
-          hir::SensitivityEntry{
-              .ref =
-                  hir::ExternalUnitValueRef{
-                      .unit_name = CompilationUnitName(*unit),
-                      .variable_name = std::string{value->name},
-                      .value_type = *value_type},
-              .footprint = footprint});
-      continue;
-    }
-    if (auto ref = TranslateReferenceRoute(frame, *value)) {
-      out.push_back(
-          hir::SensitivityEntry{
-              .ref = *std::move(ref), .footprint = footprint});
-    }
+    const auto& read_type = read.symbol->getType();
+    out.push_back(
+        hir::SensitivityEntry{
+            .ref = *std::move(*target),
+            .footprint = read_type.isIntegral() && !read_type.isEnum()
+                             ? read.footprint
+                             : std::nullopt,
+            .edge_kind = edge});
   }
   return out;
 }

--- a/tests/cases/cpp/package_compile_time_contents/case.yaml
+++ b/tests/cases/cpp/package_compile_time_contents/case.yaml
@@ -13,3 +13,8 @@ expect:
     col: 1
     wv: 8
     masked: 240
+    comb_masked: 240
+    assigned: 240
+    star_sum: 495
+    decoded: 3
+    waited: 1

--- a/tests/cases/cpp/package_compile_time_contents/main.sv
+++ b/tests/cases/cpp/package_compile_time_contents/main.sv
@@ -24,11 +24,51 @@ module Top;
   // Package constant reached by import, in value context (bare name).
   logic [7:0] masked;
 
+  // Reading a package constant inside a construct that infers its sensitivity
+  // from what it reads -- every such form, since one inference serves them all.
+  // LRM 9.2.2.2.1 infers that list from net and variable identifiers, and a
+  // parameter or enum value is neither, so the constant folds here exactly as
+  // it does above and only the signal alongside it subscribes. Each output
+  // below settles on a value reachable only by re-evaluating after time zero.
+  logic [7:0] src;
+  color_t sel;
+  logic [7:0] comb_masked;
+  logic [7:0] assigned;
+  logic [15:0] star_sum;
+  int decoded;
+  int waited;
+
+  always_comb comb_masked = src & Mask;
+  assign assigned = src & pkg::Mask;
+  always @* star_sum = src + pkg::Mask;
+
+  initial begin
+    waited = 0;
+    wait (src > pkg::Mask);
+    waited = 1;
+  end
+
+  // An enum value as a case item is read the same way (LRM 12.5).
+  always_comb begin
+    case (sel)
+      Red: decoded = 1;
+      Green: decoded = 2;
+      default: decoded = 3;
+    endcase
+  end
+
   initial begin
     wide = 8'hA5;
     nib = 4'hC;
     col = Green;
     wv = pkg::W;
     masked = 8'hFF & Mask;
+
+    src = 8'h0F;
+    sel = Red;
+    #1;
+    src = 8'hFF;
+    sel = Blue;
+    #1;
   end
 endmodule


### PR DESCRIPTION
## Summary

A `parameter`, `localparam`, or enum member read inside `always_comb`, `always @*`, a `wait`, or a continuous assign was subscribed to as though it were a signal. For a constant declared in a package or at `$unit` scope that became a by-name cross-unit reference, so the emitted C++ named a symbol the namespace never manifests and did not compile. LRM 9.2.2.2.1 infers the implicit sensitivity list from net and variable identifiers; a constant is neither, so such a read contributes nothing to it -- neither folding it into the subscription nor materializing a cell for it is right, since a value that cannot change is not something a process can wait on.

## Design

The defect was that "where does this value's cell live" had two answerers: the expression path resolved it when lowering a read, and the sensitivity path resolved it again when building a subscription. They disagreed, so one `pkg::Mask` became a folded literal on one emitted line and a subscription target on the next. `front-end-semantic-boundary.md` D3 already required that read, write, and observation reach a target through one translation and must not each re-derive it, and that entry recorded the parallel classifier as unfinished work.

`UnitLowerer::ResolveValueTarget` is now the single producer of that answer, and `hir::SensitivityTarget` is renamed `hir::ValueTarget` because it is no longer owned by one consumer. Whether a symbol has a cell at all is decided once, ahead of both ways of reaching one, which is what stops a constant declared in a namespace unit from being mistaken for that unit's program-global cell. The route translator becomes private, and the three duplicated resolution sites in the named-value, hierarchical, and sensitivity paths collapse onto it.

Two shapes on the same path are corrected alongside it, since both dropped a fact at its source and restored it afterwards. An explicit event control's edge is now composed into its entries during translation rather than stamped onto every leaf after the list is built, and `@*` builds its sensitivity from the statement it controls rather than returning an empty control the caller fills in. The sensitivity path also stops swallowing a type-interning diagnostic.

## Testing

`package_compile_time_contents` gains the sensitivity-bearing reads of a package constant -- `always_comb`, a continuous assign, `always @*`, a `wait`, and an enum member as a case item -- asserting the values each settles on after re-evaluating past time zero. It fails before this change with three undefined-symbol errors in the emitted C++.

On the full `ibex_simple_system_tb`, the emitted C++ drops from 338 compiler errors to 6; the remaining two causes are a DPI-C export declared inside a generate scope and a net whose value is an unpacked array.